### PR TITLE
feat: close auto-update UX gaps

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@ import { buildMenu } from './menu';
 import { getSettings as getThemeSettings } from './services/theme-service';
 import * as safeMode from './services/safe-mode';
 import { appLog } from './services/log-service';
-import { startPeriodicChecks as startUpdateChecks, stopPeriodicChecks as stopUpdateChecks } from './services/auto-update-service';
+import { startPeriodicChecks as startUpdateChecks, stopPeriodicChecks as stopUpdateChecks, applyUpdateOnQuit } from './services/auto-update-service';
 
 // Set the app name early so the dock, menu bar, and notifications all say "Clubhouse"
 // instead of "Electron" during development.
@@ -158,6 +158,15 @@ app.on('activate', () => {
 app.on('before-quit', () => {
   appLog('core:shutdown', 'info', 'App shutting down, restoring configs and killing all PTY sessions');
   stopUpdateChecks();
+
+  // Silently apply any downloaded update before quitting so the next launch
+  // gets the new version without user action.
+  try {
+    applyUpdateOnQuit();
+  } catch (err) {
+    appLog('core:shutdown', 'error', `Failed to apply update on quit: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   restoreAll();
   killAll();
 });

--- a/src/main/services/auto-update-quit.test.ts
+++ b/src/main/services/auto-update-quit.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => key === 'userData' ? '/tmp/test-clubhouse' : '/tmp/test-temp',
+    getVersion: () => '0.25.0',
+    exit: vi.fn(),
+    relaunch: vi.fn(),
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    rmSync: vi.fn(),
+    readdirSync: vi.fn(() => []),
+    createReadStream: actual.createReadStream,
+    createWriteStream: actual.createWriteStream,
+  };
+});
+
+import * as fs from 'fs';
+import {
+  readPendingUpdateInfo,
+  writePendingUpdateInfo,
+  clearPendingUpdateInfo,
+  applyUpdateOnQuit,
+  getStatus,
+} from './auto-update-service';
+
+describe('auto-update-service: pending update info', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('readPendingUpdateInfo', () => {
+    it('returns null when file does not exist', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      expect(readPendingUpdateInfo()).toBeNull();
+    });
+
+    it('returns parsed info when file exists', () => {
+      const info = {
+        version: '0.26.0',
+        downloadPath: '/tmp/Clubhouse-0.26.0.zip',
+        releaseNotes: 'Bug fixes',
+        releaseMessage: 'Bug Fixes & More',
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(info));
+      expect(readPendingUpdateInfo()).toEqual(info);
+    });
+
+    it('returns null when file contains invalid JSON', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('not json');
+      expect(readPendingUpdateInfo()).toBeNull();
+    });
+  });
+
+  describe('writePendingUpdateInfo', () => {
+    it('writes info as JSON to the correct path', () => {
+      const info = {
+        version: '0.26.0',
+        downloadPath: '/tmp/Clubhouse-0.26.0.zip',
+        releaseNotes: 'Bug fixes',
+        releaseMessage: null,
+      };
+      writePendingUpdateInfo(info);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('pending-update-info.json'),
+        JSON.stringify(info),
+        'utf-8',
+      );
+    });
+
+    it('does not throw when write fails', () => {
+      vi.mocked(fs.writeFileSync).mockImplementation(() => { throw new Error('EPERM'); });
+      expect(() => writePendingUpdateInfo({
+        version: '0.26.0',
+        downloadPath: '/tmp/x.zip',
+        releaseNotes: null,
+        releaseMessage: null,
+      })).not.toThrow();
+    });
+  });
+
+  describe('clearPendingUpdateInfo', () => {
+    it('unlinks the pending info file', () => {
+      clearPendingUpdateInfo();
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining('pending-update-info.json'),
+      );
+    });
+
+    it('does not throw when file does not exist', () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      expect(() => clearPendingUpdateInfo()).not.toThrow();
+    });
+  });
+});
+
+describe('auto-update-service: applyUpdateOnQuit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is a no-op when state is not ready', () => {
+    // Default state is idle
+    const status = getStatus();
+    expect(status.state).toBe('idle');
+
+    // Should not throw and should not call any fs operations
+    applyUpdateOnQuit();
+    expect(fs.existsSync).not.toHaveBeenCalled();
+  });
+
+  it('is exported as a function', () => {
+    expect(typeof applyUpdateOnQuit).toBe('function');
+  });
+});

--- a/src/renderer/stores/updateStore.ts
+++ b/src/renderer/stores/updateStore.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
 import type { UpdateStatus, UpdateSettings, PendingReleaseNotes } from '../../shared/types';
 
+export const DISMISS_DURATION_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+
 interface UpdateStoreState {
   status: UpdateStatus;
   settings: UpdateSettings;
@@ -83,6 +87,12 @@ export const useUpdateStore = create<UpdateStoreState>((set, get) => ({
 
   dismiss: () => {
     set({ dismissed: true });
+    // Re-show the banner after 4 hours
+    if (dismissTimer) clearTimeout(dismissTimer);
+    dismissTimer = setTimeout(() => {
+      set({ dismissed: false });
+      dismissTimer = null;
+    }, DISMISS_DURATION_MS);
   },
 
   checkWhatsNew: async () => {


### PR DESCRIPTION
## Summary

Closes three gaps in the auto-update experience:

- **Auto-apply on quit**: When the user quits the app with a downloaded update pending, the update is silently applied in the background (no relaunch). Next time they open Clubhouse, they get the new version automatically.
- **Re-show dismissed banner after 4 hours**: Dismissing the update banner now starts a 4-hour timer. After the timer expires, the banner reappears in the same session. Previously, dismissing hid the banner for the entire session.
- **Show banner on launch with pending update**: If an update was downloaded but never installed, the banner now appears immediately on the next app launch instead of waiting for the 30-second delayed network check. Pending update info is persisted to `pending-update-info.json` and restored at startup.

## Changes

### `src/main/services/auto-update-service.ts`
- Added `PendingUpdateInfo` persistence (`writePendingUpdateInfo`, `readPendingUpdateInfo`, `clearPendingUpdateInfo`) to track downloaded-but-not-applied updates across restarts
- Added `applyUpdateOnQuit()` — same extraction/shell-script logic as `applyUpdate()` but without `app.exit()` or relaunch (`open` command omitted from macOS shell script)
- `downloadUpdate()` now writes pending update info when state becomes `ready`
- `applyUpdate()` now clears pending update info
- `startPeriodicChecks()` now: (1) clears `dismissedVersion` on startup, (2) restores `ready` state immediately from `pending-update-info.json` if the download file still exists on disk

### `src/main/index.ts`
- `before-quit` handler now calls `applyUpdateOnQuit()` after stopping periodic checks (wrapped in try/catch so failures don't block quit)

### `src/renderer/stores/updateStore.ts`
- Exported `DISMISS_DURATION_MS` constant (4 hours)
- `dismiss()` action now starts a `setTimeout` that re-shows the banner after 4 hours; re-dismissing resets the timer

## Test plan

- [x] **Unit tests** — New test file `auto-update-quit.test.ts` covering:
  - `readPendingUpdateInfo` returns null when file doesn't exist
  - `readPendingUpdateInfo` returns parsed info when file exists
  - `readPendingUpdateInfo` returns null on invalid JSON
  - `writePendingUpdateInfo` writes JSON to correct path
  - `writePendingUpdateInfo` doesn't throw on write failure
  - `clearPendingUpdateInfo` unlinks the file
  - `clearPendingUpdateInfo` doesn't throw when file doesn't exist
  - `applyUpdateOnQuit` is a no-op when state is not ready
- [x] **Updated `updateStore.test.ts`** — New dismiss timer tests:
  - Dismiss sets `dismissed: true`
  - Banner re-shows after 4 hours (fake timers)
  - Re-dismissing resets the 4-hour timer
- [x] **Full validation**: `npm run validate` (typecheck + 2165 unit tests + build + 46 E2E tests) — all pass
- [ ] **Manual validation**: Download an update, dismiss the banner, verify it reappears after 4 hours. Quit the app with a pending update, verify the update is applied on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)