### PR TITLE
fix: onboarding UX improvements

### DIFF
--- a/src/renderer/features/onboarding/HighlightCarousel.tsx
+++ b/src/renderer/features/onboarding/HighlightCarousel.tsx
@@ -18,9 +18,9 @@ interface HighlightSlide {
 function getSlidesForCohort(cohort: Cohort): HighlightSlide[] {
   const slide1: HighlightSlide = {
     illustration: <ClubhouseStructureIllustration className="w-full h-full" />,
-    title: 'Projects, Quick Agents & Durable Agents',
+    title: 'Projects, Durable Agents & Quick Agents',
     description:
-      'Clubhouse organizes your work into projects. Use quick agents for fast tasks and durable agents for long-running missions that persist across sessions.',
+      'Clubhouse organizes your work into projects. Use durable agents for long-running missions that persist across sessions and quick agents for fast, one-off tasks.',
   };
 
   if (cohort === 'new-dev') {
@@ -28,9 +28,9 @@ function getSlidesForCohort(cohort: Cohort): HighlightSlide[] {
       slide1,
       {
         illustration: <AgentBranchesIllustration className="w-full h-full" />,
-        title: 'How Agents Work Under the Hood',
+        title: 'Agents Use Git Under the Hood',
         description:
-          'When an agent works on your code it creates a branch — a separate copy that won\'t affect your main project. When you\'re happy with the result, it gets merged back in. Your code is always safe.',
+          'Agents use Git under the hood to keep your code safe. Tell an agent to branch off, make changes, and merge back when you\'re happy with the result. Your main project is never touched until you say so.',
       },
       {
         illustration: <AgentsHandleTasksIllustration className="w-full h-full" />,
@@ -54,7 +54,7 @@ function getSlidesForCohort(cohort: Cohort): HighlightSlide[] {
         illustration: <ProjectToolsIllustration className="w-full h-full" />,
         title: 'Built-in Project Tools',
         description:
-          'Track work with Issues, document knowledge in the Wiki, and set up Automations — all without leaving Clubhouse. Your whole workflow lives in one place.',
+          'Track work with Issues, document knowledge in the Wiki, and set up Automations — all without leaving Clubhouse. Enable and configure project tools in the Plugins settings page.',
       },
     ];
   }

--- a/src/renderer/features/onboarding/OnboardingModal.test.tsx
+++ b/src/renderer/features/onboarding/OnboardingModal.test.tsx
@@ -26,6 +26,18 @@ vi.mock('../../stores/projectStore', () => ({
   }),
 }));
 
+// Mock uiStore
+const mockSetExplorerTab = vi.fn();
+const mockSetSettingsSubPage = vi.fn();
+const mockSetSettingsContext = vi.fn();
+vi.mock('../../stores/uiStore', () => ({
+  useUIStore: (selector: (s: any) => any) => selector({
+    setExplorerTab: mockSetExplorerTab,
+    setSettingsSubPage: mockSetSettingsSubPage,
+    setSettingsContext: mockSetSettingsContext,
+  }),
+}));
+
 function resetStore() {
   useOnboardingStore.setState({
     showOnboarding: false,
@@ -34,6 +46,9 @@ function resetStore() {
     step: 'cohort-select',
     highlightIndex: 0,
   });
+  mockSetExplorerTab.mockClear();
+  mockSetSettingsSubPage.mockClear();
+  mockSetSettingsContext.mockClear();
 }
 
 describe('OnboardingModal', () => {
@@ -167,19 +182,25 @@ describe('OnboardingModal', () => {
     expect(dot2.className).toContain('bg-surface-2');
   });
 
-  it('help button opens external URL', () => {
+  it('help button dismisses modal and opens in-app help view', () => {
     useOnboardingStore.setState({ showOnboarding: true, step: 'get-started' });
     render(<OnboardingModal />);
 
     fireEvent.click(screen.getByTestId('onboarding-help-btn'));
-    expect(window.open).toHaveBeenCalledWith('https://docs.clubhouse.dev/getting-started', '_blank');
+    expect(useOnboardingStore.getState().showOnboarding).toBe(false);
+    expect(useOnboardingStore.getState().completed).toBe(true);
+    expect(mockSetExplorerTab).toHaveBeenCalledWith('help');
   });
 
-  it('extensibility button opens external URL', () => {
+  it('extensibility button dismisses modal and opens plugins settings', () => {
     useOnboardingStore.setState({ showOnboarding: true, step: 'get-started' });
     render(<OnboardingModal />);
 
     fireEvent.click(screen.getByTestId('onboarding-extensibility-btn'));
-    expect(window.open).toHaveBeenCalledWith('https://docs.clubhouse.dev/plugins', '_blank');
+    expect(useOnboardingStore.getState().showOnboarding).toBe(false);
+    expect(useOnboardingStore.getState().completed).toBe(true);
+    expect(mockSetExplorerTab).toHaveBeenCalledWith('settings');
+    expect(mockSetSettingsContext).toHaveBeenCalledWith('app');
+    expect(mockSetSettingsSubPage).toHaveBeenCalledWith('plugins');
   });
 });

--- a/src/renderer/features/onboarding/OnboardingModal.tsx
+++ b/src/renderer/features/onboarding/OnboardingModal.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useCallback } from 'react';
 import { useOnboardingStore } from '../../stores/onboardingStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
 import { CohortSelection } from './CohortSelection';
 import { HighlightCarousel } from './HighlightCarousel';
 import { GetStartedScreen } from './GetStartedScreen';
-
-const HELP_URL = 'https://docs.clubhouse.dev/getting-started';
-const EXTENSIBILITY_URL = 'https://docs.clubhouse.dev/plugins';
 
 export function OnboardingModal() {
   const showOnboarding = useOnboardingStore((s) => s.showOnboarding);
@@ -18,6 +16,9 @@ export function OnboardingModal() {
   const prevHighlight = useOnboardingStore((s) => s.prevHighlight);
   const dismissOnboarding = useOnboardingStore((s) => s.dismissOnboarding);
   const pickAndAddProject = useProjectStore((s) => s.pickAndAddProject);
+  const setExplorerTab = useUIStore((s) => s.setExplorerTab);
+  const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
+  const setSettingsContext = useUIStore((s) => s.setSettingsContext);
 
   const handleDismiss = useCallback(() => {
     dismissOnboarding();
@@ -29,12 +30,16 @@ export function OnboardingModal() {
   }, [dismissOnboarding, pickAndAddProject]);
 
   const handleOpenHelp = useCallback(() => {
-    window.open(HELP_URL, '_blank');
-  }, []);
+    dismissOnboarding();
+    setExplorerTab('help');
+  }, [dismissOnboarding, setExplorerTab]);
 
   const handleOpenExtensibility = useCallback(() => {
-    window.open(EXTENSIBILITY_URL, '_blank');
-  }, []);
+    dismissOnboarding();
+    setExplorerTab('settings');
+    setSettingsContext('app');
+    setSettingsSubPage('plugins');
+  }, [dismissOnboarding, setExplorerTab, setSettingsContext, setSettingsSubPage]);
 
   // Escape key to dismiss
   useEffect(() => {

--- a/src/renderer/features/onboarding/illustrations.tsx
+++ b/src/renderer/features/onboarding/illustrations.tsx
@@ -51,15 +51,15 @@ export function ClubhouseStructureIllustration({ className }: { className?: stri
       <rect x="30" y="105" width="50" height="8" rx="4" fill="rgb(var(--ctp-surface2))" />
 
       <rect x="115" y="30" width="90" height="70" rx="12" fill="rgb(var(--ctp-surface0))" />
-      <text x="160" y="55" textAnchor="middle" fontSize="10" fill="rgb(var(--ctp-subtext0))">Quick Agents</text>
-      <circle cx="140" cy="78" r="6" fill="rgb(var(--ctp-accent))" opacity="0.5" />
-      <circle cx="160" cy="78" r="6" fill="rgb(var(--ctp-accent))" opacity="0.7" />
-      <circle cx="180" cy="78" r="6" fill="rgb(var(--ctp-accent))" opacity="0.9" />
+      <text x="160" y="55" textAnchor="middle" fontSize="10" fill="rgb(var(--ctp-subtext0))">Durable Agents</text>
+      <rect x="130" y="70" width="60" height="6" rx="3" fill="rgb(var(--ctp-accent))" opacity="0.4" />
+      <rect x="130" y="80" width="40" height="6" rx="3" fill="rgb(var(--ctp-accent))" opacity="0.6" />
 
       <rect x="115" y="115" width="90" height="70" rx="12" fill="rgb(var(--ctp-surface0))" />
-      <text x="160" y="142" textAnchor="middle" fontSize="10" fill="rgb(var(--ctp-subtext0))">Durable Agents</text>
-      <rect x="130" y="155" width="60" height="6" rx="3" fill="rgb(var(--ctp-accent))" opacity="0.4" />
-      <rect x="130" y="165" width="40" height="6" rx="3" fill="rgb(var(--ctp-accent))" opacity="0.6" />
+      <text x="160" y="142" textAnchor="middle" fontSize="10" fill="rgb(var(--ctp-subtext0))">Quick Agents</text>
+      <circle cx="140" cy="163" r="6" fill="rgb(var(--ctp-accent))" opacity="0.5" />
+      <circle cx="160" cy="163" r="6" fill="rgb(var(--ctp-accent))" opacity="0.7" />
+      <circle cx="180" cy="163" r="6" fill="rgb(var(--ctp-accent))" opacity="0.9" />
 
       <rect x="220" y="10" width="90" height="180" rx="12" fill="rgb(var(--ctp-surface0))" />
       <text x="265" y="40" textAnchor="middle" fontSize="10" fill="rgb(var(--ctp-subtext0))">Terminal</text>

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -355,11 +355,25 @@ export function PluginListSettings() {
         <h2 className="text-lg font-semibold text-ctp-text mb-1">
           {isAppContext ? 'Plugins' : 'Project Plugins'}
         </h2>
-        <p className="text-xs text-ctp-subtext0 mb-6">
+        <p className="text-xs text-ctp-subtext0 mb-4">
           {isAppContext
             ? 'Enable plugins to make them available. Project-scoped plugins also need to be enabled per project.'
             : `Enable plugins for ${project?.displayName || project?.name || 'this project'}. Only plugins enabled at the app level appear here.`}
         </p>
+        {isAppContext && (
+          <p className="text-xs text-ctp-subtext0 mb-6">
+            Discover and share plugins at the{' '}
+            <a
+              href="https://github.com/Agent-Clubhouse/Clubhouse-Workshop"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-ctp-accent hover:underline"
+              data-testid="workshop-link"
+            >
+              Clubhouse Workshop
+            </a>.
+          </p>
+        )}
 
         {/* Built-in section */}
         {builtinPlugins.length > 0 && (


### PR DESCRIPTION
## Summary

Various UX fixes and improvements to the onboarding flow:

- **Slide 1 (all cohorts):** Swapped Durable Agents above Quick Agents in both the illustration and title to emphasize durable agents first
- **New Dev slide 2:** Updated title to "Agents Use Git Under the Hood" and description to encourage users to tell agents to branch and merge
- **Experienced Dev slide 3:** Updated description to mention that project tools are enabled in the Plugins settings page, making it actionable
- **Help button (Get Started screen):** Now dismisses the onboarding modal and opens the in-app Help view instead of an external URL
- **Extensibility button (Get Started screen):** Now dismisses the onboarding modal and navigates to the in-app Plugins settings page instead of an external URL
- **Plugins settings page:** Added a link to the [Clubhouse Workshop](https://github.com/Agent-Clubhouse/Clubhouse-Workshop) for discovering and sharing plugins

## Test plan

- [x] Unit tests updated: help button test verifies in-app navigation to help view
- [x] Unit tests updated: extensibility button test verifies in-app navigation to plugins settings
- [x] All 65 E2E tests pass (including onboarding flow tests)
- [x] Full `npm run validate` passes (typecheck + unit tests + build + E2E)
- [ ] Manual: verify slide 1 illustration shows Durable Agents on top, Quick Agents on bottom
- [ ] Manual: verify new-dev slide 2 title reads "Agents Use Git Under the Hood"
- [ ] Manual: verify experienced-dev slide 3 mentions Plugins settings
- [ ] Manual: verify Help button in Get Started screen opens in-app help view
- [ ] Manual: verify Extensibility button opens Plugins settings with Workshop link visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)