### PR TITLE
fix: handle unhandled promise rejections in annex-server readBody() chains

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -623,7 +623,7 @@ describe('annex-server', () => {
       // The key assertion: no unhandled promise rejection, and appLog was called
       expect(appLog).toHaveBeenCalledWith(
         'core:annex', 'error', 'readBody failed',
-        expect.objectContaining({ error: expect.any(String) }),
+        expect.objectContaining({ meta: expect.objectContaining({ error: expect.any(String) }) }),
       );
     });
 
@@ -643,7 +643,7 @@ describe('annex-server', () => {
 
       expect(appLog).toHaveBeenCalledWith(
         'core:annex', 'error', 'readBody failed',
-        expect.objectContaining({ error: expect.any(String) }),
+        expect.objectContaining({ meta: expect.objectContaining({ error: expect.any(String) }) }),
       );
     });
 
@@ -654,7 +654,7 @@ describe('annex-server', () => {
 
       expect(appLog).toHaveBeenCalledWith(
         'core:annex', 'error', 'readBody failed',
-        expect.objectContaining({ error: expect.any(String) }),
+        expect.objectContaining({ meta: expect.objectContaining({ error: expect.any(String) }) }),
       );
     });
 
@@ -665,7 +665,7 @@ describe('annex-server', () => {
 
       expect(appLog).toHaveBeenCalledWith(
         'core:annex', 'error', 'readBody failed',
-        expect.objectContaining({ error: expect.any(String) }),
+        expect.objectContaining({ meta: expect.objectContaining({ error: expect.any(String) }) }),
       );
     });
   });

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -694,7 +694,7 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): voi
       }
       handleSpawnQuickAgent(res, projectId, null, body);
     }).catch((err) => {
-      appLog('core:annex', 'error', 'readBody failed', { error: String(err) });
+      appLog('core:annex', 'error', 'readBody failed', { meta: { error: err instanceof Error ? err.message : String(err) } });
       res.writeHead(400);
       res.end();
     });
@@ -718,7 +718,7 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): voi
       }
       handleSpawnQuickAgent(res, parentInfo.project.id, parentAgentId, body);
     }).catch((err) => {
-      appLog('core:annex', 'error', 'readBody failed', { error: String(err) });
+      appLog('core:annex', 'error', 'readBody failed', { meta: { error: err instanceof Error ? err.message : String(err) } });
       res.writeHead(400);
       res.end();
     });
@@ -737,7 +737,7 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): voi
       }
       handleWakeAgent(res, agentId, body);
     }).catch((err) => {
-      appLog('core:annex', 'error', 'readBody failed', { error: String(err) });
+      appLog('core:annex', 'error', 'readBody failed', { meta: { error: err instanceof Error ? err.message : String(err) } });
       res.writeHead(400);
       res.end();
     });
@@ -756,7 +756,7 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): voi
       }
       handlePermissionResponse(res, agentId, body);
     }).catch((err) => {
-      appLog('core:annex', 'error', 'readBody failed', { error: String(err) });
+      appLog('core:annex', 'error', 'readBody failed', { meta: { error: err instanceof Error ? err.message : String(err) } });
       res.writeHead(400);
       res.end();
     });


### PR DESCRIPTION
## Summary
- Fixed `readBody()` to reject on stream errors (e.g., client disconnects mid-request) by adding an `error` event listener
- Added `.catch()` handlers to all four `readBody().then()` chains in the HTTP request handler
- Catch handlers log the error via `appLog()` and respond with HTTP 400

## Details
The `readBody` function previously only resolved—it never rejected and did not listen for `error` events on the request stream. If a client disconnected mid-request, the promise would hang silently. In newer Node.js versions, unhandled promise rejections crash the process.

### Changes
1. **`readBody()`** now listens for `req.on('error', reject)` so the promise properly rejects on stream errors
2. **Four POST endpoint handlers** (quick agent spawn via project, quick agent spawn via agent, wake agent, permission response) now have `.catch()` handlers that:
   - Log the error with `appLog('core:annex', 'error', 'readBody failed', { meta: { error: ... } })`
   - Respond with HTTP 400 and close the response

### Files Changed
- `src/main/services/annex-server.ts` — core fix
- `src/main/services/annex-server.test.ts` — 4 new tests

## Test Plan
- [x] 4 new integration tests that abort TCP connections mid-POST to each affected endpoint, verifying:
  - No unhandled promise rejections occur
  - `appLog` is called with the error details
- [x] All 29 annex-server tests pass
- [x] Full validation passes (`npm run validate` — typecheck, unit tests, build, e2e)

## Manual Validation
To manually test, start the annex server and send a POST request to any of the affected endpoints, then kill the connection mid-body. Verify no crash/unhandled rejection warning appears in logs.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)