### PR TITLE
fix: add QuickAgentDialog to main view and fix Windows test

### DIFF
--- a/src/renderer/App.structural.test.ts
+++ b/src/renderer/App.structural.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Structural regression test: ensures QuickAgentDialog is rendered in every
+ * JSX return path of App.tsx.  Issue #142 was caused by the component being
+ * present in Home/Help/AppPlugin views but missing from the main project view.
+ */
+describe('App.tsx – QuickAgentDialog presence', () => {
+  // Normalize line endings so the test works on Windows (CRLF) and Unix (LF)
+  const source = readFileSync(join(__dirname, 'App.tsx'), 'utf-8').replace(/\r\n/g, '\n');
+
+  it('should include <QuickAgentDialog /> in every JSX return block', () => {
+    // Match only JSX return statements (indented `return (` followed by `<div`)
+    const jsxReturnPattern = /^[ ]{2,}return \(\n\s+<div/gm;
+    const matches = [...source.matchAll(jsxReturnPattern)];
+
+    expect(matches.length).toBeGreaterThanOrEqual(4); // Home, AppPlugin, Help, main
+
+    for (const match of matches) {
+      // Extract the JSX block from the match position to the next closing `);`
+      const startIdx = match.index!;
+      // Find the balanced closing `);\n` for this return block
+      const block = source.slice(startIdx, source.indexOf('\n  );', startIdx) + 5);
+
+      expect(
+        block,
+        `A JSX return block starting at offset ${startIdx} is missing <QuickAgentDialog />`
+      ).toContain('<QuickAgentDialog');
+    }
+  });
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -625,6 +625,7 @@ export function App() {
         </div>
       </div>
       <CommandPalette />
+      <QuickAgentDialog />
       <WhatsNewDialog />
       <OnboardingModal />
       <ConfigChangesDialog />


### PR DESCRIPTION
## Summary
- Adds the missing `<QuickAgentDialog />` to the main project view return block in `App.tsx` (was already present in Home/Help/AppPlugin views but missing from the main project view — Issue #142)
- Fixes the structural regression test (`App.structural.test.ts`) to normalize CRLF → LF line endings before regex matching, which was causing the Windows CI failure in PR #154

## Root Cause
The `App.structural.test.ts` test reads `App.tsx` via `readFileSync` and matches JSX return blocks using a regex with literal `\n`. On Windows, git checks out files with `\r\n` line endings by default, so the regex finds zero matches and the `toBeGreaterThanOrEqual(4)` assertion fails.

## Changes
| File | Change |
|------|--------|
| `src/renderer/App.tsx` | Add `<QuickAgentDialog />` to the main project view return block |
| `src/renderer/App.structural.test.ts` | Add `.replace(/\r\n/g, '\n')` to normalize line endings |

## Test Plan
- [x] Structural regression test passes locally (macOS)
- [x] All 3115 unit/component tests pass (143 test files)
- [x] TypeScript typecheck passes
- [ ] Windows CI should now pass (the `.replace(/\r\n/g, '\n')` fix normalizes line endings before regex matching)

## Resolves
Fixes the Windows test failure in PR #154 (`faithful-urchin/fix-quick-agent-ux`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)