### PR TITLE
feat: add Durable option to agent dropdown menu

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAgentStore } from '../../stores/agentStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useOrchestratorStore } from '../../stores/orchestratorStore';
+import { useQuickAgentStore } from '../../stores/quickAgentStore';
+import { AgentList } from './AgentList';
+import type { Agent } from '../../../shared/types';
+
+// Mock child components
+vi.mock('./AgentListItem', () => ({
+  AgentListItem: (props: any) => (
+    <div data-testid={`agent-item-${props.agent.id}`}>{props.agent.name}</div>
+  ),
+}));
+
+vi.mock('./AddAgentDialog', () => ({
+  AddAgentDialog: ({ onClose }: any) => (
+    <div data-testid="add-agent-dialog">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+vi.mock('./DeleteAgentDialog', () => ({
+  DeleteAgentDialog: () => <div data-testid="delete-agent-dialog" />,
+}));
+
+vi.mock('./QuickAgentGhost', () => ({
+  QuickAgentGhostCompact: () => <div data-testid="quick-agent-ghost" />,
+}));
+
+vi.mock('../../hooks/useModelOptions', () => ({
+  useModelOptions: () => ({
+    options: [{ id: 'default', label: 'Default' }],
+    loading: false,
+  }),
+}));
+
+const defaultAgent: Agent = {
+  id: 'agent-1',
+  projectId: 'proj-1',
+  name: 'bold-falcon',
+  kind: 'durable',
+  status: 'sleeping',
+  color: 'indigo',
+};
+
+function resetStores() {
+  useAgentStore.setState({
+    agents: { [defaultAgent.id]: defaultAgent },
+    activeAgentId: defaultAgent.id,
+    agentIcons: {},
+    agentActivity: {},
+    spawnQuickAgent: vi.fn(),
+    spawnDurableAgent: vi.fn(),
+    loadDurableAgents: vi.fn(),
+    deleteDialogAgent: null,
+    reorderAgents: vi.fn(),
+    recordActivity: vi.fn(),
+    setActiveAgent: vi.fn(),
+  });
+  useProjectStore.setState({
+    projects: [{ id: 'proj-1', name: 'my-app', path: '/project' }],
+    activeProjectId: 'proj-1',
+  });
+  useOrchestratorStore.setState({
+    enabled: ['claude-code'],
+    allOrchestrators: [{
+      id: 'claude-code',
+      displayName: 'Claude Code',
+      shortName: 'CC',
+      capabilities: { headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true },
+    }],
+  });
+  // Only set data — let the store's built-in getters work naturally
+  useQuickAgentStore.setState({
+    completedAgents: { 'proj-1': [] },
+    selectedCompletedId: null,
+  });
+}
+
+describe('AgentList dropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    // pty.onData must return a cleanup function (used directly as useEffect cleanup)
+    window.clubhouse.pty.onData = vi.fn().mockReturnValue(() => {});
+  });
+
+  it('shows both Durable and Quick Agent options in dropdown', () => {
+    render(<AgentList />);
+    const buttons = screen.getAllByRole('button');
+    const dropdownBtn = buttons.find((b) => b.textContent === '\u25BE');
+    expect(dropdownBtn).toBeTruthy();
+    fireEvent.click(dropdownBtn!);
+
+    expect(screen.getByText('Durable')).toBeInTheDocument();
+    expect(screen.getByText('Quick Agent')).toBeInTheDocument();
+  });
+
+  it('opens AddAgentDialog when Durable is clicked in dropdown', () => {
+    render(<AgentList />);
+    const buttons = screen.getAllByRole('button');
+    const dropdownBtn = buttons.find((b) => b.textContent === '\u25BE');
+    fireEvent.click(dropdownBtn!);
+
+    fireEvent.click(screen.getByText('Durable'));
+    expect(screen.getByTestId('add-agent-dialog')).toBeInTheDocument();
+  });
+
+  it('opens AddAgentDialog when top-level + Agent button is clicked', () => {
+    render(<AgentList />);
+    fireEvent.click(screen.getByText('+ Agent'));
+    expect(screen.getByTestId('add-agent-dialog')).toBeInTheDocument();
+  });
+
+  it('shows mission input with correct placeholder when Quick Agent is selected', () => {
+    render(<AgentList />);
+    const buttons = screen.getAllByRole('button');
+    const dropdownBtn = buttons.find((b) => b.textContent === '\u25BE');
+    fireEvent.click(dropdownBtn!);
+
+    fireEvent.click(screen.getByText('Quick Agent'));
+    expect(screen.getByPlaceholderText('What should this quick agent do?')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -229,7 +229,7 @@ export function AgentList() {
             if (e.key === 'Enter' && mission.trim()) handleMissionSubmit();
             if (e.key === 'Escape') handleCancelMission();
           }}
-          placeholder="What should this agent do?"
+          placeholder="What should this quick agent do?"
           className="w-full px-2 py-1.5 text-xs rounded border border-surface-0
             bg-ctp-base text-ctp-text placeholder:text-ctp-overlay0
             focus:outline-none focus:border-indigo-500"
@@ -334,6 +334,17 @@ export function AgentList() {
                 className="fixed bg-ctp-mantle border border-surface-0 rounded-lg shadow-xl py-1 z-50 min-w-[160px]"
                 style={rect ? { top: rect.bottom + 4, right: window.innerWidth - rect.right } : undefined}
               >
+                <button
+                  onClick={() => { setShowDropdown(false); setShowDialog(true); }}
+                  className="w-full px-3 py-1.5 text-xs text-left text-ctp-subtext1 hover:bg-surface-0 hover:text-ctp-text cursor-pointer flex items-center gap-2 whitespace-nowrap"
+                >
+                  <svg className="flex-shrink-0" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10" />
+                    <line x1="12" y1="8" x2="12" y2="16" />
+                    <line x1="8" y1="12" x2="16" y2="12" />
+                  </svg>
+                  Durable
+                </button>
                 <button
                   onClick={handleQuickAgent}
                   className="w-full px-3 py-1.5 text-xs text-left text-ctp-subtext1 hover:bg-surface-0 hover:text-ctp-text cursor-pointer flex items-center gap-2 whitespace-nowrap"


### PR DESCRIPTION
## Summary
- Added a **Durable** option to the agent pane split-button dropdown, alongside the existing **Quick Agent** option. The top-level `+ Agent` button remains the default for creating durable agents.
- Updated the quick agent mission input placeholder from "What should this agent do?" to **"What should this quick agent do?"** for clarity.

## Changes
- `src/renderer/features/agents/AgentList.tsx`: Added "Durable" button to dropdown menu (opens AddAgentDialog, same as top-level button). Updated mission input placeholder text.
- `src/renderer/features/agents/AgentList.test.tsx`: New test suite covering dropdown options, dialog opening behavior, and placeholder text.

## Test plan
- [x] Dropdown shows both "Durable" and "Quick Agent" options
- [x] Clicking "Durable" in dropdown opens AddAgentDialog
- [x] Top-level "+ Agent" button still opens AddAgentDialog
- [x] Clicking "Quick Agent" shows mission input with "What should this quick agent do?" placeholder
- [x] All unit tests pass (4 new tests)
- [x] All E2E tests pass (66/66)
- [x] Full validation passes (typecheck, test, build, e2e)

## Manual validation
- Open the agent pane and click the dropdown arrow (▾) next to "+ Agent"
- Verify both "Durable" and "Quick Agent" options appear
- Click "Durable" — should open the Add Agent dialog
- Click "Quick Agent" — should show the mission input with the updated placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)