### PR TITLE
fix: headless agent timer resets on navigation (#185)

### DIFF
--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -124,13 +124,17 @@ export function HeadlessAgentView({ agent }: Props) {
   const feedRef = useRef<HTMLDivElement>(null);
   const prevCountRef = useRef(0);
   const killAgent = useAgentStore((s) => s.killAgent);
+  const spawnedAt = useAgentStore((s) => s.agentSpawnedAt[agent.id]);
 
-  // Elapsed time counter
+  // Elapsed time counter — use the store's spawn timestamp so remounts
+  // don't reset the timer (fixes #185).
   useEffect(() => {
-    const start = Date.now();
+    const start = spawnedAt || Date.now();
+    setElapsed(Date.now() - start);
+    if (agent.status !== 'running') return;
     const tick = setInterval(() => setElapsed(Date.now() - start), 1000);
     return () => clearInterval(tick);
-  }, [agent.id]);
+  }, [agent.id, spawnedAt, agent.status]);
 
   // Real-time feed from hook events (primary source — instant, no polling delay)
   const appendItem = useCallback((item: FeedItem) => {


### PR DESCRIPTION
## Summary
- Fixes the elapsed-time timer in `HeadlessAgentView` resetting to `0:00` whenever the user navigates away and back
- Uses `agentSpawnedAt` from the agent store (already populated at spawn time) as the timer baseline instead of `Date.now()` at mount time
- Freezes the timer when the agent is no longer running (status !== 'running')

Closes #185

## Changes
- **`HeadlessAgentView.tsx`**: Read `agentSpawnedAt` from the store via `useAgentStore` selector; use it as the `start` baseline in the timer `useEffect`; skip interval setup when agent is not running
- **`HeadlessAgentView.test.tsx`**: Added 3 tests covering:
  - Timer persists across unmount/remount cycles
  - Timer continues ticking while agent is running
  - Timer freezes when agent stops

## Test plan
- [x] Unit tests pass (`npx vitest run src/renderer/features/agents/HeadlessAgentView.test.tsx` — 8/8 pass)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Full test suite passes (3037/3037, 1 pre-existing failure in `app-handlers.test.ts` unrelated)
- [ ] Manual: launch a headless agent, navigate away, navigate back — timer should show correct elapsed time
- [ ] Manual: wait for agent to complete — timer should freeze at final duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)