### PR TITLE
ui: move Free Agent Mode to top of agent settings

### DIFF
--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -569,6 +569,43 @@ export function AgentSettingsView({ agent }: Props) {
                   ))}
                 </select>
               </div>
+
+              {/* Free Agent Mode */}
+              <div>
+                <label
+                  className={`flex items-center gap-2 ${
+                    !isRunning && (capabilities?.permissions ?? false)
+                      ? 'cursor-pointer'
+                      : 'cursor-not-allowed opacity-50'
+                  }`}
+                  title={
+                    !(capabilities?.permissions ?? false)
+                      ? 'Not supported by this orchestrator'
+                      : isRunning
+                      ? 'Stop agent to change this setting'
+                      : 'Skip all permission prompts when running'
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={freeAgentMode}
+                    onChange={(e) => handleFreeAgentModeChange(e.target.checked)}
+                    disabled={isRunning || !(capabilities?.permissions ?? false)}
+                    className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-red-500 focus:ring-red-500 accent-red-500"
+                  />
+                  <span className="text-sm text-ctp-text">Free Agent Mode</span>
+                </label>
+                {freeAgentMode && (capabilities?.permissions ?? false) && (
+                  <p className="mt-1 text-[10px] text-red-400 pl-6">
+                    This agent will run with full access — no tool approvals required.
+                  </p>
+                )}
+                {!(capabilities?.permissions ?? false) && (
+                  <p className="mt-1 text-[10px] text-ctp-subtext0/60 pl-6">
+                    Not supported by {orchestratorInfo?.displayName || 'this orchestrator'}.
+                  </p>
+                )}
+              </div>
             </div>
           </div>
         </section>
@@ -762,44 +799,6 @@ export function AgentSettingsView({ agent }: Props) {
                 pathLabel={mcpPathLabel}
               />
             )}
-
-            {/* Free Agent Mode Section */}
-            <section>
-              <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider mb-2">Free Agent Mode</h3>
-              <label
-                className={`flex items-center gap-2 ${
-                  !isRunning && (capabilities?.permissions ?? false)
-                    ? 'cursor-pointer'
-                    : 'cursor-not-allowed opacity-50'
-                }`}
-                title={
-                  !(capabilities?.permissions ?? false)
-                    ? 'Not supported by this orchestrator'
-                    : isRunning
-                    ? 'Stop agent to change this setting'
-                    : 'Skip all permission prompts when running'
-                }
-              >
-                <input
-                  type="checkbox"
-                  checked={freeAgentMode}
-                  onChange={(e) => handleFreeAgentModeChange(e.target.checked)}
-                  disabled={isRunning || !(capabilities?.permissions ?? false)}
-                  className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-red-500 focus:ring-red-500 accent-red-500"
-                />
-                <span className="text-sm text-ctp-text">Skip all permission prompts</span>
-              </label>
-              {freeAgentMode && (capabilities?.permissions ?? false) && (
-                <p className="mt-1.5 text-[10px] text-red-400">
-                  This agent will run with full access — no tool approvals required.
-                </p>
-              )}
-              {!(capabilities?.permissions ?? false) && (
-                <p className="mt-1.5 text-[10px] text-ctp-subtext0/60">
-                  Not supported by {orchestratorInfo?.displayName || 'this orchestrator'}.
-                </p>
-              )}
-            </section>
 
             {/* Permissions Section (hidden when managed) */}
             {!isManagedByClubhouse && permLoaded && (

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -123,6 +123,22 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             </span>
           </div>
 
+          {/* Default Free Agent Mode */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={freeAgentMode}
+              onChange={(e) => { setFreeAgentMode(e.target.checked); setDirty(true); }}
+              className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-red-500 focus:ring-red-500 accent-red-500"
+            />
+            <span className="text-xs text-ctp-subtext0">Free Agent Mode by default</span>
+          </label>
+          {freeAgentMode && (
+            <p className="text-[10px] text-red-400 pl-6">
+              New agents will skip all permission prompts by default.
+            </p>
+          )}
+
           {/* Default instructions */}
           <div>
             <label className="block text-xs text-ctp-subtext0 mb-1">Default Instructions</label>
@@ -172,21 +188,6 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             />
           </div>
 
-          {/* Default Free Agent Mode */}
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={freeAgentMode}
-              onChange={(e) => { setFreeAgentMode(e.target.checked); setDirty(true); }}
-              className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-red-500 focus:ring-red-500 accent-red-500"
-            />
-            <span className="text-xs text-ctp-subtext0">Free Agent Mode by default</span>
-          </label>
-          {freeAgentMode && (
-            <p className="text-[10px] text-red-400 pl-6">
-              New agents will skip all permission prompts by default.
-            </p>
-          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Moved the **Free Agent Mode** checkbox to be directly under the **Model** selector in agent settings, making it more prominent and discoverable
- Applied the same reordering in **Project Default Agent Settings**, moving Free Agent Mode from the very bottom to right after the info note at the top

## Changes

| File | Change |
|------|--------|
| `src/renderer/features/agents/AgentSettingsView.tsx` | Moved Free Agent Mode from after MCP JSON section (halfway down Main Agent tab) to the Appearance section, right under Model dropdown |
| `src/renderer/features/settings/ProjectAgentDefaultsSection.tsx` | Moved Free Agent Mode from last item to first item after the mode note |

## Before / After

**Agent Settings (before):** Appearance > Model > [Tab Bar] > Instructions > Skills > Agent Definitions > MCP > **Free Agent Mode** > Permissions

**Agent Settings (after):** Appearance > Model > **Free Agent Mode** > [Tab Bar] > Instructions > Skills > Agent Definitions > MCP > Permissions

**Project Defaults (before):** Instructions > Permissions > MCP > **Free Agent Mode**

**Project Defaults (after):** **Free Agent Mode** > Instructions > Permissions > MCP

## Test Plan

- [x] All 2418 unit tests pass
- [x] All 65 E2E tests pass
- [ ] **Manual**: Open agent settings → verify Free Agent Mode checkbox appears directly under Model dropdown
- [ ] **Manual**: Open project settings → expand Default Agent Settings → verify Free Agent Mode is the first setting after the info note

🤖 Generated with [Claude Code](https://claude.com/claude-code)