### PR TITLE
fix: preserve agent icon when waking from agent view

### DIFF
--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -564,6 +564,49 @@ describe('agentStore', () => {
     });
   });
 
+  describe('spawnDurableAgent', () => {
+    const mockAgent = window.clubhouse.agent as any;
+
+    beforeEach(() => {
+      mockAgent.spawnAgent.mockResolvedValue(undefined);
+    });
+
+    it('preserves icon from config so avatar does not reset to initials', async () => {
+      const config = {
+        id: 'durable_icon',
+        name: 'icon-agent',
+        color: 'indigo',
+        icon: 'durable_icon.png',
+        worktreePath: '/wt/icon-agent',
+        branch: 'icon-agent/standby',
+        createdAt: '2024-01-01',
+        model: 'sonnet',
+      };
+
+      await getState().spawnDurableAgent('proj_1', '/project', config, true);
+
+      const agent = getState().agents['durable_icon'];
+      expect(agent).toBeDefined();
+      expect(agent.icon).toBe('durable_icon.png');
+      expect(agent.status).toBe('running');
+    });
+
+    it('works without icon in config', async () => {
+      const config = {
+        id: 'durable_noicon',
+        name: 'no-icon-agent',
+        color: 'emerald',
+        createdAt: '2024-01-01',
+      };
+
+      await getState().spawnDurableAgent('proj_1', '/project', config, true);
+
+      const agent = getState().agents['durable_noicon'];
+      expect(agent).toBeDefined();
+      expect(agent.icon).toBeUndefined();
+    });
+  });
+
   describe('loadDurableAgents', () => {
     it('loads model from durable config', async () => {
       const mockAgent = window.clubhouse.agent as any;

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -280,6 +280,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       kind: 'durable',
       status: 'running',
       color: config.color,
+      icon: config.icon,
       worktreePath: config.worktreePath,
       branch: config.branch,
       exitCode: undefined,


### PR DESCRIPTION
## Summary
- **Bug**: When waking a sleeping agent from the agent view (or hub), the avatar resets to initials instead of showing the photo override
- **Root cause**: `spawnDurableAgent` in `agentStore.ts` creates a new `Agent` object without copying `icon` from the config. The `AgentAvatar` component checks `agent.icon && iconDataUrl` — since `icon` was `undefined` after wake, it fell through to initials
- **Fix**: Added `icon: config.icon` to the Agent object in `spawnDurableAgent`, matching what `loadDurableAgents` already does

## Test plan
- [x] Added unit test: `spawnDurableAgent > preserves icon from config so avatar does not reset to initials`
- [x] Added unit test: `spawnDurableAgent > works without icon in config`
- [x] All 3101 tests pass
- [x] Typecheck passes
- [x] Build passes

### Manual validation
- Set a photo override on a durable agent
- Put the agent to sleep
- Wake the agent from the agent list view — avatar should show the photo, not initials
- Wake the agent from the hub view — avatar should show the photo, not initials

🤖 Generated with [Claude Code](https://claude.com/claude-code)