### PR TITLE
feat: tag-driven release pipeline with signing, notarization, and DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,294 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  verify-tag:
+    name: Verify Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      release_notes: ${{ steps.meta.outputs.release_notes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag signature via GitHub API
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" --jq '.object.sha')
+
+          # Dereference if it's an annotated tag (points to a tag object, not a commit)
+          TAG_TYPE=$(gh api "repos/${{ github.repository }}/git/tags/${TAG_SHA}" --jq '.object.type' 2>/dev/null || echo "commit")
+          if [ "$TAG_TYPE" = "commit" ]; then
+            VERIFIED=$(gh api "repos/${{ github.repository }}/git/tags/${TAG_SHA}" --jq '.verification.verified')
+          else
+            VERIFIED=$(gh api "repos/${{ github.repository }}/git/tags/${TAG_SHA}" --jq '.verification.verified')
+          fi
+
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error::Tag ${TAG_NAME} is not signed or signature verification failed"
+            exit 1
+          fi
+          echo "Tag ${TAG_NAME} signature verified"
+
+      - name: Extract version and release notes
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Verify tag version matches package.json
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version (${VERSION}) does not match package.json (${PKG_VERSION})"
+            exit 1
+          fi
+
+          # Extract annotated tag message as release notes
+          NOTES=$(git tag -l --format='%(contents)' "${GITHUB_REF_NAME}" | head -50)
+          {
+            echo "release_notes<<RELEASE_NOTES_EOF"
+            echo "$NOTES"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build (${{ matrix.arch }})
+    needs: verify-tag
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-14
+          - arch: x64
+            runner: macos-13
+    outputs:
+      sha256_arm64: ${{ steps.hash.outputs.sha256_arm64 }}
+      size_arm64: ${{ steps.hash.outputs.size_arm64 }}
+      sha256_x64: ${{ steps.hash.outputs.sha256_x64 }}
+      size_x64: ${{ steps.hash.outputs.size_x64 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Import signing certificate
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          echo "$APPLE_CERTIFICATE_P12" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # Extract the signing identity name from the imported cert
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "APPLE_SIGNING_IDENTITY=${IDENTITY}" >> "$GITHUB_ENV"
+          echo "Signing identity: ${IDENTITY}"
+
+      - name: Build, sign, and notarize
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          npx electron-forge make --arch=${{ matrix.arch }}
+
+      - name: Compute artifact hashes
+        id: hash
+        run: |
+          VERSION="${{ needs.verify-tag.outputs.version }}"
+          ARCH="${{ matrix.arch }}"
+
+          # Find the ZIP (for auto-updater)
+          ZIP_PATH=$(find out/make -name "*.zip" -type f | head -1)
+          SHA256=$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')
+          SIZE=$(stat -f%z "$ZIP_PATH")
+
+          echo "sha256_${ARCH}=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "size_${ARCH}=${SIZE}" >> "$GITHUB_OUTPUT"
+
+      - name: Rename artifacts for upload
+        run: |
+          VERSION="${{ needs.verify-tag.outputs.version }}"
+          ARCH="${{ matrix.arch }}"
+          mkdir -p dist
+
+          # Find and rename ZIP
+          ZIP_PATH=$(find out/make -name "*.zip" -type f | head -1)
+          cp "$ZIP_PATH" "dist/Clubhouse-${VERSION}-darwin-${ARCH}.zip"
+
+          # Find and rename DMG
+          DMG_PATH=$(find out/make -name "*.dmg" -type f | head -1)
+          cp "$DMG_PATH" "dist/Clubhouse-${VERSION}-darwin-${ARCH}.dmg"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-darwin-${{ matrix.arch }}
+          path: dist/
+          retention-days: 5
+
+  publish:
+    name: Publish
+    needs: [verify-tag, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate latest.json
+        run: |
+          VERSION="${{ needs.verify-tag.outputs.version }}"
+          NOTES=$(cat <<'NOTES_EOF'
+          ${{ needs.verify-tag.outputs.release_notes }}
+          NOTES_EOF
+          )
+          BASE_URL="https://stclubhousereleases.blob.core.windows.net/releases/artifacts"
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg notes "$NOTES" \
+            --arg min_version "0.1.0" \
+            --arg url_arm64 "${BASE_URL}/Clubhouse-${VERSION}-darwin-arm64.zip" \
+            --arg sha256_arm64 "${{ needs.build.outputs.sha256_arm64 }}" \
+            --argjson size_arm64 ${{ needs.build.outputs.size_arm64 }} \
+            --arg url_x64 "${BASE_URL}/Clubhouse-${VERSION}-darwin-x64.zip" \
+            --arg sha256_x64 "${{ needs.build.outputs.sha256_x64 }}" \
+            --argjson size_x64 ${{ needs.build.outputs.size_x64 }} \
+            '{
+              version: $version,
+              releaseDate: $date,
+              releaseNotes: $notes,
+              minVersion: $min_version,
+              artifacts: {
+                "darwin-arm64": {
+                  url: $url_arm64,
+                  sha256: $sha256_arm64,
+                  size: $size_arm64
+                },
+                "darwin-x64": {
+                  url: $url_x64,
+                  sha256: $sha256_x64,
+                  size: $size_x64
+                }
+              }
+            }' > artifacts/latest.json
+
+          echo "Generated latest.json:"
+          cat artifacts/latest.json
+
+      - name: Authenticate to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Upload to Azure Blob Storage
+        run: |
+          VERSION="${{ needs.verify-tag.outputs.version }}"
+          ACCOUNT="stclubhousereleases"
+          CONTAINER="releases"
+
+          # Upload versioned artifacts (immutable)
+          for file in artifacts/Clubhouse-*.zip artifacts/Clubhouse-*.dmg; do
+            BLOB_NAME="artifacts/$(basename "$file")"
+            az storage blob upload \
+              --account-name "$ACCOUNT" \
+              --container-name "$CONTAINER" \
+              --name "$BLOB_NAME" \
+              --file "$file" \
+              --overwrite false \
+              --auth-mode login
+          done
+
+          # Upload latest.json
+          az storage blob upload \
+            --account-name "$ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --name "updates/latest.json" \
+            --file artifacts/latest.json \
+            --overwrite \
+            --content-type "application/json" \
+            --auth-mode login
+
+          # Copy DMGs to the latest slot
+          for ARCH in arm64 x64; do
+            az storage blob copy start \
+              --account-name "$ACCOUNT" \
+              --destination-container "$CONTAINER" \
+              --destination-blob "latest/Clubhouse-latest-darwin-${ARCH}.dmg" \
+              --source-uri "https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}/artifacts/Clubhouse-${VERSION}-darwin-${ARCH}.dmg" \
+              --auth-mode login
+          done
+
+          # Wait for copies to complete
+          for ARCH in arm64 x64; do
+            while true; do
+              STATUS=$(az storage blob show \
+                --account-name "$ACCOUNT" \
+                --container-name "$CONTAINER" \
+                --name "latest/Clubhouse-latest-darwin-${ARCH}.dmg" \
+                --query "properties.copy.status" \
+                --output tsv \
+                --auth-mode login)
+              if [ "$STATUS" = "success" ]; then
+                echo "Copy complete: latest/Clubhouse-latest-darwin-${ARCH}.dmg"
+                break
+              elif [ "$STATUS" = "failed" ] || [ "$STATUS" = "aborted" ]; then
+                echo "::error::Blob copy failed for darwin-${ARCH}"
+                exit 1
+              fi
+              sleep 2
+            done
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.verify-tag.outputs.version }}"
+
+          gh release create "v${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --title "v${VERSION}" \
+            --notes "${{ needs.verify-tag.outputs.release_notes }}" \
+            artifacts/Clubhouse-*.zip \
+            artifacts/Clubhouse-*.dmg \
+            artifacts/latest.json

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,6 +1,7 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
+import { MakerDMG } from '@electron-forge/maker-dmg';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
@@ -42,11 +43,20 @@ const config: ForgeConfig = {
       NSUserNotificationAlertStyle: 'alert',
     },
     osxSign: {
-      identity: '-', // ad-hoc signing
+      identity: process.env.APPLE_SIGNING_IDENTITY || '-',
       optionsForFile: () => ({
         entitlements: path.resolve(__dirname, 'entitlements.plist'),
       }),
     },
+    ...(process.env.APPLE_ID && process.env.APPLE_ID_PASSWORD && process.env.APPLE_TEAM_ID
+      ? {
+          osxNotarize: {
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.APPLE_TEAM_ID,
+          },
+        }
+      : {}),
     asar: {
       unpack: '{**/node_modules/node-pty/**/*.node,**/node_modules/node-pty/**/spawn-helper}',
     },
@@ -65,6 +75,9 @@ const config: ForgeConfig = {
   rebuildConfig: {},
   makers: [
     new MakerZIP({}, ['darwin']),
+    new MakerDMG({
+      icon: path.resolve(__dirname, 'assets', 'icon.icns'),
+    }, ['darwin']),
     new MakerSquirrel({
       iconUrl: 'https://raw.githubusercontent.com/masonallen/Clubhouse/main/assets/icon.ico',
       ...(fs.existsSync(path.resolve(__dirname, 'assets', 'icon.ico'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "clubhouse",
       "version": "0.25.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@kutalia/whisper-node-addon": "^1.1.0",
         "@monaco-editor/react": "^4.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
         "@electron-forge/maker-deb": "^7.11.1",
+        "@electron-forge/maker-dmg": "^7.11.1",
         "@electron-forge/maker-rpm": "^7.11.1",
         "@electron-forge/maker-squirrel": "^7.11.1",
         "@electron-forge/maker-zip": "^7.11.1",
@@ -529,6 +530,24 @@
       },
       "optionalDependencies": {
         "electron-installer-debian": "^3.2.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.1.tgz",
+      "integrity": "sha512-7zs5/Ewz1PcOl4N1102stFgBiFGWxU18+UPFUSd/fgf9MErBl4HBWuVNMIHyeJ/56rdfkcmTxTqE+9TBEYrZcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.1",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-installer-dmg": "^5.0.1"
       }
     },
     "node_modules/@electron-forge/maker-rpm": {
@@ -2223,25 +2242,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kutalia/whisper-node-addon": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@kutalia/whisper-node-addon/-/whisper-node-addon-1.1.0.tgz",
-      "integrity": "sha512-tfTQcvllmgO+X5Vmk+a+iF/dXj0LCS/oJgbLALPA2T8JKOQ2LhCozj5wjFZyEZ8JqivNhlewSpTSFlV/A/ofbA==",
-      "license": "MIT",
-      "dependencies": {
-        "node-abi": "^3.74.0",
-        "node-addon-api": "^8.3.1"
-      }
-    },
-    "node_modules/@kutalia/whisper-node-addon/node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -3183,6 +3183,17 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/appdmg": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/appdmg/-/appdmg-0.5.5.tgz",
+      "integrity": "sha512-G+n6DgZTZFOteITE30LnWj+HRVIGr7wMlAiLWOO02uJFWVEitaPU9JVXm9wJokkgshBawb2O1OykdcsmkkZfgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/aria-query": {
@@ -4700,6 +4711,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/appdmg": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
+      "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "async": "^1.4.2",
+        "ds-store": "^0.1.5",
+        "execa": "^1.0.0",
+        "fs-temp": "^1.0.0",
+        "fs-xattr": "^0.3.0",
+        "image-size": "^0.7.4",
+        "is-my-json-valid": "^2.20.0",
+        "minimist": "^1.1.3",
+        "parse-color": "^1.0.0",
+        "path-exists": "^4.0.0",
+        "repeat-string": "^1.5.4"
+      },
+      "bin": {
+        "appdmg": "bin/appdmg.js"
+      },
+      "engines": {
+        "node": ">=8.5"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4756,6 +4797,14 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -4782,6 +4831,17 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-data-view": "^1.1.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4941,6 +5001,17 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stream-buffers": "~2.2.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -6312,6 +6383,19 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/ds-store": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bplist-creator": "~0.0.3",
+        "macos-alias": "~0.2.5",
+        "tn1150": "^0.1.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6594,6 +6678,28 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-dmg": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-5.0.1.tgz",
+      "integrity": "sha512-qOa1aAQdX57C+vzhDk3549dd/PRlNL4F8y736MTD1a43qptD+PvHY97Bo9gSf+OZ8iUWE7BrYSpk/FgLUe40EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@types/appdmg": "^0.5.5",
+        "debug": "^4.3.2",
+        "minimist": "^1.2.7"
+      },
+      "bin": {
+        "electron-installer-dmg": "dist/electron-installer-dmg-bin.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "optionalDependencies": {
+        "appdmg": "^0.6.4"
       }
     },
     "node_modules/electron-installer-redhat": {
@@ -6953,6 +7059,14 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7930,6 +8044,17 @@
         "node": ">= 12"
       }
     },
+    "node_modules/fmix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "imul": "^1.0.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -8034,6 +8159,32 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/fs-temp": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
+      "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "random-path": "^0.1.0"
+      }
+    },
+    "node_modules/fs-xattr": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
+      "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8089,6 +8240,28 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -8843,6 +9016,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8868,6 +9055,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/imul": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -9061,6 +9259,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9103,6 +9324,14 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-stream": {
       "version": "1.1.0",
@@ -9433,6 +9662,17 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/junk": {
@@ -10083,6 +10323,21 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/macos-alias": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
+      "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "nan": "^2.4.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10613,6 +10868,19 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/murmur-32": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
+      "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "encode-utf8": "^1.0.3",
+        "fmix": "^0.1.0",
+        "imul": "^1.0.0"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
@@ -10622,6 +10890,14 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -10704,6 +10980,7 @@
       "version": "3.87.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
       "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -11282,6 +11559,24 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "~0.5.0"
+      }
+    },
+    "node_modules/parse-color/node_modules/color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -11921,6 +12216,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/random-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
+      "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base32-encode": "^0.1.0 || ^1.0.0",
+        "murmur-32": "^0.1.0 || ^0.2.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12183,6 +12490,17 @@
         "htmlparser2": "^6.1.0",
         "lodash": "^4.17.21",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -12529,6 +12847,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13129,6 +13448,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
+      "license": "Unlicense",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -13700,6 +14030,28 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tn1150": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "unorm": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13947,6 +14299,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
+      "license": "MIT or GPL-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/unpipe": {
@@ -15004,6 +15367,17 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/xterm": {
       "version": "4.19.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
     "@electron-forge/maker-deb": "^7.11.1",
+    "@electron-forge/maker-dmg": "^7.11.1",
     "@electron-forge/maker-rpm": "^7.11.1",
     "@electron-forge/maker-squirrel": "^7.11.1",
     "@electron-forge/maker-zip": "^7.11.1",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — a tag-driven release pipeline that builds, signs, notarizes, and publishes macOS artifacts to Azure Blob Storage
- Updates `forge.config.ts` to support real code signing + notarization in CI while falling back to ad-hoc signing for local dev
- Adds DMG maker for polished macOS disk image distribution

## Release workflow (`release.yml`)

Triggered by pushing a signed `v*` tag. Four jobs:

| Job | Runner | What it does |
|-----|--------|-------------|
| `verify-tag` | ubuntu | Verifies tag signature via GitHub API, checks version matches `package.json`, extracts release notes |
| `build` (arm64) | macos-14 | Imports cert, builds/signs/notarizes, computes SHA-256 |
| `build` (x64) | macos-13 | Same, for Intel |
| `publish` | ubuntu | Uploads to Azure Blob (OIDC auth), generates `latest.json` via `jq`, copies DMGs to `latest/` slot, creates GitHub Release |

## Forge config changes
- `osxSign.identity`: reads `APPLE_SIGNING_IDENTITY` env var, falls back to `'-'` (ad-hoc) for local dev
- `osxNotarize`: conditionally enabled when `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID` are set
- `MakerDMG` added for `.dmg` output alongside `.zip`

## Design decisions
- `latest.json` generated via `jq` (not bash heredoc) to handle special chars in release notes
- Tag signature verified via GitHub API (not `git verify-tag`) since CI runner lacks signing keys
- Concurrency group prevents parallel releases from racing
- Versioned artifacts uploaded with `--overwrite false` (immutable); `latest/` slot overwritten each release
- Azure blob copy is polled to completion before the job finishes

## Prerequisites (all done)
- GitHub secrets configured: `APPLE_CERTIFICATE_P12`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
- Azure OIDC federation scoped to `repo:masra91/Clubhouse:ref:refs/tags/v*`

## Test plan
- [x] `npm run validate` passes locally (1930 unit tests, 43+1 flaky E2E tests, typecheck clean)
- [x] `npm run make` produces both `.zip` and `.dmg` locally
- [ ] Push a test tag (`v0.25.0`) to verify the full pipeline end-to-end
- [ ] Verify signed + notarized DMG passes Gatekeeper (`spctl --assess`)
- [ ] Verify `latest.json` is publicly readable at the blob endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)