### PR TITLE
fix: extract update banner title from PR body (#51)

### DIFF
--- a/.claude/skills/prepare-release/skill.md
+++ b/.claude/skills/prepare-release/skill.md
@@ -140,9 +140,11 @@ Once the user confirms:
 5. **Open PR** using `gh pr create`. The PR format is critical — the release pipeline extracts release notes from the PR body.
 
    - **Title:** `chore: bump version to <new-version>`
-   - **Body:** Markdown with the following structure. Skip any section that has no items. Do not include a section header if its list would be empty.
+   - **Body:** Markdown with the following structure. The first line **must** be the `Release:` title — the release pipeline parses this to populate the update banner. Skip any section that has no items. Do not include a section header if its list would be empty.
 
    ```markdown
+   Release: <Release Title>
+
    # New Features
    - Description A from the confirmed table
    - Description B from the confirmed table
@@ -162,6 +164,8 @@ Once the user confirms:
    Use a HEREDOC to pass the body:
    ```bash
    gh pr create --title "chore: bump version to <new-version>" --body "$(cat <<'EOF'
+   Release: <Release Title>
+
    ...body content...
    EOF
    )"
@@ -192,6 +196,6 @@ git checkout <agent-name>/standby
 2. **Never propose a major version bump.**
 3. **Non-User changes never appear in the release title, release notes table, or PR body.**
 4. **Internal changes appear in the table and PR body (as "Improvements") but not in the release title.**
-5. **The PR body format is load-bearing** — the release pipeline parses it. Do not add extra markdown, emoji, test plans, or co-authored-by lines to the PR body.
+5. **The PR body format is load-bearing** — the release pipeline parses `Release: <title>` from the first line and the section content as release notes. Do not add extra markdown, emoji, test plans, or co-authored-by lines to the PR body.
 6. **Version bump commits from previous releases must be skipped** during classification.
 7. **Iterate with the user** — do not open the PR until the user explicitly confirms the version, title, and notes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,18 +67,28 @@ jobs:
           COMMIT_SHA=$(git rev-list -n 1 "${GITHUB_REF_NAME}")
           PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" --jq '.[0].number // empty')
 
-          # Release message = tag subject line (always clean, no signature)
-          RELEASE_MESSAGE=$(git tag -l --format='%(subject)' "${GITHUB_REF_NAME}")
-          echo "release_message=${RELEASE_MESSAGE}" >> "$GITHUB_OUTPUT"
-
-          # Release notes = PR body of the tagged commit
-          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" --jq '.[0].number // empty')
+          # Tag subject as fallback for release message
+          TAG_SUBJECT=$(git tag -l --format='%(subject)' "${GITHUB_REF_NAME}")
 
           if [ -z "$PR_NUMBER" ]; then
             echo "::warning::No PR found for tagged commit — release notes will be empty"
+            RELEASE_MESSAGE="$TAG_SUBJECT"
             RELEASE_NOTES=""
           else
-            RELEASE_NOTES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.body // ""' \
+            PR_BODY=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.body // ""')
+
+            # Release message: extract from PR body "Release: ..." line, fall back to tag subject
+            PR_FIRST_LINE=$(echo "$PR_BODY" | head -1)
+            if echo "$PR_FIRST_LINE" | grep -q '^Release: '; then
+              RELEASE_MESSAGE=$(echo "$PR_FIRST_LINE" | sed 's/^Release: //')
+            else
+              RELEASE_MESSAGE="$TAG_SUBJECT"
+            fi
+
+            # Release notes: strip release title line, test plan, and metadata
+            RELEASE_NOTES=$(echo "$PR_BODY" \
+              | sed '1{/^Release: /d}' \
+              | sed '/./,$!d' \
               | sed '/^## Test [Pp]lan/,$d' \
               | sed '/Co-[Aa]uthored-[Bb]y:/d' \
               | sed '/Generated with \[Claude Code\]/d' \
@@ -86,6 +96,8 @@ jobs:
               | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }' \
             )
           fi
