### PR TITLE
fix: data URL regex to match svg+xml MIME types

### DIFF
--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -641,7 +641,7 @@ export function saveAgentIcon(projectPath: string, agentId: string, dataUrl: str
   const dest = path.join(getAgentIconsDir(), filename);
 
   // Strip data URL prefix and write binary
-  const base64 = dataUrl.replace(/^data:image\/\w+;base64,/, '');
+  const base64 = dataUrl.replace(/^data:image\/[\w+.-]+;base64,/, '');
   fs.writeFileSync(dest, Buffer.from(base64, 'base64'));
 
   // Update agents.json


### PR DESCRIPTION
## Summary
Fixes #190 — The data URL regex in `saveAgentIcon` used `\w+` for the MIME subtype, which doesn't match compound subtypes like `svg+xml` because `+` is not a word character. SVG data URLs were silently failing to have their prefix stripped.

- Changed regex from `/^data:image\/\w+;base64,/` to `/^data:image\/[\w+.-]+;base64,/`
- The character class `[\w+.-]+` supports compound MIME subtypes per RFC 6838 (e.g., `svg+xml`, `vnd.microsoft.icon`)

## Test plan
- [x] Added unit test: strips standard `png` data URL prefix
- [x] Added unit test: strips `svg+xml` data URL prefix (the bug scenario)
- [x] Added unit test: strips `jpeg` data URL prefix
- [x] Added unit test: strips `webp` data URL prefix
- [x] Added unit test: updates agent icon field in `agents.json`
- [x] All 3090 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Build (`npm run make`) succeeds
- [ ] Manual: upload an SVG image as an agent icon and verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)