### PR TITLE
fix: activity spinner renders behind free agent badge (#121)

### DIFF
--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -114,7 +114,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
         {/* Free Agent Mode badge */}
         {agent.freeAgentMode && (
           <div
-            className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full bg-red-500 flex items-center justify-center ring-2 ring-ctp-base"
+            className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full bg-red-500 flex items-center justify-center ring-2 ring-ctp-base z-20"
             title="Free Agent Mode — all permissions bypassed"
           >
             <span className="text-[9px] font-bold text-white leading-none">!</span>
@@ -123,7 +123,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
         {/* Headless indicator */}
         {agent.headless && agent.status === 'running' && (
           <div
-            className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-ctp-blue flex items-center justify-center ring-2 ring-ctp-base"
+            className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-ctp-blue flex items-center justify-center ring-2 ring-ctp-base z-20"
             title="Running headless"
           >
             <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round">


### PR DESCRIPTION
## Summary

Fixes #121 — the rotating 'bright spinner' highlight was rendering on top of the free agent badge (and headless indicator badge) when an agent was both working and had free agent mode enabled.

## Root Cause

The `.animate-pulse-ring::after` pseudo-element (the rotating conic-gradient ring) had `z-index: 10` in CSS. The absolutely-positioned badge elements had no explicit z-index set, so they defaulted to `z-index: auto` and stacked below the spinner.

## Fix

Added Tailwind's `z-20` class to both the free agent badge and the headless indicator badge in `AgentListItem.tsx`. This ensures both badges always layer above the spinner animation (`z-index: 10`).

## Files Changed

- `src/renderer/features/agents/AgentListItem.tsx` — added `z-20` to free agent mode badge and headless indicator badge

## Manual Validation

1. Start an agent with Free Agent Mode enabled
2. Trigger the agent to perform work (so the spinning animation activates)
4. Verify the same for the headless indicator badge when applicable