### PR TITLE
fix: ipcMain.once listener leak in window-handlers (#188)

### DIFF
--- a/src/main/ipc/window-handlers.ts
+++ b/src/main/ipc/window-handlers.ts
@@ -134,16 +134,19 @@ export function registerWindowHandlers(): void {
       }
 
       const requestId = `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+      const channel = `${IPC.WINDOW.AGENT_STATE_RESPONSE}:${requestId}`;
+
+      const handler = (_e: any, state: any) => {
+        clearTimeout(timeout);
+        resolve(state);
+      };
 
       const timeout = setTimeout(() => {
-        ipcMain.removeAllListeners(`${IPC.WINDOW.AGENT_STATE_RESPONSE}:${requestId}`);
+        ipcMain.removeListener(channel, handler);
         resolve({ agents: {}, agentDetailedStatus: {}, agentIcons: {} });
       }, 5000);
 
-      ipcMain.once(`${IPC.WINDOW.AGENT_STATE_RESPONSE}:${requestId}` as any, (_e: any, state: any) => {
-        clearTimeout(timeout);
-        resolve(state);
-      });
+      ipcMain.once(channel as any, handler);
 
       mainWindow.webContents.send(IPC.WINDOW.REQUEST_AGENT_STATE, requestId);
     });
@@ -174,16 +177,19 @@ export function registerWindowHandlers(): void {
       }
 
       const requestId = `hub_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+      const channel = `${IPC.WINDOW.HUB_STATE_RESPONSE}:${requestId}`;
+
+      const handler = (_e: any, state: any) => {
+        clearTimeout(timeout);
+        resolve(state);
+      };
 
       const timeout = setTimeout(() => {
-        ipcMain.removeAllListeners(`${IPC.WINDOW.HUB_STATE_RESPONSE}:${requestId}`);
+        ipcMain.removeListener(channel, handler);
         resolve(null);
       }, 5000);
 
-      ipcMain.once(`${IPC.WINDOW.HUB_STATE_RESPONSE}:${requestId}` as any, (_e: any, state: any) => {
-        clearTimeout(timeout);
-        resolve(state);
-      });
+      ipcMain.once(channel as any, handler);
 
       mainWindow.webContents.send(IPC.WINDOW.REQUEST_HUB_STATE, requestId, hubId, scope, projectId);
     });


### PR DESCRIPTION
## Summary
- Fixes listener leak in `window-handlers.ts` where `ipcMain.once()` listeners were never removed on timeout
- Replaced `ipcMain.removeAllListeners(channel)` with `ipcMain.removeListener(channel, handler)` using stored handler references
- Applied fix to both `GET_AGENT_STATE` and `GET_HUB_STATE` request/response relay patterns

## Changes
**`src/main/ipc/window-handlers.ts`**
- Extract the `once` callback into a named `handler` variable
- Extract the channel string into a `channel` variable for clarity
- In the timeout path, call `ipcMain.removeListener(channel, handler)` instead of `removeAllListeners`

**`src/main/ipc/window-handlers.test.ts`**
- Added `removeListener` mock to the ipcMain mock (with proper handler-matching logic)
- Added test: `GET_AGENT_STATE` cleans up once listener on timeout using `removeListener`
- Added test: `GET_HUB_STATE` cleans up once listener on timeout using `removeListener`
- Added test: `GET_AGENT_STATE` does NOT call `removeListener` when response arrives before timeout
- All tests verify handler identity (same reference passed to `once` and `removeListener`)

## Test Plan
- [x] All 11 window-handler unit tests pass
- [x] Full `npm run validate` passes (typecheck, unit tests, build, e2e)
- [ ] Manual: Verify no `MaxListenersExceeded` warnings under sustained popout agent-state polling

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)