### PR TITLE
fix: add pull-requests: read permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: write
   id-token: write
+  pull-requests: read
 
 jobs:
   verify-tag:


### PR DESCRIPTION
## Summary

- PR #32 changed release notes extraction to query the `commits/{sha}/pulls` GitHub API endpoint, but didn't add the required `pull-requests: read` permission to the workflow
- This caused the v0.27.0 release to fail with `HTTP 403` in the verify-tag job
- Adds `pull-requests: read` to the workflow permissions block