### PR TITLE
fix: cap unbounded array growth in permissionViolations and feedItems

### DIFF
--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Agent, AgentHookEvent } from '../../../shared/types';
 import { useAgentStore } from '../../stores/agentStore';
 
+export const MAX_FEED_ITEMS = 200;
+
 interface Props {
   agent: Agent;
 }
@@ -138,7 +140,12 @@ export function HeadlessAgentView({ agent }: Props) {
 
   // Real-time feed from hook events (primary source — instant, no polling delay)
   const appendItem = useCallback((item: FeedItem) => {
-    setFeedItems((prev) => [...prev, item]);
+    setFeedItems((prev) => {
+      const updated = [...prev, item];
+      return updated.length > MAX_FEED_ITEMS
+        ? updated.slice(updated.length - MAX_FEED_ITEMS)
+        : updated;
+    });
   }, []);
 
   useEffect(() => {
@@ -252,7 +259,10 @@ export function HeadlessAgentView({ agent }: Props) {
 
         // Only update if we have more items than the current feed
         if (items.length > 0) {
-          setFeedItems((prev) => items.length > prev.length ? items : prev);
+          const capped = items.length > MAX_FEED_ITEMS
+            ? items.slice(items.length - MAX_FEED_ITEMS)
+            : items;
+          setFeedItems((prev) => capped.length > prev.length ? capped : prev);
         }
       } catch {
         // transcript not ready yet

--- a/src/renderer/plugins/plugin-store.ts
+++ b/src/renderer/plugins/plugin-store.ts
@@ -8,6 +8,8 @@ import type {
   PluginPermission,
 } from '../../shared/plugin-types';
 
+export const MAX_PERMISSION_VIOLATIONS = 100;
+
 export interface PermissionViolation {
   pluginId: string;
   pluginName: string;
@@ -173,9 +175,15 @@ export const usePluginStore = create<PluginState>((set) => ({
     }),
 
   recordPermissionViolation: (violation) =>
-    set((s) => ({
-      permissionViolations: [...s.permissionViolations, violation],
-    })),
+    set((s) => {
+      const updated = [...s.permissionViolations, violation];
+      return {
+        permissionViolations:
+          updated.length > MAX_PERMISSION_VIOLATIONS
+            ? updated.slice(updated.length - MAX_PERMISSION_VIOLATIONS)
+            : updated,
+      };
+    }),
 
   clearPermissionViolation: (pluginId) =>
     set((s) => ({


### PR DESCRIPTION
## Summary
Fixes #196 — Two arrays grew without bound causing memory consumption and rendering slowdowns over time.

### Changes
- **`permissionViolations` (plugin-store.ts)**: Capped at 100 entries (`MAX_PERMISSION_VIOLATIONS`). When the limit is exceeded, oldest entries are dropped (rolling window). This prevents unbounded Zustand state growth and unnecessary re-renders.
- **`feedItems` (HeadlessAgentView.tsx)**: Capped at 200 entries (`MAX_FEED_ITEMS`). Applied to both the real-time hook event path (`appendItem` callback) and the transcript polling path. Long-running agents will now retain only the most recent 200 feed items.

### Test plan
- [x] Added test: `caps violations at MAX_PERMISSION_VIOLATIONS, dropping oldest` — records 120 violations and verifies only the latest 100 are retained
- [x] Added test: `does not trim when at exactly the limit` — records exactly 100 violations and verifies all are retained with no trimming
- [x] Added test: `caps feedItems from hook events at MAX_FEED_ITEMS` — fires 250 hook events and verifies rendered items do not exceed 200
- [x] All 3074 existing tests continue to pass
- [x] Typecheck passes

### Manual validation
- Observe HeadlessAgentView live feed during a long-running agent session — feed should stop growing past 200 items
- Trigger many permission violations via a misbehaving plugin — violations array should cap at 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)