### PR TITLE
fix(wiki): ADO folder expansion, index page selection, and back button

### DIFF
--- a/src/renderer/plugins/builtin/wiki/WikiViewer.ts
+++ b/src/renderer/plugins/builtin/wiki/WikiViewer.ts
@@ -88,6 +88,7 @@ export function WikiViewer({ api }: { api: PluginAPI }) {
   const [unsavedDialog, setUnsavedDialog] = useState<{ pendingPath: string } | null>(null);
   const [showSendDialog, setShowSendDialog] = useState(false);
   const [pageNames, setPageNames] = useState<string[]>([]);
+  const [canGoBack, setCanGoBack] = useState(wikiState.canGoBack());
 
   const contentRef = useRef(content);
   contentRef.current = content;
@@ -238,6 +239,7 @@ export function WikiViewer({ api }: { api: PluginAPI }) {
         switchToFile(newPath);
       }
       setViewMode(wikiState.viewMode);
+      setCanGoBack(wikiState.canGoBack());
     });
   }, [switchToFile]);
 
@@ -280,6 +282,11 @@ export function WikiViewer({ api }: { api: PluginAPI }) {
   const handleToggleMode = useCallback((mode: 'view' | 'edit') => {
     setViewMode(mode);
     wikiState.setViewMode(mode);
+  }, []);
+
+  // Back navigation
+  const handleGoBack = useCallback(() => {
+    wikiState.goBack();
   }, []);
 
   // Unsaved dialog handlers
@@ -341,6 +348,20 @@ export function WikiViewer({ api }: { api: PluginAPI }) {
     className: 'flex items-center justify-between px-3 py-1.5 border-b border-ctp-surface0 bg-ctp-mantle flex-shrink-0',
   },
     React.createElement('div', { className: 'flex items-center gap-2 min-w-0' },
+      // Back button
+      React.createElement('button', {
+        className: `p-0.5 rounded transition-colors flex-shrink-0 ${canGoBack ? 'text-ctp-subtext0 hover:text-ctp-text hover:bg-ctp-surface0' : 'text-ctp-surface1 cursor-default'}`,
+        onClick: canGoBack ? handleGoBack : undefined,
+        disabled: !canGoBack,
+        title: 'Go back',
+      },
+        React.createElement('svg', {
+          width: 14, height: 14, viewBox: '0 0 24 24', fill: 'none',
+          stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+        },
+          React.createElement('polyline', { points: '15 18 9 12 15 6' }),
+        ),
+      ),
       React.createElement('span', { className: 'text-xs font-medium text-ctp-text truncate' }, displayName),
       isDirty
         ? React.createElement('span', {

--- a/src/renderer/plugins/builtin/wiki/state.ts
+++ b/src/renderer/plugins/builtin/wiki/state.ts
@@ -13,9 +13,34 @@ export const wikiState = {
   refreshCount: 0,
   listeners: new Set<() => void>(),
 
+  // Navigation history
+  history: [] as string[],
+  historyIndex: -1,
+  _isNavigatingHistory: false,
+
   setSelectedPath(path: string | null): void {
+    // Track navigation history for non-null paths
+    if (path && !this._isNavigatingHistory) {
+      // Truncate any forward history
+      this.history = this.history.slice(0, this.historyIndex + 1);
+      this.history.push(path);
+      this.historyIndex = this.history.length - 1;
+    }
+    this._isNavigatingHistory = false;
     this.selectedPath = path;
     this.notify();
+  },
+
+  goBack(): void {
+    if (this.historyIndex > 0) {
+      this.historyIndex--;
+      this._isNavigatingHistory = true;
+      this.setSelectedPath(this.history[this.historyIndex]);
+    }
+  },
+
+  canGoBack(): boolean {
+    return this.historyIndex > 0;
   },
 
   setDirty(dirty: boolean): void {
@@ -51,6 +76,9 @@ export const wikiState = {
     this.isDirty = false;
     this.viewMode = 'view';
     this.refreshCount = 0;
+    this.history = [];
+    this.historyIndex = -1;
+    this._isNavigatingHistory = false;
     this.listeners.clear();
   },
 };


### PR DESCRIPTION
## Summary

Fixes #52 — ADO Wiki Mode does not expand folders / show sub pages, and adds a back button for navigation.

### Root Cause
`filterMarkdownTree` filtered out directories whose children were empty arrays. With `readTree(path, {depth: 1})`, subdirectories get `children: []` from the lazy-loading depth limit, causing all folders to be invisible and un-expandable in the sidebar.

### Changes
- **Fix folder visibility** (`WikiTree.ts`): Modified `filterMarkdownTree` to show directories when children haven't been loaded yet (empty array or undefined). Directories are only filtered out when children ARE loaded and contain no markdown files
- **Fix ADO index page auto-selection** (`WikiTree.ts`): Moved index page selection from `TreeNode.handleClick` (where `node.children` was stale/empty) to `toggleExpand` (where children are actually loaded from the filesystem). Also skips redundant `readTree` calls when collapsing
- **Add navigation history** (`state.ts`): Added `history`, `historyIndex`, `goBack()`, `canGoBack()` to `wikiState`. `setSelectedPath` now tracks history; `goBack` navigates without pushing to history
- **Add back button** (`WikiViewer.ts`): Added a chevron-left back button in the viewer header, disabled when no history exists

### Files Changed
| File | Changes |
|------|---------|
| `WikiTree.ts` | `filterMarkdownTree` fix, `selectFile` reordering, `toggleExpand` improvements |
| `WikiViewer.ts` | Back button UI, `canGoBack` state tracking, `handleGoBack` handler |
| `state.ts` | Navigation history (`history`, `historyIndex`, `goBack`, `canGoBack`) |
| `wiki-main.test.tsx` | 16 new tests covering all three fixes |

## Test plan
- [x] `filterMarkdownTree` unit tests for empty/undefined children (6 tests)
- [x] ADO folder expansion with lazy-loaded empty children renders correctly
- [x] ADO folder click auto-selects index page after children load
- [x] `wikiState` navigation history: goBack, canGoBack, truncation, reset (7 tests)
- [x] WikiViewer back button: renders, disabled state, click navigation (3 tests)
- [x] All 132 wiki plugin tests pass
- [x] Full validation: 2116 unit tests pass, typecheck clean, build successful
- [x] Playwright e2e: 44 passed (1 pre-existing flaky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)