+
+          echo "release_message=${RELEASE_MESSAGE}" >> "$GITHUB_OUTPUT"
 
           {
             echo "release_notes<<RELEASE_NOTES_EOF"

--- a/src/main/services/release-message-parsing.test.ts
+++ b/src/main/services/release-message-parsing.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for the release message extraction logic used in .github/workflows/release.yml.
+ *
+ * The workflow parses the first line of the version-bump PR body for a
+ * "Release: <title>" prefix, using the title as the update banner tagline and
+ * the remainder as release notes. These TypeScript functions replicate the
+ * shell pipeline so we can validate the parsing without platform-specific sed.
+ */
+
+/** Extracts the release message from the first line if it starts with "Release: ". */
+function extractReleaseMessage(prBody: string): string {
+  const firstLine = prBody.split('\n')[0] || '';
+  if (firstLine.startsWith('Release: ')) {
+    return firstLine.slice('Release: '.length);
+  }
+  return '';
+}
+
+/** Extracts release notes by stripping the Release: line, test plan, and metadata. */
+function extractReleaseNotes(prBody: string): string {
+  let lines = prBody.split('\n');
+
+  // Strip "Release: ..." first line (mirrors: sed '1{/^Release: /d}')
+  if (lines[0]?.startsWith('Release: ')) {
+    lines = lines.slice(1);
+  }
+
+  // Trim leading blank lines (mirrors: sed '/./,$!d')
+  while (lines.length > 0 && lines[0].trim() === '') {
+    lines.shift();
+  }
+
+  // Remove everything from "## Test Plan" onward (mirrors: sed '/^## Test [Pp]lan/,$d')
+  const testPlanIdx = lines.findIndex((l) => /^## Test [Pp]lan/.test(l));
+  if (testPlanIdx !== -1) {
+    lines = lines.slice(0, testPlanIdx);
+  }
+
+  // Strip Co-Authored-By lines
+  lines = lines.filter((l) => !/Co-[Aa]uthored-[Bb]y:/.test(l));
+
+  // Strip "Generated with [Claude Code]" lines
+  lines = lines.filter((l) => !/Generated with \[Claude Code\]/.test(l));
+
+  // Strip emoji-prefixed bot lines
+  lines = lines.filter((l) => !l.startsWith('🤖'));
+
+  // Trim trailing blank lines
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+
+  return lines.join('\n');
+}
+
+describe('release message parsing (workflow shell pipeline)', () => {
+  describe('extractReleaseMessage', () => {
+    it('extracts title from "Release: ..." first line', () => {
+      const body = 'Release: Plugin Improvements & More\n\n# New Features\n- Added widget';
+      expect(extractReleaseMessage(body)).toBe('Plugin Improvements & More');
+    });
+
+    it('returns empty when PR body has no Release: prefix', () => {
+      const body = '# New Features\n- Added widget\n\n# Bug Fixes\n- Fixed crash';
+      expect(extractReleaseMessage(body)).toBe('');
+    });
+
+    it('returns empty for empty body', () => {
+      expect(extractReleaseMessage('')).toBe('');
+    });
+
+    it('handles title with special characters', () => {
+      const body = 'Release: Bug Fixes & Performance — v2\n\n# Bug Fixes\n- Fixed crash';
+      expect(extractReleaseMessage(body)).toBe('Bug Fixes & Performance — v2');
+    });
+
+    it('does not match "Release:" on non-first lines', () => {
+      const body = '# Notes\nRelease: Not a title\n- Stuff';
+      expect(extractReleaseMessage(body)).toBe('');
+    });
+  });
+
+  describe('extractReleaseNotes', () => {
+    it('strips Release: line and returns remaining content', () => {
+      const body = 'Release: Some Title\n\n# New Features\n- Added widget';
+      const notes = extractReleaseNotes(body);
+      expect(notes).not.toContain('Release:');
+      expect(notes).toContain('# New Features');
+      expect(notes).toContain('- Added widget');
+    });
+
+    it('preserves body as-is when no Release: line', () => {
+      const body = '# New Features\n- Added widget\n\n# Bug Fixes\n- Fixed crash';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toContain('# New Features');
+      expect(notes).toContain('# Bug Fixes');
+    });
+
+    it('strips test plan section', () => {
+      const body = 'Release: Title\n\n# New Features\n- Widget\n\n## Test Plan\n- Run tests\n- Check UI';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toContain('- Widget');
+      expect(notes).not.toContain('Test Plan');
+      expect(notes).not.toContain('Run tests');
+    });
+
+    it('strips Co-Authored-By lines', () => {
+      const body = 'Release: Title\n\n# Bug Fixes\n- Fix\nCo-Authored-By: Bot <bot@test.com>';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toContain('- Fix');
+      expect(notes).not.toContain('Co-Authored-By');
+    });
+
+    it('strips Claude Code generated line', () => {
+      const body = 'Release: Title\n\n# Bug Fixes\n- Fix\nGenerated with [Claude Code](https://claude.com)';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toContain('- Fix');
+      expect(notes).not.toContain('Generated with');
+    });
+
+    it('strips emoji bot lines', () => {
+      const body = 'Release: Title\n\n# Bug Fixes\n- Fix\n🤖 Auto-generated';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toContain('- Fix');
+      expect(notes).not.toContain('🤖');
+    });
+
+    it('trims leading blank lines after stripping Release: line', () => {
+      const body = 'Release: Title\n\n# New Features\n- Widget';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toMatch(/^#/);
+    });
+
+    it('trims trailing blank lines', () => {
+      const body = 'Release: Title\n\n# Bug Fixes\n- Fix\n\n\n';
+      const notes = extractReleaseNotes(body);
+      expect(notes).toBe('# Bug Fixes\n- Fix');
+    });
+
+    it('handles full realistic PR body', () => {
+      const body = [
+        'Release: Plugin System & Agent Improvements',
+        '',
+        '# New Features',
+        '- Added plugin permission system with configurable allow/deny rules',
+        '- Added model selector to agent settings',
+        '',
+        '# Bug Fixes',
+        '- Fixed plugin popups clipping under side panels',
+        '',
+        '# Improvements',
+        '- Improved agent restart reliability',
+        '',
+        '## Test Plan',
+        '- Verify plugin permissions work',
+        '- Check agent settings UI',
+        '',
+        '🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+        '',
+        'Co-Authored-By: Claude <noreply@anthropic.com>',
+      ].join('\n');
+
+      const message = extractReleaseMessage(body);
+      expect(message).toBe('Plugin System & Agent Improvements');
+
+      const notes = extractReleaseNotes(body);
+      expect(notes).toContain('# New Features');
+      expect(notes).toContain('plugin permission system');
+      expect(notes).toContain('# Bug Fixes');
+      expect(notes).toContain('# Improvements');
+      expect(notes).not.toContain('Release:');
+      expect(notes).not.toContain('Test Plan');
+      expect(notes).not.toContain('Co-Authored-By');
+      expect(notes).not.toContain('Generated with');
+      expect(notes).not.toContain('🤖');
+      expect(notes).toMatch(/^#/); // starts with heading, no leading blanks
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #51 — the update banner was showing the merge commit subject (e.g. "chore: bump version to 0.29.0") as the release tagline instead of a meaningful title
- The release workflow now parses a `Release: <title>` line from the version-bump PR body as the primary source for `releaseMessage`, falling back to the git tag subject for backwards compatibility
- The prepare-release skill now includes a `Release: <title>` line as the first line of the PR body, making the PR the single source of truth for the update banner title

## Changes

### `.github/workflows/release.yml`
- Fetch the PR body once (removed duplicate `PR_NUMBER` fetch)
- Extract `releaseMessage` from the PR body's first line if it starts with `Release: `
- Fall back to the tag subject when no `Release:` line is found
- Strip the `Release:` line from release notes and trim leading blank lines

### `.claude/skills/prepare-release/skill.md`
- Added `Release: <Release Title>` as the required first line of the PR body format
- Updated the HEREDOC example to include the `Release:` line
- Updated critical rule #5 to document the `Release:` line parsing

### `src/main/services/release-message-parsing.test.ts` (new)
- 14 tests validating the release message extraction and release notes stripping logic
- Covers: title extraction, missing prefix fallback, special characters, test plan stripping, metadata stripping, leading/trailing blank line trimming, and a full realistic PR body integration test

## Test plan
- [x] All 2112 unit tests pass (`npm test`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run make`)
- [x] All 45 e2e tests pass (`npm run test:e2e`)
- [ ] Manual: next release PR should include `Release: <title>` line and the update banner should display it correctly