### PR TITLE
feat: redirect About menu to in-app About page

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,11 +27,6 @@ process.on('unhandledRejection', (reason) => {
   });
 });
 
-app.setAboutPanelOptions({
-  applicationName: 'Clubhouse',
-  applicationVersion: app.getVersion(),
-  copyright: 'Supported Plugin API Versions: 0.1, 0.2',
-});
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,7 +6,15 @@ export function buildMenu(): void {
     {
       label: app.name,
       submenu: [
-        { role: 'about', label: `About ${app.name}` },
+        {
+          label: `About ${app.name}`,
+          click: () => {
+            const win = BrowserWindow.getFocusedWindow();
+            if (win) {
+              win.webContents.send(IPC.APP.OPEN_ABOUT);
+            }
+          },
+        },
         { type: 'separator' },
         {
           label: 'Preferences…',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -273,6 +273,11 @@ const api = {
       ipcRenderer.on(IPC.APP.OPEN_SETTINGS, listener);
       return () => { ipcRenderer.removeListener(IPC.APP.OPEN_SETTINGS, listener); };
     },
+    onOpenAbout: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on(IPC.APP.OPEN_ABOUT, listener);
+      return () => { ipcRenderer.removeListener(IPC.APP.OPEN_ABOUT, listener); };
+    },
     getTheme: () =>
       ipcRenderer.invoke(IPC.APP.GET_THEME),
     saveTheme: (settings: { themeId: string }) =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -76,6 +76,18 @@ export function App() {
     return () => remove();
   }, []);
 
+  useEffect(() => {
+    const remove = window.clubhouse.app.onOpenAbout(() => {
+      const state = useUIStore.getState();
+      if (state.explorerTab !== 'settings') {
+        state.openAbout();
+      } else {
+        state.setSettingsSubPage('about');
+      }
+    });
+    return () => remove();
+  }, []);
+
   // Navigate to agent when notification is clicked
   useEffect(() => {
     const remove = window.clubhouse.app.onNotificationClicked((agentId: string, projectId: string) => {

--- a/src/renderer/panels/AccessoryPanel.tsx
+++ b/src/renderer/panels/AccessoryPanel.tsx
@@ -36,13 +36,12 @@ function SettingsCategoryNav() {
       <nav className="py-1 flex-1 flex flex-col">
         {isApp ? (
           <>
+            {navButton('About', 'about')}
             {navButton('Agents', 'orchestrators')}
             {navButton('Display & UI', 'display')}
             {navButton('Notifications', 'notifications')}
             {navButton('Logging', 'logging')}
             {navButton('Plugins', 'plugins')}
-            <div className="flex-1" />
-            {navButton('About', 'about')}
           </>
         ) : (
           <>

--- a/src/renderer/stores/uiStore.test.ts
+++ b/src/renderer/stores/uiStore.test.ts
@@ -132,6 +132,24 @@ describe('uiStore', () => {
     });
   });
 
+  describe('openAbout', () => {
+    it('opens settings to about page and saves previous tab', () => {
+      useUIStore.setState({ explorerTab: 'agents' });
+      getState().openAbout();
+      expect(getState().explorerTab).toBe('settings');
+      expect(getState().previousExplorerTab).toBe('agents');
+      expect(getState().settingsSubPage).toBe('about');
+      expect(getState().settingsContext).toBe('app');
+    });
+
+    it('preserves previous tab when coming from a plugin tab', () => {
+      useUIStore.setState({ explorerTab: 'plugin:hub' });
+      getState().openAbout();
+      expect(getState().previousExplorerTab).toBe('plugin:hub');
+      expect(getState().settingsSubPage).toBe('about');
+    });
+  });
+
   describe('settingsContext', () => {
     it('defaults to app', () => {
       expect(getState().settingsContext).toBe('app');

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -40,6 +40,7 @@ interface UIState {
   setHelpSection: (id: string) => void;
   setHelpTopic: (id: string | null) => void;
   setShowHome: (show: boolean) => void;
+  openAbout: () => void;
   openPluginSettings: (pluginId: string) => void;
   closePluginSettings: () => void;
 }
@@ -94,6 +95,10 @@ export const useUIStore = create<UIState>((set, get) => ({
   setShowHome: (show) => {
     set({ showHome: show });
     saveViewPrefs({ showHome: show });
+  },
+  openAbout: () => {
+    const { explorerTab } = get();
+    set({ previousExplorerTab: explorerTab, explorerTab: 'settings', settingsSubPage: 'about', settingsContext: 'app' });
   },
   openPluginSettings: (pluginId) => {
     set({ pluginSettingsId: pluginId, settingsSubPage: 'plugin-detail' });

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -90,6 +90,7 @@ export const IPC = {
   APP: {
     OPEN_EXTERNAL_URL: 'app:open-external-url',
     OPEN_SETTINGS: 'app:open-settings',
+    OPEN_ABOUT: 'app:open-about',
     GET_NOTIFICATION_SETTINGS: 'app:get-notification-settings',
     SAVE_NOTIFICATION_SETTINGS: 'app:save-notification-settings',
     SEND_NOTIFICATION: 'app:send-notification',


### PR DESCRIPTION
## Summary
- **Replaces the native macOS Electron "About" dialog** with a custom menu item that opens the in-app About settings page (similar to MS Edge behavior)
- **Removes `app.setAboutPanelOptions()`** — no more hardcoded, stale API version strings
- **Moves About to the top** of the settings nav (was pinned to footer with a spacer, which felt out of place)
- The in-app About page already dynamically reads from `SUPPORTED_API_VERSIONS` and `app.getVersion()`, so it's always accurate

## Changes
| File | What changed |
|---|---|
| `src/main/index.ts` | Removed `app.setAboutPanelOptions()` |
| `src/main/menu.ts` | Replaced `{ role: 'about' }` with custom click → `IPC.APP.OPEN_ABOUT` |
| `src/shared/ipc-channels.ts` | Added `OPEN_ABOUT` channel |
| `src/preload/index.ts` | Added `onOpenAbout` handler |
| `src/renderer/App.tsx` | Listener for `onOpenAbout` → opens settings at About page |
| `src/renderer/stores/uiStore.ts` | Added `openAbout()` action |
| `src/renderer/panels/AccessoryPanel.tsx` | Moved About from nav footer to first item |
| `src/renderer/stores/uiStore.test.ts` | Added 2 tests for `openAbout` |

## Test plan
- [x] 1932 unit tests pass (`npm test`)
- [x] TypeScript compiles clean (`npm run typecheck`)
- [x] Full build succeeds (`npm run make`)
- [x] 44 Playwright E2E tests pass (`npm run test:e2e`)
- [ ] **Manual**: Launch app → app menu → "About Clubhouse" → verify it opens the in-app Settings > About page (not native dialog)
- [ ] **Manual**: Verify About is now the first item in the settings sidebar nav
- [ ] **Manual**: Verify Cmd+, still opens settings normally (to Agents page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)