### PR TITLE
fix: default clipboard compatibility to enabled on Windows (#109)

### DIFF
--- a/src/main/services/clipboard-settings.ts
+++ b/src/main/services/clipboard-settings.ts
@@ -1,8 +1,9 @@
 import { createSettingsStore } from './settings-store';
 import type { ClipboardSettings } from '../../shared/types';
 
+// Default clipboard compatibility to enabled on Windows where it is required
 const store = createSettingsStore<ClipboardSettings>('clipboard-settings.json', {
-  clipboardCompat: false,
+  clipboardCompat: process.platform === 'win32',
 });
 
 export const getSettings = store.get;

--- a/src/renderer/stores/clipboardSettingsStore.test.ts
+++ b/src/renderer/stores/clipboardSettingsStore.test.ts
@@ -5,10 +5,12 @@ import { useClipboardSettingsStore } from './clipboardSettingsStore';
 const mockGetClipboardSettings = vi.fn(async () => ({ clipboardCompat: false }));
 const mockSaveClipboardSettings = vi.fn(async () => {});
 
+let mockPlatform = 'darwin';
+
 Object.defineProperty(window, 'clubhouse', {
   configurable: true,
   get: () => ({
-    platform: 'darwin',
+    platform: mockPlatform,
     app: {
       getClipboardSettings: mockGetClipboardSettings,
       saveClipboardSettings: mockSaveClipboardSettings,
@@ -19,6 +21,7 @@ Object.defineProperty(window, 'clubhouse', {
 
 describe('clipboardSettingsStore', () => {
   beforeEach(() => {
+    mockPlatform = 'darwin';
     mockGetClipboardSettings.mockReset().mockResolvedValue({ clipboardCompat: false });
     mockSaveClipboardSettings.mockReset();
     // Reset store state
@@ -38,11 +41,21 @@ describe('clipboardSettingsStore', () => {
     expect(useClipboardSettingsStore.getState().loaded).toBe(true);
   });
 
-  it('defaults to false when load returns null', async () => {
+  it('defaults to false on mac when load returns null', async () => {
+    mockPlatform = 'darwin';
     mockGetClipboardSettings.mockResolvedValue(null);
     await useClipboardSettingsStore.getState().loadSettings();
 
     expect(useClipboardSettingsStore.getState().clipboardCompat).toBe(false);
+    expect(useClipboardSettingsStore.getState().loaded).toBe(true);
+  });
+
+  it('defaults to true on windows when load returns null', async () => {
+    mockPlatform = 'win32';
+    mockGetClipboardSettings.mockResolvedValue(null);
+    await useClipboardSettingsStore.getState().loadSettings();
+
+    expect(useClipboardSettingsStore.getState().clipboardCompat).toBe(true);
     expect(useClipboardSettingsStore.getState().loaded).toBe(true);
   });
 

--- a/src/renderer/stores/clipboardSettingsStore.ts
+++ b/src/renderer/stores/clipboardSettingsStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
 
+function defaultClipboardCompat(): boolean {
+  return window.clubhouse.platform === 'win32';
+}
+
 interface ClipboardSettingsState {
   clipboardCompat: boolean;
   loaded: boolean;
@@ -14,7 +18,7 @@ export const useClipboardSettingsStore = create<ClipboardSettingsState>((set, ge
   loadSettings: async () => {
     try {
       const settings = await window.clubhouse.app.getClipboardSettings();
-      set({ clipboardCompat: settings?.clipboardCompat ?? false, loaded: true });
+      set({ clipboardCompat: settings?.clipboardCompat ?? defaultClipboardCompat(), loaded: true });
     } catch {
       set({ loaded: true });
     }


### PR DESCRIPTION
## Summary

Fixes #109 — Paste Compatibility should be default enabled on Windows.

On Windows, the clipboard compatibility mode is required for paste to work correctly in the terminal. Previously it defaulted to `false` on all platforms, requiring Windows users to manually discover and enable the setting.

## Changes

- **`src/main/services/clipboard-settings.ts`**: Default `clipboardCompat` to `true` when running on `win32`
- **`src/renderer/stores/clipboardSettingsStore.ts`**: Fall back to platform-appropriate default (`true` on win32, `false` on mac/linux) when no saved settings exist (i.e. first run)
- **`src/renderer/stores/clipboardSettingsStore.test.ts`**: Added separate test cases for mac (expects `false`) and Windows (expects `true`) fallback defaults

## Behavior

| Platform | No saved settings | Explicit `true` saved | Explicit `false` saved |
|----------|-------------------|------------------------|-------------------------|
| macOS    | `false` (unchanged) | `true` | `false` |
| Windows  | **`true` (new)** | `true` | `false` |

Existing users who have already saved a preference retain their setting; only the default for first-run is changed.

## Testing

- All 2714 unit tests pass (`npm test`)
- Manual validation: Paste (Ctrl+V) should work out of the box on Windows without toggling the setting