### PR TITLE
fix: use macos-latest for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,9 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-14
+            runner: macos-latest
           - arch: x64
-            runner: macos-13
+            runner: macos-latest
     outputs:
       sha256_arm64: ${{ steps.hash.outputs.sha256_arm64 }}
       size_arm64: ${{ steps.hash.outputs.size_arm64 }}


### PR DESCRIPTION
## Summary
- `macos-13` runner was deprecated by GitHub, breaking the x64 release build
- Switched both arm64 and x64 build jobs to `macos-latest` so the runner auto-updates
- Electron Forge's `--arch` flag handles cross-compilation — build OS doesn't constrain deployment target

## Test plan
- [ ] Merge, delete and re-push `v0.26.0` tag to re-trigger the release workflow
- [ ] Verify both arm64 and x64 build jobs start successfully on the new runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)