### PR TITLE
fix: rail hover flyout clipped by overflow-hidden (#23)

### DIFF
--- a/e2e/rail-hover-flyout.spec.ts
+++ b/e2e/rail-hover-flyout.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, _electron as electron, Page } from '@playwright/test';
+import * as path from 'path';
+import { launchApp } from './launch';
+
+let electronApp: Awaited<ReturnType<typeof electron.launch>>;
+let window: Page;
+
+const FIXTURE_A = path.resolve(__dirname, 'fixtures/project-a');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function stubDialogForPath(dirPath: string) {
+  await electronApp.evaluate(
+    async ({ dialog, BrowserWindow }, fixturePath) => {
+      const win =
+        BrowserWindow.getAllWindows().find(
+          (w) => !w.webContents.getURL().startsWith('devtools://'),
+        ) ?? BrowserWindow.getAllWindows()[0] ?? null;
+      BrowserWindow.getFocusedWindow = () => win;
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [fixturePath],
+      });
+    },
+    dirPath,
+  );
+}
+
+async function addProject(dirPath: string) {
+  await stubDialogForPath(dirPath);
+  const addBtn = window.locator('[data-testid="nav-add-project"]');
+  await addBtn.click();
+  const name = path.basename(dirPath);
+  await expect(window.locator(`text=${name}`).first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  ({ electronApp, window } = await launchApp());
+});
+
+test.afterAll(async () => {
+  await electronApp?.close();
+});
+
+// ---------------------------------------------------------------------------
+// Rail Hover Flyout Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Rail Hover Flyout', () => {
+  test('rail expands beyond collapsed width on hover', async () => {
+    // Add a project so there is content to display in the flyout
+    await addProject(FIXTURE_A);
+
+    // Locate the rail outer container (parent of the inner styled rail)
+    // The ProjectRail root is the first child of the grid, with class "relative"
+    const railOuter = window.locator('[data-testid="nav-home"]').locator('..').locator('..');
+
+    // Measure collapsed width of the inner rail div
+    const innerRail = railOuter.locator('> div').first();
+    const collapsedWidth = await innerRail.evaluate((el) => el.getBoundingClientRect().width);
+
+    // Collapsed width should be the base width (68 or 74 depending on scroll)
+    expect(collapsedWidth).toBeLessThan(100);
+
+    // Hover over the rail to trigger expansion
+    await railOuter.hover();
+
+    // Wait for the 600ms hover delay + 200ms animation
+    await window.waitForTimeout(900);
+
+    // Measure expanded width — should be 200px
+    const expandedWidth = await innerRail.evaluate((el) => el.getBoundingClientRect().width);
+    expect(expandedWidth).toBeGreaterThanOrEqual(190); // ~200px, allow small rounding
+
+    // Move mouse away to collapse
+    await window.locator('[data-testid="title-bar"]').hover();
+    await window.waitForTimeout(300);
+
+    // Should return to collapsed width
+    const afterWidth = await innerRail.evaluate((el) => el.getBoundingClientRect().width);
+    expect(afterWidth).toBeLessThan(100);
+  });
+
+  test('project labels are visible when rail is expanded', async () => {
+    // The project label spans should be visible when expanded
+    const railOuter = window.locator('[data-testid="nav-home"]').locator('..').locator('..');
+
+    // Hover to expand
+    await railOuter.hover();
+    await window.waitForTimeout(900);
+
+    // The label text for project-a should be visible (not clipped)
+    const label = window.locator('text=project-a').first();
+    const bbox = await label.boundingBox();
+    expect(bbox).not.toBeNull();
+    // Label should be visible and not zero-width clipped
+    expect(bbox!.width).toBeGreaterThan(10);
+
+    // Move away
+    await window.locator('[data-testid="title-bar"]').hover();
+    await window.waitForTimeout(300);
+  });
+});

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -299,7 +299,7 @@ export function ProjectRail() {
 
   return (
     <div
-      className="relative h-full min-h-0 overflow-hidden"
+      className="relative h-full min-h-0"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >


### PR DESCRIPTION
## Summary

- **Fixes** #23 — Rail Expansion is Broken
- Removes `overflow-hidden` from the `ProjectRail` outer wrapper that was clipping the absolutely-positioned hover flyout overlay
- The outer `overflow-hidden` was introduced in commit `4b0d91b` (grid overflow layout fix) and prevented the flyout from expanding beyond the grid column width (~68-74px) to its intended 200px
- The inner rail div already has its own `overflow-hidden` for the width transition, so the outer one was redundant for normal flow but fatally clipped the hover expansion

## Root cause

The grid overflow fix in `4b0d91b` added `overflow-hidden` to the ProjectRail wrapper to prevent grid items from overflowing. However, `overflow: hidden` on a positioned parent clips absolutely-positioned children, which broke the flyout overlay that uses `absolute inset-y-0 left-0 z-30` to expand from 68px to 200px on hover.

## Test plan

- [x] Added `e2e/rail-hover-flyout.spec.ts` with two tests:
  - Rail expands from collapsed width (~68px) to 200px on hover
  - Project labels are visible (not clipped) when rail is expanded
- [x] TypeScript typecheck passes
- [x] All 2012 unit tests pass
- [x] Build (make) succeeds
- [x] All 45 e2e tests pass (1 pre-existing flaky test on drag-reorder, passes on retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)