### PR TITLE
feat: badge settings — app & project-level controls

### DIFF
--- a/src/main/ipc/app-handlers.ts
+++ b/src/main/ipc/app-handlers.ts
@@ -1,10 +1,11 @@
 import { app, ipcMain, shell } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
-import { LogEntry, LoggingSettings, NotificationSettings } from '../../shared/types';
+import { BadgeSettings, LogEntry, LoggingSettings, NotificationSettings } from '../../shared/types';
 import * as notificationService from '../services/notification-service';
 import * as themeService from '../services/theme-service';
 import * as orchestratorSettings from '../services/orchestrator-settings';
 import * as headlessSettings from '../services/headless-settings';
+import * as badgeSettings from '../services/badge-settings';
 import * as logService from '../services/log-service';
 import * as logSettings from '../services/log-settings';
 
@@ -51,6 +52,14 @@ export function registerAppHandlers(): void {
 
   ipcMain.handle(IPC.APP.SAVE_HEADLESS_SETTINGS, (_event, settings: headlessSettings.HeadlessSettings) => {
     headlessSettings.saveSettings(settings);
+  });
+
+  ipcMain.handle(IPC.APP.GET_BADGE_SETTINGS, () => {
+    return badgeSettings.getSettings();
+  });
+
+  ipcMain.handle(IPC.APP.SAVE_BADGE_SETTINGS, (_event, settings: BadgeSettings) => {
+    badgeSettings.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.APP.SET_DOCK_BADGE, (_event, count: number) => {

--- a/src/main/services/badge-settings.ts
+++ b/src/main/services/badge-settings.ts
@@ -1,0 +1,11 @@
+import { createSettingsStore } from './settings-store';
+import type { BadgeSettings } from '../../shared/types';
+
+const store = createSettingsStore<BadgeSettings>('badge-settings.json', {
+  enabled: true,
+  pluginBadges: true,
+  projectRailBadges: true,
+});
+
+export const getSettings = store.get;
+export const saveSettings = store.save;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -287,6 +287,10 @@ const api = {
       ipcRenderer.invoke(IPC.APP.SAVE_HEADLESS_SETTINGS, settings),
     setDockBadge: (count: number) =>
       ipcRenderer.invoke(IPC.APP.SET_DOCK_BADGE, count),
+    getBadgeSettings: () =>
+      ipcRenderer.invoke(IPC.APP.GET_BADGE_SETTINGS),
+    saveBadgeSettings: (settings: any) =>
+      ipcRenderer.invoke(IPC.APP.SAVE_BADGE_SETTINGS, settings),
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { useThemeStore } from './stores/themeStore';
 import { useOrchestratorStore } from './stores/orchestratorStore';
 import { useLoggingStore } from './stores/loggingStore';
 import { useHeadlessStore } from './stores/headlessStore';
+import { useBadgeSettingsStore } from './stores/badgeSettingsStore';
 import { initBadgeSideEffects } from './stores/badgeStore';
 import { usePluginStore } from './plugins/plugin-store';
 import { initializePluginSystem, handleProjectSwitch, getBuiltinProjectPluginIds } from './plugins/plugin-loader';
@@ -49,6 +50,7 @@ export function App() {
   const loadOrchestratorSettings = useOrchestratorStore((s) => s.loadSettings);
   const loadLoggingSettings = useLoggingStore((s) => s.loadSettings);
   const loadHeadlessSettings = useHeadlessStore((s) => s.loadSettings);
+  const loadBadgeSettings = useBadgeSettingsStore((s) => s.loadSettings);
 
   useEffect(() => {
     loadProjects();
@@ -57,11 +59,12 @@ export function App() {
     loadOrchestratorSettings();
     loadLoggingSettings();
     loadHeadlessSettings();
+    loadBadgeSettings();
     initBadgeSideEffects();
     initializePluginSystem().catch((err) => {
       console.error('[Plugins] Failed to initialize plugin system:', err);
     });
-  }, [loadProjects, loadNotificationSettings, loadTheme, loadOrchestratorSettings, loadLoggingSettings, loadHeadlessSettings]);
+  }, [loadProjects, loadNotificationSettings, loadTheme, loadOrchestratorSettings, loadLoggingSettings, loadHeadlessSettings, loadBadgeSettings]);
 
   useEffect(() => {
     const remove = window.clubhouse.app.onOpenSettings(() => {

--- a/src/renderer/features/settings/NotificationSettingsView.tsx
+++ b/src/renderer/features/settings/NotificationSettingsView.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNotificationStore } from '../../stores/notificationStore';
 import { useBadgeStore } from '../../stores/badgeStore';
+import { useBadgeSettingsStore, ResolvedBadgeSettings } from '../../stores/badgeSettingsStore';
 
 const TOGGLES: { key: keyof Omit<import('../../../shared/types').NotificationSettings, 'enabled' | 'playSound'>; label: string; description: string }[] = [
   { key: 'permissionNeeded', label: 'Permission Needed', description: 'Notify when an agent is waiting for approval' },
@@ -30,15 +31,180 @@ function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (
   );
 }
 
-export function NotificationSettingsView() {
+// Three-state toggle for project overrides: global default / on / off
+function TriStateToggle({ value, onChange, disabled }: {
+  value: boolean | undefined; // undefined = use global
+  onChange: (v: boolean | undefined) => void;
+  disabled?: boolean;
+}) {
+  const states: Array<{ label: string; val: boolean | undefined }> = [
+    { label: 'Global', val: undefined },
+    { label: 'On', val: true },
+    { label: 'Off', val: false },
+  ];
+
+  return (
+    <div className={`flex rounded-md overflow-hidden border border-surface-1 ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
+      {states.map(({ label, val }) => (
+        <button
+          key={label}
+          type="button"
+          onClick={() => !disabled && onChange(val)}
+          className={`
+            px-2.5 py-1 text-xs font-medium cursor-pointer transition-colors
+            ${value === val ? 'bg-indigo-500 text-white' : 'bg-surface-0 text-ctp-subtext0 hover:bg-surface-1'}
+          `}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const BADGE_TOGGLES: { key: keyof ResolvedBadgeSettings; label: string; description: string }[] = [
+  { key: 'pluginBadges', label: 'Plugin Badges', description: 'Show badge indicators from plugins' },
+  { key: 'projectRailBadges', label: 'Project Rail Badges', description: 'Show aggregated badges on project icons in the sidebar' },
+];
+
+function BadgeSettingsSection({ projectId }: { projectId?: string }) {
+  const badgeSettings = useBadgeSettingsStore();
+  const resolved = projectId
+    ? badgeSettings.getProjectSettings(projectId)
+    : { enabled: badgeSettings.enabled, pluginBadges: badgeSettings.pluginBadges, projectRailBadges: badgeSettings.projectRailBadges };
+  const overrides = projectId ? badgeSettings.projectOverrides[projectId] : undefined;
+
+  const handleAppToggle = (key: keyof ResolvedBadgeSettings, value: boolean) => {
+    badgeSettings.saveAppSettings({ [key]: value });
+  };
+
+  const handleProjectToggle = (key: keyof ResolvedBadgeSettings, value: boolean | undefined) => {
+    if (!projectId) return;
+    if (value === undefined) {
+      // Remove this key from overrides
+      const current = badgeSettings.projectOverrides[projectId] ?? {};
+      const { [key]: _, ...rest } = current;
+      if (Object.keys(rest).length === 0) {
+        badgeSettings.clearProjectOverride(projectId);
+      } else {
+        // Rewrite the override without this key
+        badgeSettings.clearProjectOverride(projectId).then(() => {
+          if (Object.keys(rest).length > 0) {
+            badgeSettings.setProjectOverride(projectId, rest);
+          }
+        });
+      }
+    } else {
+      badgeSettings.setProjectOverride(projectId, { [key]: value });
+    }
+  };
+
+  if (projectId) {
+    return (
+      <>
+        <h3 className="text-md font-semibold text-ctp-text mt-6 mb-4">Badges</h3>
+        <div className="space-y-5">
+          {/* Master toggle */}
+          <div className="flex items-center justify-between py-2">
+            <div>
+              <div className="text-sm text-ctp-text font-medium">Enable Badges</div>
+              <div className="text-xs text-ctp-subtext0 mt-0.5">Show badge indicators on tabs and the project rail</div>
+            </div>
+            <TriStateToggle
+              value={overrides?.enabled}
+              onChange={(v) => handleProjectToggle('enabled', v)}
+            />
+          </div>
+
+          {BADGE_TOGGLES.map(({ key, label, description }) => (
+            <div key={key} className="flex items-center justify-between py-2">
+              <div>
+                <div className="text-sm text-ctp-text font-medium">{label}</div>
+                <div className="text-xs text-ctp-subtext0 mt-0.5">{description}</div>
+              </div>
+              <TriStateToggle
+                value={overrides?.[key]}
+                onChange={(v) => handleProjectToggle(key, v)}
+                disabled={!resolved.enabled}
+              />
+            </div>
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h3 className="text-md font-semibold text-ctp-text mt-6 mb-4">Badges</h3>
+      <div className="space-y-5">
+        {/* Master toggle */}
+        <div className="flex items-center justify-between py-2">
+          <div>
+            <div className="text-sm text-ctp-text font-medium">Enable Badges</div>
+            <div className="text-xs text-ctp-subtext0 mt-0.5">Show badge indicators on tabs and the project rail</div>
+          </div>
+          <Toggle checked={resolved.enabled} onChange={(v) => handleAppToggle('enabled', v)} />
+        </div>
+
+        {BADGE_TOGGLES.map(({ key, label, description }) => (
+          <div key={key} className="flex items-center justify-between py-2">
+            <div>
+              <div className="text-sm text-ctp-text font-medium">{label}</div>
+              <div className="text-xs text-ctp-subtext0 mt-0.5">{description}</div>
+            </div>
+            <Toggle
+              checked={resolved[key]}
+              onChange={(v) => handleAppToggle(key, v)}
+              disabled={!resolved.enabled}
+            />
+          </div>
+        ))}
+
+        <div className="border-t border-surface-0" />
+
+        {/* Clear all badges */}
+        <div className="flex items-center justify-between py-2">
+          <div>
+            <div className="text-sm text-ctp-text font-medium">Clear All Badges</div>
+            <div className="text-xs text-ctp-subtext0 mt-0.5">Remove all badge indicators from tabs, projects, and the dock</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => useBadgeStore.getState().clearAll()}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-surface-2 text-ctp-text hover:bg-surface-1 transition-colors cursor-pointer"
+          >
+            Clear All
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function NotificationSettingsView({ projectId }: { projectId?: string }) {
   const { settings, loadSettings, saveSettings } = useNotificationStore();
+  const loadBadgeSettings = useBadgeSettingsStore((s) => s.loadSettings);
 
   useEffect(() => {
     loadSettings();
-  }, [loadSettings]);
+    loadBadgeSettings();
+  }, [loadSettings, loadBadgeSettings]);
 
   if (!settings) {
     return <div className="p-6 text-ctp-subtext0 text-sm">Loading…</div>;
+  }
+
+  // Project context: only show badge settings
+  if (projectId) {
+    return (
+      <div className="h-full overflow-y-auto p-6">
+        <div className="max-w-2xl">
+          <h2 className="text-lg font-semibold text-ctp-text mb-4">Notifications</h2>
+          <BadgeSettingsSection projectId={projectId} />
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -104,24 +270,9 @@ export function NotificationSettingsView() {
               Send Test
             </button>
           </div>
-
-          <div className="border-t border-surface-0" />
-
-          {/* Clear all badges */}
-          <div className="flex items-center justify-between py-2">
-            <div>
-              <div className="text-sm text-ctp-text font-medium">Clear All Badges</div>
-              <div className="text-xs text-ctp-subtext0 mt-0.5">Remove all badge indicators from tabs, projects, and the dock</div>
-            </div>
-            <button
-              type="button"
-              onClick={() => useBadgeStore.getState().clearAll()}
-              className="px-3 py-1.5 text-xs font-medium rounded-md bg-surface-2 text-ctp-text hover:bg-surface-1 transition-colors cursor-pointer"
-            >
-              Clear All
-            </button>
-          </div>
         </div>
+
+        <BadgeSettingsSection />
       </div>
     </div>
   );

--- a/src/renderer/panels/AccessoryPanel.tsx
+++ b/src/renderer/panels/AccessoryPanel.tsx
@@ -48,6 +48,7 @@ function SettingsCategoryNav() {
           <>
             {navButton('Project Settings', 'project')}
             {navButton('Agents', 'orchestrators')}
+            {navButton('Notifications', 'notifications')}
             {navButton('Plugins', 'plugins')}
           </>
         )}

--- a/src/renderer/panels/MainContentView.tsx
+++ b/src/renderer/panels/MainContentView.tsx
@@ -82,7 +82,7 @@ export function MainContentView() {
   if (explorerTab === 'settings') {
     const projectId = settingsContext !== 'app' ? settingsContext : undefined;
     if (settingsSubPage === 'orchestrators') return <OrchestratorSettingsView projectId={projectId} />;
-    if (settingsSubPage === 'notifications') return <NotificationSettingsView />;
+    if (settingsSubPage === 'notifications') return <NotificationSettingsView projectId={projectId} />;
     if (settingsSubPage === 'logging') return <LoggingSettingsView />;
     if (settingsSubPage === 'display') return <DisplaySettingsView />;
     if (settingsSubPage === 'plugin-detail') return <PluginDetailSettings />;

--- a/src/renderer/stores/badgeSettingsStore.test.ts
+++ b/src/renderer/stores/badgeSettingsStore.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useBadgeSettingsStore } from './badgeSettingsStore';
+
+// Mock the window.clubhouse API
+const mockGetBadgeSettings = vi.fn();
+const mockSaveBadgeSettings = vi.fn();
+
+Object.defineProperty(globalThis, 'window', {
+  value: {
+    clubhouse: {
+      app: {
+        getBadgeSettings: mockGetBadgeSettings,
+        saveBadgeSettings: mockSaveBadgeSettings,
+      },
+    },
+  },
+  writable: true,
+});
+
+function getState() {
+  return useBadgeSettingsStore.getState();
+}
+
+function reset() {
+  useBadgeSettingsStore.setState({
+    enabled: true,
+    pluginBadges: true,
+    projectRailBadges: true,
+    projectOverrides: {},
+  });
+  vi.clearAllMocks();
+}
+
+describe('badgeSettingsStore', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  describe('loadSettings', () => {
+    it('loads settings from IPC', async () => {
+      mockGetBadgeSettings.mockResolvedValue({
+        enabled: false,
+        pluginBadges: false,
+        projectRailBadges: true,
+        projectOverrides: { proj1: { enabled: true } },
+      });
+      await getState().loadSettings();
+      expect(getState().enabled).toBe(false);
+      expect(getState().pluginBadges).toBe(false);
+      expect(getState().projectRailBadges).toBe(true);
+      expect(getState().projectOverrides).toEqual({ proj1: { enabled: true } });
+    });
+
+    it('uses defaults when IPC returns null', async () => {
+      mockGetBadgeSettings.mockResolvedValue(null);
+      await getState().loadSettings();
+      expect(getState().enabled).toBe(true);
+      expect(getState().pluginBadges).toBe(true);
+      expect(getState().projectRailBadges).toBe(true);
+    });
+
+    it('keeps defaults on error', async () => {
+      mockGetBadgeSettings.mockRejectedValue(new Error('fail'));
+      await getState().loadSettings();
+      expect(getState().enabled).toBe(true);
+    });
+  });
+
+  describe('saveAppSettings', () => {
+    it('updates app-level settings and persists', async () => {
+      await getState().saveAppSettings({ enabled: false });
+      expect(getState().enabled).toBe(false);
+      expect(mockSaveBadgeSettings).toHaveBeenCalledWith({
+        enabled: false,
+        pluginBadges: true,
+        projectRailBadges: true,
+        projectOverrides: {},
+      });
+    });
+
+    it('reverts on save failure', async () => {
+      mockSaveBadgeSettings.mockImplementation(() => { throw new Error('fail'); });
+      await getState().saveAppSettings({ enabled: false });
+      // Should revert to previous
+      expect(getState().enabled).toBe(true);
+    });
+  });
+
+  describe('getProjectSettings', () => {
+    it('returns app defaults when no project override exists', () => {
+      const settings = getState().getProjectSettings('proj1');
+      expect(settings).toEqual({ enabled: true, pluginBadges: true, projectRailBadges: true });
+    });
+
+    it('merges project overrides with app defaults', () => {
+      useBadgeSettingsStore.setState({
+        projectOverrides: { proj1: { pluginBadges: false } },
+      });
+      const settings = getState().getProjectSettings('proj1');
+      expect(settings).toEqual({ enabled: true, pluginBadges: false, projectRailBadges: true });
+    });
+
+    it('fully overrides all settings when all specified', () => {
+      useBadgeSettingsStore.setState({
+        enabled: true,
+        pluginBadges: true,
+        projectRailBadges: true,
+        projectOverrides: { proj1: { enabled: false, pluginBadges: false, projectRailBadges: false } },
+      });
+      const settings = getState().getProjectSettings('proj1');
+      expect(settings).toEqual({ enabled: false, pluginBadges: false, projectRailBadges: false });
+    });
+
+    it('returns app defaults for a different project', () => {
+      useBadgeSettingsStore.setState({
+        enabled: false,
+        projectOverrides: { proj1: { enabled: true } },
+      });
+      const settings = getState().getProjectSettings('proj2');
+      expect(settings.enabled).toBe(false);
+    });
+  });
+
+  describe('setProjectOverride', () => {
+    it('sets a project-level override and persists', async () => {
+      await getState().setProjectOverride('proj1', { pluginBadges: false });
+      expect(getState().projectOverrides).toEqual({ proj1: { pluginBadges: false } });
+      expect(mockSaveBadgeSettings).toHaveBeenCalled();
+    });
+
+    it('merges with existing overrides for the same project', async () => {
+      await getState().setProjectOverride('proj1', { pluginBadges: false });
+      await getState().setProjectOverride('proj1', { projectRailBadges: false });
+      expect(getState().projectOverrides.proj1).toEqual({
+        pluginBadges: false,
+        projectRailBadges: false,
+      });
+    });
+
+    it('reverts on save failure', async () => {
+      mockSaveBadgeSettings.mockImplementation(() => { throw new Error('fail'); });
+      await getState().setProjectOverride('proj1', { enabled: false });
+      expect(getState().projectOverrides).toEqual({});
+    });
+  });
+
+  describe('clearProjectOverride', () => {
+    it('removes project override and persists', async () => {
+      useBadgeSettingsStore.setState({
+        projectOverrides: { proj1: { enabled: false }, proj2: { pluginBadges: false } },
+      });
+      await getState().clearProjectOverride('proj1');
+      expect(getState().projectOverrides).toEqual({ proj2: { pluginBadges: false } });
+      expect(mockSaveBadgeSettings).toHaveBeenCalled();
+    });
+
+    it('does nothing for non-existent project', async () => {
+      await getState().clearProjectOverride('nonexistent');
+      expect(getState().projectOverrides).toEqual({});
+    });
+
+    it('reverts on save failure', async () => {
+      useBadgeSettingsStore.setState({
+        projectOverrides: { proj1: { enabled: false } },
+      });
+      mockSaveBadgeSettings.mockImplementation(() => { throw new Error('fail'); });
+      await getState().clearProjectOverride('proj1');
+      expect(getState().projectOverrides).toEqual({ proj1: { enabled: false } });
+    });
+  });
+});

--- a/src/renderer/stores/badgeSettingsStore.ts
+++ b/src/renderer/stores/badgeSettingsStore.ts
@@ -1,0 +1,93 @@
+import { create } from 'zustand';
+
+export interface ResolvedBadgeSettings {
+  enabled: boolean;
+  pluginBadges: boolean;
+  projectRailBadges: boolean;
+}
+
+interface BadgeSettingsState {
+  enabled: boolean;
+  pluginBadges: boolean;
+  projectRailBadges: boolean;
+  projectOverrides: Record<string, Partial<ResolvedBadgeSettings>>;
+
+  loadSettings: () => Promise<void>;
+  saveAppSettings: (partial: Partial<ResolvedBadgeSettings>) => Promise<void>;
+  getProjectSettings: (projectId: string) => ResolvedBadgeSettings;
+  setProjectOverride: (projectId: string, partial: Partial<ResolvedBadgeSettings>) => Promise<void>;
+  clearProjectOverride: (projectId: string) => Promise<void>;
+}
+
+function persist(state: BadgeSettingsState): void {
+  window.clubhouse.app.saveBadgeSettings({
+    enabled: state.enabled,
+    pluginBadges: state.pluginBadges,
+    projectRailBadges: state.projectRailBadges,
+    projectOverrides: state.projectOverrides,
+  });
+}
+
+export const useBadgeSettingsStore = create<BadgeSettingsState>((set, get) => ({
+  enabled: true,
+  pluginBadges: true,
+  projectRailBadges: true,
+  projectOverrides: {},
+
+  loadSettings: async () => {
+    try {
+      const settings = await window.clubhouse.app.getBadgeSettings();
+      set({
+        enabled: settings?.enabled ?? true,
+        pluginBadges: settings?.pluginBadges ?? true,
+        projectRailBadges: settings?.projectRailBadges ?? true,
+        projectOverrides: settings?.projectOverrides ?? {},
+      });
+    } catch {
+      // Keep defaults
+    }
+  },
+
+  saveAppSettings: async (partial) => {
+    const prev = { enabled: get().enabled, pluginBadges: get().pluginBadges, projectRailBadges: get().projectRailBadges };
+    set(partial);
+    try {
+      persist(get());
+    } catch {
+      set(prev);
+    }
+  },
+
+  getProjectSettings: (projectId) => {
+    const { enabled, pluginBadges, projectRailBadges, projectOverrides } = get();
+    const overrides = projectOverrides[projectId];
+    return {
+      enabled: overrides?.enabled ?? enabled,
+      pluginBadges: overrides?.pluginBadges ?? pluginBadges,
+      projectRailBadges: overrides?.projectRailBadges ?? projectRailBadges,
+    };
+  },
+
+  setProjectOverride: async (projectId, partial) => {
+    const prevOverrides = get().projectOverrides;
+    const existing = prevOverrides[projectId] ?? {};
+    const newOverrides = { ...prevOverrides, [projectId]: { ...existing, ...partial } };
+    set({ projectOverrides: newOverrides });
+    try {
+      persist(get());
+    } catch {
+      set({ projectOverrides: prevOverrides });
+    }
+  },
+
+  clearProjectOverride: async (projectId) => {
+    const prevOverrides = get().projectOverrides;
+    const { [projectId]: _, ...rest } = prevOverrides;
+    set({ projectOverrides: rest });
+    try {
+      persist(get());
+    } catch {
+      set({ projectOverrides: prevOverrides });
+    }
+  },
+}));

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -101,6 +101,8 @@ export const IPC = {
     GET_HEADLESS_SETTINGS: 'app:get-headless-settings',
     SAVE_HEADLESS_SETTINGS: 'app:save-headless-settings',
     SET_DOCK_BADGE: 'app:set-dock-badge',
+    GET_BADGE_SETTINGS: 'app:get-badge-settings',
+    SAVE_BADGE_SETTINGS: 'app:save-badge-settings',
   },
   PLUGIN: {
     DISCOVER_COMMUNITY: 'plugin:discover-community',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -119,6 +119,13 @@ export interface FileNode {
 export type ExplorerTab = string;
 
 
+export interface BadgeSettings {
+  enabled: boolean;
+  pluginBadges: boolean;
+  projectRailBadges: boolean;
+  projectOverrides?: Record<string, Partial<Pick<BadgeSettings, 'enabled' | 'pluginBadges' | 'projectRailBadges'>>>;
+}
+
 export interface NotificationSettings {
   enabled: boolean;
   permissionNeeded: boolean;


### PR DESCRIPTION
## Summary

- Adds `BadgeSettings` with three toggles: **Enable Badges** (master kill switch), **Plugin Badges** (hide plugin-sourced badges), and **Project Rail Badges** (hide aggregated project icons)
- Settings follow the existing app+project-override pattern (like headless settings) — project-level overrides merge with app defaults
- Filtering is applied in badge store **selectors** (`getTabBadge`, `getProjectBadge`, `getAppPluginBadge`, `getDockCount`) so all UI components and dock sync automatically respect settings without any component changes
- Plugins can still call `api.badges.set()` when disabled — badges are stored but filtered at display time, so toggling back on instantly shows accumulated badges
- Project settings nav now includes a "Notifications" entry with per-project badge overrides using a tri-state toggle (Global/On/Off)

## Files Changed

### New Files
- `src/main/services/badge-settings.ts` — Main process JSON file persistence
- `src/renderer/stores/badgeSettingsStore.ts` — Renderer Zustand store
- `src/renderer/stores/badgeSettingsStore.test.ts` — 15 unit tests

### Modified Files
- `src/shared/types.ts` — Added `BadgeSettings` interface
- `src/shared/ipc-channels.ts` — Added `GET_BADGE_SETTINGS`, `SAVE_BADGE_SETTINGS`
- `src/main/ipc/app-handlers.ts` — Badge settings IPC handlers
- `src/preload/index.ts` — Preload bridge for badge settings
- `src/renderer/stores/badgeStore.ts` — Selectors now filter based on settings
- `src/renderer/stores/badgeStore.test.ts` — Added 17 filtering tests (59 total)
- `src/renderer/features/settings/NotificationSettingsView.tsx` — Badge settings UI (app + project)
- `src/renderer/panels/AccessoryPanel.tsx` — "Notifications" in project settings nav
- `src/renderer/panels/MainContentView.tsx` — Pass `projectId` to `NotificationSettingsView`
- `src/renderer/App.tsx` — Initialize badge settings store on startup

## Test plan

- [x] `npm run validate` passes (typecheck, 1842 tests, build, 31 Playwright E2E tests)
- [ ] App-level toggles: disable all → no badges anywhere. Disable plugin badges → only core agent dots show. Disable project rail → tabs still show badges but project icons don't
- [ ] Project override: set project A to disable plugin badges, project B uses global default → badges filter correctly per project
- [ ] Persistence: change settings, restart app → settings preserved
- [ ] Toggle back on: disabled badges reappear instantly (badges were still stored, just filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)