### PR TITLE
fix: add ws mock for annex-server test stability (#197)

### DIFF
--- a/src/__mocks__/ws.ts
+++ b/src/__mocks__/ws.ts
@@ -1,0 +1,46 @@
+// Stub for ws module so annex-server can be imported in tests without
+// CJS/ESM interop issues. Only the surface used by annex-server is mocked.
+
+import { EventEmitter } from 'events';
+
+export class WebSocketServer extends EventEmitter {
+  clients: Set<WebSocket>;
+
+  constructor(_opts?: Record<string, unknown>) {
+    super();
+    this.clients = new Set();
+  }
+
+  handleUpgrade(
+    _req: unknown,
+    _socket: unknown,
+    _head: unknown,
+    cb: (ws: WebSocket) => void,
+  ): void {
+    const ws = new WebSocket();
+    this.clients.add(ws);
+    cb(ws);
+  }
+
+  close(): void {
+    for (const client of this.clients) {
+      try { client.close(); } catch { /* ignore */ }
+    }
+    this.clients.clear();
+  }
+}
+
+export class WebSocket extends EventEmitter {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readyState: number = WebSocket.OPEN;
+
+  send(_data: unknown): void { /* no-op */ }
+
+  close(): void {
+    this.readyState = WebSocket.CLOSED;
+  }
+}
+
+export default WebSocket;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ const sharedTestConfig = {
 const aliases = {
   electron: path.resolve(__dirname, 'src/__mocks__/electron.ts'),
   'monaco-editor': path.resolve(__dirname, 'src/__mocks__/monaco-editor.ts'),
+  ws: path.resolve(__dirname, 'src/__mocks__/ws.ts'),
 };
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Adds `src/__mocks__/ws.ts` with minimal `WebSocketServer` and `WebSocket` stubs, following the existing pattern used by `electron` and `monaco-editor` mocks
- Wires `ws` into `vitest.config.ts` resolve aliases so all test projects use the mock instead of relying on CJS/ESM interop

## Problem
The `ws` module is CommonJS and its named exports (`WebSocketServer`, `WebSocket`) may not resolve correctly through Vite's ESM transformation depending on environment. This caused `TypeError: WebSocketServer is not a constructor` failures across all 25+ annex-server tests (Issue #197).

## Changes
| File | Change |
|------|--------|
| `src/__mocks__/ws.ts` | New mock with `WebSocketServer` (extends `EventEmitter`, has `clients` Set, `handleUpgrade`, `close`) and `WebSocket` (has `OPEN`/`CLOSED` constants, `send`, `close`) |
| `vitest.config.ts` | Added `ws` to the shared `aliases` object |

## Test plan
- [x] All 29 annex-server tests pass with the mock
- [x] Full `npm run validate` passes: 3085 unit tests, 152 test files, build, and 89/90 E2E tests (1 pre-existing flaky rail-hover-flyout test)
- [x] Mock provides the full surface area used by `annex-server.ts`: `WebSocketServer` constructor, `clients`, `handleUpgrade`, `emit`, `on`, `close`; `WebSocket.OPEN`, `readyState`, `send`, `close`

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)