### PR TITLE
feat: add Windows ARM64 to release build flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,12 +199,20 @@ jobs:
           retention-days: 5
 
   build-windows:
-    name: Build Windows (x64)
+    name: Build Windows (${{ matrix.arch }})
     needs: verify-tag
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+          - arch: arm64
     outputs:
       sha256_win_x64: ${{ steps.hash.outputs.sha256_win_x64 }}
       size_win_x64: ${{ steps.hash.outputs.size_win_x64 }}
+      sha256_win_arm64: ${{ steps.hash.outputs.sha256_win_arm64 }}
+      size_win_arm64: ${{ steps.hash.outputs.size_win_arm64 }}
     steps:
       - uses: actions/checkout@v4
 
@@ -217,13 +225,14 @@ jobs:
         run: npm ci
 
       - name: Build Windows installer
-        run: npx electron-forge make --arch=x64
+        run: npx electron-forge make --arch=${{ matrix.arch }}
 
       - name: Compute artifact hashes
         id: hash
         shell: pwsh
         run: |
           $version = "${{ needs.verify-tag.outputs.version }}"
+          $arch = "${{ matrix.arch }}"
 
           # Find the Setup exe (Squirrel output)
           $exe = Get-ChildItem -Path out/make -Recurse -Filter "*Setup*.exe" | Select-Object -First 1
@@ -236,23 +245,24 @@ jobs:
           $hash = (Get-FileHash -Path $exe.FullName -Algorithm SHA256).Hash.ToLower()
           $size = $exe.Length
 
-          echo "sha256_win_x64=$hash" >> $env:GITHUB_OUTPUT
-          echo "size_win_x64=$size" >> $env:GITHUB_OUTPUT
+          echo "sha256_win_${arch}=$hash" >> $env:GITHUB_OUTPUT
+          echo "size_win_${arch}=$size" >> $env:GITHUB_OUTPUT
 
       - name: Rename artifacts for upload
         shell: pwsh
         run: |
           $version = "${{ needs.verify-tag.outputs.version }}"
+          $arch = "${{ matrix.arch }}"
           New-Item -ItemType Directory -Force -Path dist | Out-Null
 
           # Find and rename Setup exe
           $exe = Get-ChildItem -Path out/make -Recurse -Filter "*Setup*.exe" | Select-Object -First 1
-          Copy-Item $exe.FullName "dist/Clubhouse-${version}-win32-x64-Setup.exe"
+          Copy-Item $exe.FullName "dist/Clubhouse-${version}-win32-${arch}-Setup.exe"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-win32-x64
+          name: release-win32-${{ matrix.arch }}
           path: dist/
           retention-days: 5
 
@@ -296,6 +306,9 @@ jobs:
             --arg url_win_x64 "${BASE_URL}/Clubhouse-${VERSION}-win32-x64-Setup.exe" \
             --arg sha256_win_x64 "${{ needs.build-windows.outputs.sha256_win_x64 }}" \
             --argjson size_win_x64 ${{ needs.build-windows.outputs.size_win_x64 }} \
+            --arg url_win_arm64 "${BASE_URL}/Clubhouse-${VERSION}-win32-arm64-Setup.exe" \
+            --arg sha256_win_arm64 "${{ needs.build-windows.outputs.sha256_win_arm64 }}" \
+            --argjson size_win_arm64 ${{ needs.build-windows.outputs.size_win_arm64 }} \
             '{
               version: $version,
               releaseDate: $date,
@@ -317,6 +330,11 @@ jobs:
                   url: $url_win_x64,
                   sha256: $sha256_win_x64,
                   size: $size_win_x64
+                },
+                "win32-arm64": {
+                  url: $url_win_arm64,
+                  sha256: $sha256_win_arm64,
+                  size: $size_win_arm64
                 }
               }
             }' > artifacts/latest.json
@@ -427,19 +445,22 @@ jobs:
               --auth-mode login
           done
 
-          # Copy Windows installer to the latest slot
-          az storage blob copy start \
-            --account-name "$ACCOUNT" \
-            --destination-container "$CONTAINER" \
-            --destination-blob "latest/Clubhouse-latest-win32-x64-Setup.exe" \
-            --source-uri "https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}/artifacts/Clubhouse-${VERSION}-win32-x64-Setup.exe" \
-            --auth-mode login
+          # Copy Windows installers to the latest slot
+          for WIN_ARCH in x64 arm64; do
+            az storage blob copy start \
+              --account-name "$ACCOUNT" \
+              --destination-container "$CONTAINER" \
+              --destination-blob "latest/Clubhouse-latest-win32-${WIN_ARCH}-Setup.exe" \
+              --source-uri "https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}/artifacts/Clubhouse-${VERSION}-win32-${WIN_ARCH}-Setup.exe" \
+              --auth-mode login
+          done
 
           # Wait for copies to complete
           LATEST_BLOBS=(
             "latest/Clubhouse-latest-darwin-arm64.dmg"
             "latest/Clubhouse-latest-darwin-x64.dmg"
             "latest/Clubhouse-latest-win32-x64-Setup.exe"
+            "latest/Clubhouse-latest-win32-arm64-Setup.exe"
           )
           for BLOB in "${LATEST_BLOBS[@]}"; do
             while true; do


### PR DESCRIPTION
## Summary

- Refactors the `build-windows` job in the release workflow to use a matrix strategy (`x64` + `arm64`), matching the existing macOS build pattern
- Cross-compiles the ARM64 installer on the `windows-latest` (x64) runner using `electron-forge make --arch=arm64`
- Adds the `win32-arm64` artifact to the `latest.json` update manifest so the auto-update service can serve it to ARM64 Windows clients
- Uploads the ARM64 Setup.exe to Azure Blob Storage and copies it to the `latest/` slot

## Changes

**`.github/workflows/release.yml`** — the only file modified:
- `build-windows` job now uses `strategy.matrix` with `[x64, arm64]` instead of a hardcoded single architecture
- Job outputs expanded to include `sha256_win_arm64` and `size_win_arm64`
- `latest.json` generation now includes the `win32-arm64` artifact entry
- Windows installer blob copy loop covers both `x64` and `arm64`
- `LATEST_BLOBS` wait array includes the new ARM64 latest slot

**No changes needed to:**
- `forge.config.ts` — `MakerSquirrel` is already architecture-agnostic
- `auto-update-service.ts` — `platformKey()` already dynamically resolves to `win32-arm64` on ARM64 Windows machines and looks up the artifact from the manifest

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (all unit tests)
- [x] `npm run make` builds successfully
- [x] `npm run test:e2e` passes (54 passed, 1 pre-existing flaky)
- [ ] Manually verify the release workflow by triggering a test tag on a development fork to confirm:
  - Both `win32-x64` and `win32-arm64` matrix jobs complete
  - `latest.json` contains all 4 artifact entries (darwin-arm64, darwin-x64, win32-x64, win32-arm64)
  - Both Windows installers are uploaded to blob storage and copied to the latest slot
- [ ] Verify the ARM64 Setup.exe installs correctly on a Windows ARM64 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)