### PR TITLE
ci: stop validate workflow from double-triggering on merge

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,8 +3,6 @@ name: Validate
 on:
   pull_request:
     branches: [main, dev/*]
-  push:
-    branches: [main]
 
 concurrency:
   group: validate-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Removes the `push: branches: [main]` trigger from the validate workflow
- Validation now only runs on `pull_request` events, preventing the redundant second run that fires when a PR is merged to main

## Why
The validate workflow was configured to trigger on both `pull_request` (targeting main/dev/*) and `push` (to main). When a PR is merged, GitHub fires a push event to main, causing the exact same validation to run again — doubling CI minute usage for every merge with no benefit since the PR already passed.

The release workflow (`release.yml`) is unaffected — it triggers on tag pushes (`v*`), not branch pushes.

## Test Plan
- [x] `npm run validate` passes locally (typecheck, unit tests, build, E2E)
- [ ] Manual: Merge this PR and confirm only the PR-triggered workflow run appears (no second run on the push to main)