### PR TITLE
feat: orchestrator-specific sleeping mascots

### DIFF
--- a/src/renderer/features/agents/SleepingAgent.tsx
+++ b/src/renderer/features/agents/SleepingAgent.tsx
@@ -2,6 +2,7 @@ import { Agent } from '../../../shared/types';
 import { AGENT_COLORS } from '../../../shared/name-generator';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { SleepingMascot } from './SleepingMascots';
 
 export function SleepingAgent({ agent }: { agent: Agent }) {
   const { spawnDurableAgent } = useAgentStore();
@@ -22,31 +23,9 @@ export function SleepingAgent({ agent }: { agent: Agent }) {
   return (
     <div className="flex items-center justify-center h-full bg-ctp-base">
       <div className="flex flex-col items-center gap-6">
-        {/* Pixel agent sleeping */}
+        {/* Orchestrator-specific sleeping mascot */}
         <div className="relative">
-          <svg width="160" height="160" viewBox="0 0 80 80" className="drop-shadow-lg">
-            {/* Body */}
-            <rect x="16" y="20" width="48" height="40" rx="8" fill="#c4795b" />
-            {/* Head highlight */}
-            <rect x="20" y="24" width="40" height="4" rx="2" fill="#d4896b" opacity="0.4" />
-            {/* Eyes - closed (sleeping) */}
-            <line x1="30" y1="38" x2="35" y2="38" stroke="#2a1f1a" strokeWidth="2.5" strokeLinecap="round" />
-            <line x1="45" y1="38" x2="50" y2="38" stroke="#2a1f1a" strokeWidth="2.5" strokeLinecap="round" />
-            {/* Legs */}
-            <rect x="24" y="60" width="6" height="8" rx="2" fill="#a86a4e" />
-            <rect x="34" y="60" width="6" height="8" rx="2" fill="#a86a4e" />
-            <rect x="44" y="60" width="6" height="8" rx="2" fill="#a86a4e" />
-            {/* Zzz */}
-            <text x="60" y="18" fill="#6c7086" fontSize="10" fontWeight="bold" fontFamily="monospace">
-              <tspan className="animate-pulse">z</tspan>
-            </text>
-            <text x="65" y="12" fill="#585b70" fontSize="8" fontWeight="bold" fontFamily="monospace">
-              <tspan className="animate-pulse" style={{ animationDelay: '0.3s' }}>z</tspan>
-            </text>
-            <text x="69" y="7" fill="#45475a" fontSize="6" fontWeight="bold" fontFamily="monospace">
-              <tspan className="animate-pulse" style={{ animationDelay: '0.6s' }}>z</tspan>
-            </text>
-          </svg>
+          <SleepingMascot orchestrator={agent.orchestrator} />
         </div>
 
         {/* Agent info */}

--- a/src/renderer/features/agents/SleepingMascots.test.tsx
+++ b/src/renderer/features/agents/SleepingMascots.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+  SleepingMascot,
+  ClaudeCodeSleeping,
+  CopilotSleeping,
+  GenericRobotSleeping,
+} from './SleepingMascots';
+
+describe('SleepingMascots', () => {
+  describe('SleepingMascot selector', () => {
+    it('renders ClaudeCodeSleeping for claude-code orchestrator', () => {
+      const { container } = render(<SleepingMascot orchestrator="claude-code" />);
+      // Claude mascot uses its distinctive salmon/pink body color
+      const body = container.querySelector('rect[fill="#d4896b"]');
+      expect(body).not.toBeNull();
+    });
+
+    it('renders CopilotSleeping for copilot-cli orchestrator', () => {
+      const { container } = render(<SleepingMascot orchestrator="copilot-cli" />);
+      // Copilot mascot uses the dark body color
+      const body = container.querySelector('rect[fill="#1e1e2e"]');
+      expect(body).not.toBeNull();
+    });
+
+    it('renders GenericRobotSleeping for opencode orchestrator', () => {
+      const { container } = render(<SleepingMascot orchestrator="opencode" />);
+      // Generic robot uses grey body color
+      const body = container.querySelector('rect[fill="#5a5a6e"]');
+      expect(body).not.toBeNull();
+    });
+
+    it('renders GenericRobotSleeping for unknown orchestrator', () => {
+      const { container } = render(<SleepingMascot orchestrator="some-unknown" />);
+      const body = container.querySelector('rect[fill="#5a5a6e"]');
+      expect(body).not.toBeNull();
+    });
+
+    it('renders GenericRobotSleeping when orchestrator is undefined', () => {
+      const { container } = render(<SleepingMascot orchestrator={undefined} />);
+      const body = container.querySelector('rect[fill="#5a5a6e"]');
+      expect(body).not.toBeNull();
+    });
+  });
+
+  describe('ClaudeCodeSleeping', () => {
+    it('renders an SVG with 200x200 dimensions', () => {
+      const { container } = render(<ClaudeCodeSleeping />);
+      const svg = container.querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg!.getAttribute('width')).toBe('200');
+      expect(svg!.getAttribute('height')).toBe('200');
+    });
+
+    it('contains animated Zzz text elements', () => {
+      const { container } = render(<ClaudeCodeSleeping />);
+      const zTexts = container.querySelectorAll('text tspan');
+      expect(zTexts.length).toBe(3);
+      zTexts.forEach((z) => {
+        expect(z.textContent).toBe('z');
+        expect(z.classList.contains('animate-pulse')).toBe(true);
+      });
+    });
+  });
+
+  describe('CopilotSleeping', () => {
+    it('renders an SVG with 200x200 dimensions', () => {
+      const { container } = render(<CopilotSleeping />);
+      const svg = container.querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg!.getAttribute('width')).toBe('200');
+      expect(svg!.getAttribute('height')).toBe('200');
+    });
+
+    it('contains the magenta top stripe', () => {
+      const { container } = render(<CopilotSleeping />);
+      const stripe = container.querySelector('rect[fill="#d946ef"]');
+      expect(stripe).not.toBeNull();
+    });
+
+    it('contains animated Zzz text elements', () => {
+      const { container } = render(<CopilotSleeping />);
+      const zTexts = container.querySelectorAll('text tspan');
+      expect(zTexts.length).toBe(3);
+    });
+  });
+
+  describe('GenericRobotSleeping', () => {
+    it('renders an SVG with 200x200 dimensions', () => {
+      const { container } = render(<GenericRobotSleeping />);
+      const svg = container.querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg!.getAttribute('width')).toBe('200');
+      expect(svg!.getAttribute('height')).toBe('200');
+    });
+
+    it('contains the antenna', () => {
+      const { container } = render(<GenericRobotSleeping />);
+      // Antenna line
+      const line = container.querySelector('line[x1="50"][y1="14"]');
+      expect(line).not.toBeNull();
+    });
+
+    it('contains animated Zzz text elements', () => {
+      const { container } = render(<GenericRobotSleeping />);
+      const zTexts = container.querySelectorAll('text tspan');
+      expect(zTexts.length).toBe(3);
+    });
+  });
+});

