### PR TITLE
fix: correct outdated API versions in about panel

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,7 +30,7 @@ process.on('unhandledRejection', (reason) => {
 app.setAboutPanelOptions({
   applicationName: 'Clubhouse',
   applicationVersion: app.getVersion(),
-  copyright: 'Supported Plugin API Versions: 0.1, 0.2',
+  copyright: 'Supported Plugin API Versions: 0.5',
 });
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;

--- a/src/renderer/plugins/manifest-validator.test.ts
+++ b/src/renderer/plugins/manifest-validator.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { validateManifest, SUPPORTED_API_VERSIONS } from './manifest-validator';
 
 describe('manifest-validator', () => {
@@ -19,6 +21,12 @@ describe('manifest-validator', () => {
 
     it('does not include version 0.4', () => {
       expect(SUPPORTED_API_VERSIONS).not.toContain(0.4);
+    });
+
+    it('matches the about panel copyright string in main/index.ts', () => {
+      const indexSrc = readFileSync(join(__dirname, '../../main/index.ts'), 'utf-8');
+      const expected = `Supported Plugin API Versions: ${SUPPORTED_API_VERSIONS.join(', ')}`;
+      expect(indexSrc).toContain(expected);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixed the Electron about panel (`app.setAboutPanelOptions`) which displayed **"Supported Plugin API Versions: 0.1, 0.2"** — these versions have not been valid since the API moved to **0.5**
- Updated the hardcoded copyright string in `src/main/index.ts` to show the correct version: **0.5**
- Added a regression test in `manifest-validator.test.ts` that cross-checks the about panel string against the `SUPPORTED_API_VERSIONS` constant, so it will fail if they drift apart again

## Test plan
- [x] New unit test: `matches the about panel copyright string in main/index.ts` — reads `src/main/index.ts` source and verifies it contains the expected version string derived from `SUPPORTED_API_VERSIONS`
- [x] All 1931 unit tests pass (`npm test`)
- [x] Full build succeeds (`npm run make`)
- [x] All 44 Playwright E2E tests pass (`npm run test:e2e`)
- [ ] **Manual**: Launch app → menu bar → *Clubhouse* → *About Clubhouse* → verify it shows "Supported Plugin API Versions: 0.5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)