### PR TITLE
chore: bump version to 0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.25.0` to `0.26.0`
- First release candidate for the new tag-driven pipeline

## After merging
Tag and push to trigger the release workflow:
```bash
git tag -s v0.26.0 -m "First signed release"
git push origin v0.26.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)