### PR TITLE
fix: show 'Clubhouse' in macOS local network permission dialog

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -41,6 +41,9 @@ const config: ForgeConfig = {
     extendInfo: {
       CFBundleDisplayName: 'Clubhouse',
       NSUserNotificationAlertStyle: 'alert',
+      NSLocalNetworkUsageDescription:
+        'Clubhouse uses your local network to discover and connect to Annex companion devices.',
+      NSBonjourServices: ['_clubhouse-annex._tcp.'],
     },
     osxSign: {
       identity: process.env.APPLE_SIGNING_IDENTITY || '-',

--- a/src/main/forge-plist-entries.test.ts
+++ b/src/main/forge-plist-entries.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Validates that forge.config.ts includes the required macOS Info.plist
+ * entries so the packaged app shows "Clubhouse" (not "Electron") in
+ * system permission dialogs — particularly the local-network prompt
+ * triggered by Bonjour/Annex pairing.
+ */
+describe('forge.config.ts macOS plist entries', () => {
+  const configPath = path.resolve(__dirname, '../../forge.config.ts');
+  const configSource = fs.readFileSync(configPath, 'utf-8');
+
+  it('sets CFBundleDisplayName to Clubhouse', () => {
+    expect(configSource).toContain("CFBundleDisplayName: 'Clubhouse'");
+  });
+
+  it('includes NSLocalNetworkUsageDescription', () => {
+    expect(configSource).toContain('NSLocalNetworkUsageDescription');
+  });
+
+  it('declares _clubhouse-annex._tcp. in NSBonjourServices', () => {
+    expect(configSource).toContain('NSBonjourServices');
+    expect(configSource).toContain('_clubhouse-annex._tcp.');
+  });
+
+  it('sets packagerConfig name to Clubhouse', () => {
+    expect(configSource).toMatch(/name:\s*'Clubhouse'/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `NSLocalNetworkUsageDescription` and `NSBonjourServices` to the Electron Forge packager config's `extendInfo`, so the macOS local network permission dialog displays **"Clubhouse"** instead of **"Electron"** when Annex pairing triggers Bonjour discovery.

## Changes

- **`forge.config.ts`** — Added `NSLocalNetworkUsageDescription` with a user-facing explanation of why local network access is needed, and `NSBonjourServices` declaring the `_clubhouse-annex._tcp.` service type used by the annex server.
- **`src/main/forge-plist-entries.test.ts`** — New regression test verifying the required plist entries are present in the forge config.

## Test plan

- [x] Unit tests verify `CFBundleDisplayName`, `NSLocalNetworkUsageDescription`, `NSBonjourServices`, and packager `name` are all configured correctly
- [x] Full validation passes (typecheck, unit tests, build, E2E)
- [ ] **Manual**: On macOS, reset local network permissions (`tccutil reset SystemPolicyAllNetworking`), launch the packaged app, enable Annex — the permission dialog should say "Allow **Clubhouse** to find devices on local networks?"

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)