--- a/src/renderer/features/agents/SleepingMascots.tsx
+++ b/src/renderer/features/agents/SleepingMascots.tsx
@@ -1,0 +1,255 @@
+/**
+ * Orchestrator-specific sleeping mascots for the SleepingAgent view.
+ * Each renders a 200×200 SVG (100×100 viewBox) with animated Zzz.
+ */
+
+import type { OrchestratorId } from '../../../shared/types';
+
+/* ── Shared Zzz animation ─────────────────────────────────────────── */
+
+function SleepingZzz({ x, y }: { x: number; y: number }) {
+  return (
+    <>
+      <text x={x} y={y} fill="#6c7086" fontSize="11" fontWeight="bold" fontFamily="monospace">
+        <tspan className="animate-pulse">z</tspan>
+      </text>
+      <text
+        x={x + 6}
+        y={y - 8}
+        fill="#585b70"
+        fontSize="9"
+        fontWeight="bold"
+        fontFamily="monospace"
+      >
+        <tspan className="animate-pulse" style={{ animationDelay: '0.3s' }}>
+          z
+        </tspan>
+      </text>
+      <text
+        x={x + 11}
+        y={y - 15}
+        fill="#45475a"
+        fontSize="7"
+        fontWeight="bold"
+        fontFamily="monospace"
+      >
+        <tspan className="animate-pulse" style={{ animationDelay: '0.6s' }}>
+          z
+        </tspan>
+      </text>
+    </>
+  );
+}
+
+/* ── Claude Code mascot ───────────────────────────────────────────── */
+
+export function ClaudeCodeSleeping() {
+  return (
+    <svg width="200" height="200" viewBox="0 0 100 100" className="drop-shadow-lg">
+      {/* Ground shadow */}
+      <ellipse cx="50" cy="90" rx="28" ry="3.5" fill="#181825" opacity="0.3" />
+
+      {/* Nightcap — droops to upper-left */}
+      <path d="M 56 27 L 36 27 Q 24 10 20 16" fill="#6366f1" />
+      <path d="M 38 25 Q 30 16 26 20" stroke="#818cf8" strokeWidth="1.5" fill="none" opacity="0.4" />
+      <circle cx="20" cy="15" r="3.5" fill="#a5b4fc" />
+      <rect x="30" y="26" width="32" height="3" rx="1.5" fill="#4f46e5" opacity="0.35" />
+
+      {/* Body */}
+      <rect x="18" y="27" width="64" height="48" rx="10" fill="#d4896b" />
+
+      {/* Horizontal shading bands (like original pixel art) */}
+      <rect x="18" y="27" width="64" height="8" rx="10" fill="#e0a88d" opacity="0.3" />
+      <rect x="18" y="50" width="64" height="6" fill="#c4795b" opacity="0.15" />
+      <path
+        d="M 18 63 L 82 63 L 82 65 Q 82 75 72 75 L 28 75 Q 18 75 18 65 Z"
+        fill="#c4795b"
+        opacity="0.2"
+      />
+
+      {/* Closed eyes — peaceful arcs */}
+      <path
+        d="M 33 45 Q 37 40 41 45"
+        stroke="#2a1f1a"
+        strokeWidth="2.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <path
+        d="M 59 45 Q 63 40 67 45"
+        stroke="#2a1f1a"
+        strokeWidth="2.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+
+      {/* Eyelashes */}
+      <line x1="32" y1="45" x2="31" y2="42.5" stroke="#2a1f1a" strokeWidth="0.8" strokeLinecap="round" />
+      <line x1="42" y1="45" x2="43" y2="42.5" stroke="#2a1f1a" strokeWidth="0.8" strokeLinecap="round" />
+      <line x1="58" y1="45" x2="57" y2="42.5" stroke="#2a1f1a" strokeWidth="0.8" strokeLinecap="round" />
+      <line x1="68" y1="45" x2="69" y2="42.5" stroke="#2a1f1a" strokeWidth="0.8" strokeLinecap="round" />
+
+      {/* Blush */}
+      <circle cx="29" cy="51" r="4.5" fill="#e88" opacity="0.2" />
+      <circle cx="71" cy="51" r="4.5" fill="#e88" opacity="0.2" />
+
+      {/* Content smile */}
+      <path
+        d="M 44 56 Q 50 60 56 56"
+        stroke="#2a1f1a"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+
+      {/* Legs */}
+      <rect x="28" y="75" width="9" height="11" rx="3" fill="#a86a4e" />
+      <rect x="45.5" y="75" width="9" height="11" rx="3" fill="#a86a4e" />
+      <rect x="63" y="75" width="9" height="11" rx="3" fill="#a86a4e" />
+      {/* Feet / shoes */}
+      <rect x="26.5" y="83" width="12" height="3.5" rx="1.75" fill="#8a5a3e" />
+      <rect x="44" y="83" width="12" height="3.5" rx="1.75" fill="#8a5a3e" />
+      <rect x="61.5" y="83" width="12" height="3.5" rx="1.75" fill="#8a5a3e" />
+
+      <SleepingZzz x={74} y={22} />
+    </svg>
+  );
+}
+
+/* ── GitHub Copilot mascot ────────────────────────────────────────── */
+
+export function CopilotSleeping() {
+  return (
+    <svg width="200" height="200" viewBox="0 0 100 100" className="drop-shadow-lg">
+      {/* Ground shadow */}
+      <ellipse cx="50" cy="91" rx="26" ry="3" fill="#181825" opacity="0.3" />
+
+      {/* Legs */}
+      <rect x="30" y="76" width="12" height="10" rx="4" fill="#14141e" />
+      <rect x="58" y="76" width="12" height="10" rx="4" fill="#14141e" />
+      {/* Feet */}
+      <rect x="28" y="83" width="16" height="4" rx="2" fill="#0e0e18" />
+      <rect x="56" y="83" width="16" height="4" rx="2" fill="#0e0e18" />
+
+      {/* Main face / body */}
+      <rect x="15" y="18" width="70" height="58" rx="10" fill="#1e1e2e" stroke="#2d2d3d" strokeWidth="0.5" />
+
+      {/* Top magenta stripe */}
+      <rect x="15" y="18" width="70" height="4" rx="10" fill="#d946ef" opacity="0.8" />
+
+      {/* Eye socket backgrounds (dim teal) */}
+      <rect x="23" y="34" width="22" height="18" rx="5" fill="#0d2e2e" />
+      <rect x="55" y="34" width="22" height="18" rx="5" fill="#0d2e2e" />
+
+      {/* Eye "eyelid" overlay — covers top portion for half-closed look */}
+      <rect x="23" y="34" width="22" height="11" rx="5" fill="#1e1e2e" />
+      <rect x="55" y="34" width="22" height="11" rx="5" fill="#1e1e2e" />
+
+      {/* Dim eye glow — bottom sliver visible */}
+      <rect x="23" y="45" width="22" height="7" rx="0 0 5 5" fill="#0a4a4a" opacity="0.6" />
+      <rect x="55" y="45" width="22" height="7" rx="0 0 5 5" fill="#0a4a4a" opacity="0.6" />
+
+      {/* Subtle eyelid line */}
+      <line x1="24" y1="45" x2="44" y2="45" stroke="#2a6a6a" strokeWidth="0.5" opacity="0.4" />
+      <line x1="56" y1="45" x2="76" y2="45" stroke="#2a6a6a" strokeWidth="0.5" opacity="0.4" />
+
+      {/* Green LED indicators (dimmed) */}
+      <rect x="39" y="60" width="5" height="3" rx="1" fill="#1a3a1a" />
+      <rect x="48" y="60" width="5" height="3" rx="1" fill="#1a3a1a" />
+
+      {/* Magenta side panels (dimmed) */}
+      <rect x="20" y="59" width="8" height="5" rx="2" fill="#4a1a4a" />
+      <rect x="64" y="59" width="8" height="5" rx="2" fill="#4a1a4a" />
+
+      {/* Mouth — small horizontal bar */}
+      <rect x="42" y="67" width="8" height="2" rx="1" fill="#2d2d3d" />
+
+      <SleepingZzz x={76} y={14} />
+    </svg>
+  );
+}
+
+/* ── Generic robot mascot ─────────────────────────────────────────── */
+
+export function GenericRobotSleeping() {
+  return (
+    <svg width="200" height="200" viewBox="0 0 100 100" className="drop-shadow-lg">
+      {/* Ground shadow */}
+      <ellipse cx="50" cy="93" rx="24" ry="3" fill="#181825" opacity="0.3" />
+
+      {/* Antenna */}
+      <line x1="50" y1="14" x2="50" y2="6" stroke="#5a5a6e" strokeWidth="2" strokeLinecap="round" />
+      <circle cx="50" cy="5" r="3" fill="#3a3a4c" />
+      {/* Dim antenna glow */}
+      <circle cx="50" cy="5" r="1.5" fill="#5a5a6e" opacity="0.3" />
+
+      {/* Head — dome shape */}
+      <rect x="28" y="14" width="44" height="28" rx="12" fill="#6a6a7e" />
+      {/* Head highlight */}
+      <rect x="32" y="16" width="36" height="4" rx="2" fill="#7a7a8e" opacity="0.35" />
+
+      {/* Visor / face area */}
+      <rect x="32" y="22" width="36" height="14" rx="5" fill="#3a3a4c" />
+
+      {/* Closed eyes — horizontal lines */}
+      <line x1="38" y1="29" x2="44" y2="29" stroke="#8a8a9e" strokeWidth="2" strokeLinecap="round" />
+      <line x1="56" y1="29" x2="62" y2="29" stroke="#8a8a9e" strokeWidth="2" strokeLinecap="round" />
+
+      {/* Small eyelash accents */}
+      <line x1="37" y1="29" x2="36" y2="27" stroke="#8a8a9e" strokeWidth="0.7" strokeLinecap="round" />
+      <line x1="45" y1="29" x2="46" y2="27" stroke="#8a8a9e" strokeWidth="0.7" strokeLinecap="round" />
+      <line x1="55" y1="29" x2="54" y2="27" stroke="#8a8a9e" strokeWidth="0.7" strokeLinecap="round" />
+      <line x1="63" y1="29" x2="64" y2="27" stroke="#8a8a9e" strokeWidth="0.7" strokeLinecap="round" />
+
+      {/* Neck */}
+      <rect x="42" y="42" width="16" height="8" rx="3" fill="#5a5a6e" />
+
+      {/* Body */}
+      <rect x="26" y="48" width="48" height="30" rx="6" fill="#5a5a6e" />
+      {/* Body highlight */}
+      <rect x="30" y="50" width="40" height="4" rx="2" fill="#6a6a7e" opacity="0.3" />
+
+      {/* Chest panel */}
+      <rect x="36" y="55" width="28" height="16" rx="3" fill="#4a4a5c" stroke="#6a6a7e" strokeWidth="0.5" />
+
+      {/* Power LED (dim / off) */}
+      <circle cx="50" cy="63" r="2.5" fill="#2a1515" />
+      <circle cx="50" cy="63" r="1.2" fill="#4a2020" opacity="0.4" />
+
+      {/* Panel details — small screws / rivets */}
+      <circle cx="39" cy="58" r="1" fill="#5a5a6e" />
+      <circle cx="61" cy="58" r="1" fill="#5a5a6e" />
+      <circle cx="39" cy="68" r="1" fill="#5a5a6e" />
+      <circle cx="61" cy="68" r="1" fill="#5a5a6e" />
+
+      {/* Arms (hanging down, relaxed) */}
+      <rect x="17" y="50" width="9" height="22" rx="4" fill="#5a5a6e" />
+      <rect x="74" y="50" width="9" height="22" rx="4" fill="#5a5a6e" />
+      {/* Hands */}
+      <circle cx="21.5" cy="73" r="4.5" fill="#4a4a5c" />
+      <circle cx="78.5" cy="73" r="4.5" fill="#4a4a5c" />
+
+      {/* Legs */}
+      <rect x="33" y="78" width="10" height="12" rx="3" fill="#4a4a5c" />
+      <rect x="57" y="78" width="10" height="12" rx="3" fill="#4a4a5c" />
+      {/* Feet */}
+      <rect x="31" y="87" width="14" height="4" rx="2" fill="#3a3a4c" />
+      <rect x="55" y="87" width="14" height="4" rx="2" fill="#3a3a4c" />
+
+      <SleepingZzz x={74} y={10} />
+    </svg>
+  );
+}
+
+/* ── Mascot selector ──────────────────────────────────────────────── */
+
+export function SleepingMascot({ orchestrator }: { orchestrator?: OrchestratorId }) {
+  switch (orchestrator) {
+    case 'claude-code':
+      return <ClaudeCodeSleeping />;
+    case 'copilot-cli':
+      return <CopilotSleeping />;
+    default:
+      return <GenericRobotSleeping />;
+  }
+}


