### PR TITLE
fix: resolve flaky drag-to-reorder test (#50)

### DIFF
--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -531,6 +531,21 @@ describe('agentStore', () => {
       await getState().loadDurableAgents('proj_1', '/project');
       expect(getState().agents['durable_nomodel'].model).toBeUndefined();
     });
+
+    it('updates projectId when same agent is loaded under a different project', async () => {
+      const mockAgent = window.clubhouse.agent as any;
+      mockAgent.listDurable.mockResolvedValue([
+        { id: 'durable_dup', name: 'dup-agent', color: 'indigo', createdAt: '2024-01-01' },
+      ]);
+
+      // First load under project A
+      await getState().loadDurableAgents('proj_A', '/shared-path');
+      expect(getState().agents['durable_dup'].projectId).toBe('proj_A');
+
+      // Second load under project B (same path, different store ID)
+      await getState().loadDurableAgents('proj_B', '/shared-path');
+      expect(getState().agents['durable_dup'].projectId).toBe('proj_B');
+    });
   });
 
   describe('openAgentSettings', () => {

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -314,6 +314,11 @@ export const useAgentStore = create<AgentState>((set, get) => ({
           model: config.model,
           orchestrator: config.orchestrator,
         };
+      } else {
+        // Always update projectId — the same agents.json may be loaded
+        // under a different project store ID when a project is re-added
+        // or when multiple store entries share the same path.
+        agents[config.id] = { ...agents[config.id], projectId };
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes #50 — the "Durable Agents Drag to Reorder" e2e test was flaky because `getDurableAgentOrder()` returned an empty array on the first attempt.

### Root Cause
Parallel e2e test files share `~/.clubhouse-dev/projects.json`. When multiple Electron apps add the same fixture project (`project-a`) under different store IDs, `loadDurableAgents` would register agents under the **first** project ID it encounters (via the `if (!agents[config.id])` guard), then **refuse to update** the `projectId` for subsequent project entries pointing to the same path. This left `durableAgents` empty for the active project — the agents existed in the store but were filtered out because their `projectId` didn't match `activeProjectId`.

### Changes

**Product code fix** (`src/renderer/stores/agentStore.ts`):
- In `loadDurableAgents`, always update `projectId` when an agent already exists in the store. This ensures the active project's ID wins regardless of IPC load order.

**Test fix** (`e2e/agent-list-ui.spec.ts`):
- Added `toBeVisible` wait in `getDurableAgentOrder()` before the raw `evaluate()` call, preventing empty-array returns from the timing issue described in #50
- Removed the now-unnecessary `projects.json` cleanup from `beforeAll` (the store fix handles the cross-contamination)

**New unit test** (`src/renderer/stores/agentStore.test.ts`):
- Added test case: "updates projectId when same agent is loaded under a different project"

## Test plan
- [x] `npm run validate` passes all 46 e2e + 2142 unit tests (0 flaky)
- [x] Ran full validation 3 consecutive times — all green
- [x] Ran `npx playwright test e2e/agent-list-ui.spec.ts` 3 consecutive times — all green
- [x] New unit test covers the projectId update behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)