### PR TITLE
feat: pull release notes from version bump PR description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,18 @@ jobs:
           COMMIT_SHA=$(git rev-list -n 1 "${GITHUB_REF_NAME}")
           PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" --jq '.[0].number // empty')
 
+          # Release message = tag subject line (always clean, no signature)
+          RELEASE_MESSAGE=$(git tag -l --format='%(subject)' "${GITHUB_REF_NAME}")
+          echo "release_message=${RELEASE_MESSAGE}" >> "$GITHUB_OUTPUT"
+
+          # Release notes = PR body of the tagged commit
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" --jq '.[0].number // empty')
+
           if [ -z "$PR_NUMBER" ]; then
-            echo "::warning::No PR found for tagged commit — using tag message as fallback"
-            BODY=$(git tag -l --format='%(subject)' "${GITHUB_REF_NAME}")
+            echo "::warning::No PR found for tagged commit — release notes will be empty"
+            RELEASE_NOTES=""
           else
-            # Extract PR body, strip boilerplate noise
-            BODY=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.body // ""' \
+            RELEASE_NOTES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.body // ""' \
               | sed '/^## Test [Pp]lan/,$d' \
               | sed '/Co-[Aa]uthored-[Bb]y:/d' \
               | sed '/Generated with \[Claude Code\]/d' \
@@ -80,11 +86,6 @@ jobs:
             )
           fi
 
-          # First line = release message (tagline), rest = release notes
-          RELEASE_MESSAGE=$(echo "$BODY" | head -1)
-          RELEASE_NOTES=$(echo "$BODY" | tail -n +2 | sed '/./,$!d')
-
-          echo "release_message=${RELEASE_MESSAGE}" >> "$GITHUB_OUTPUT"
           {
             echo "release_notes<<RELEASE_NOTES_EOF"
             echo "$RELEASE_NOTES"


### PR DESCRIPTION
## Summary
Formalizes the release notes pipeline so the app manifest has everything needed for update UX.

**Two separate data sources, no string parsing:**
- `releaseMessage` — from the tag subject (`git tag -s v0.27.0 -m "Plugin Improvements & More"`)
- `releaseNotes` — from the version bump PR body (structured markdown via GitHub API)

**Version bump PR body format (becomes `releaseNotes`):**
```
## New Features
- KanBoss — Kanban boards with AI-powered automation

## Bug Fixes
- Fixed badge re-render crash

## Improvements
- Windows CI coverage
```

**Tag command (becomes `releaseMessage`):**
```
git tag -s v0.27.0 <commit> -m "Plugin Improvements & More"
```

**`latest.json` output:**
```json
{
  "version": "0.27.0",
  "releaseMessage": "Plugin Improvements & More",
  "releaseNotes": "## New Features\n- ...",
  ...
}
```

**Changes:**
- Release notes extracted from PR body (not tag annotation) — avoids SSH signature noise
- Tag `%(subject)` used for release message — always clean, single line
- Boilerplate auto-stripped from PR body: co-authored-by, Claude Code attribution, test plan sections
- `latest.json` now includes both `releaseMessage` and `releaseNotes` fields
- GitHub Release title includes the tagline (e.g. "v0.27.0 — Plugin Improvements & More")
- Falls back gracefully if no PR found for tagged commit

## Test plan
- [ ] Merge, create a version bump PR with structured notes, tag with a release message, verify latest.json contains both fields
- [ ] Verify GitHub Release title includes the tagline