### PR DESCRIPTION
## Summary
- Sleeping agents now display a different mascot based on their orchestrator selection
- **Claude Code** (`claude-code`): Warm salmon/pink creature with nightcap, blush circles, closed eyes with eyelashes, a content smile, and three-legged shoes — inspired by the CC pixel mascot
- **GitHub Copilot** (`copilot-cli`): Dark robot face with half-closed cyan eye sockets, dimmed green LED indicators, magenta side panels and top stripe, with small dark legs
- **Generic robot** (opencode, unknown, or undefined): Metallic grey robot with dome head, antenna (dimmed), visor with closed eyes, chest panel with dim power LED, hanging arms, and sturdy legs
- All mascots are 200×200px SVGs (up from 160×160) with the familiar animated Zzz pulse effect
- Agents without an explicit orchestrator default to the generic robot

## Test plan
- [x] Unit tests: 13 new tests in `SleepingMascots.test.tsx` covering mascot selection logic, SVG dimensions, and animation elements
- [x] TypeScript: passes `tsc --noEmit`
- [x] Full test suite: all unit tests pass
- [x] E2E: 43 passed (1 pre-existing flaky test unrelated to this change)
- [ ] **Manual**: Create durable agents with each orchestrator (claude-code, copilot-cli, opencode) and verify the correct sleeping mascot renders when the agent is sleeping/stopped
- [ ] **Manual**: Verify agents with no orchestrator set show the generic robot
- [ ] **Manual**: Verify the Zzz animation pulses with staggered timing on all three mascots
- [ ] **Manual**: Verify the Wake Up button and agent info section still work correctly below each mascot

🤖 Generated with [Claude Code](https://claude.com/claude-code)