### PR TITLE
fix: eliminate Zustand anti-patterns (#192)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -51,7 +51,6 @@ export function App() {
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const updateAgentStatus = useAgentStore((s) => s.updateAgentStatus);
   const handleHookEvent = useAgentStore((s) => s.handleHookEvent);
-  const _agents = useAgentStore((s) => s.agents);
   const loadDurableAgents = useAgentStore((s) => s.loadDurableAgents);
   const explorerTab = useUIStore((s) => s.explorerTab);
   const pluginsMap = usePluginStore((s) => s.plugins);

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -14,13 +14,18 @@ import type { CompletedQuickAgent } from '../../../shared/types';
 const EMPTY_COMPLETED: CompletedQuickAgent[] = [];
 
 export function AgentList() {
-  const {
-    agents, activeAgentId, setActiveAgent,
-    spawnQuickAgent, spawnDurableAgent,
-    loadDurableAgents, agentActivity, recordActivity,
-    deleteDialogAgent, reorderAgents,
-  } = useAgentStore();
-  const { activeProjectId, projects } = useProjectStore();
+  const agents = useAgentStore((s) => s.agents);
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const setActiveAgent = useAgentStore((s) => s.setActiveAgent);
+  const spawnQuickAgent = useAgentStore((s) => s.spawnQuickAgent);
+  const spawnDurableAgent = useAgentStore((s) => s.spawnDurableAgent);
+  const loadDurableAgents = useAgentStore((s) => s.loadDurableAgents);
+  const agentActivity = useAgentStore((s) => s.agentActivity);
+  const recordActivity = useAgentStore((s) => s.recordActivity);
+  const deleteDialogAgent = useAgentStore((s) => s.deleteDialogAgent);
+  const reorderAgents = useAgentStore((s) => s.reorderAgents);
+  const activeProjectId = useProjectStore((s) => s.activeProjectId);
+  const projects = useProjectStore((s) => s.projects);
   const { options: MODEL_OPTIONS } = useModelOptions();
   const enabled = useOrchestratorStore((s) => s.enabled);
   const allOrchestrators = useOrchestratorStore((s) => s.allOrchestrators);
@@ -32,8 +37,6 @@ export function AgentList() {
     () => (activeProjectId ? allCompleted[activeProjectId] ?? EMPTY_COMPLETED : EMPTY_COMPLETED),
     [allCompleted, activeProjectId]
   );
-  const getCompletedByParent = useQuickAgentStore((s) => s.getCompletedByParent);
-  const getCompletedOrphans = useQuickAgentStore((s) => s.getCompletedOrphans);
   const dismissCompleted = useQuickAgentStore((s) => s.dismissCompleted);
   const clearCompleted = useQuickAgentStore((s) => s.clearCompleted);
   const selectCompleted = useQuickAgentStore((s) => s.selectCompleted);
@@ -98,7 +101,10 @@ export function AgentList() {
   const durableAgents = projectAgents.filter((a) => a.kind === 'durable');
   const quickAgents = projectAgents.filter((a) => a.kind === 'quick');
   const orphanQuickAgents = quickAgents.filter((a) => !a.parentAgentId);
-  const orphanCompleted = activeProjectId ? getCompletedOrphans(activeProjectId) : [];
+  const orphanCompleted = useMemo(
+    () => completedAgents.filter((r) => !r.parentAgentId),
+    [completedAgents]
+  );
 
   useEffect(() => {
     if (showMissionInput && missionInputRef.current) {
@@ -381,7 +387,7 @@ export function AgentList() {
             </div>
             {durableAgents.map((durable, i) => {
               const childQuick = quickAgents.filter((a) => a.parentAgentId === durable.id);
-              const childCompleted = activeProjectId ? getCompletedByParent(activeProjectId, durable.id) : [];
+              const childCompleted = completedAgents.filter((r) => r.parentAgentId === durable.id);
               const isMissionTarget = showMissionInput && quickTargetParentId === durable.id;
 
               return (

--- a/src/renderer/features/projects/Dashboard.tsx
+++ b/src/renderer/features/projects/Dashboard.tsx
@@ -612,7 +612,8 @@ function EmptyState({ onAddProject }: { onAddProject: () => void }) {
 /* ─── Dashboard ─── */
 
 export function Dashboard() {
-  const { projects, pickAndAddProject } = useProjectStore();
+  const projects = useProjectStore((s) => s.projects);
+  const pickAndAddProject = useProjectStore((s) => s.pickAndAddProject);
 
   if (projects.length === 0) {
     return (

--- a/src/renderer/features/settings/OrchestratorSettingsView.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.tsx
@@ -13,8 +13,12 @@ interface Props {
 // ── App-level: global headless toggle + orchestrator enable/disable ──────
 
 function AppAgentSettings() {
-  const { enabled, allOrchestrators, availability, loadSettings, setEnabled, checkAllAvailability } =
-    useOrchestratorStore();
+  const enabled = useOrchestratorStore((s) => s.enabled);
+  const allOrchestrators = useOrchestratorStore((s) => s.allOrchestrators);
+  const availability = useOrchestratorStore((s) => s.availability);
+  const loadSettings = useOrchestratorStore((s) => s.loadSettings);
+  const setEnabled = useOrchestratorStore((s) => s.setEnabled);
+  const checkAllAvailability = useOrchestratorStore((s) => s.checkAllAvailability);
   const headlessEnabled = useHeadlessStore((s) => s.enabled);
   const setHeadlessEnabled = useHeadlessStore((s) => s.setEnabled);
   const clubhouseEnabled = useClubhouseModeStore((s) => s.enabled);

--- a/src/renderer/panels/AccessoryPanel.tsx
+++ b/src/renderer/panels/AccessoryPanel.tsx
@@ -9,7 +9,9 @@ import { AgentList } from '../features/agents/AgentList';
 import { SettingsSubPage } from '../../shared/types';
 
 function SettingsCategoryNav() {
-  const { settingsContext, settingsSubPage, setSettingsSubPage } = useUIStore();
+  const settingsContext = useUIStore((s) => s.settingsContext);
+  const settingsSubPage = useUIStore((s) => s.settingsSubPage);
+  const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
 
   const navButton = (label: string, page: SettingsSubPage) => (
     <button
@@ -89,7 +91,8 @@ function PluginSidebarPanel({ pluginId }: { pluginId: string }) {
 }
 
 export function AccessoryPanel() {
-  const { explorerTab } = useUIStore();
+  const explorerTab = useUIStore((s) => s.explorerTab);
+  const plugins = usePluginStore((s) => s.plugins);
 
   if (explorerTab === 'agents') {
     return (
@@ -106,7 +109,7 @@ export function AccessoryPanel() {
   // Plugin tabs with sidebar layout
   if (explorerTab.startsWith('plugin:')) {
     const pluginId = explorerTab.slice('plugin:'.length);
-    const entry = usePluginStore.getState().plugins[pluginId];
+    const entry = plugins[pluginId];
     const layout = entry?.manifest.contributes?.tab?.layout ?? 'sidebar-content';
 
     if (layout === 'sidebar-content') {

--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -49,8 +49,9 @@ function getSettingsColorHex(colorId?: string): string {
 }
 
 function SettingsContextPicker() {
-  const { settingsContext, setSettingsContext } = useUIStore();
-  const { projects } = useProjectStore();
+  const settingsContext = useUIStore((s) => s.settingsContext);
+  const setSettingsContext = useUIStore((s) => s.setSettingsContext);
+  const projects = useProjectStore((s) => s.projects);
   const projectIcons = useProjectStore((s) => s.projectIcons);
 
   return (
@@ -120,9 +121,10 @@ const PLUGIN_FALLBACK_ICON = (
 
 function TabButton({ tab, isActive, projectId, onClick }: { tab: TabEntry; isActive: boolean; projectId: string | null; onClick: () => void }) {
   const badges = useBadgeStore((s) => s.badges);
+  const badgeSettings = useBadgeSettingsStore();
   const tabBadge = useMemo(() => {
     if (!projectId) return null;
-    const settings = useBadgeSettingsStore.getState().getProjectSettings(projectId);
+    const settings = badgeSettings.getProjectSettings(projectId);
     if (!settings.enabled) return null;
     let filtered = Object.values(badges).filter(
       (b) => b.target.kind === 'explorer-tab' && b.target.projectId === projectId && b.target.tabId === tab.id,
@@ -131,7 +133,7 @@ function TabButton({ tab, isActive, projectId, onClick }: { tab: TabEntry; isAct
       filtered = filtered.filter((b) => !b.source.startsWith('plugin:'));
     }
     return aggregateBadges(filtered);
-  }, [badges, projectId, tab.id]);
+  }, [badges, projectId, tab.id, badgeSettings]);
 
   return (
     <button
@@ -155,8 +157,10 @@ function TabButton({ tab, isActive, projectId, onClick }: { tab: TabEntry; isAct
 }
 
 export function ExplorerRail() {
-  const { explorerTab, setExplorerTab } = useUIStore();
-  const { projects, activeProjectId } = useProjectStore();
+  const explorerTab = useUIStore((s) => s.explorerTab);
+  const setExplorerTab = useUIStore((s) => s.setExplorerTab);
+  const projects = useProjectStore((s) => s.projects);
+  const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const activeProject = projects.find((p) => p.id === activeProjectId);
   const plugins = usePluginStore((s) => s.plugins);
   const projectEnabled = usePluginStore((s) => s.projectEnabled);

--- a/src/renderer/panels/MainContentView.tsx
+++ b/src/renderer/panels/MainContentView.tsx
@@ -25,8 +25,12 @@ import { GettingStartedSettingsView } from '../features/settings/GettingStartedS
 import { KeyboardShortcutsSettingsView } from '../features/settings/KeyboardShortcutsSettingsView';
 
 export function MainContentView() {
-  const { explorerTab, settingsSubPage, settingsContext } = useUIStore();
-  const { activeAgentId, agents, agentSettingsOpenFor } = useAgentStore();
+  const explorerTab = useUIStore((s) => s.explorerTab);
+  const settingsSubPage = useUIStore((s) => s.settingsSubPage);
+  const settingsContext = useUIStore((s) => s.settingsContext);
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const agents = useAgentStore((s) => s.agents);
+  const agentSettingsOpenFor = useAgentStore((s) => s.agentSettingsOpenFor);
   const selectedCompletedId = useQuickAgentStore((s) => s.selectedCompletedId);
   const completedAgentsMap = useQuickAgentStore((s) => s.completedAgents);
   const selectCompleted = useQuickAgentStore((s) => s.selectCompleted);

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -27,8 +27,9 @@ function ProjectIcon({ project, isActive, onClick, expanded }: {
   const letter = label.charAt(0).toUpperCase();
   const hasImage = !!project.icon && !!iconDataUrl;
   const badges = useBadgeStore((s) => s.badges);
+  const badgeSettings = useBadgeSettingsStore();
   const projectBadge = useMemo(() => {
-    const settings = useBadgeSettingsStore.getState().getProjectSettings(project.id);
+    const settings = badgeSettings.getProjectSettings(project.id);
     if (!settings.enabled || !settings.projectRailBadges) return null;
     let filtered = Object.values(badges).filter(
       (b) => b.target.kind === 'explorer-tab' && b.target.projectId === project.id,
@@ -37,7 +38,7 @@ function ProjectIcon({ project, isActive, onClick, expanded }: {
       filtered = filtered.filter((b) => !b.source.startsWith('plugin:'));
     }
     return aggregateBadges(filtered);
-  }, [badges, project.id]);
+  }, [badges, project.id, badgeSettings]);
 
   return (
     <button
@@ -98,14 +99,14 @@ function PluginRailButton({ entry, isActive, onClick, expanded }: {
   const label = entry.manifest.contributes!.railItem!.label;
   const customIcon = entry.manifest.contributes!.railItem!.icon;
   const pluginBadges = useBadgeStore((s) => s.badges);
+  const pluginBadgeSettings = useBadgeSettingsStore();
   const pluginBadge = useMemo(() => {
-    const { enabled, pluginBadges: pluginBadgesEnabled } = useBadgeSettingsStore.getState();
-    if (!enabled || !pluginBadgesEnabled) return null;
+    if (!pluginBadgeSettings.enabled || !pluginBadgeSettings.pluginBadges) return null;
     const filtered = Object.values(pluginBadges).filter(
       (b) => b.target.kind === 'app-plugin' && b.target.pluginId === entry.manifest.id,
     );
     return aggregateBadges(filtered);
-  }, [pluginBadges, entry.manifest.id]);
+  }, [pluginBadges, entry.manifest.id, pluginBadgeSettings]);
 
   return (
     <button

--- a/src/renderer/stores/orchestratorStore.test.ts
+++ b/src/renderer/stores/orchestratorStore.test.ts
@@ -191,8 +191,8 @@ describe('orchestratorStore', () => {
     });
   });
 
-  describe('getEnabledOrchestrators', () => {
-    it('filters allOrchestrators by enabled list', () => {
+  describe('enabled orchestrators (computed inline by consumers)', () => {
+    it('can be computed by filtering allOrchestrators by enabled list', () => {
       useOrchestratorStore.setState({
         enabled: ['claude-code'],
         allOrchestrators: [
@@ -201,7 +201,8 @@ describe('orchestratorStore', () => {
         ],
       });
 
-      const result = useOrchestratorStore.getState().getEnabledOrchestrators();
+      const { enabled, allOrchestrators } = useOrchestratorStore.getState();
+      const result = allOrchestrators.filter((o) => enabled.includes(o.id));
       expect(result).toEqual([{ id: 'claude-code', displayName: 'Claude Code' }]);
     });
 
@@ -211,7 +212,8 @@ describe('orchestratorStore', () => {
         allOrchestrators: [{ id: 'claude-code', displayName: 'Claude Code' } as any],
       });
 
-      const result = useOrchestratorStore.getState().getEnabledOrchestrators();
+      const { enabled, allOrchestrators } = useOrchestratorStore.getState();
+      const result = allOrchestrators.filter((o) => enabled.includes(o.id));
       expect(result).toEqual([]);
     });
   });

--- a/src/renderer/stores/orchestratorStore.ts
+++ b/src/renderer/stores/orchestratorStore.ts
@@ -8,7 +8,6 @@ interface OrchestratorState {
   loadSettings: () => Promise<void>;
   setEnabled: (id: string, enabled: boolean) => Promise<void>;
   checkAllAvailability: () => Promise<void>;
-  getEnabledOrchestrators: () => OrchestratorInfo[];
   getCapabilities: (orchestratorId: string) => ProviderCapabilities | undefined;
 }
 
@@ -65,11 +64,6 @@ export const useOrchestratorStore = create<OrchestratorState>((set, get) => ({
       })
     );
     set({ availability: results });
-  },
-
-  getEnabledOrchestrators: () => {
-    const { enabled, allOrchestrators } = get();
-    return allOrchestrators.filter((o) => enabled.includes(o.id));
   },
 
   getCapabilities: (orchestratorId: string) => {

--- a/src/renderer/stores/quickAgentStore.ts
+++ b/src/renderer/stores/quickAgentStore.ts
@@ -29,11 +29,7 @@ interface QuickAgentState {
   addCompleted: (record: CompletedQuickAgent) => void;
   dismissCompleted: (projectId: string, agentId: string) => void;
   clearCompleted: (projectId: string) => void;
-  getCompleted: (projectId: string) => CompletedQuickAgent[];
-  getCompletedByParent: (projectId: string, parentAgentId: string) => CompletedQuickAgent[];
-  getCompletedOrphans: (projectId: string) => CompletedQuickAgent[];
   selectCompleted: (id: string | null) => void;
-  getSelectedCompleted: () => CompletedQuickAgent | null;
 }
 
 export const useQuickAgentStore = create<QuickAgentState>((set, get) => ({
@@ -72,31 +68,5 @@ export const useQuickAgentStore = create<QuickAgentState>((set, get) => ({
     }));
   },
 
-  getCompleted: (projectId) => {
-    return get().completedAgents[projectId] || [];
-  },
-
-  getCompletedByParent: (projectId, parentAgentId) => {
-    return (get().completedAgents[projectId] || []).filter(
-      (r) => r.parentAgentId === parentAgentId
-    );
-  },
-
-  getCompletedOrphans: (projectId) => {
-    return (get().completedAgents[projectId] || []).filter(
-      (r) => !r.parentAgentId
-    );
-  },
-
   selectCompleted: (id) => set({ selectedCompletedId: id }),
-
-  getSelectedCompleted: () => {
-    const id = get().selectedCompletedId;
-    if (!id) return null;
-    for (const records of Object.values(get().completedAgents)) {
-      const found = records.find((r) => r.id === id);
-      if (found) return found;
-    }
-    return null;
-  },
 }));


### PR DESCRIPTION
## Summary
Fixes multiple Zustand usage anti-patterns in the renderer that cause performance issues and stale UI (issue #192).

### Changes

**Removed infinite-loop footgun methods from stores:**
- Removed `getEnabledOrchestrators()` from `orchestratorStore` — returned new filtered array on every call
- Removed `getCompleted()`, `getCompletedByParent()`, `getCompletedOrphans()`, `getSelectedCompleted()` from `quickAgentStore` — same issue
- Callers now compute filtered results inline from raw state with `useMemo` or direct filtering

**Added proper selectors to prevent excessive re-renders:**
- `MainContentView.tsx`: replaced bare `useUIStore()` and `useAgentStore()` with individual field selectors
- `AccessoryPanel.tsx`: replaced bare `useUIStore()` with field selector
- `OrchestratorSettingsView.tsx`: replaced bare `useOrchestratorStore()` with individual field selectors
- `Dashboard.tsx`: replaced bare `useProjectStore()` with individual field selectors
- `AgentList.tsx`: replaced bare `useAgentStore()` and `useProjectStore()` with individual field selectors
- `ExplorerRail.tsx`: replaced bare `useUIStore()` and `useProjectStore()` destructures with selectors
- `SettingsCategoryNav` (AccessoryPanel): replaced bare `useUIStore()` with selectors

**Removed unused subscription causing app-wide re-renders:**
- Removed `const _agents = useAgentStore((s) => s.agents)` from `App.tsx` — subscribed the entire App tree to all agent mutations but was never used

**Fixed stale UI from imperative `.getState()` reads in render paths:**
- `ExplorerRail.tsx` (`TabButton`): replaced `useBadgeSettingsStore.getState()` in `useMemo` with reactive hook
- `ProjectRail.tsx` (`ProjectIcon`): replaced `useBadgeSettingsStore.getState()` in `useMemo` with reactive hook
- `ProjectRail.tsx` (`PluginRailButton`): replaced `useBadgeSettingsStore.getState()` in `useMemo` with reactive hook
- `AccessoryPanel.tsx`: replaced `usePluginStore.getState().plugins[pluginId]` in render with hook selector

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — all 3071 tests pass (152 files)
- [x] `npm run make` — builds successfully
- [x] `npm run test:e2e` — 89 passed (1 pre-existing flaky)
- [ ] Manual: verify badge settings changes propagate to ExplorerRail tabs and ProjectRail icons without needing a reload
- [ ] Manual: verify completed quick agent lists update correctly in AgentList sidebar
- [ ] Manual: verify plugin sidebar layout detection works in AccessoryPanel

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)