### PR TITLE
feat: detect agent config changes on sleep

### DIFF
--- a/src/main/services/config-diff-service.test.ts
+++ b/src/main/services/config-diff-service.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/test-app' },
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  rmSync: vi.fn(),
+}));
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+}));
+
+vi.mock('./clubhouse-mode-settings', () => ({
+  getSettings: vi.fn(() => ({ enabled: false })),
+}));
+
+vi.mock('./git-exclude-manager', () => ({
+  addExclusions: vi.fn(),
+  removeExclusions: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { computeConfigDiff, propagateChanges } from './config-diff-service';
+import type { DurableAgentConfig } from '../../shared/types';
+import type { OrchestratorProvider, OrchestratorConventions } from '../orchestrators/types';
+
+// --- Fixtures ---
+
+const testAgent: DurableAgentConfig = {
+  id: 'test_001',
+  name: 'bold-falcon',
+  color: 'blue',
+  branch: 'bold-falcon/standby',
+  worktreePath: '/project/.clubhouse/agents/bold-falcon',
+  createdAt: '2024-01-01',
+};
+
+const testConventions: OrchestratorConventions = {
+  configDir: '.claude',
+  localInstructionsFile: 'CLAUDE.local.md',
+  legacyInstructionsFile: 'CLAUDE.md',
+  mcpConfigFile: '.mcp.json',
+  skillsDir: 'skills',
+  agentTemplatesDir: 'agents',
+  localSettingsFile: 'settings.local.json',
+};
+
+const mockProvider: OrchestratorProvider = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  shortName: 'CC',
+  conventions: testConventions,
+  writeInstructions: vi.fn(),
+  readInstructions: vi.fn(() => ''),
+  getCapabilities: vi.fn(() => ({
+    headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true,
+  })),
+  checkAvailability: vi.fn(async () => ({ available: true })),
+  buildSpawnCommand: vi.fn(async () => ({ binary: 'claude', args: [], env: {} })),
+  getExitCommand: vi.fn(() => '/exit'),
+  writeHooksConfig: vi.fn(async () => {}),
+  parseHookEvent: vi.fn(() => null),
+  getModelOptions: vi.fn(async () => []),
+  getDefaultPermissions: vi.fn(() => []),
+  toolVerb: vi.fn(() => undefined),
+  buildSummaryInstruction: vi.fn(() => ''),
+  readQuickSummary: vi.fn(async () => null),
+};
+
+/**
+ * Helper to configure fs.readFileSync mock responses based on file path patterns.
+ * Each call to readFileSync returns data based on the path argument.
+ * Patterns are sorted longest-first to avoid partial matches (e.g. settings.local.json before settings.json).
+ * Also configures existsSync to return true for paths matching these patterns.
+ */
+function mockFileSystem(files: Record<string, string>): void {
+  const sortedEntries = Object.entries(files).sort(
+    ([a], [b]) => b.length - a.length,
+  );
+  vi.mocked(fs.readFileSync).mockImplementation((p: unknown) => {
+    const filePath = String(p);
+    for (const [pattern, content] of sortedEntries) {
+      if (filePath.includes(pattern)) return content;
+    }
+    throw new Error('ENOENT');
+  });
+  vi.mocked(fs.existsSync).mockImplementation((p: unknown) => {
+    const filePath = String(p);
+    for (const [pattern] of sortedEntries) {
+      if (filePath.includes(pattern)) return true;
+    }
+    return false;
+  });
+}
+
+function agentsJsonWith(agent: DurableAgentConfig): string {
+  return JSON.stringify([agent]);
+}
+
+function settingsJsonWith(agentDefaults: Record<string, unknown>): string {
+  return JSON.stringify({ defaults: {}, quickOverrides: {}, agentDefaults });
+}
+
+describe('config-diff-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+  });
+
+  describe('computeConfigDiff', () => {
+    it('returns empty diff when agent matches defaults', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          instructions: 'Agent @@AgentName at @@Path',
+          permissions: { allow: ['Read(@@Path**)'] },
+        }),
+        'settings.local.json': JSON.stringify({
+          permissions: { allow: ['Read(.clubhouse/agents/bold-falcon/**)'] },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue(
+        'Agent bold-falcon at .clubhouse/agents/bold-falcon/',
+      );
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(false);
+      expect(result.items).toHaveLength(0);
+    });
+
+    it('detects added permission rules (allow)', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          permissions: { allow: ['Read(@@Path**)'] },
+        }),
+        'settings.local.json': JSON.stringify({
+          permissions: { allow: ['Read(.clubhouse/agents/bold-falcon/**)', 'Bash(npm test:*)'] },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const addedAllow = result.items.filter(
+        (i) => i.category === 'permissions-allow' && i.action === 'added',
+      );
+      expect(addedAllow).toHaveLength(1);
+      expect(addedAllow[0].label).toBe('Bash(npm test:*)');
+    });
+
+    it('detects removed permission rules (allow)', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          permissions: { allow: ['Read(@@Path**)', 'Edit(@@Path**)'] },
+        }),
+        'settings.local.json': JSON.stringify({
+          permissions: { allow: ['Read(.clubhouse/agents/bold-falcon/**)'] },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const removed = result.items.filter(
+        (i) => i.category === 'permissions-allow' && i.action === 'removed',
+      );
+      expect(removed).toHaveLength(1);
+      expect(removed[0].label).toContain('Edit');
+    });
+
+    it('detects added and removed deny rules', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          permissions: { deny: ['Write(../**)'] },
+        }),
+        'settings.local.json': JSON.stringify({
+          permissions: { deny: ['Read(../**)'] },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const addedDeny = result.items.filter(
+        (i) => i.category === 'permissions-deny' && i.action === 'added',
+      );
+      const removedDeny = result.items.filter(
+        (i) => i.category === 'permissions-deny' && i.action === 'removed',
+      );
+      expect(addedDeny).toHaveLength(1);
+      expect(removedDeny).toHaveLength(1);
+    });
+
+    it('detects modified instructions', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          instructions: 'Original instructions for @@AgentName',
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue(
+        'Modified instructions for bold-falcon with extra content',
+      );
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const instrItem = result.items.find((i) => i.category === 'instructions');
+      expect(instrItem).toBeDefined();
+      expect(instrItem!.action).toBe('modified');
+      expect(instrItem!.agentValue).toContain('Modified');
+      expect(instrItem!.defaultValue).toContain('Original');
+    });
+
+    it('detects added MCP servers', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          mcpJson: '{"mcpServers": {"existing": {"command": "test"}}}',
+        }),
+        '.mcp.json': JSON.stringify({
+          mcpServers: {
+            existing: { command: 'test' },
+            newServer: { command: 'new-cmd' },
+          },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const added = result.items.filter((i) => i.category === 'mcp' && i.action === 'added');
+      expect(added).toHaveLength(1);
+      expect(added[0].label).toContain('newServer');
+    });
+
+    it('detects removed MCP servers', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          mcpJson: '{"mcpServers": {"server1": {"command": "a"}, "server2": {"command": "b"}}}',
+        }),
+        '.mcp.json': JSON.stringify({
+          mcpServers: { server1: { command: 'a' } },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const removed = result.items.filter((i) => i.category === 'mcp' && i.action === 'removed');
+      expect(removed).toHaveLength(1);
+      expect(removed[0].label).toContain('server2');
+    });
+
+    it('detects modified MCP servers', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          mcpJson: '{"mcpServers": {"server1": {"command": "old"}}}',
+        }),
+        '.mcp.json': JSON.stringify({
+          mcpServers: { server1: { command: 'new' } },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(true);
+      const modified = result.items.filter((i) => i.category === 'mcp' && i.action === 'modified');
+      expect(modified).toHaveLength(1);
+    });
+
+    it('skips diff when clubhouseModeOverride is true', () => {
+      const overrideAgent = { ...testAgent, clubhouseModeOverride: true };
+      mockFileSystem({
+        'agents.json': agentsJsonWith(overrideAgent),
+        'settings.json': settingsJsonWith({ instructions: 'Different' }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('Completely different');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(false);
+      expect(result.items).toHaveLength(0);
+    });
+
+    it('returns empty result when no project defaults exist', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': JSON.stringify({ defaults: {}, quickOverrides: {} }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      expect(result.hasDiffs).toBe(false);
+    });
+
+    it('detects added skills', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': JSON.stringify({ defaults: {}, quickOverrides: {} }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      // Override existsSync to handle agents.json + SKILL.md checks
+      vi.mocked(fs.existsSync).mockImplementation((p: unknown) => {
+        const filePath = String(p);
+        return filePath.includes('agents.json') || filePath.includes('README.md');
+      });
+
+      // Agent has a skill in its worktree, project has none
+      vi.mocked(fs.readdirSync).mockImplementation((p: unknown) => {
+        const dirPath = String(p);
+        if (dirPath.includes('bold-falcon') && dirPath.includes('skills')) {
+          return [{ name: 'custom-skill', isDirectory: () => true, isFile: () => false }] as any;
+        }
+        return [];
+      });
+
+      const result = computeConfigDiff({ projectPath: '/project', agentId: 'test_001', provider: mockProvider });
+
+      const addedSkills = result.items.filter((i) => i.category === 'skills' && i.action === 'added');
+      expect(addedSkills).toHaveLength(1);
+      expect(addedSkills[0].label).toContain('custom-skill');
+    });
+  });
+
+  describe('propagateChanges', () => {
+    it('correctly merges permission additions', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          permissions: { allow: ['Read(@@Path**)'] },
+        }),
+        'settings.local.json': JSON.stringify({
+          permissions: { allow: ['Read(.clubhouse/agents/bold-falcon/**)', 'Bash(npm test:*)'] },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = propagateChanges({
+        projectPath: '/project',
+        agentId: 'test_001',
+        selectedItemIds: ['permissions-allow:added:Bash(npm test:*)'],
+        provider: mockProvider,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.propagatedCount).toBe(1);
+
+      // Verify writeFileSync was called with updated settings
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+        (call) => String(call[0]).includes('settings.json'),
+      );
+      expect(writeCall).toBeDefined();
+      const written = JSON.parse(writeCall![1] as string);
+      expect(written.agentDefaults.permissions.allow).toContain('Bash(npm test:*)');
+    });
+
+    it('correctly merges permission removals', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          permissions: { allow: ['Read(@@Path**)', 'Edit(@@Path**)'] },
+        }),
+        'settings.local.json': JSON.stringify({
+          permissions: { allow: ['Read(.clubhouse/agents/bold-falcon/**)'] },
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue('');
+
+      const result = propagateChanges({
+        projectPath: '/project',
+        agentId: 'test_001',
+        selectedItemIds: ['permissions-allow:removed:Edit(.clubhouse/agents/bold-falcon/**)'],
+        provider: mockProvider,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.propagatedCount).toBe(1);
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+        (call) => String(call[0]).includes('settings.json'),
+      );
+      expect(writeCall).toBeDefined();
+      const written = JSON.parse(writeCall![1] as string);
+      expect(written.agentDefaults.permissions.allow).not.toContain('Edit(@@Path**)');
+    });
+
+    it('correctly updates instructions with unreplace', () => {
+      mockFileSystem({
+        'agents.json': agentsJsonWith(testAgent),
+        'settings.json': settingsJsonWith({
+          instructions: 'Original @@AgentName',
+        }),
+      });
+      vi.mocked(mockProvider.readInstructions).mockReturnValue(
+        'Updated bold-falcon instructions at .clubhouse/agents/bold-falcon/',
+      );
+
+      const result = propagateChanges({
+        projectPath: '/project',
+        agentId: 'test_001',
+        selectedItemIds: ['instructions:modified'],
+        provider: mockProvider,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.propagatedCount).toBe(1);
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+        (call) => String(call[0]).includes('settings.json'),
+      );
+      expect(writeCall).toBeDefined();
+      const written = JSON.parse(writeCall![1] as string);
+      // Should have unreplaced agent values back to wildcards
+      expect(written.agentDefaults.instructions).toContain('@@AgentName');
+      expect(written.agentDefaults.instructions).toContain('@@Path');
+      expect(written.agentDefaults.instructions).not.toContain('bold-falcon');
+    });
+
+    it('returns error when agent not found', () => {
+      mockFileSystem({
+        'agents.json': JSON.stringify([]),
+      });
+
+      const result = propagateChanges({
+        projectPath: '/project',
+        agentId: 'nonexistent',
+        selectedItemIds: [],
+        provider: mockProvider,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('not found');
+    });
+  });
+});

