### PR TITLE
fix: use GitHub environment for Azure OIDC in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,7 @@ jobs:
     name: Publish
     needs: [verify-tag, build]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Download all build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Azure federated credentials don't support wildcards in subject claims, so `refs/tags/v*` didn't match the actual token (`refs/tags/v0.26.0`)
- Adds `environment: release` to the publish job so the OIDC subject is `repo:masra91/Clubhouse:environment:release` — consistent for every release
- Requires a GitHub environment named `release` to be created in repo settings (infra team already updated the Bicep)

## Test plan
- [ ] Create `release` environment in repo Settings → Environments
- [ ] Merge this PR, delete + re-create `v0.26.0` tag, verify publish job authenticates to Azure

🤖 Generated with [Claude Code](https://claude.com/claude-code)