### PR TITLE
feat: Add true fullscreen mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog } from 'electron';
+import { IPC } from '../shared/ipc-channels';
 import { registerAllHandlers } from './ipc';
 import { killAll } from './services/pty-manager';
 import { restoreAll } from './services/config-pipeline';
@@ -65,6 +66,7 @@ const createWindow = (): void => {
     minWidth: 900,
     minHeight: 600,
     show: false,
+    fullscreen: true,
     titleBarStyle: 'hiddenInset',
     backgroundColor: getThemeBgColor(),
     webPreferences: {
@@ -79,6 +81,13 @@ const createWindow = (): void => {
   // Show window once the renderer is ready (avoids white flash on startup).
   mainWindow.once('ready-to-show', () => {
     mainWindow?.show();
+  });
+
+  mainWindow.on('enter-full-screen', () => {
+    mainWindow?.webContents.send(IPC.APP.FULLSCREEN_CHANGED, true);
+  });
+  mainWindow.on('leave-full-screen', () => {
+    mainWindow?.webContents.send(IPC.APP.FULLSCREEN_CHANGED, false);
   });
 
   if (process.env.NODE_ENV === 'development' || !app.isPackaged) {

--- a/src/main/ipc/app-handlers.ts
+++ b/src/main/ipc/app-handlers.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { app, ipcMain, shell } from 'electron';
+import { app, ipcMain, shell, BrowserWindow } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import { ArchInfo, BadgeSettings, LogEntry, LoggingSettings, NotificationSettings } from '../../shared/types';
 import * as notificationService from '../services/notification-service';
@@ -126,6 +126,20 @@ export function registerAppHandlers(): void {
 
   ipcMain.handle(IPC.APP.GET_VERSION_HISTORY, () => {
     return autoUpdateService.getVersionHistory();
+  });
+
+  ipcMain.handle(IPC.APP.TOGGLE_FULLSCREEN, () => {
+    const win = BrowserWindow.getFocusedWindow();
+    if (win) {
+      win.setFullScreen(!win.isFullScreen());
+      return win.isFullScreen();
+    }
+    return false;
+  });
+
+  ipcMain.handle(IPC.APP.GET_FULLSCREEN, () => {
+    const win = BrowserWindow.getFocusedWindow();
+    return win ? win.isFullScreen() : false;
   });
 
   // --- Logging ---

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -347,6 +347,16 @@ const api = {
       ipcRenderer.on(IPC.APP.UPDATE_STATUS_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.APP.UPDATE_STATUS_CHANGED, listener); };
     },
+    toggleFullscreen: (): Promise<boolean> =>
+      ipcRenderer.invoke(IPC.APP.TOGGLE_FULLSCREEN),
+    getFullscreen: (): Promise<boolean> =>
+      ipcRenderer.invoke(IPC.APP.GET_FULLSCREEN),
+    onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, isFullscreen: boolean) =>
+        callback(isFullscreen);
+      ipcRenderer.on(IPC.APP.FULLSCREEN_CHANGED, listener);
+      return () => { ipcRenderer.removeListener(IPC.APP.FULLSCREEN_CHANGED, listener); };
+    },
   },
 };
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -124,6 +124,9 @@ export const IPC = {
     GET_PENDING_RELEASE_NOTES: 'app:get-pending-release-notes',
     CLEAR_PENDING_RELEASE_NOTES: 'app:clear-pending-release-notes',
     GET_VERSION_HISTORY: 'app:get-version-history',
+    TOGGLE_FULLSCREEN: 'app:toggle-fullscreen',
+    GET_FULLSCREEN: 'app:get-fullscreen',
+    FULLSCREEN_CHANGED: 'app:fullscreen-changed',
   },
   PLUGIN: {
     DISCOVER_COMMUNITY: 'plugin:discover-community',


### PR DESCRIPTION
## What

Adds true fullscreen support so Clubhouse takes over the entire screen on launch — no dock, no menu bar, just the app.

## Changes

- **Window launches in fullscreen** — `fullscreen: true` on `BrowserWindow`
- **Fullscreen state IPC** — new `toggleFullscreen`, `getFullscreen`, and `onFullscreenChanged` APIs exposed to the renderer via preload bridge
- **State change events** — main process emits `enter-full-screen` / `leave-full-screen` to the renderer

## How to toggle

Use the existing **View → Toggle Full Screen** menu item (`Ctrl+Cmd+F` on macOS, `F11` on other platforms), or call `window.clubhouse.app.toggleFullscreen()` from the renderer.

## Files changed

- `src/shared/ipc-channels.ts` — added `TOGGLE_FULLSCREEN`, `GET_FULLSCREEN`, `FULLSCREEN_CHANGED` channels
- `src/main/index.ts` — set `fullscreen: true`, emit fullscreen change events
- `src/main/ipc/app-handlers.ts` — IPC handlers for toggle/get
- `src/preload/index.ts` — preload bridge methods