--- a/src/main/services/config-diff-service.ts
+++ b/src/main/services/config-diff-service.ts
@@ -1,0 +1,555 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ConfigDiffItem, ConfigDiffResult, DurableAgentConfig } from '../../shared/types';
+import { replaceWildcards, unreplaceWildcards } from '../../shared/wildcard-replacer';
+import { OrchestratorProvider } from '../orchestrators/types';
+import {
+  readProjectAgentDefaults,
+  readPermissions,
+  readMcpRawJson,
+  readSkillContent,
+  listSkills,
+  listAgentTemplates,
+  readAgentTemplateContent,
+  listSourceSkills,
+  listSourceAgentTemplates,
+  readSourceSkillContent,
+  readSourceAgentTemplateContent,
+  writeProjectAgentDefaults,
+  writeSourceSkillContent,
+  deleteSourceSkill,
+  writeSourceAgentTemplateContent,
+  deleteSourceAgentTemplate,
+} from './agent-settings-service';
+import { getDurableConfig } from './agent-config';
+import { buildWildcardContext, resolveSourceControlProvider } from './materialization-service';
+import { appLog } from './log-service';
+
+/**
+ * Compute config diffs between an agent's current worktree state
+ * and the project-level defaults (what would be materialized on next wake).
+ */
+export function computeConfigDiff(params: {
+  projectPath: string;
+  agentId: string;
+  provider: OrchestratorProvider;
+}): ConfigDiffResult {
+  const { projectPath, agentId, provider } = params;
+  const agent = getDurableConfig(projectPath, agentId);
+  if (!agent) {
+    return { agentId, agentName: '', hasDiffs: false, items: [] };
+  }
+
+  // Skip if agent opted out of materialization
+  if (agent.clubhouseModeOverride) {
+    return { agentId, agentName: agent.name, hasDiffs: false, items: [] };
+  }
+
+  const worktreePath = agent.worktreePath;
+  if (!worktreePath) {
+    return { agentId, agentName: agent.name, hasDiffs: false, items: [] };
+  }
+
+  const defaults = readProjectAgentDefaults(projectPath);
+  const scp = resolveSourceControlProvider(projectPath);
+  const ctx = buildWildcardContext(agent, projectPath, scp);
+  const conv = provider.conventions;
+
+  const items: ConfigDiffItem[] = [];
+
+  // 1. Instructions
+  diffInstructions(items, defaults.instructions, worktreePath, provider, ctx);
+
+  // 2. Permissions
+  diffPermissions(items, defaults.permissions, worktreePath, conv, ctx);
+
+  // 3. MCP
+  diffMcp(items, defaults.mcpJson, worktreePath, conv, ctx);
+
+  // 4. Skills
+  diffSkills(items, projectPath, worktreePath, conv, ctx);
+
+  // 5. Agent templates
+  diffAgentTemplates(items, projectPath, worktreePath, conv, ctx);
+
+  return {
+    agentId,
+    agentName: agent.name,
+    hasDiffs: items.length > 0,
+    items,
+  };
+}
+
+/**
+ * Propagate selected config changes back to project defaults.
+ */
+export function propagateChanges(params: {
+  projectPath: string;
+  agentId: string;
+  selectedItemIds: string[];
+  provider: OrchestratorProvider;
+}): { ok: boolean; message: string; propagatedCount: number } {
+  const { projectPath, agentId, selectedItemIds, provider } = params;
+  const agent = getDurableConfig(projectPath, agentId);
+  if (!agent) {
+    return { ok: false, message: 'Agent not found', propagatedCount: 0 };
+  }
+
+  const worktreePath = agent.worktreePath;
+  if (!worktreePath) {
+    return { ok: false, message: 'Agent has no worktree', propagatedCount: 0 };
+  }
+
+  const scp = resolveSourceControlProvider(projectPath);
+  const ctx = buildWildcardContext(agent, projectPath, scp);
+  const conv = provider.conventions;
+
+  // Re-compute the diff to get full item data
+  const diffResult = computeConfigDiff({ projectPath, agentId, provider });
+  const itemMap = new Map(diffResult.items.map((item) => [item.id, item]));
+
+  const defaults = readProjectAgentDefaults(projectPath);
+  let propagatedCount = 0;
+
+  for (const itemId of selectedItemIds) {
+    const item = itemMap.get(itemId);
+    if (!item) continue;
+
+    try {
+      switch (item.category) {
+        case 'permissions-allow':
+          propagatePermission(defaults, 'allow', item);
+          propagatedCount++;
+          break;
+        case 'permissions-deny':
+          propagatePermission(defaults, 'deny', item);
+          propagatedCount++;
+          break;
+        case 'instructions':
+          if (item.action === 'modified' && item.agentValue != null) {
+            defaults.instructions = unreplaceWildcards(item.agentValue, ctx);
+            propagatedCount++;
+          }
+          break;
+        case 'mcp':
+          propagateMcp(defaults, item, worktreePath, conv, ctx);
+          propagatedCount++;
+          break;
+        case 'skills':
+          propagateSkill(projectPath, item, worktreePath, conv, ctx);
+          propagatedCount++;
+          break;
+        case 'agent-templates':
+          propagateAgentTemplate(projectPath, item, worktreePath, conv, ctx);
+          propagatedCount++;
+          break;
+      }
+    } catch (err) {
+      appLog('core:config-diff', 'warn', `Failed to propagate item ${itemId}`, {
+        meta: { error: String(err) },
+      });
+    }
+  }
+
+  writeProjectAgentDefaults(projectPath, defaults);
+
+  return {
+    ok: true,
+    message: `Propagated ${propagatedCount} change(s) to project defaults`,
+    propagatedCount,
+  };
+}
+
+// ── Diff helpers ──────────────────────────────────────────────────────────
+
+function diffInstructions(
+  items: ConfigDiffItem[],
+  defaultInstructions: string | undefined,
+  worktreePath: string,
+  provider: OrchestratorProvider,
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  const resolvedDefault = defaultInstructions ? replaceWildcards(defaultInstructions, ctx) : '';
+  const agentInstructions = provider.readInstructions(worktreePath);
+
+  if (normalizeWhitespace(resolvedDefault) !== normalizeWhitespace(agentInstructions)) {
+    if (agentInstructions || resolvedDefault) {
+      items.push({
+        id: 'instructions:modified',
+        category: 'instructions',
+        action: 'modified',
+        label: 'Instructions (CLAUDE.md)',
+        agentValue: agentInstructions,
+        defaultValue: resolvedDefault,
+      });
+    }
+  }
+}
+
+function diffPermissions(
+  items: ConfigDiffItem[],
+  defaultPermissions: { allow?: string[]; deny?: string[] } | undefined,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  const resolvedAllow = new Set(
+    (defaultPermissions?.allow || []).map((r) => replaceWildcards(r, ctx)),
+  );
+  const resolvedDeny = new Set(
+    (defaultPermissions?.deny || []).map((r) => replaceWildcards(r, ctx)),
+  );
+
+  const agentPerms = readPermissions(worktreePath, conv);
+  const agentAllow = new Set(agentPerms.allow || []);
+  const agentDeny = new Set(agentPerms.deny || []);
+
+  // Allow: added
+  for (const rule of agentAllow) {
+    if (!resolvedAllow.has(rule)) {
+      items.push({
+        id: `permissions-allow:added:${rule}`,
+        category: 'permissions-allow',
+        action: 'added',
+        label: rule,
+        agentValue: rule,
+        rawAgentValue: unreplaceWildcards(rule, ctx),
+      });
+    }
+  }
+
+  // Allow: removed
+  for (const rule of resolvedAllow) {
+    if (!agentAllow.has(rule)) {
+      items.push({
+        id: `permissions-allow:removed:${rule}`,
+        category: 'permissions-allow',
+        action: 'removed',
+        label: rule,
+        defaultValue: rule,
+        rawAgentValue: unreplaceWildcards(rule, ctx),
+      });
+    }
+  }
+
+  // Deny: added
+  for (const rule of agentDeny) {
+    if (!resolvedDeny.has(rule)) {
+      items.push({
+        id: `permissions-deny:added:${rule}`,
+        category: 'permissions-deny',
+        action: 'added',
+        label: rule,
+        agentValue: rule,
+        rawAgentValue: unreplaceWildcards(rule, ctx),
+      });
+    }
+  }
+
+  // Deny: removed
+  for (const rule of resolvedDeny) {
+    if (!agentDeny.has(rule)) {
+      items.push({
+        id: `permissions-deny:removed:${rule}`,
+        category: 'permissions-deny',
+        action: 'removed',
+        label: rule,
+        defaultValue: rule,
+        rawAgentValue: unreplaceWildcards(rule, ctx),
+      });
+    }
+  }
+}
+
+function diffMcp(
+  items: ConfigDiffItem[],
+  defaultMcpJson: string | undefined,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  let defaultServers: Record<string, unknown> = {};
+  if (defaultMcpJson) {
+    try {
+      const resolved = replaceWildcards(defaultMcpJson, ctx);
+      const parsed = JSON.parse(resolved);
+      defaultServers = parsed.mcpServers || {};
+    } catch { /* ignore invalid JSON */ }
+  }
+
+  let agentServers: Record<string, unknown> = {};
+  try {
+    const rawJson = readMcpRawJson(worktreePath, conv);
+    const parsed = JSON.parse(rawJson);
+    agentServers = parsed.mcpServers || {};
+  } catch { /* ignore */ }
+
+  const defaultNames = new Set(Object.keys(defaultServers));
+  const agentNames = new Set(Object.keys(agentServers));
+
+  // Added servers
+  for (const name of agentNames) {
+    if (!defaultNames.has(name)) {
+      items.push({
+        id: `mcp:added:${name}`,
+        category: 'mcp',
+        action: 'added',
+        label: `MCP server: ${name}`,
+        agentValue: JSON.stringify(agentServers[name], null, 2),
+      });
+    }
+  }
+
+  // Removed servers
+  for (const name of defaultNames) {
+    if (!agentNames.has(name)) {
+      items.push({
+        id: `mcp:removed:${name}`,
+        category: 'mcp',
+        action: 'removed',
+        label: `MCP server: ${name}`,
+        defaultValue: JSON.stringify(defaultServers[name], null, 2),
+      });
+    }
+  }
+
+  // Modified servers
+  for (const name of agentNames) {
+    if (defaultNames.has(name)) {
+      const agentStr = JSON.stringify(agentServers[name]);
+      const defaultStr = JSON.stringify(defaultServers[name]);
+      if (agentStr !== defaultStr) {
+        items.push({
+          id: `mcp:modified:${name}`,
+          category: 'mcp',
+          action: 'modified',
+          label: `MCP server: ${name}`,
+          agentValue: JSON.stringify(agentServers[name], null, 2),
+          defaultValue: JSON.stringify(defaultServers[name], null, 2),
+        });
+      }
+    }
+  }
+}
+
+function diffSkills(
+  items: ConfigDiffItem[],
+  projectPath: string,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  const sourceSkills = listSourceSkills(projectPath);
+  const agentSkills = listSkills(worktreePath, conv);
+
+  const sourceNames = new Set(sourceSkills.map((s) => s.name));
+  const agentNames = new Set(agentSkills.map((s) => s.name));
+
+  // Added in agent
+  for (const name of agentNames) {
+    if (!sourceNames.has(name)) {
+      items.push({
+        id: `skills:added:${name}`,
+        category: 'skills',
+        action: 'added',
+        label: `Skill: ${name}`,
+        agentValue: readSkillContent(worktreePath, name, conv),
+      });
+    }
+  }
+
+  // Removed from agent
+  for (const name of sourceNames) {
+    if (!agentNames.has(name)) {
+      const sourceContent = readSourceSkillContent(projectPath, name);
+      items.push({
+        id: `skills:removed:${name}`,
+        category: 'skills',
+        action: 'removed',
+        label: `Skill: ${name}`,
+        defaultValue: replaceWildcards(sourceContent, ctx),
+      });
+    }
+  }
+
+  // Modified
+  for (const name of agentNames) {
+    if (sourceNames.has(name)) {
+      const agentContent = readSkillContent(worktreePath, name, conv);
+      const sourceContent = readSourceSkillContent(projectPath, name);
+      const resolvedSource = replaceWildcards(sourceContent, ctx);
+      if (normalizeWhitespace(agentContent) !== normalizeWhitespace(resolvedSource)) {
+        items.push({
+          id: `skills:modified:${name}`,
+          category: 'skills',
+          action: 'modified',
+          label: `Skill: ${name}`,
+          agentValue: agentContent,
+          defaultValue: resolvedSource,
+        });
+      }
+    }
+  }
+}
+
+function diffAgentTemplates(
+  items: ConfigDiffItem[],
+  projectPath: string,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  const sourceTemplates = listSourceAgentTemplates(projectPath);
+  const agentTemplates = listAgentTemplates(worktreePath, conv);
+
+  const sourceNames = new Set(sourceTemplates.map((t) => t.name));
+  const agentNames = new Set(agentTemplates.map((t) => t.name));
+
+  // Added in agent
+  for (const name of agentNames) {
+    if (!sourceNames.has(name)) {
+      items.push({
+        id: `agent-templates:added:${name}`,
+        category: 'agent-templates',
+        action: 'added',
+        label: `Agent template: ${name}`,
+        agentValue: readAgentTemplateContent(worktreePath, name, conv),
+      });
+    }
+  }
+
+  // Removed from agent
+  for (const name of sourceNames) {
+    if (!agentNames.has(name)) {
+      const sourceContent = readSourceAgentTemplateContent(projectPath, name);
+      items.push({
+        id: `agent-templates:removed:${name}`,
+        category: 'agent-templates',
+        action: 'removed',
+        label: `Agent template: ${name}`,
+        defaultValue: replaceWildcards(sourceContent, ctx),
+      });
+    }
+  }
+
+  // Modified
+  for (const name of agentNames) {
+    if (sourceNames.has(name)) {
+      const agentContent = readAgentTemplateContent(worktreePath, name, conv);
+      const sourceContent = readSourceAgentTemplateContent(projectPath, name);
+      const resolvedSource = replaceWildcards(sourceContent, ctx);
+      if (normalizeWhitespace(agentContent) !== normalizeWhitespace(resolvedSource)) {
+        items.push({
+          id: `agent-templates:modified:${name}`,
+          category: 'agent-templates',
+          action: 'modified',
+          label: `Agent template: ${name}`,
+          agentValue: agentContent,
+          defaultValue: resolvedSource,
+        });
+      }
+    }
+  }
+}
+
+// ── Propagation helpers ──────────────────────────────────────────────────
+
+function propagatePermission(
+  defaults: ReturnType<typeof readProjectAgentDefaults>,
+  kind: 'allow' | 'deny',
+  item: ConfigDiffItem,
+): void {
+  if (!defaults.permissions) defaults.permissions = {};
+  if (!defaults.permissions[kind]) defaults.permissions[kind] = [];
+
+  if (item.action === 'added' && item.rawAgentValue) {
+    if (!defaults.permissions[kind]!.includes(item.rawAgentValue)) {
+      defaults.permissions[kind]!.push(item.rawAgentValue);
+    }
+  } else if (item.action === 'removed' && item.rawAgentValue) {
+    defaults.permissions[kind] = defaults.permissions[kind]!.filter(
+      (r) => r !== item.rawAgentValue,
+    );
+  }
+}
+
+function propagateMcp(
+  defaults: ReturnType<typeof readProjectAgentDefaults>,
+  item: ConfigDiffItem,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  let mcpObj: { mcpServers: Record<string, unknown> } = { mcpServers: {} };
+  if (defaults.mcpJson) {
+    try {
+      mcpObj = JSON.parse(defaults.mcpJson);
+      if (!mcpObj.mcpServers) mcpObj.mcpServers = {};
+    } catch { /* start fresh */ }
+  }
+
+  const serverName = item.id.split(':').slice(2).join(':');
+
+  if (item.action === 'removed') {
+    delete mcpObj.mcpServers[serverName];
+  } else {
+    // added or modified — read current agent value and unreplace
+    try {
+      const rawJson = readMcpRawJson(worktreePath, conv);
+      const agentMcp = JSON.parse(rawJson);
+      const serverConfig = agentMcp.mcpServers?.[serverName];
+      if (serverConfig) {
+        const unreplaced = JSON.parse(
+          unreplaceWildcards(JSON.stringify(serverConfig), ctx),
+        );
+        mcpObj.mcpServers[serverName] = unreplaced;
+      }
+    } catch { /* skip */ }
+  }
+
+  defaults.mcpJson = JSON.stringify(mcpObj, null, 2);
+}
+
+function propagateSkill(
+  projectPath: string,
+  item: ConfigDiffItem,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  const skillName = item.id.split(':').slice(2).join(':');
+
+  if (item.action === 'removed') {
+    deleteSourceSkill(projectPath, skillName);
+  } else {
+    // added or modified
+    const agentContent = readSkillContent(worktreePath, skillName, conv);
+    const unreplaced = unreplaceWildcards(agentContent, ctx);
+    writeSourceSkillContent(projectPath, skillName, unreplaced);
+  }
+}
+
+function propagateAgentTemplate(
+  projectPath: string,
+  item: ConfigDiffItem,
+  worktreePath: string,
+  conv: OrchestratorProvider['conventions'],
+  ctx: ReturnType<typeof buildWildcardContext>,
+): void {
+  const templateName = item.id.split(':').slice(2).join(':');
+
+  if (item.action === 'removed') {
+    deleteSourceAgentTemplate(projectPath, templateName);
+  } else {
+    // added or modified
+    const agentContent = readAgentTemplateContent(worktreePath, templateName, conv);
+    const unreplaced = unreplaceWildcards(agentContent, ctx);
+    writeSourceAgentTemplateContent(projectPath, templateName, unreplaced);
+  }
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────
+
+function normalizeWhitespace(s: string): string {
+  return s.trim().replace(/\r\n/g, '\n');
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -257,6 +257,27 @@ const api = {
       agentTemplates: string[];
     } | null> =>
       ipcRenderer.invoke(IPC.AGENT.PREVIEW_MATERIALIZATION, projectPath, agentId),
+    computeConfigDiff: (projectPath: string, agentId: string): Promise<{
+      agentId: string;
+      agentName: string;
+      hasDiffs: boolean;
+      items: Array<{
+        id: string;
+        category: string;
+        action: string;
+        label: string;
+        agentValue?: string;
+        defaultValue?: string;
+        rawAgentValue?: string;
+      }>;
+    }> =>
+      ipcRenderer.invoke(IPC.AGENT.COMPUTE_CONFIG_DIFF, projectPath, agentId),
+    propagateConfigChanges: (projectPath: string, agentId: string, selectedItemIds: string[]): Promise<{
+      ok: boolean;
+      message: string;
+      propagatedCount: number;
+    }> =>
+      ipcRenderer.invoke(IPC.AGENT.PROPAGATE_CONFIG_CHANGES, projectPath, agentId, selectedItemIds),
   },
   file: {
     readTree: (dirPath: string, options?: { includeHidden?: boolean; depth?: number }) => ipcRenderer.invoke(IPC.FILE.READ_TREE, dirPath, options),

--- a/src/renderer/features/agents/ConfigChangesDialog.tsx
+++ b/src/renderer/features/agents/ConfigChangesDialog.tsx
@@ -1,0 +1,331 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAgentStore } from '../../stores/agentStore';
+import { ConfigDiffCategory, ConfigDiffAction } from '../../../shared/types';
+
+interface DiffItem {
+  id: string;
+  category: string;
+  action: string;
+  label: string;
+  agentValue?: string;
+  defaultValue?: string;
+  rawAgentValue?: string;
+}
+
+const CATEGORY_LABELS: Record<ConfigDiffCategory, string> = {
+  'instructions': 'Instructions',
+  'permissions-allow': 'Permissions (Allow)',
+  'permissions-deny': 'Permissions (Deny)',
+  'mcp': 'MCP Servers',
+  'skills': 'Skills',
+  'agent-templates': 'Agent Templates',
+};
+
+const ACTION_BADGE: Record<ConfigDiffAction, { label: string; cls: string }> = {
+  added: { label: '+', cls: 'bg-green-500/20 text-green-300' },
+  removed: { label: '\u2212', cls: 'bg-red-500/20 text-red-300' },
+  modified: { label: '~', cls: 'bg-yellow-500/20 text-yellow-300' },
+};
+
+export function ConfigChangesDialog() {
+  const agentId = useAgentStore((s) => s.configChangesDialogAgent);
+  const projectPath = useAgentStore((s) => s.configChangesProjectPath);
+  const closeDialog = useAgentStore((s) => s.closeConfigChangesDialog);
+  const agents = useAgentStore((s) => s.agents);
+
+  const [items, setItems] = useState<DiffItem[]>([]);
+  const [agentName, setAgentName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [executing, setExecuting] = useState(false);
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+
+  const agent = agentId ? agents[agentId] : null;
+
+  const fetchDiff = useCallback(async () => {
+    if (!agentId || !projectPath) return;
+    setLoading(true);
+    try {
+      const result = await window.clubhouse.agentSettings.computeConfigDiff(projectPath, agentId);
+      setItems(result.items);
+      setAgentName(result.agentName);
+      // Default: select all items
+      setSelectedIds(new Set(result.items.map((i) => i.id)));
+    } catch {
+      setItems([]);
+    }
+    setLoading(false);
+  }, [agentId, projectPath]);
+
+  useEffect(() => {
+    fetchDiff();
+  }, [fetchDiff]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeDialog();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [closeDialog]);
+
+  if (!agentId || !projectPath) return null;
+
+  const toggleItem = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selectedIds.size === items.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(items.map((i) => i.id)));
+    }
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedItems((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    setExecuting(true);
+    try {
+      await window.clubhouse.agentSettings.propagateConfigChanges(
+        projectPath,
+        agentId,
+        Array.from(selectedIds),
+      );
+    } catch {
+      // silent
+    }
+    setExecuting(false);
+    closeDialog();
+  };
+
+  const handleKeepForAgent = async () => {
+    setExecuting(true);
+    try {
+      await window.clubhouse.agent.updateDurableConfig(projectPath, agentId, {
+        clubhouseModeOverride: true,
+      });
+    } catch {
+      // silent
+    }
+    setExecuting(false);
+    closeDialog();
+  };
+
+  const handleDiscard = () => {
+    closeDialog();
+  };
+
+  // Group items by category
+  const grouped = new Map<string, DiffItem[]>();
+  for (const item of items) {
+    const list = grouped.get(item.category) || [];
+    list.push(item);
+    grouped.set(item.category, list);
+  }
+
+  const hasExpandableContent = (item: DiffItem) =>
+    item.category === 'instructions' || item.category === 'skills' || item.category === 'agent-templates';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeDialog}>
+      <div
+        className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[540px] shadow-2xl max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="w-5 h-5 border-2 border-ctp-subtext0 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : items.length === 0 ? (
+          <>
+            <h2 className="text-base font-semibold text-ctp-text mb-2">
+              No config changes detected
+            </h2>
+            <p className="text-sm text-ctp-subtext0 mb-4">
+              {agentName || agent?.name || 'Agent'} has no configuration changes to propagate.
+            </p>
+            <div className="flex justify-end">
+              <button
+                onClick={closeDialog}
+                className="px-3 py-1.5 text-xs rounded bg-surface-1 text-ctp-subtext1
+                  hover:bg-surface-2 cursor-pointer"
+              >
+                Close
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-base font-semibold text-ctp-text mb-1">
+              Config changes detected
+            </h2>
+            <p className="text-xs text-ctp-subtext0 mb-3">
+              {agentName || agent?.name} accumulated config changes during this session.
+              Save them to Clubhouse so all agents benefit on next wake.
+            </p>
+
+            {/* Select all / deselect all */}
+            <div className="flex items-center gap-2 mb-2">
+              <button
+                onClick={toggleAll}
+                className="text-xs text-ctp-link hover:underline cursor-pointer"
+              >
+                {selectedIds.size === items.length ? 'Deselect all' : 'Select all'}
+              </button>
+              <span className="text-xs text-ctp-subtext0">
+                {selectedIds.size} of {items.length} selected
+              </span>
+            </div>
+
+            {/* Grouped items */}
+            <div className="flex-1 overflow-y-auto min-h-0 mb-3 space-y-3">
+              {Array.from(grouped.entries()).map(([category, categoryItems]) => (
+                <div key={category}>
+                  <div className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider mb-1.5">
+                    {CATEGORY_LABELS[category as ConfigDiffCategory] || category}
+                  </div>
+                  <div className="space-y-1">
+                    {categoryItems.map((item) => {
+                      const badge = ACTION_BADGE[item.action as ConfigDiffAction] || { label: '?', cls: 'bg-gray-500/20 text-gray-300' };
+                      const isExpanded = expandedItems.has(item.id);
+                      const canExpand = hasExpandableContent(item);
+
+                      return (
+                        <div key={item.id} className="bg-surface-0 rounded border border-surface-0">
+                          <div className="flex items-center gap-2 px-2.5 py-1.5">
+                            <input
+                              type="checkbox"
+                              checked={selectedIds.has(item.id)}
+                              onChange={() => toggleItem(item.id)}
+                              className="accent-ctp-accent flex-shrink-0"
+                            />
+                            <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono font-bold flex-shrink-0 ${badge.cls}`}>
+                              {badge.label}
+                            </span>
+                            <span className="text-xs text-ctp-text truncate flex-1">
+                              {item.label}
+                            </span>
+                            {canExpand && (
+                              <button
+                                onClick={() => toggleExpand(item.id)}
+                                className="text-[10px] text-ctp-subtext0 hover:text-ctp-text cursor-pointer flex-shrink-0"
+                              >
+                                {isExpanded ? 'Hide diff' : 'View diff'}
+                              </button>
+                            )}
+                          </div>
+                          {isExpanded && canExpand && (
+                            <div className="px-2.5 pb-2 border-t border-surface-0">
+                              <DiffView
+                                agentValue={item.agentValue || ''}
+                                defaultValue={item.defaultValue || ''}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex justify-between gap-2">
+              <button
+                onClick={handleDiscard}
+                disabled={executing}
+                className="px-3 py-1.5 text-xs rounded bg-surface-1 text-ctp-subtext1
+                  hover:bg-surface-2 cursor-pointer disabled:opacity-50"
+              >
+                Discard
+              </button>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleKeepForAgent}
+                  disabled={executing}
+                  className="px-3 py-1.5 text-xs rounded bg-surface-1 text-ctp-subtext1
+                    hover:bg-surface-2 cursor-pointer disabled:opacity-50"
+                >
+                  Keep for this agent
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={executing || selectedIds.size === 0}
+                  className="px-4 py-1.5 text-xs rounded bg-ctp-accent/80 text-ctp-base
+                    hover:bg-ctp-accent cursor-pointer font-medium disabled:opacity-50 flex items-center gap-1.5"
+                >
+                  {executing && <span className="w-3 h-3 border-2 border-ctp-base/50 border-t-ctp-base rounded-full animate-spin" />}
+                  Save to Clubhouse
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Simple line-by-line diff view with red/green highlighting.
+ */
+function DiffView({ agentValue, defaultValue }: { agentValue: string; defaultValue: string }) {
+  const agentLines = agentValue.split('\n');
+  const defaultLines = defaultValue.split('\n');
+
+  // Simple line-by-line comparison
+  const maxLen = Math.max(agentLines.length, defaultLines.length);
+  const diffLines: Array<{ text: string; type: 'same' | 'added' | 'removed' }> = [];
+
+  for (let i = 0; i < maxLen; i++) {
+    const a = agentLines[i];
+    const d = defaultLines[i];
+    if (a === d) {
+      diffLines.push({ text: a || '', type: 'same' });
+    } else {
+      if (d !== undefined) {
+        diffLines.push({ text: d, type: 'removed' });
+      }
+      if (a !== undefined) {
+        diffLines.push({ text: a, type: 'added' });
+      }
+    }
+  }
+
+  return (
+    <div className="mt-1.5 max-h-[200px] overflow-auto text-[11px] font-mono leading-relaxed">
+      {diffLines.map((line, i) => (
+        <div
+          key={i}
+          className={`px-1.5 ${
+            line.type === 'added'
+              ? 'bg-green-500/10 text-green-300'
+              : line.type === 'removed'
+                ? 'bg-red-500/10 text-red-300'
+                : 'text-ctp-subtext0'
+          }`}
+        >
+          <span className="select-none mr-1.5 text-ctp-subtext0/50">
+            {line.type === 'added' ? '+' : line.type === 'removed' ? '-' : ' '}
+          </span>
+          {line.text || '\u00A0'}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -17,6 +17,8 @@ interface AgentState {
   activeAgentId: string | null;
   agentSettingsOpenFor: string | null;
   deleteDialogAgent: string | null;
+  configChangesDialogAgent: string | null;
+  configChangesProjectPath: string | null;
   agentActivity: Record<string, number>; // agentId -> last data timestamp
   agentSpawnedAt: Record<string, number>; // agentId -> spawn timestamp
   agentDetailedStatus: Record<string, AgentDetailedStatus>;
@@ -27,6 +29,8 @@ interface AgentState {
   closeAgentSettings: () => void;
   openDeleteDialog: (agentId: string) => void;
   closeDeleteDialog: () => void;
+  openConfigChangesDialog: (agentId: string, projectPath: string) => void;
+  closeConfigChangesDialog: () => void;
   executeDelete: (mode: DeleteMode, projectPath: string) => Promise<DeleteResult>;
   spawnQuickAgent: (projectId: string, projectPath: string, mission: string, model?: string, parentAgentId?: string, orchestrator?: string, freeAgentMode?: boolean) => Promise<string>;
   spawnDurableAgent: (projectId: string, projectPath: string, config: DurableAgentConfig, resume: boolean, mission?: string) => Promise<string>;
@@ -56,6 +60,8 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   activeAgentId: null,
   agentSettingsOpenFor: null,
   deleteDialogAgent: null,
+  configChangesDialogAgent: null,
+  configChangesProjectPath: null,
   agentActivity: {},
   agentSpawnedAt: {},
   agentDetailedStatus: {},
@@ -94,6 +100,16 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   openDeleteDialog: (agentId) => set({ deleteDialogAgent: agentId }),
 
   closeDeleteDialog: () => set({ deleteDialogAgent: null }),
+
+  openConfigChangesDialog: (agentId, projectPath) => set({
+    configChangesDialogAgent: agentId,
+    configChangesProjectPath: projectPath,
+  }),
+
+  closeConfigChangesDialog: () => set({
+    configChangesDialogAgent: null,
+    configChangesProjectPath: null,
+  }),
 
   executeDelete: async (mode, projectPath) => {
     const agentId = get().deleteDialogAgent;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -86,6 +86,8 @@ export const IPC = {
     READ_SOURCE_AGENT_TEMPLATE_CONTENT: 'agent:read-source-agent-template-content',
     WRITE_SOURCE_AGENT_TEMPLATE_CONTENT: 'agent:write-source-agent-template-content',
     DELETE_SOURCE_AGENT_TEMPLATE: 'agent:delete-source-agent-template',
+    COMPUTE_CONFIG_DIFF: 'agent:compute-config-diff',
+    PROPAGATE_CONFIG_CHANGES: 'agent:propagate-config-changes',
   },
   FILE: {
     READ_TREE: 'file:read-tree',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -142,6 +142,26 @@ export interface ClubhouseModeSettings {
   sourceControlProvider?: SourceControlProvider;
 }
 
+export type ConfigDiffCategory = 'instructions' | 'permissions-allow' | 'permissions-deny' | 'mcp' | 'skills' | 'agent-templates';
+export type ConfigDiffAction = 'added' | 'removed' | 'modified';
+
+export interface ConfigDiffItem {
+  id: string;                    // e.g. "permissions-allow:Read(.clubhouse/agents/x/**)"
+  category: ConfigDiffCategory;
+  action: ConfigDiffAction;
+  label: string;                 // Human-readable
+  agentValue?: string;           // Current agent value (resolved)
+  defaultValue?: string;         // Project default value (resolved)
+  rawAgentValue?: string;        // Agent value with wildcards re-applied (for propagation)
+}
+
+export interface ConfigDiffResult {
+  agentId: string;
+  agentName: string;
+  hasDiffs: boolean;
+  items: ConfigDiffItem[];
+}
+
 export interface MaterializationPreview {
   instructions: string;
   permissions: PermissionsConfig;


### PR DESCRIPTION
## Summary
- Detects config diffs (permissions, instructions, MCP servers, skills, agent templates) between an agent's worktree state and project-level defaults when the agent goes to sleep
- Shows a dialog letting users propagate changes back to project defaults so all agents benefit on next wake
- Adds `unreplaceWildcards()` to reverse resolved agent-specific values back to wildcard tokens for correct propagation

## New Files
- `src/main/services/config-diff-service.ts` — diff engine + propagation logic
- `src/main/services/config-diff-service.test.ts` — 15 tests covering diff detection and propagation
- `src/renderer/features/agents/ConfigChangesDialog.tsx` — dialog UI with grouped diffs, checkboxes, diff viewer

## Modified Files
- `src/shared/types.ts` — `ConfigDiffCategory`, `ConfigDiffAction`, `ConfigDiffItem`, `ConfigDiffResult` types
- `src/shared/ipc-channels.ts` — `COMPUTE_CONFIG_DIFF`, `PROPAGATE_CONFIG_CHANGES` channels
- `src/shared/wildcard-replacer.ts` — `unreplaceWildcards()` function
- `src/shared/wildcard-replacer.test.ts` — 9 new tests for unreplace
- `src/main/ipc/agent-settings-handlers.ts` — 2 new IPC handlers
- `src/preload/index.ts` — 2 new bridge methods
- `src/renderer/stores/agentStore.ts` — dialog open/close state
- `src/renderer/App.tsx` — hook into sleep transition + mount dialog

## Test plan
- [x] All 3073 unit tests pass
- [x] Build succeeds
- [x] Lint passes
- [ ] Manual: Enable clubhouse mode, wake an agent, approve permissions, let it sleep → dialog appears
- [ ] Manual: Click "Save to Clubhouse" → project defaults updated, next agent wake has rules pre-approved
- [ ] Manual: Click "Keep for this agent" → `clubhouseModeOverride` set, no dialog on future sleeps
- [ ] Manual: Click "Discard" → no changes saved, next wake re-materializes from defaults