### PR TITLE
fix: home view settings gear navigates to project settings

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -372,6 +372,31 @@ test.describe('Home Navigation', () => {
     // Should restore to agents tab (the default/saved tab)
     expect(title).toContain('Agents');
   });
+
+  test('settings gear on project card in home view opens project settings', async () => {
+    // Navigate to Home first
+    const homeBtn = window.locator('[data-testid="nav-home"]');
+    const homeVisible = await homeBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+    if (!homeVisible) return; // Home not enabled, skip
+
+    await homeBtn.click();
+    await window.waitForTimeout(500);
+
+    let title = await getTitleBarText();
+    expect(title).toBe('Home');
+
+    // Click the gear icon on a project card — it has title="Project Settings"
+    const settingsGear = window.locator('[title="Project Settings"]').first();
+    const gearVisible = await settingsGear.isVisible({ timeout: 3_000 }).catch(() => false);
+    if (!gearVisible) return; // No project cards visible, skip
+
+    await settingsGear.click();
+    await window.waitForTimeout(500);
+
+    // Should navigate to Settings view, NOT the Agents (project root) view
+    title = await getTitleBarText();
+    expect(title).toContain('Settings');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -179,8 +179,12 @@ export function App() {
     const prevId = prevProjectIdRef.current;
     prevProjectIdRef.current = activeProjectId;
     if (activeProjectId && activeProjectId !== prevId) {
-      // Restore per-project navigation state
-      useUIStore.getState().restoreProjectView(activeProjectId);
+      // Restore per-project navigation state, but skip if the user
+      // intentionally navigated to settings (e.g. gear icon on Home dashboard)
+      const currentTab = useUIStore.getState().explorerTab;
+      if (currentTab !== 'settings' && currentTab !== 'help') {
+        useUIStore.getState().restoreProjectView(activeProjectId);
+      }
       useAgentStore.getState().restoreProjectAgent(activeProjectId);
 
       const project = projects.find((p) => p.id === activeProjectId);


### PR DESCRIPTION
## Summary

- **Bug**: The settings gear icon on project cards in the Home dashboard navigated to the project's agents view (project root) instead of project settings
- **Root cause**: The `useEffect` in `App.tsx` that handles project switches unconditionally called `restoreProjectView()`, which overwrote `explorerTab` from `'settings'` back to the saved tab (usually `'agents'`)
- **Fix**: Guard `restoreProjectView()` so it only runs when the current explorer tab is NOT `'settings'` or `'help'`, preserving intentional navigation from the Home dashboard

## Changes

| File | Change |
|------|--------|
| `src/renderer/App.tsx` | Guard `restoreProjectView()` in project-switch `useEffect` to skip when `explorerTab` is already `'settings'` or `'help'` |
| `e2e/navigation.spec.ts` | New E2E test: "settings gear on project card in home view opens project settings" |

## Test Plan

- [x] All 2418 unit tests pass (`npx vitest run`)
- [x] All 65 E2E tests pass (`npm run validate`), including the new test
- [x] New E2E test verifies: click Home → click gear icon on project card → title bar shows "Settings" (not "Agents")
- [ ] **Manual**: Open app → go to Home view → click gear icon on any project card → verify project settings panel opens (not the agents/project root view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)