### PR TITLE
test: close IPC handler test coverage gaps (#225)

### DIFF
--- a/src/main/ipc/agent-settings-handlers.test.ts
+++ b/src/main/ipc/agent-settings-handlers.test.ts
@@ -7,7 +7,7 @@ vi.mock('electron', () => ({
 vi.mock('../services/agent-settings-service', () => ({
   readClaudeMd: vi.fn(() => '# Instructions'),
   writeClaudeMd: vi.fn(),
-  readMcpConfig: vi.fn(() => []),
+  readMcpConfig: vi.fn(() => [{ name: 'server-1' }]),
   listSkills: vi.fn(() => ['skill-a']),
   listAgentTemplates: vi.fn(() => ['template-a']),
   listSourceSkills: vi.fn(() => ['src-skill']),
@@ -25,7 +25,7 @@ vi.mock('../services/agent-settings-service', () => ({
   listAgentTemplateFiles: vi.fn(() => ['file.md']),
   readMcpRawJson: vi.fn(() => '{"mcpServers": {}}'),
   writeMcpRawJson: vi.fn(),
-  readProjectAgentDefaults: vi.fn(() => ({})),
+  readProjectAgentDefaults: vi.fn(() => ({ model: 'default' })),
   writeProjectAgentDefaults: vi.fn(),
   readSourceSkillContent: vi.fn(() => 'src skill content'),
   writeSourceSkillContent: vi.fn(),
@@ -44,17 +44,17 @@ vi.mock('../services/agent-system', () => ({
 }));
 
 vi.mock('../services/agent-config', () => ({
-  getDurableConfig: vi.fn(() => ({ id: 'a1', orchestrator: 'claude-code' })),
+  getDurableConfig: vi.fn(() => ({ id: 'a1', name: 'Bot', orchestrator: 'claude-code' })),
 }));
 
 vi.mock('../services/materialization-service', () => ({
   materializeAgent: vi.fn(),
-  previewMaterialization: vi.fn(() => ({ instructions: '', permissions: {}, mcpJson: null, skills: [], agentTemplates: [] })),
+  previewMaterialization: vi.fn(() => ({ instructions: 'merged', permissions: {}, mcpJson: null, skills: [], agentTemplates: [] })),
 }));
 
 vi.mock('../services/config-diff-service', () => ({
-  computeConfigDiff: vi.fn(() => ({ agentId: 'a1', agentName: 'Bot', hasDiffs: false, items: [] })),
-  propagateChanges: vi.fn(() => ({ ok: true, message: 'done', propagatedCount: 0 })),
+  computeConfigDiff: vi.fn(() => ({ agentId: 'a1', agentName: 'Bot', hasDiffs: true, items: [{ id: 'i1' }] })),
+  propagateChanges: vi.fn(() => ({ ok: true, message: 'done', propagatedCount: 2 })),
 }));
 
 import { ipcMain } from 'electron';
@@ -62,6 +62,9 @@ import { IPC } from '../../shared/ipc-channels';
 import { registerAgentSettingsHandlers } from './agent-settings-handlers';
 import * as agentSettings from '../services/agent-settings-service';
 import * as agentSystem from '../services/agent-system';
+import * as agentConfig from '../services/agent-config';
+import { materializeAgent, previewMaterialization } from '../services/materialization-service';
+import { computeConfigDiff, propagateChanges } from '../services/config-diff-service';
 
 describe('agent-settings-handlers', () => {
   let handlers: Map<string, (...args: any[]) => any>;
@@ -99,6 +102,8 @@ describe('agent-settings-handlers', () => {
     }
   });
 
+  // --- Instructions ---
+
   it('READ_INSTRUCTIONS uses provider when projectPath is given', async () => {
     const handler = handlers.get(IPC.AGENT.READ_INSTRUCTIONS)!;
     await handler({}, '/worktree', '/project');
@@ -124,12 +129,162 @@ describe('agent-settings-handlers', () => {
     expect(agentSettings.writeClaudeMd).toHaveBeenCalledWith('/worktree', 'new content');
   });
 
+  // --- MCP ---
+
+  it('READ_MCP_CONFIG delegates to agentSettings.readMcpConfig', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_MCP_CONFIG)!;
+    const result = await handler({}, '/worktree');
+    expect(agentSettings.readMcpConfig).toHaveBeenCalled();
+    expect(result).toEqual([{ name: 'server-1' }]);
+  });
+
+  it('READ_MCP_RAW_JSON delegates to agentSettings.readMcpRawJson', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_MCP_RAW_JSON)!;
+    const result = await handler({}, '/worktree');
+    expect(agentSettings.readMcpRawJson).toHaveBeenCalled();
+    expect(result).toBe('{"mcpServers": {}}');
+  });
+
+  it('WRITE_MCP_RAW_JSON delegates to agentSettings.writeMcpRawJson', async () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_MCP_RAW_JSON)!;
+    await handler({}, '/worktree', '{"mcpServers": {"new": {}}}');
+    expect(agentSettings.writeMcpRawJson).toHaveBeenCalled();
+  });
+
+  // --- Skills ---
+
   it('LIST_SKILLS delegates to agentSettings.listSkills', async () => {
     const handler = handlers.get(IPC.AGENT.LIST_SKILLS)!;
     const result = await handler({}, '/worktree');
     expect(agentSettings.listSkills).toHaveBeenCalled();
     expect(result).toEqual(['skill-a']);
   });
+
+  it('LIST_SOURCE_SKILLS delegates to agentSettings.listSourceSkills', async () => {
+    const handler = handlers.get(IPC.AGENT.LIST_SOURCE_SKILLS)!;
+    const result = await handler({}, '/project');
+    expect(agentSettings.listSourceSkills).toHaveBeenCalledWith('/project');
+    expect(result).toEqual(['src-skill']);
+  });
+
+  it('CREATE_SKILL delegates to agentSettings.createSkillDir', async () => {
+    const handler = handlers.get(IPC.AGENT.CREATE_SKILL)!;
+    const result = await handler({}, '/base', 'my-skill', false);
+    expect(agentSettings.createSkillDir).toHaveBeenCalled();
+    expect(result).toBe('/path/to/skill');
+  });
+
+  it('READ_SKILL_CONTENT delegates to agentSettings.readSkillContent', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_SKILL_CONTENT)!;
+    const result = await handler({}, '/worktree', 'skill-a');
+    expect(agentSettings.readSkillContent).toHaveBeenCalled();
+    expect(result).toBe('skill content');
+  });
+
+  it('WRITE_SKILL_CONTENT delegates to agentSettings.writeSkillContent', async () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_SKILL_CONTENT)!;
+    await handler({}, '/worktree', 'skill-a', 'updated content');
+    expect(agentSettings.writeSkillContent).toHaveBeenCalled();
+  });
+
+  it('DELETE_SKILL delegates to agentSettings.deleteSkill', async () => {
+    const handler = handlers.get(IPC.AGENT.DELETE_SKILL)!;
+    await handler({}, '/worktree', 'skill-a');
+    expect(agentSettings.deleteSkill).toHaveBeenCalled();
+  });
+
+  // --- Source skills ---
+
+  it('READ_SOURCE_SKILL_CONTENT delegates to agentSettings.readSourceSkillContent', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_SOURCE_SKILL_CONTENT)!;
+    const result = await handler({}, '/project', 'src-skill');
+    expect(agentSettings.readSourceSkillContent).toHaveBeenCalledWith('/project', 'src-skill');
+    expect(result).toBe('src skill content');
+  });
+
+  it('WRITE_SOURCE_SKILL_CONTENT delegates to agentSettings.writeSourceSkillContent', async () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_SOURCE_SKILL_CONTENT)!;
+    await handler({}, '/project', 'src-skill', 'new content');
+    expect(agentSettings.writeSourceSkillContent).toHaveBeenCalledWith('/project', 'src-skill', 'new content');
+  });
+
+  it('DELETE_SOURCE_SKILL delegates to agentSettings.deleteSourceSkill', async () => {
+    const handler = handlers.get(IPC.AGENT.DELETE_SOURCE_SKILL)!;
+    await handler({}, '/project', 'src-skill');
+    expect(agentSettings.deleteSourceSkill).toHaveBeenCalledWith('/project', 'src-skill');
+  });
+
+  // --- Agent templates ---
+
+  it('LIST_AGENT_TEMPLATES delegates to agentSettings.listAgentTemplates', async () => {
+    const handler = handlers.get(IPC.AGENT.LIST_AGENT_TEMPLATES)!;
+    const result = await handler({}, '/worktree');
+    expect(agentSettings.listAgentTemplates).toHaveBeenCalled();
+    expect(result).toEqual(['template-a']);
+  });
+
+  it('LIST_SOURCE_AGENT_TEMPLATES delegates to agentSettings.listSourceAgentTemplates', async () => {
+    const handler = handlers.get(IPC.AGENT.LIST_SOURCE_AGENT_TEMPLATES)!;
+    const result = await handler({}, '/project');
+    expect(agentSettings.listSourceAgentTemplates).toHaveBeenCalledWith('/project');
+    expect(result).toEqual(['src-template']);
+  });
+
+  it('CREATE_AGENT_TEMPLATE delegates to agentSettings.createAgentTemplateDir', async () => {
+    const handler = handlers.get(IPC.AGENT.CREATE_AGENT_TEMPLATE)!;
+    const result = await handler({}, '/base', 'my-template', true);
+    expect(agentSettings.createAgentTemplateDir).toHaveBeenCalled();
+    expect(result).toBe('/path/to/template');
+  });
+
+  it('READ_AGENT_TEMPLATE_CONTENT delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_AGENT_TEMPLATE_CONTENT)!;
+    const result = await handler({}, '/worktree', 'template-a');
+    expect(agentSettings.readAgentTemplateContent).toHaveBeenCalled();
+    expect(result).toBe('template content');
+  });
+
+  it('WRITE_AGENT_TEMPLATE_CONTENT delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_AGENT_TEMPLATE_CONTENT)!;
+    await handler({}, '/worktree', 'template-a', 'updated');
+    expect(agentSettings.writeAgentTemplateContent).toHaveBeenCalled();
+  });
+
+  it('DELETE_AGENT_TEMPLATE delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.DELETE_AGENT_TEMPLATE)!;
+    await handler({}, '/worktree', 'template-a');
+    expect(agentSettings.deleteAgentTemplate).toHaveBeenCalled();
+  });
+
+  it('LIST_AGENT_TEMPLATE_FILES delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.LIST_AGENT_TEMPLATE_FILES)!;
+    const result = await handler({}, '/worktree');
+    expect(agentSettings.listAgentTemplateFiles).toHaveBeenCalled();
+    expect(result).toEqual(['file.md']);
+  });
+
+  // --- Source agent templates ---
+
+  it('READ_SOURCE_AGENT_TEMPLATE_CONTENT delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_SOURCE_AGENT_TEMPLATE_CONTENT)!;
+    const result = await handler({}, '/project', 'src-template');
+    expect(agentSettings.readSourceAgentTemplateContent).toHaveBeenCalledWith('/project', 'src-template');
+    expect(result).toBe('src template content');
+  });
+
+  it('WRITE_SOURCE_AGENT_TEMPLATE_CONTENT delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_SOURCE_AGENT_TEMPLATE_CONTENT)!;
+    await handler({}, '/project', 'src-template', 'new content');
+    expect(agentSettings.writeSourceAgentTemplateContent).toHaveBeenCalledWith('/project', 'src-template', 'new content');
+  });
+
+  it('DELETE_SOURCE_AGENT_TEMPLATE delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.DELETE_SOURCE_AGENT_TEMPLATE)!;
+    await handler({}, '/project', 'src-template');
+    expect(agentSettings.deleteSourceAgentTemplate).toHaveBeenCalledWith('/project', 'src-template');
+  });
+
+  // --- Permissions ---
 
   it('READ_PERMISSIONS delegates to agentSettings.readPermissions', async () => {
     const handler = handlers.get(IPC.AGENT.READ_PERMISSIONS)!;
@@ -143,6 +298,23 @@ describe('agent-settings-handlers', () => {
     await handler({}, '/worktree', { allow: ['read', 'edit'] });
     expect(agentSettings.writePermissions).toHaveBeenCalled();
   });
+
+  // --- Project agent defaults ---
+
+  it('READ_PROJECT_AGENT_DEFAULTS delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.READ_PROJECT_AGENT_DEFAULTS)!;
+    const result = await handler({}, '/project');
+    expect(agentSettings.readProjectAgentDefaults).toHaveBeenCalledWith('/project');
+    expect(result).toEqual({ model: 'default' });
+  });
+
+  it('WRITE_PROJECT_AGENT_DEFAULTS delegates to agentSettings', async () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_PROJECT_AGENT_DEFAULTS)!;
+    await handler({}, '/project', { model: 'opus' });
+    expect(agentSettings.writeProjectAgentDefaults).toHaveBeenCalledWith('/project', { model: 'opus' });
+  });
+
+  // --- Conventions ---
 
   it('GET_CONVENTIONS returns provider conventions', async () => {
     const handler = handlers.get(IPC.AGENT.GET_CONVENTIONS)!;
@@ -159,10 +331,77 @@ describe('agent-settings-handlers', () => {
     expect(result).toBeNull();
   });
 
-  it('READ_PROJECT_AGENT_DEFAULTS delegates to agentSettings', async () => {
-    const handler = handlers.get(IPC.AGENT.READ_PROJECT_AGENT_DEFAULTS)!;
-    const result = await handler({}, '/project');
-    expect(agentSettings.readProjectAgentDefaults).toHaveBeenCalledWith('/project');
-    expect(result).toEqual({});
+  // --- Materialization ---
+
+  it('MATERIALIZE_AGENT calls materializeAgent with agent config', async () => {
+    const handler = handlers.get(IPC.AGENT.MATERIALIZE_AGENT)!;
+    await handler({}, '/project', 'a1');
+    expect(agentConfig.getDurableConfig).toHaveBeenCalledWith('/project', 'a1');
+    expect(materializeAgent).toHaveBeenCalledWith(expect.objectContaining({
+      projectPath: '/project',
+      agent: expect.objectContaining({ id: 'a1' }),
+    }));
+  });
+
+  it('MATERIALIZE_AGENT returns early when agent config is null', async () => {
+    vi.mocked(agentConfig.getDurableConfig).mockReturnValueOnce(null as any);
+    const handler = handlers.get(IPC.AGENT.MATERIALIZE_AGENT)!;
+    await handler({}, '/project', 'missing');
+    expect(materializeAgent).not.toHaveBeenCalled();
+  });
+
+  it('PREVIEW_MATERIALIZATION returns preview result', async () => {
+    const handler = handlers.get(IPC.AGENT.PREVIEW_MATERIALIZATION)!;
+    const result = await handler({}, '/project', 'a1');
+    expect(agentConfig.getDurableConfig).toHaveBeenCalledWith('/project', 'a1');
+    expect(previewMaterialization).toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ instructions: 'merged' }));
+  });
+
+  it('PREVIEW_MATERIALIZATION returns null when agent config is null', async () => {
+    vi.mocked(agentConfig.getDurableConfig).mockReturnValueOnce(null as any);
+    const handler = handlers.get(IPC.AGENT.PREVIEW_MATERIALIZATION)!;
+    const result = await handler({}, '/project', 'missing');
+    expect(result).toBeNull();
+  });
+
+  // --- Config diff ---
+
+  it('COMPUTE_CONFIG_DIFF returns diff result', async () => {
+    const handler = handlers.get(IPC.AGENT.COMPUTE_CONFIG_DIFF)!;
+    const result = await handler({}, '/project', 'a1');
+    expect(agentConfig.getDurableConfig).toHaveBeenCalledWith('/project', 'a1');
+    expect(computeConfigDiff).toHaveBeenCalledWith(expect.objectContaining({
+      projectPath: '/project',
+      agentId: 'a1',
+    }));
+    expect(result).toEqual(expect.objectContaining({ hasDiffs: true }));
+  });
+
+  it('COMPUTE_CONFIG_DIFF returns empty result when agent not found', async () => {
+    vi.mocked(agentConfig.getDurableConfig).mockReturnValueOnce(null as any);
+    const handler = handlers.get(IPC.AGENT.COMPUTE_CONFIG_DIFF)!;
+    const result = await handler({}, '/project', 'missing');
+    expect(result).toEqual({ agentId: 'missing', agentName: '', hasDiffs: false, items: [] });
+    expect(computeConfigDiff).not.toHaveBeenCalled();
+  });
+
+  it('PROPAGATE_CONFIG_CHANGES propagates selected items', async () => {
+    const handler = handlers.get(IPC.AGENT.PROPAGATE_CONFIG_CHANGES)!;
+    const result = await handler({}, '/project', 'a1', ['i1', 'i2']);
+    expect(propagateChanges).toHaveBeenCalledWith(expect.objectContaining({
+      projectPath: '/project',
+      agentId: 'a1',
+      selectedItemIds: ['i1', 'i2'],
+    }));
+    expect(result).toEqual({ ok: true, message: 'done', propagatedCount: 2 });
+  });
+
+  it('PROPAGATE_CONFIG_CHANGES returns error when agent not found', async () => {
+    vi.mocked(agentConfig.getDurableConfig).mockReturnValueOnce(null as any);
+    const handler = handlers.get(IPC.AGENT.PROPAGATE_CONFIG_CHANGES)!;
+    const result = await handler({}, '/project', 'missing', ['i1']);
+    expect(result).toEqual({ ok: false, message: 'Agent not found', propagatedCount: 0 });
+    expect(propagateChanges).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes #225 — Expands unit test coverage for the IPC handler layer, which is the contract between main and renderer processes.

The existing test scaffolding (from PR #207) covered channel registration and basic delegation for most handlers, but left significant behavioral gaps:

- **agent-handlers.test.ts**: 9-10 handlers had no delegation tests; SPAWN_AGENT error logging/rethrow untested
- **agent-settings-handlers.test.ts**: 25 of 32 handlers completely untested (~78% gap)
- **app-handlers.test.ts**: 33 of 43+ handlers untested (~77% gap), including critical SAVE_CLUBHOUSE_MODE_SETTINGS logic
- **annex-handlers.test.ts**: Missing error logging paths
- **process-handlers.test.ts**: Missing MAX_TIMEOUT clamping and default timeout tests

### Changes

| File | Tests Added | Key Coverage |
|------|-------------|-------------|
| `agent-handlers.test.ts` | +15 | CRUD delegation, icon ops, worktree/delete variants, SPAWN_AGENT error logging, orchestrator methods |
| `agent-settings-handlers.test.ts` | +30 | Skills/templates CRUD, source skills/templates, MCP raw JSON, materialization, config diff, null guards |
| `app-handlers.test.ts` | +34 | Notifications, clipboard, badge, dock badge, headless, auto-update, sound packs, logging, clubhouse mode enable/disable |
| `annex-handlers.test.ts` | +3 | Error logging on server start failure, broadcast after save, auto-start failure |
| `process-handlers.test.ts` | +5 | MAX_TIMEOUT clamping, default timeout, backslash rejection, null allowedCommands |

**Total: 133 → 224 IPC handler tests (+91 new tests)**

## Test plan

- [x] All 224 IPC handler tests pass (`npx vitest run src/main/ipc/`)
- [x] Full test suite passes (`npm test` — 3,186 tests across 152 files)
- [ ] Note: pre-existing `tsc --noEmit` failure for `adm-zip` types (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)