### PR TITLE
fix: ADO wiki folders auto-select sibling index page on expand

### DIFF
--- a/src/renderer/plugins/builtin/wiki/WikiTree.ts
+++ b/src/renderer/plugins/builtin/wiki/WikiTree.ts
@@ -430,6 +430,16 @@ export function WikiTree({ api }: { api: PluginAPI }) {
         );
         if (indexPage) {
           selectFile(indexPage.path);
+        } else {
+          // ADO pattern: check for sibling .md file at the same level as the folder
+          // e.g., Architecture.md alongside Architecture/ folder
+          const siblingPath = dirPath + '.md';
+          try {
+            await scoped.stat(siblingPath);
+            selectFile(siblingPath);
+          } catch {
+            // No sibling .md page exists, nothing to auto-select
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## Summary

Fixes #71 — ADO Wiki Folders now expand, but do not show their page.

In Azure DevOps wikis, a folder (e.g., `Architecture/`) can have a sibling `.md` page with the same name (`Architecture.md`) at the same directory level. This sibling page acts as the "index" or "stub" page for the folder.

**Before:** When expanding the folder, `toggleExpand` only looked for an index page _inside_ the folder's children (e.g., `Architecture/Architecture.md`). If the index page only existed as a sibling, no page was auto-selected — the folder expanded but showed no content.

**After:** When no child index page is found, the code now also checks for a sibling `.md` file at the same level (via `stat()`). If found, it is auto-selected, so the user sees the page content alongside the expanded sub-pages.

## Changes

- **`WikiTree.ts`** (`toggleExpand`): Added fallback logic to check for a sibling `.md` file when no child index page exists in ADO mode
- **`wiki-main.test.tsx`**: Added 2 new test cases:
  - Root-level folder with sibling `.md` (no child index)
  - Nested folder with sibling `.md` at the same parent level

## Test plan

- [x] Unit tests: All 2219 tests pass (45 wiki tests, up from 43)
- [x] Build: `npm run make` succeeds
- [x] E2E tests: All 55 Playwright tests pass
- [ ] Manual: Configure an ADO wiki with folder + sibling `.md` pattern, verify folder expand shows page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)