### PR TITLE
fix: project settings use project icons (#162)

### DIFF
--- a/src/renderer/panels/ExplorerRail.test.tsx
+++ b/src/renderer/panels/ExplorerRail.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../stores/projectStore';
+import { useUIStore } from '../stores/uiStore';
+import { ExplorerRail } from './ExplorerRail';
+import type { Project } from '../../shared/types';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-1',
+    name: 'test-project',
+    path: '/home/user/test-project',
+    ...overrides,
+  };
+}
+
+function resetStores() {
+  useProjectStore.setState({
+    projects: [],
+    activeProjectId: null,
+    projectIcons: {},
+  });
+  useUIStore.setState({
+    explorerTab: 'settings',
+    settingsContext: 'app',
+  });
+}
+
+describe('SettingsContextPicker (via ExplorerRail)', () => {
+  beforeEach(resetStores);
+
+  it('renders project initials when no icon is set', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+      projectIcons: {},
+    });
+
+    render(<ExplorerRail />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('renders project icon image when icon override is set', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha', icon: 'custom.png' })],
+      projectIcons: { p1: 'data:image/png;base64,abc123' },
+    });
+
+    render(<ExplorerRail />);
+    const img = screen.getByRole('img', { name: 'Alpha' });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'data:image/png;base64,abc123');
+  });
+
+  it('falls back to initials when icon field is set but data URL is missing', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Beta', icon: 'custom.png' })],
+      projectIcons: {},
+    });
+
+    render(<ExplorerRail />);
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('uses project color for initials background', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Gamma', color: 'emerald' })],
+      projectIcons: {},
+    });
+
+    render(<ExplorerRail />);
+    const initial = screen.getByText('G');
+    // emerald hex is #10b981, appended 20 (hex) = ~12.5% opacity
+    expect(initial.closest('span')).toHaveStyle({ color: '#10b981' });
+  });
+
+  it('uses displayName over name for initials', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'original', displayName: 'Custom Name' })],
+      projectIcons: {},
+    });
+
+    render(<ExplorerRail />);
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('Custom Name')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -5,6 +5,7 @@ import { usePluginStore } from '../plugins/plugin-store';
 import { useBadgeStore, aggregateBadges } from '../stores/badgeStore';
 import { useBadgeSettingsStore } from '../stores/badgeSettingsStore';
 import { Badge } from '../components/Badge';
+import { AGENT_COLORS } from '../../shared/name-generator';
 
 interface TabEntry { id: string; label: string; icon: ReactNode }
 
@@ -42,9 +43,15 @@ const CORE_TABS: TabEntry[] = [
   },
 ];
 
+function getSettingsColorHex(colorId?: string): string {
+  if (!colorId) return '#6366f1'; // indigo default
+  return AGENT_COLORS.find((c) => c.id === colorId)?.hex || '#6366f1';
+}
+
 function SettingsContextPicker() {
   const { settingsContext, setSettingsContext } = useUIStore();
   const { projects } = useProjectStore();
+  const projectIcons = useProjectStore((s) => s.projectIcons);
 
   return (
     <div className="flex flex-col bg-ctp-mantle border-r border-surface-0 h-full">
@@ -87,8 +94,15 @@ function SettingsContextPicker() {
               }
             `}
           >
-            <span className="w-[18px] h-[18px] rounded flex items-center justify-center text-[10px] font-bold bg-surface-2 flex-shrink-0">
-              {(p.displayName || p.name).charAt(0).toUpperCase()}
+            <span
+              className="w-[18px] h-[18px] rounded flex items-center justify-center text-[10px] font-bold flex-shrink-0 overflow-hidden"
+              style={p.icon && projectIcons[p.id] ? undefined : { backgroundColor: `${getSettingsColorHex(p.color)}20`, color: getSettingsColorHex(p.color) }}
+            >
+              {p.icon && projectIcons[p.id] ? (
+                <img src={projectIcons[p.id]} alt={(p.displayName || p.name)} className="w-full h-full object-cover" />
+              ) : (
+                (p.displayName || p.name).charAt(0).toUpperCase()
+              )}
             </span>
             <span className="truncate">{p.displayName || p.name}</span>
           </button>


### PR DESCRIPTION
## Summary
- **Fixes #162** — Project rows in the settings context picker now display the project icon when one is set, instead of always showing the default grey initials square
- Falls back to colored initials (using the project's configured color) when no icon is set, matching the visual style used in ProjectRail and Dashboard
- Added `AGENT_COLORS` import and `projectIcons` store access to `SettingsContextPicker`

## Changes
- `src/renderer/panels/ExplorerRail.tsx` — Updated `SettingsContextPicker` to render project icon images when available, with colored initials as fallback
- `src/renderer/panels/ExplorerRail.test.tsx` — New test suite (5 tests) covering icon rendering, fallback behavior, color styling, and displayName usage

## Test plan
- [x] Unit tests: project initials render when no icon is set
- [x] Unit tests: project icon image renders when icon override exists
- [x] Unit tests: falls back to initials when icon field is set but data URL is missing
- [x] Unit tests: project color is applied to initials
- [x] Unit tests: displayName takes precedence over name
- [ ] Manual: open Settings, verify project rows show custom icons for projects that have them
- [ ] Manual: verify projects without icons show colored letter initials (not grey squares)

🤖 Generated with [Claude Code](https://claude.com/claude-code)