### PR TITLE
test: add unit tests for 5 settings services with zero coverage

### DIFF
--- a/src/main/services/annex-settings.test.ts
+++ b/src/main/services/annex-settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as os from 'os';
+import * as path from 'path';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/test-app' },
@@ -64,7 +65,7 @@ describe('annex-settings', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
-        '/tmp/test-app/annex-settings.json',
+        path.join('/tmp/test-app', 'annex-settings.json'),
         'utf-8',
       );
     });

--- a/src/main/services/badge-settings.test.ts
+++ b/src/main/services/badge-settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/test-app' },
@@ -79,7 +80,7 @@ describe('badge-settings', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
-        '/tmp/test-app/badge-settings.json',
+        path.join('/tmp/test-app', 'badge-settings.json'),
         'utf-8',
       );
     });

--- a/src/main/services/clipboard-settings.test.ts
+++ b/src/main/services/clipboard-settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/test-app' },
@@ -59,7 +60,7 @@ describe('clipboard-settings', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
-        '/tmp/test-app/clipboard-settings.json',
+        path.join('/tmp/test-app', 'clipboard-settings.json'),
         'utf-8',
       );
     });

--- a/src/main/services/orchestrator-settings.test.ts
+++ b/src/main/services/orchestrator-settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/test-app' },
@@ -56,7 +57,7 @@ describe('orchestrator-settings', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
-        '/tmp/test-app/orchestrator-settings.json',
+        path.join('/tmp/test-app', 'orchestrator-settings.json'),
         'utf-8',
       );
     });

--- a/src/main/services/settings-store.test.ts
+++ b/src/main/services/settings-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/test-app' },
@@ -122,7 +123,7 @@ describe('settings-store', () => {
       const store = createSettingsStore<TestSettings>('my-settings.json', DEFAULTS);
       store.get();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
-        '/tmp/test-app/my-settings.json',
+        path.join('/tmp/test-app', 'my-settings.json'),
         'utf-8',
       );
     });
@@ -134,7 +135,7 @@ describe('settings-store', () => {
       const settings: TestSettings = { name: 'saved', count: 10, nested: { flag: true } };
       store.save(settings);
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        '/tmp/test-app/test.json',
+        path.join('/tmp/test-app', 'test.json'),
         expect.any(String),
         'utf-8',
       );


### PR DESCRIPTION
## Summary

Closes #228

Adds comprehensive unit tests for 5 settings services that previously had zero test coverage:

- **`settings-store.ts`** (16 tests) — Base class for all settings stores. Tests cover `createSettingsStore` factory function including read/write round-trip, defaults on missing file, corrupt JSON fallback, partial settings merge, `console.warn` behavior, empty string handling, file path resolution, and store independence.
- **`orchestrator-settings.ts`** (9 tests) — Provider enable/disable persistence. Tests cover default enabled list (`['claude-code']`), read/write round-trip, corrupt JSON fallback, empty enabled list handling.
- **`annex-settings.ts`** (9 tests) — Annex PIN/enabled state persistence. Tests cover defaults (`enabled: false`, dynamic `deviceName`), read/write round-trip, partial merge preserving device name, corrupt JSON fallback.
- **`badge-settings.ts`** (11 tests) — Badge notification preferences. Tests cover defaults (all badges enabled), read/write round-trip, partial merge, optional `projectOverrides` field, independent badge type toggling, corrupt JSON fallback.
- **`clipboard-settings.ts`** (9 tests) — Clipboard compatibility flag. Tests cover platform-specific default (`true` on win32, `false` otherwise), read/write round-trip, explicit true/false overrides, corrupt JSON fallback.

**Total: 54 new tests**

## Test Coverage

All tests verify the four areas specified in the issue:
- Read/write round-trip (value persists and can be read back)
- Default values when no prior data exists
- Corrupt/missing file handling (graceful fallback)
- Partial settings merge with defaults

## Test Plan

- [x] All 54 new tests pass
- [x] All 3149 existing tests continue to pass (zero regressions)
- [x] Tests follow existing project patterns (vitest, fs/electron mocking)
- [ ] Manual: Verify no type regressions (pre-existing `adm-zip` type issue on main unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)