### PR TITLE
fix: enable new folder creation in project picker dialog

### DIFF
--- a/src/main/ipc/project-handlers.test.ts
+++ b/src/main/ipc/project-handlers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('electron', () => {
+  const mockWin = {
+    id: 1,
+    isDestroyed: () => false,
+    webContents: { getURL: () => 'http://localhost:3000' },
+  };
+
+  return {
+    BrowserWindow: {
+      getFocusedWindow: vi.fn(() => mockWin),
+      getAllWindows: () => [mockWin],
+    },
+    dialog: {
+      showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] as string[] })),
+    },
+    ipcMain: {
+      handle: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../services/project-store', () => ({
+  list: vi.fn(() => []),
+  add: vi.fn((dirPath: string) => ({ id: 'proj_1', name: 'test', path: dirPath })),
+  remove: vi.fn(),
+  update: vi.fn(),
+  reorder: vi.fn(),
+  setIcon: vi.fn(),
+  readIconData: vi.fn(),
+  saveCroppedIcon: vi.fn(),
+}));
+
+vi.mock('../services/agent-config', () => ({
+  ensureGitignore: vi.fn(),
+}));
+
+vi.mock('../services/log-service', () => ({
+  appLog: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { BrowserWindow, dialog, ipcMain } from 'electron';
+import { IPC } from '../../shared/ipc-channels';
+import { registerProjectHandlers } from './project-handlers';
+
+describe('project-handlers', () => {
+  let handlers: Map<string, (...args: any[]) => any>;
+
+  beforeEach(() => {
+    handlers = new Map();
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: any) => {
+      handlers.set(channel, handler);
+    });
+    registerProjectHandlers();
+  });
+
+  it('registers PICK_DIR handler', () => {
+    expect(handlers.has(IPC.PROJECT.PICK_DIR)).toBe(true);
+  });
+
+  it('PICK_DIR opens dialog with createDirectory property', async () => {
+    const handler = handlers.get(IPC.PROJECT.PICK_DIR)!;
+    await handler({});
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        properties: expect.arrayContaining(['openDirectory', 'createDirectory']),
+      }),
+    );
+  });
+
+  it('PICK_DIR returns null when no focused window', async () => {
+    vi.mocked(BrowserWindow.getFocusedWindow).mockReturnValueOnce(null);
+    const handler = handlers.get(IPC.PROJECT.PICK_DIR)!;
+    const result = await handler({});
+    expect(result).toBeNull();
+  });
+
+  it('PICK_DIR returns null when dialog is canceled', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+      canceled: true,
+      filePaths: [],
+    });
+    const handler = handlers.get(IPC.PROJECT.PICK_DIR)!;
+    const result = await handler({});
+    expect(result).toBeNull();
+  });
+
+  it('PICK_DIR returns selected path on success', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+      canceled: false,
+      filePaths: ['/Users/me/new-project'],
+    });
+    const handler = handlers.get(IPC.PROJECT.PICK_DIR)!;
+    const result = await handler({});
+    expect(result).toBe('/Users/me/new-project');
+  });
+});

--- a/src/main/ipc/project-handlers.ts
+++ b/src/main/ipc/project-handlers.ts
@@ -30,7 +30,7 @@ export function registerProjectHandlers(): void {
     const win = BrowserWindow.getFocusedWindow();
     if (!win) return null;
     const result = await dialog.showOpenDialog(win, {
-      properties: ['openDirectory'],
+      properties: ['openDirectory', 'createDirectory'],
       title: 'Select Project Directory',
     });
     if (result.canceled || result.filePaths.length === 0) return null;


### PR DESCRIPTION
## Summary
- Adds `createDirectory` property to `dialog.showOpenDialog` in the project directory picker, enabling users to create new folders directly from the dialog when adding a project
- Fixes #110 — users could only select existing folders, not create new ones

## Changes
- **`src/main/ipc/project-handlers.ts`**: Added `'createDirectory'` to the `properties` array in the `PICK_DIR` handler. This is a macOS-specific Electron dialog property that shows a "New Folder" button in the native directory picker. On Windows, the native directory picker already includes this button by default.
- **`src/main/ipc/project-handlers.test.ts`**: New unit test file covering the `PICK_DIR` handler — verifies `createDirectory` is passed, and covers null window, canceled dialog, and successful selection paths.

## Test plan
- [x] Unit tests verify `createDirectory` property is included in dialog options
- [x] Unit tests cover edge cases (no focused window, canceled dialog, successful selection)
- [x] Full validation passes (typecheck, unit tests, build, E2E)
- [ ] **Manual (macOS)**: Click "+" to add a project → verify "New Folder" button appears in the directory picker dialog
- [ ] **Manual (Windows)**: Click "+" to add a project → verify "New Folder" button is available (should already be present natively)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)