### PR TITLE
fix: use Copilot CLI tool names in default permissions

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -53,8 +53,8 @@ function parseModelChoicesFromHelp(helpText: string): Array<{ id: string; label:
   ];
 }
 
-const DEFAULT_DURABLE_PERMISSIONS = ['Bash(git:*)', 'Bash(npm:*)', 'Bash(npx:*)'];
-const DEFAULT_QUICK_PERMISSIONS = ['Bash(git:*)', 'Bash(npm:*)', 'Bash(npx:*)', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
+const DEFAULT_DURABLE_PERMISSIONS = ['shell(git:*)', 'shell(npm:*)', 'shell(npx:*)'];
+const DEFAULT_QUICK_PERMISSIONS = ['shell(git:*)', 'shell(npm:*)', 'shell(npx:*)', 'read', 'edit', 'search'];
 
 const EVENT_NAME_MAP: Record<string, NormalizedHookEvent['kind']> = {
   preToolUse: 'pre_tool',

--- a/src/main/orchestrators/provider-integration.test.ts
+++ b/src/main/orchestrators/provider-integration.test.ts
@@ -463,22 +463,26 @@ describe('Provider integration tests', () => {
       expect(perms).toContain('Grep');
     });
 
-    it('CopilotCli quick agents get PascalCase file tools', () => {
+    it('CopilotCli quick agents get lowercase Copilot CLI tool names', () => {
       const provider = new CopilotCliProvider();
       const perms = provider.getDefaultPermissions('quick');
-      expect(perms).toContain('Read');
-      expect(perms).toContain('Write');
-      expect(perms).toContain('Edit');
-      expect(perms).toContain('Glob');
-      expect(perms).toContain('Grep');
+      expect(perms).toContain('read');
+      expect(perms).toContain('edit');
+      expect(perms).toContain('search');
+      expect(perms).toContain('shell(git:*)');
+      expect(perms).not.toContain('Read');
+      expect(perms).not.toContain('Write');
+      expect(perms).not.toContain('Glob');
+      expect(perms).not.toContain('Grep');
     });
 
-    it('CopilotCli durable agents get PascalCase Bash permissions', () => {
+    it('CopilotCli durable agents get shell-scoped permissions', () => {
       const provider = new CopilotCliProvider();
       const perms = provider.getDefaultPermissions('durable');
-      expect(perms).toContain('Bash(git:*)');
-      expect(perms).toContain('Bash(npm:*)');
-      expect(perms).toContain('Bash(npx:*)');
+      expect(perms).toContain('shell(git:*)');
+      expect(perms).toContain('shell(npm:*)');
+      expect(perms).toContain('shell(npx:*)');
+      expect(perms).not.toContain('Bash(git:*)');
     });
 
     it('CodexCli durable agents get shell-scoped permissions', () => {


### PR DESCRIPTION
## Summary

Fixes #167

The Copilot CLI provider's `DEFAULT_DURABLE_PERMISSIONS` and `DEFAULT_QUICK_PERMISSIONS` were using **Claude Code tool names** (`Bash(git:*)`, `Read`, `Write`, `Edit`, `Glob`, `Grep`) instead of Copilot CLI's actual tool names (`shell`, `read`, `edit`, `search`). This made all default permissions completely ineffective for Copilot CLI users — tools that should be auto-allowed were never matched.

## Changes

- **`src/main/orchestrators/copilot-cli-provider.ts`**: Updated permission constants to use Copilot CLI tool names:
  - `Bash(git:*)` → `shell(git:*)` (same for npm/npx scopes)
  - `Read`, `Write`, `Edit`, `Glob`, `Grep` → `read`, `edit`, `search`
- **`src/main/orchestrators/provider-integration.test.ts`**: Updated test expectations to assert the correct Copilot CLI tool names and added negative assertions to ensure Claude Code names are not present

## Test plan

- [x] All 3125 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Build (make) succeeds
- [x] 89/90 e2e tests pass (1 pre-existing flaky rail-hover-flyout test unrelated to this change)
- [ ] Manual: verify Copilot CLI agents auto-approve `shell(git:*)` for durable agents without prompting
- [ ] Manual: verify Copilot CLI quick agents auto-approve `read`, `edit`, `search` without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)