### PR TITLE
fix: remove headless badge from agent avatars

### DIFF
--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -370,17 +370,6 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
               <span className="text-[9px] font-bold text-white leading-none">!</span>
             </div>
           )}
-          {/* Headless indicator */}
-          {agent.headless && agent.status === 'running' && (
-            <div
-              className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-ctp-blue flex items-center justify-center ring-2 ring-ctp-base z-20"
-              title="Running headless"
-            >
-              <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round">
-                <circle cx="12" cy="12" r="4" />
-              </svg>
-            </div>
-          )}
         </div>
 
         {/* Info */}


### PR DESCRIPTION
## Summary
- Removes the bottom-right headless indicator badge (dark circle with white dot) from all agent avatars
- The only avatar badge that remains is the free agent mode "!" indicator (top-right), shown when free agent mode is enabled
- All other agents show just the basic avatar with status ring

## Changes
- `src/renderer/features/agents/AgentListItem.tsx`: Removed the headless indicator `<div>` block entirely (lines 373-383)

## Test plan
- [x] Typecheck passes
- [x] All 2822 tests pass
- [ ] Manual: Verify running quick agents show no bottom-right badge
- [ ] Manual: Verify running durable headless agents show no bottom-right badge  
- [ ] Manual: Verify free agent mode "!" badge still appears at top-right when enabled
- [ ] Manual: Verify avatar status ring colors still work (green=running, orange=needs permission, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)