### PR TITLE
test: add component tests for 5 critical untested components

### DIFF
--- a/src/renderer/features/agents/AgentTerminal.test.tsx
+++ b/src/renderer/features/agents/AgentTerminal.test.tsx
@@ -1,0 +1,236 @@
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useThemeStore } from '../../stores/themeStore';
+import { useClipboardSettingsStore } from '../../stores/clipboardSettingsStore';
+
+// Shared state holders for mock instances (using globalThis so hoisted vi.mock can set them)
+const g = globalThis as any;
+g.__testTerminal = null;
+g.__testFitAddon = null;
+g.__testAttachClipboard = vi.fn().mockReturnValue(vi.fn());
+
+vi.mock('@xterm/xterm', () => {
+  class Terminal {
+    loadAddon = vi.fn();
+    open = vi.fn();
+    write = vi.fn();
+    focus = vi.fn();
+    dispose = vi.fn();
+    onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    options: Record<string, any> = {};
+    cols = 80;
+    rows = 24;
+    constructor(opts?: any) {
+      (globalThis as any).__testTerminal = this;
+      if (opts?.theme) this.options.theme = opts.theme;
+    }
+  }
+  return { Terminal };
+});
+
+vi.mock('@xterm/addon-fit', () => {
+  class FitAddon {
+    fit = vi.fn();
+    constructor() {
+      (globalThis as any).__testFitAddon = this;
+    }
+  }
+  return { FitAddon };
+});
+
+vi.mock('../terminal/clipboard', () => ({
+  attachClipboardHandlers: (...args: any[]) => (globalThis as any).__testAttachClipboard(...args),
+}));
+
+import { AgentTerminal } from './AgentTerminal';
+
+let mockOnDataCallback: ((id: string, data: string) => void) | null = null;
+let mockOnExitCallback: ((id: string, exitCode: number) => void) | null = null;
+const mockRemoveDataListener = vi.fn();
+const mockRemoveExitListener = vi.fn();
+const mockDisconnect = vi.fn();
+
+describe('AgentTerminal', () => {
+  beforeEach(() => {
+    g.__testTerminal = null;
+    g.__testFitAddon = null;
+    g.__testAttachClipboard.mockClear();
+    g.__testAttachClipboard.mockReturnValue(vi.fn());
+    mockOnDataCallback = null;
+    mockOnExitCallback = null;
+    mockRemoveDataListener.mockClear();
+    mockRemoveExitListener.mockClear();
+    mockDisconnect.mockClear();
+
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(_cb: () => void) {}
+      observe = vi.fn();
+      disconnect = mockDisconnect;
+      unobserve = vi.fn();
+    });
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 0; });
+
+    window.clubhouse.pty.write = vi.fn();
+    window.clubhouse.pty.resize = vi.fn();
+    window.clubhouse.pty.getBuffer = vi.fn().mockResolvedValue('');
+    window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: any) => {
+      mockOnDataCallback = cb;
+      return mockRemoveDataListener;
+    });
+    window.clubhouse.pty.onExit = vi.fn().mockImplementation((cb: any) => {
+      mockOnExitCallback = cb;
+      return mockRemoveExitListener;
+    });
+
+    useThemeStore.setState({
+      theme: { terminal: { background: '#000', foreground: '#fff' } } as any,
+    });
+
+    useClipboardSettingsStore.setState({
+      clipboardCompat: false,
+      loaded: false,
+      loadSettings: vi.fn(),
+      saveSettings: vi.fn(),
+    });
+  });
+
+  function term() { return g.__testTerminal; }
+  function fitAddon() { return g.__testFitAddon; }
+
+  describe('initialization', () => {
+    it('creates a Terminal instance with theme colors', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(term()).toBeTruthy();
+      expect(term().options.theme).toEqual({ background: '#000', foreground: '#fff' });
+    });
+
+    it('creates and loads FitAddon', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(fitAddon()).toBeTruthy();
+      expect(term().loadAddon).toHaveBeenCalled();
+    });
+
+    it('opens terminal on the container element', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(term().open).toHaveBeenCalled();
+    });
+
+    it('calls fit and resize on mount', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(fitAddon().fit).toHaveBeenCalled();
+      expect(window.clubhouse.pty.resize).toHaveBeenCalledWith('agent-1', 80, 24);
+    });
+
+    it('requests buffer content on mount', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(window.clubhouse.pty.getBuffer).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('loads clipboard settings on mount', () => {
+      const loadSettings = vi.fn();
+      useClipboardSettingsStore.setState({ loadSettings });
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(loadSettings).toHaveBeenCalled();
+    });
+  });
+
+  describe('PTY communication', () => {
+    it('subscribes to PTY onData events', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(window.clubhouse.pty.onData).toHaveBeenCalled();
+    });
+
+    it('subscribes to PTY onExit events', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(window.clubhouse.pty.onExit).toHaveBeenCalled();
+    });
+
+    it('forwards terminal input to PTY write', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      const onDataCb = term().onData.mock.calls[0][0];
+      onDataCb('test input');
+      expect(window.clubhouse.pty.write).toHaveBeenCalledWith('agent-1', 'test input');
+    });
+
+    it('writes PTY data to terminal for matching agentId', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(mockOnDataCallback).toBeTruthy();
+      act(() => { mockOnDataCallback!('agent-1', 'hello world'); });
+      expect(term().write).toHaveBeenCalledWith('hello world');
+    });
+
+    it('ignores PTY data for other agentIds', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      term().write.mockClear();
+      act(() => { mockOnDataCallback!('agent-2', 'other agent data'); });
+      expect(term().write).not.toHaveBeenCalledWith('other agent data');
+    });
+
+    it('writes reset sequences on exit for matching agent', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      act(() => { mockOnExitCallback!('agent-1', 0); });
+      expect(term().write).toHaveBeenCalledWith(expect.stringContaining('\x1b[?1049l'));
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('removes PTY listeners on unmount', () => {
+      const { unmount } = render(<AgentTerminal agentId="agent-1" />);
+      unmount();
+      expect(mockRemoveDataListener).toHaveBeenCalled();
+      expect(mockRemoveExitListener).toHaveBeenCalled();
+    });
+
+    it('disconnects ResizeObserver on unmount', () => {
+      const { unmount } = render(<AgentTerminal agentId="agent-1" />);
+      unmount();
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it('disposes terminal on unmount', () => {
+      const { unmount } = render(<AgentTerminal agentId="agent-1" />);
+      unmount();
+      expect(term().dispose).toHaveBeenCalled();
+    });
+  });
+
+  describe('theme updates', () => {
+    it('updates terminal theme when theme store changes', () => {
+      render(<AgentTerminal agentId="agent-1" />);
+      const newTheme = { background: '#111', foreground: '#eee' };
+      act(() => {
+        useThemeStore.setState({ theme: { terminal: newTheme } as any });
+      });
+      expect(term().options.theme).toEqual(newTheme);
+    });
+  });
+
+  describe('focus behavior', () => {
+    it('focuses terminal when focused prop is true', () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      expect(term().focus).toHaveBeenCalled();
+    });
+  });
+
+  describe('clipboard', () => {
+    it('attaches clipboard handlers when clipboardCompat is true', () => {
+      useClipboardSettingsStore.setState({ clipboardCompat: true });
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(g.__testAttachClipboard).toHaveBeenCalled();
+    });
+
+    it('does not attach clipboard handlers when clipboardCompat is false', () => {
+      useClipboardSettingsStore.setState({ clipboardCompat: false });
+      render(<AgentTerminal agentId="agent-1" />);
+      expect(g.__testAttachClipboard).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('container rendering', () => {
+    it('renders a container div with padding', () => {
+      const { container } = render(<AgentTerminal agentId="agent-1" />);
+      const div = container.firstElementChild as HTMLElement;
+      expect(div.style.padding).toBe('8px');
+    });
+  });
+});

--- a/src/renderer/features/agents/ConfigChangesDialog.test.tsx
+++ b/src/renderer/features/agents/ConfigChangesDialog.test.tsx
@@ -1,0 +1,312 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConfigChangesDialog } from './ConfigChangesDialog';
+import { useAgentStore } from '../../stores/agentStore';
+
+const mockCloseDialog = vi.fn();
+const mockComputeConfigDiff = vi.fn();
+const mockPropagateConfigChanges = vi.fn();
+const mockUpdateDurableConfig = vi.fn();
+
+function resetStore(overrides: Record<string, any> = {}) {
+  useAgentStore.setState({
+    configChangesDialogAgent: 'agent-1',
+    configChangesProjectPath: '/project/path',
+    closeConfigChangesDialog: mockCloseDialog,
+    agents: {
+      'agent-1': {
+        id: 'agent-1', name: 'bold-falcon', kind: 'durable',
+        status: 'sleeping', color: 'indigo', projectId: 'proj-1',
+      },
+    },
+    ...overrides,
+  });
+}
+
+const sampleDiffItems = [
+  { id: 'item-1', category: 'instructions', action: 'modified', label: 'Updated CLAUDE.md', agentValue: 'new content', defaultValue: 'old content' },
+  { id: 'item-2', category: 'permissions-allow', action: 'added', label: 'Allow shell access' },
+  { id: 'item-3', category: 'mcp', action: 'removed', label: 'Removed old MCP server' },
+];
+
+describe('ConfigChangesDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComputeConfigDiff.mockResolvedValue({ items: sampleDiffItems, agentName: 'bold-falcon' });
+    mockPropagateConfigChanges.mockResolvedValue(undefined);
+    mockUpdateDurableConfig.mockResolvedValue(undefined);
+
+    window.clubhouse.agentSettings.computeConfigDiff = mockComputeConfigDiff;
+    window.clubhouse.agentSettings.propagateConfigChanges = mockPropagateConfigChanges;
+    window.clubhouse.agent.updateDurableConfig = mockUpdateDurableConfig;
+  });
+
+  describe('null guard', () => {
+    it('renders nothing when no agentId', () => {
+      resetStore({ configChangesDialogAgent: null });
+      const { container } = render(<ConfigChangesDialog />);
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders nothing when no projectPath', () => {
+      resetStore({ configChangesProjectPath: null });
+      const { container } = render(<ConfigChangesDialog />);
+      expect(container.innerHTML).toBe('');
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows spinner while loading', async () => {
+      // Make the computation hang
+      mockComputeConfigDiff.mockReturnValue(new Promise(() => {}));
+      resetStore();
+      const { container } = render(<ConfigChangesDialog />);
+      // spinner is a div with animate-spin
+      expect(container.querySelector('.animate-spin')).toBeTruthy();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows "No config changes detected" when no items', async () => {
+      mockComputeConfigDiff.mockResolvedValue({ items: [], agentName: 'bold-falcon' });
+      resetStore();
+      render(<ConfigChangesDialog />);
+      expect(await screen.findByText('No config changes detected')).toBeInTheDocument();
+    });
+
+    it('shows agent name in empty message', async () => {
+      mockComputeConfigDiff.mockResolvedValue({ items: [], agentName: 'bold-falcon' });
+      resetStore();
+      render(<ConfigChangesDialog />);
+      expect(await screen.findByText(/bold-falcon has no configuration changes/)).toBeInTheDocument();
+    });
+
+    it('close button calls closeDialog', async () => {
+      mockComputeConfigDiff.mockResolvedValue({ items: [], agentName: 'test' });
+      resetStore();
+      render(<ConfigChangesDialog />);
+      const closeBtn = await screen.findByText('Close');
+      fireEvent.click(closeBtn);
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+  });
+
+  describe('items rendering', () => {
+    it('renders diff items grouped by category', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      expect(await screen.findByText('Instructions')).toBeInTheDocument();
+      expect(screen.getByText('Permissions (Allow)')).toBeInTheDocument();
+      expect(screen.getByText('MCP Servers')).toBeInTheDocument();
+    });
+
+    it('renders item labels', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      expect(await screen.findByText('Updated CLAUDE.md')).toBeInTheDocument();
+      expect(screen.getByText('Allow shell access')).toBeInTheDocument();
+      expect(screen.getByText('Removed old MCP server')).toBeInTheDocument();
+    });
+
+    it('renders action badges with correct symbols', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Updated CLAUDE.md');
+
+      // modified = ~, added = +, removed = −
+      expect(screen.getByText('~')).toBeInTheDocument();
+      expect(screen.getByText('+')).toBeInTheDocument();
+      // − is a special minus sign (U+2212)
+      expect(screen.getByText('−')).toBeInTheDocument();
+    });
+
+    it('shows selection count', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      expect(await screen.findByText('3 of 3 selected')).toBeInTheDocument();
+    });
+  });
+
+  describe('checkbox interactions', () => {
+    it('all items are checked by default', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Updated CLAUDE.md');
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(3);
+      checkboxes.forEach((cb) => expect(cb).toBeChecked());
+    });
+
+    it('unchecking an item updates selection count', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Updated CLAUDE.md');
+      const checkboxes = screen.getAllByRole('checkbox');
+      fireEvent.click(checkboxes[0]);
+
+      expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
+    });
+
+    it('deselect all removes all selections', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Deselect all');
+      fireEvent.click(screen.getByText('Deselect all'));
+
+      expect(screen.getByText('0 of 3 selected')).toBeInTheDocument();
+      expect(screen.getByText('Select all')).toBeInTheDocument();
+    });
+
+    it('select all after deselect restores all', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Deselect all');
+      fireEvent.click(screen.getByText('Deselect all'));
+      fireEvent.click(screen.getByText('Select all'));
+
+      expect(screen.getByText('3 of 3 selected')).toBeInTheDocument();
+    });
+  });
+
+  describe('expand/collapse diff view', () => {
+    it('shows View diff button for instructions items', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+      expect(await screen.findByText('View diff')).toBeInTheDocument();
+    });
+
+    it('clicking View diff shows diff content', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      const viewDiff = await screen.findByText('View diff');
+      fireEvent.click(viewDiff);
+
+      expect(screen.getByText('Hide diff')).toBeInTheDocument();
+    });
+
+    it('does not show View diff for permissions items', async () => {
+      mockComputeConfigDiff.mockResolvedValue({
+        items: [{ id: 'perm-1', category: 'permissions-allow', action: 'added', label: 'Allow access' }],
+        agentName: 'test',
+      });
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Allow access');
+      expect(screen.queryByText('View diff')).toBeNull();
+    });
+  });
+
+  describe('actions', () => {
+    it('save button calls propagateConfigChanges with selected IDs', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Save to Clubhouse');
+      fireEvent.click(screen.getByText('Save to Clubhouse'));
+
+      await waitFor(() => {
+        expect(mockPropagateConfigChanges).toHaveBeenCalledWith(
+          '/project/path',
+          'agent-1',
+          expect.arrayContaining(['item-1', 'item-2', 'item-3']),
+        );
+      });
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+
+    it('save button is disabled when nothing is selected', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Deselect all');
+      fireEvent.click(screen.getByText('Deselect all'));
+
+      expect(screen.getByText('Save to Clubhouse').closest('button')).toBeDisabled();
+    });
+
+    it('keep for agent calls updateDurableConfig', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      const keepBtn = await screen.findByText('Keep for this agent');
+      fireEvent.click(keepBtn);
+
+      await waitFor(() => {
+        expect(mockUpdateDurableConfig).toHaveBeenCalledWith(
+          '/project/path',
+          'agent-1',
+          { clubhouseModeOverride: true },
+        );
+      });
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+
+    it('discard closes dialog without saving', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      const discardBtn = await screen.findByText('Discard');
+      fireEvent.click(discardBtn);
+
+      expect(mockCloseDialog).toHaveBeenCalled();
+      expect(mockPropagateConfigChanges).not.toHaveBeenCalled();
+      expect(mockUpdateDurableConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('keyboard and overlay', () => {
+    it('pressing Escape closes the dialog', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Save to Clubhouse');
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+
+    it('clicking the backdrop overlay closes the dialog', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Save to Clubhouse');
+      // The outer div is the backdrop
+      const backdrop = screen.getByText('Save to Clubhouse').closest('.fixed');
+      expect(backdrop).toBeTruthy();
+      fireEvent.click(backdrop!);
+
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+
+    it('clicking inside the dialog does not close it', async () => {
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      await screen.findByText('Config changes detected');
+      // Click on the dialog content area
+      fireEvent.click(screen.getByText('Config changes detected'));
+
+      expect(mockCloseDialog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('shows empty state when computeConfigDiff throws', async () => {
+      mockComputeConfigDiff.mockRejectedValue(new Error('Network error'));
+      resetStore();
+      render(<ConfigChangesDialog />);
+
+      expect(await screen.findByText('No config changes detected')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/features/agents/SleepingAgent.test.tsx
+++ b/src/renderer/features/agents/SleepingAgent.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SleepingAgent } from './SleepingAgent';
+import { useAgentStore } from '../../stores/agentStore';
+import { useProjectStore } from '../../stores/projectStore';
+import type { Agent } from '../../../shared/types';
+
+vi.mock('./SleepingMascots', () => ({
+  SleepingMascot: ({ orchestrator }: { orchestrator?: string }) => (
+    <div data-testid="sleeping-mascot" data-orchestrator={orchestrator || ''} />
+  ),
+}));
+
+const baseAgent: Agent = {
+  id: 'agent-1',
+  projectId: 'proj-1',
+  name: 'bold-falcon',
+  kind: 'durable',
+  status: 'sleeping',
+  color: 'indigo',
+};
+
+const mockSpawnDurableAgent = vi.fn().mockResolvedValue(undefined);
+
+function resetStores(agentOverrides: Partial<Agent> = {}) {
+  const agent = { ...baseAgent, ...agentOverrides };
+  useAgentStore.setState({
+    agents: { [agent.id]: agent },
+    spawnDurableAgent: mockSpawnDurableAgent,
+  });
+  useProjectStore.setState({
+    projects: [{ id: 'proj-1', name: 'test-project', path: '/projects/test' }],
+    activeProjectId: 'proj-1',
+  });
+}
+
+function renderComponent(agentOverrides: Partial<Agent> = {}) {
+  const agent = { ...baseAgent, ...agentOverrides };
+  resetStores(agentOverrides);
+  return render(<SleepingAgent agent={agent} />);
+}
+
+describe('SleepingAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.clubhouse.agent.listDurable = vi.fn().mockResolvedValue([]);
+  });
+
+  describe('rendering', () => {
+    it('renders agent name', () => {
+      renderComponent();
+      expect(screen.getByText('bold-falcon')).toBeInTheDocument();
+    });
+
+    it('renders sleeping mascot', () => {
+      renderComponent();
+      expect(screen.getByTestId('sleeping-mascot')).toBeInTheDocument();
+    });
+
+    it('passes orchestrator to SleepingMascot', () => {
+      renderComponent({ orchestrator: 'claude-code' });
+      expect(screen.getByTestId('sleeping-mascot')).toHaveAttribute('data-orchestrator', 'claude-code');
+    });
+
+    it('shows "This agent is sleeping" for sleeping durable agent', () => {
+      renderComponent({ kind: 'durable', status: 'sleeping' });
+      expect(screen.getByText('This agent is sleeping')).toBeInTheDocument();
+    });
+
+    it('shows "Session ended" for non-durable agent', () => {
+      renderComponent({ kind: 'quick', status: 'sleeping' });
+      expect(screen.getByText('Session ended')).toBeInTheDocument();
+    });
+
+    it('shows "Failed to launch" for error status', () => {
+      renderComponent({ status: 'error' });
+      expect(screen.getByText('Failed to launch')).toBeInTheDocument();
+    });
+
+    it('shows custom error message when available', () => {
+      renderComponent({ status: 'error', errorMessage: 'CLI not found' });
+      expect(screen.getByText('CLI not found')).toBeInTheDocument();
+    });
+
+    it('shows default error hint when no errorMessage', () => {
+      renderComponent({ status: 'error' });
+      expect(screen.getByText('Agent CLI may not be installed or accessible')).toBeInTheDocument();
+    });
+  });
+
+  describe('color indicator', () => {
+    it('renders color dot for durable agents', () => {
+      const { container } = renderComponent({ kind: 'durable', color: 'indigo' });
+      const dot = container.querySelector('.rounded-full');
+      expect(dot).toBeTruthy();
+    });
+
+    it('does not render color dot for quick agents', () => {
+      const { container } = renderComponent({ kind: 'quick' });
+      const dot = container.querySelector('.w-3.h-3.rounded-full');
+      expect(dot).toBeNull();
+    });
+  });
+
+  describe('branch display', () => {
+    it('shows branch name when branch is set', () => {
+      renderComponent({ branch: 'feature/test' });
+      expect(screen.getByText('Branch:')).toBeInTheDocument();
+      expect(screen.getByText('feature/test')).toBeInTheDocument();
+    });
+
+    it('does not show branch when not set', () => {
+      renderComponent();
+      expect(screen.queryByText('Branch:')).toBeNull();
+    });
+  });
+
+  describe('wake button', () => {
+    it('renders Wake Up button for sleeping durable agent', () => {
+      renderComponent({ kind: 'durable', status: 'sleeping' });
+      expect(screen.getByText('Wake Up')).toBeInTheDocument();
+    });
+
+    it('renders Retry button for error durable agent', () => {
+      renderComponent({ kind: 'durable', status: 'error' });
+      expect(screen.getByText('Retry')).toBeInTheDocument();
+    });
+
+    it('does not render wake button for quick agents', () => {
+      renderComponent({ kind: 'quick', status: 'sleeping' });
+      expect(screen.queryByText('Wake Up')).toBeNull();
+      expect(screen.queryByText('Retry')).toBeNull();
+    });
+
+    it('calls spawnDurableAgent when Wake Up is clicked', async () => {
+      const durableConfig = { id: 'agent-1', name: 'bold-falcon' };
+      window.clubhouse.agent.listDurable = vi.fn().mockResolvedValue([durableConfig]);
+
+      renderComponent({ kind: 'durable', status: 'sleeping' });
+      fireEvent.click(screen.getByText('Wake Up'));
+
+      await waitFor(() => {
+        expect(window.clubhouse.agent.listDurable).toHaveBeenCalledWith('/projects/test');
+      });
+
+      await waitFor(() => {
+        expect(mockSpawnDurableAgent).toHaveBeenCalledWith(
+          'proj-1',
+          '/projects/test',
+          durableConfig,
+          true,
+        );
+      });
+    });
+
+    it('does not spawn if config not found', async () => {
+      window.clubhouse.agent.listDurable = vi.fn().mockResolvedValue([
+        { id: 'other-agent', name: 'other' },
+      ]);
+
+      renderComponent({ kind: 'durable', status: 'sleeping' });
+      fireEvent.click(screen.getByText('Wake Up'));
+
+      await waitFor(() => {
+        expect(window.clubhouse.agent.listDurable).toHaveBeenCalled();
+      });
+
+      expect(mockSpawnDurableAgent).not.toHaveBeenCalled();
+    });
+
+    it('does not spawn if project not found', async () => {
+      useProjectStore.setState({ projects: [] });
+      const agent = { ...baseAgent, kind: 'durable' as const, status: 'sleeping' as const };
+      render(<SleepingAgent agent={agent} />);
+      fireEvent.click(screen.getByText('Wake Up'));
+
+      // Should return early without calling listDurable
+      await new Promise((r) => setTimeout(r, 50));
+      expect(window.clubhouse.agent.listDurable).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/features/popout/PopoutHubPane.test.tsx
+++ b/src/renderer/features/popout/PopoutHubPane.test.tsx
@@ -1,0 +1,478 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PopoutHubPane } from './PopoutHubPane';
+import { useAgentStore } from '../../stores/agentStore';
+import type { LeafPane } from '../../plugins/builtin/hub/pane-tree';
+import type { Agent, AgentDetailedStatus, CompletedQuickAgent } from '../../../shared/types';
+
+vi.mock('../agents/AgentTerminal', () => ({
+  AgentTerminal: ({ agentId }: { agentId: string }) => (
+    <div data-testid={`agent-terminal-${agentId}`} />
+  ),
+}));
+
+vi.mock('../agents/SleepingAgent', () => ({
+  SleepingAgent: ({ agent }: { agent: { id: string } }) => (
+    <div data-testid={`sleeping-agent-${agent.id}`} />
+  ),
+}));
+
+vi.mock('../agents/AgentAvatar', () => ({
+  AgentAvatarWithRing: ({ agent }: { agent: { name: string } }) => (
+    <div data-testid="agent-avatar" data-name={agent.name} />
+  ),
+}));
+
+vi.mock('../agents/QuickAgentGhost', () => ({
+  QuickAgentGhost: ({ completed, onDismiss }: { completed: { id: string }; onDismiss: () => void }) => (
+    <div data-testid={`quick-agent-ghost-${completed.id}`}>
+      <button data-testid="ghost-dismiss" onClick={onDismiss}>Dismiss</button>
+    </div>
+  ),
+}));
+
+const mockKillAgent = vi.fn().mockResolvedValue(undefined);
+
+const defaultPane: LeafPane = {
+  type: 'leaf',
+  id: 'pane-1',
+  agentId: 'agent-1',
+  projectId: 'proj-1',
+};
+
+const defaultAgent: Agent = {
+  id: 'agent-1',
+  projectId: 'proj-1',
+  name: 'bold-falcon',
+  kind: 'durable',
+  status: 'running',
+  color: 'indigo',
+};
+
+const defaultProps = {
+  pane: defaultPane,
+  focused: false,
+  canClose: true,
+  agents: { 'agent-1': defaultAgent } as Record<string, Agent>,
+  detailedStatuses: {} as Record<string, AgentDetailedStatus>,
+  completedAgents: [] as CompletedQuickAgent[],
+  projectId: 'proj-1',
+  onSplit: vi.fn(),
+  onClose: vi.fn(),
+  onSwap: vi.fn(),
+  onAssign: vi.fn(),
+  onFocus: vi.fn(),
+  onZoom: vi.fn(),
+  dismissCompleted: vi.fn(),
+};
+
+function renderPane(overrides: Partial<typeof defaultProps> = {}) {
+  const props = { ...defaultProps, ...overrides };
+  return render(<PopoutHubPane {...props} />);
+}
+
+describe('PopoutHubPane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAgentStore.setState({ killAgent: mockKillAgent });
+    window.clubhouse.window.focusMain = vi.fn().mockResolvedValue(undefined);
+  });
+
+  describe('content rendering', () => {
+    it('renders AgentTerminal for running agent', () => {
+      renderPane();
+      expect(screen.getByTestId('agent-terminal-agent-1')).toBeInTheDocument();
+    });
+
+    it('renders SleepingAgent for sleeping agent', () => {
+      renderPane({
+        agents: { 'agent-1': { ...defaultAgent, status: 'sleeping' } },
+      });
+      expect(screen.getByTestId('sleeping-agent-agent-1')).toBeInTheDocument();
+      expect(screen.queryByTestId('agent-terminal-agent-1')).toBeNull();
+    });
+
+    it('renders SleepingAgent for error agent', () => {
+      renderPane({
+        agents: { 'agent-1': { ...defaultAgent, status: 'error' } },
+      });
+      expect(screen.getByTestId('sleeping-agent-agent-1')).toBeInTheDocument();
+    });
+
+    it('renders QuickAgentGhost for completed quick agent', () => {
+      const completed: CompletedQuickAgent = {
+        id: 'agent-1', projectId: 'proj-1', name: 'quick-done',
+        mission: 'test', summary: null, filesModified: [],
+        exitCode: 0, completedAt: Date.now(),
+      };
+      renderPane({
+        pane: { ...defaultPane, agentId: 'agent-1' },
+        agents: {},
+        completedAgents: [completed],
+      });
+      expect(screen.getByTestId('quick-agent-ghost-agent-1')).toBeInTheDocument();
+    });
+
+    it('renders agent picker for unassigned pane', () => {
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+      });
+      expect(screen.getByText('Assign an agent')).toBeInTheDocument();
+    });
+
+    it('shows "No agents available" when no agents exist', () => {
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        agents: {},
+      });
+      expect(screen.getByText('No agents available')).toBeInTheDocument();
+    });
+  });
+
+  describe('agent picker', () => {
+    it('shows durable agents under Durable heading', () => {
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        agents: { 'agent-1': defaultAgent },
+      });
+      expect(screen.getByText('Durable')).toBeInTheDocument();
+      expect(screen.getByText('bold-falcon')).toBeInTheDocument();
+    });
+
+    it('shows quick running agents under Quick heading', () => {
+      const quickAgent: Agent = {
+        id: 'quick-1', projectId: 'proj-1', name: 'quick-fox',
+        kind: 'quick', status: 'running', color: 'emerald',
+      };
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        agents: { 'quick-1': quickAgent },
+      });
+      expect(screen.getByText('Quick')).toBeInTheDocument();
+      expect(screen.getByText('quick-fox')).toBeInTheDocument();
+    });
+
+    it('does not show quick sleeping agents', () => {
+      const quickSleeping: Agent = {
+        id: 'quick-1', projectId: 'proj-1', name: 'sleeping-fox',
+        kind: 'quick', status: 'sleeping', color: 'emerald',
+      };
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        agents: { 'quick-1': quickSleeping },
+      });
+      expect(screen.queryByText('Quick')).toBeNull();
+    });
+
+    it('calls onAssign when agent is picked', () => {
+      const onAssign = vi.fn();
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        agents: { 'agent-1': defaultAgent },
+        onAssign,
+      });
+      fireEvent.click(screen.getByText('bold-falcon'));
+      expect(onAssign).toHaveBeenCalledWith('pane-1', 'agent-1');
+    });
+  });
+
+  describe('floating name chip', () => {
+    it('renders agent name in chip', () => {
+      renderPane();
+      expect(screen.getByText('bold-falcon')).toBeInTheDocument();
+    });
+
+    it('renders agent avatar', () => {
+      renderPane();
+      expect(screen.getByTestId('agent-avatar')).toBeInTheDocument();
+    });
+
+    it('does not render chip for empty pane', () => {
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        agents: {},
+      });
+      expect(screen.queryByTestId('agent-avatar')).toBeNull();
+    });
+  });
+
+  describe('expanded actions on hover', () => {
+    function hoverPane() {
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+      return paneEl!;
+    }
+
+    it('shows action buttons on hover', () => {
+      renderPane();
+      hoverPane();
+
+      expect(screen.getByTitle('View in main window')).toBeInTheDocument();
+      expect(screen.getByTestId('zoom-button')).toBeInTheDocument();
+      expect(screen.getByTitle('Remove from pane')).toBeInTheDocument();
+    });
+
+    it('shows Stop button for running agents', () => {
+      renderPane();
+      hoverPane();
+      expect(screen.getByTitle('Stop agent')).toBeInTheDocument();
+    });
+
+    it('does not show Stop button for sleeping agents', () => {
+      renderPane({
+        agents: { 'agent-1': { ...defaultAgent, status: 'sleeping' } },
+      });
+      const paneEl = screen.getByTestId('sleeping-agent-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+      expect(screen.queryByTitle('Stop agent')).toBeNull();
+    });
+
+    it('View button calls focusMain', () => {
+      renderPane();
+      hoverPane();
+      fireEvent.click(screen.getByTitle('View in main window'));
+      expect(window.clubhouse.window.focusMain).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('Zoom button calls onZoom', () => {
+      const onZoom = vi.fn();
+      renderPane({ onZoom });
+      hoverPane();
+      fireEvent.click(screen.getByTestId('zoom-button'));
+      expect(onZoom).toHaveBeenCalledWith('pane-1');
+    });
+
+    it('shows Restore text when isZoomed is true', () => {
+      renderPane({ isZoomed: true });
+      hoverPane();
+      expect(screen.getByText('Restore')).toBeInTheDocument();
+    });
+
+    it('shows Zoom text when isZoomed is false', () => {
+      renderPane({ isZoomed: false });
+      hoverPane();
+      expect(screen.getByText('Zoom')).toBeInTheDocument();
+    });
+
+    it('Stop button calls killAgent', () => {
+      renderPane();
+      hoverPane();
+      fireEvent.click(screen.getByTitle('Stop agent'));
+      expect(mockKillAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('Remove button calls onAssign with null', () => {
+      const onAssign = vi.fn();
+      renderPane({ onAssign });
+      hoverPane();
+      fireEvent.click(screen.getByTitle('Remove from pane'));
+      expect(onAssign).toHaveBeenCalledWith('pane-1', null);
+    });
+  });
+
+  describe('edge split indicators', () => {
+    it('shows split indicators on hover', () => {
+      renderPane();
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+
+      expect(screen.getByTitle('Split Up')).toBeInTheDocument();
+      expect(screen.getByTitle('Split Down')).toBeInTheDocument();
+      expect(screen.getByTitle('Split Left')).toBeInTheDocument();
+      expect(screen.getByTitle('Split Right')).toBeInTheDocument();
+    });
+
+    it('split Up calls onSplit with vertical/before', () => {
+      const onSplit = vi.fn();
+      renderPane({ onSplit });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+
+      fireEvent.click(screen.getByTitle('Split Up'));
+      expect(onSplit).toHaveBeenCalledWith('pane-1', 'vertical', 'before');
+    });
+
+    it('split Down calls onSplit with vertical/after', () => {
+      const onSplit = vi.fn();
+      renderPane({ onSplit });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+
+      fireEvent.click(screen.getByTitle('Split Down'));
+      expect(onSplit).toHaveBeenCalledWith('pane-1', 'vertical', 'after');
+    });
+
+    it('split Left calls onSplit with horizontal/before', () => {
+      const onSplit = vi.fn();
+      renderPane({ onSplit });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+
+      fireEvent.click(screen.getByTitle('Split Left'));
+      expect(onSplit).toHaveBeenCalledWith('pane-1', 'horizontal', 'before');
+    });
+
+    it('split Right calls onSplit with horizontal/after', () => {
+      const onSplit = vi.fn();
+      renderPane({ onSplit });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+
+      fireEvent.click(screen.getByTitle('Split Right'));
+      expect(onSplit).toHaveBeenCalledWith('pane-1', 'horizontal', 'after');
+    });
+  });
+
+  describe('click and focus', () => {
+    it('clicking pane calls onFocus', () => {
+      const onFocus = vi.fn();
+      renderPane({ onFocus });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.click(paneEl!);
+      expect(onFocus).toHaveBeenCalledWith('pane-1');
+    });
+  });
+
+  describe('drag and drop', () => {
+    it('sets pane id on drag start', () => {
+      renderPane();
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+      fireEvent.mouseEnter(paneEl!);
+
+      // The draggable element is the chip, not the pane
+      const draggable = screen.getByText('bold-falcon').closest('[draggable]');
+      const dataTransfer = { setData: vi.fn(), effectAllowed: '' };
+      fireEvent.dragStart(draggable!, { dataTransfer });
+      expect(dataTransfer.setData).toHaveBeenCalledWith('text/x-pane-id', 'pane-1');
+    });
+
+    it('shows drag-over overlay during drag', () => {
+      const { container } = renderPane();
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+
+      const dataTransfer = {
+        types: ['text/x-pane-id'],
+        dropEffect: '',
+      };
+      fireEvent.dragOver(paneEl!, { dataTransfer });
+
+      // Should show a drag-over overlay
+      expect(container.querySelector('.border-dashed')).toBeTruthy();
+    });
+
+    it('calls onSwap when drop occurs from a different pane', () => {
+      const onSwap = vi.fn();
+      renderPane({ onSwap });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+
+      const dataTransfer = {
+        types: ['text/x-pane-id'],
+        getData: vi.fn().mockReturnValue('pane-2'),
+        dropEffect: '',
+      };
+      fireEvent.drop(paneEl!, { dataTransfer });
+      expect(onSwap).toHaveBeenCalledWith('pane-2', 'pane-1');
+    });
+
+    it('does not call onSwap when dropping on same pane', () => {
+      const onSwap = vi.fn();
+      renderPane({ onSwap });
+      const paneEl = screen.getByTestId('agent-terminal-agent-1').closest('[class*="rounded-sm"]');
+
+      const dataTransfer = {
+        types: ['text/x-pane-id'],
+        getData: vi.fn().mockReturnValue('pane-1'),
+        dropEffect: '',
+      };
+      fireEvent.drop(paneEl!, { dataTransfer });
+      expect(onSwap).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close pane', () => {
+    it('shows close button on unassigned pane when canClose is true', () => {
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        canClose: true,
+        agents: {},
+      });
+      expect(screen.getByTitle('Close pane')).toBeInTheDocument();
+    });
+
+    it('does not show close button when canClose is false', () => {
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        canClose: false,
+        agents: {},
+      });
+      expect(screen.queryByTitle('Close pane')).toBeNull();
+    });
+
+    it('clicking close calls onClose', () => {
+      const onClose = vi.fn();
+      renderPane({
+        pane: { ...defaultPane, agentId: null },
+        canClose: true,
+        agents: {},
+        onClose,
+      });
+      fireEvent.click(screen.getByTitle('Close pane'));
+      expect(onClose).toHaveBeenCalledWith('pane-1');
+    });
+  });
+
+  describe('border styles', () => {
+    it('applies orange border for needs_permission status', () => {
+      const { container } = renderPane({
+        detailedStatuses: { 'agent-1': { state: 'needs_permission', message: 'Allow?' } },
+      });
+      const pane = container.firstElementChild as HTMLElement;
+      expect(pane.style.boxShadow).toContain('rgb(249,115,22)');
+    });
+
+    it('applies yellow border for tool_error status', () => {
+      const { container } = renderPane({
+        detailedStatuses: { 'agent-1': { state: 'tool_error', message: 'Error' } },
+      });
+      const pane = container.firstElementChild as HTMLElement;
+      expect(pane.style.boxShadow).toContain('rgb(234,179,8)');
+    });
+
+    it('applies indigo border for focused pane', () => {
+      const { container } = renderPane({ focused: true });
+      const pane = container.firstElementChild as HTMLElement;
+      expect(pane.style.boxShadow).toContain('rgb(99,102,241)');
+    });
+
+    it('adds animate-pulse class for needs_permission', () => {
+      const { container } = renderPane({
+        detailedStatuses: { 'agent-1': { state: 'needs_permission', message: 'Allow?' } },
+      });
+      const pane = container.firstElementChild as HTMLElement;
+      expect(pane.className).toContain('animate-pulse');
+    });
+  });
+
+  describe('completed agent ghost dismissal', () => {
+    it('dismisses completed agent and unassigns pane', () => {
+      const dismissCompleted = vi.fn();
+      const onAssign = vi.fn();
+      const completed: CompletedQuickAgent = {
+        id: 'agent-1', projectId: 'proj-1', name: 'done-agent',
+        mission: 'test', summary: null, filesModified: [],
+        exitCode: 0, completedAt: Date.now(),
+      };
+      renderPane({
+        pane: { ...defaultPane, agentId: 'agent-1' },
+        agents: {},
+        completedAgents: [completed],
+        dismissCompleted,
+        onAssign,
+      });
+
+      fireEvent.click(screen.getByTestId('ghost-dismiss'));
+      expect(dismissCompleted).toHaveBeenCalledWith('proj-1', 'agent-1');
+      expect(onAssign).toHaveBeenCalledWith('pane-1', null);
+    });
+  });
+});

--- a/src/renderer/features/settings/ProjectSettings.test.tsx
+++ b/src/renderer/features/settings/ProjectSettings.test.tsx
@@ -1,0 +1,338 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProjectSettings } from './ProjectSettings';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+import type { Project } from '../../../shared/types';
+
+vi.mock('./ResetProjectDialog', () => ({
+  ResetProjectDialog: ({ projectName, onConfirm, onCancel }: any) => (
+    <div data-testid="reset-dialog">
+      <span data-testid="reset-project-name">{projectName}</span>
+      <button data-testid="reset-confirm" onClick={onConfirm}>Confirm Reset</button>
+      <button data-testid="reset-cancel" onClick={onCancel}>Cancel Reset</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/ImageCropDialog', () => ({
+  ImageCropDialog: ({ onConfirm, onCancel }: any) => (
+    <div data-testid="image-crop-dialog">
+      <button data-testid="crop-confirm" onClick={() => onConfirm('cropped-data-url')}>Confirm Crop</button>
+      <button data-testid="crop-cancel" onClick={onCancel}>Cancel Crop</button>
+    </div>
+  ),
+}));
+
+const baseProject: Project = {
+  id: 'proj-1',
+  name: 'my-project',
+  path: '/home/user/my-project',
+  color: 'indigo',
+};
+
+const mockUpdateProject = vi.fn();
+const mockRemoveProject = vi.fn();
+const mockPickProjectImage = vi.fn().mockResolvedValue(null);
+const mockSaveCroppedProjectIcon = vi.fn().mockResolvedValue(undefined);
+const mockToggleSettings = vi.fn();
+
+function resetStores(projectOverrides: Partial<Project> = {}) {
+  const project = { ...baseProject, ...projectOverrides };
+  useProjectStore.setState({
+    projects: [project],
+    activeProjectId: project.id,
+    projectIcons: {},
+    updateProject: mockUpdateProject,
+    removeProject: mockRemoveProject,
+    pickProjectImage: mockPickProjectImage,
+    saveCroppedProjectIcon: mockSaveCroppedProjectIcon,
+  });
+  useUIStore.setState({
+    toggleSettings: mockToggleSettings,
+  });
+}
+
+describe('ProjectSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.clubhouse.project.resetProject = vi.fn().mockResolvedValue(undefined);
+  });
+
+  describe('no project selected', () => {
+    it('shows fallback message when no project found', () => {
+      useProjectStore.setState({ projects: [], activeProjectId: null });
+      render(<ProjectSettings />);
+      expect(screen.getByText('Select a project')).toBeInTheDocument();
+    });
+
+    it('shows fallback when projectId does not match', () => {
+      resetStores();
+      render(<ProjectSettings projectId="nonexistent" />);
+      expect(screen.getByText('Select a project')).toBeInTheDocument();
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders Project Settings heading', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.getByText('Project Settings')).toBeInTheDocument();
+    });
+
+    it('renders the project path', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.getByText('/home/user/my-project')).toBeInTheDocument();
+    });
+
+    it('renders color picker with all colors', () => {
+      resetStores();
+      render(<ProjectSettings />);
+
+      expect(screen.getByTitle('Indigo')).toBeInTheDocument();
+      expect(screen.getByTitle('Emerald')).toBeInTheDocument();
+      expect(screen.getByTitle('Amber')).toBeInTheDocument();
+      expect(screen.getByTitle('Rose')).toBeInTheDocument();
+      expect(screen.getByTitle('Cyan')).toBeInTheDocument();
+      expect(screen.getByTitle('Violet')).toBeInTheDocument();
+      expect(screen.getByTitle('Orange')).toBeInTheDocument();
+      expect(screen.getByTitle('Teal')).toBeInTheDocument();
+    });
+
+    it('uses activeProjectId when projectId prop is not provided', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      // The project path should be rendered, confirming the correct project was found
+      expect(screen.getByText('/home/user/my-project')).toBeInTheDocument();
+    });
+
+    it('uses provided projectId over activeProjectId', () => {
+      const secondProject: Project = { id: 'proj-2', name: 'other-project', path: '/other' };
+      useProjectStore.setState({
+        projects: [baseProject, secondProject],
+        activeProjectId: 'proj-1',
+        projectIcons: {},
+        updateProject: mockUpdateProject,
+        removeProject: mockRemoveProject,
+        pickProjectImage: mockPickProjectImage,
+        saveCroppedProjectIcon: mockSaveCroppedProjectIcon,
+      });
+      useUIStore.setState({ toggleSettings: mockToggleSettings });
+
+      render(<ProjectSettings projectId="proj-2" />);
+      expect(screen.getByText('/other')).toBeInTheDocument();
+    });
+  });
+
+  describe('name editing', () => {
+    it('renders name input with current name', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      const input = screen.getByPlaceholderText('my-project') as HTMLInputElement;
+      expect(input.value).toBe('my-project');
+    });
+
+    it('shows Save button when name is changed', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      const input = screen.getByPlaceholderText('my-project');
+      fireEvent.change(input, { target: { value: 'new-name' } });
+      expect(screen.getByText('Save')).toBeInTheDocument();
+    });
+
+    it('does not show Save button when name matches', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.queryByText('Save')).toBeNull();
+    });
+
+    it('calls updateProject when Save is clicked', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      const input = screen.getByPlaceholderText('my-project');
+      fireEvent.change(input, { target: { value: 'new-name' } });
+      fireEvent.click(screen.getByText('Save'));
+
+      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { displayName: 'new-name' });
+    });
+
+    it('clears displayName when name matches original', () => {
+      resetStores({ displayName: 'custom-name' });
+      render(<ProjectSettings />);
+      const input = screen.getByDisplayValue('custom-name');
+      fireEvent.change(input, { target: { value: 'my-project' } });
+      fireEvent.click(screen.getByText('Save'));
+
+      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { displayName: '' });
+    });
+
+    it('saves on Enter key', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      const input = screen.getByPlaceholderText('my-project');
+      fireEvent.change(input, { target: { value: 'enter-name' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { displayName: 'enter-name' });
+    });
+
+    it('clears displayName for blank input', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      const input = screen.getByPlaceholderText('my-project');
+      fireEvent.change(input, { target: { value: '   ' } });
+      fireEvent.click(screen.getByText('Save'));
+
+      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { displayName: '' });
+    });
+  });
+
+  describe('color picker', () => {
+    it('clicking a color calls updateProject', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      fireEvent.click(screen.getByTitle('Emerald'));
+      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { color: 'emerald' });
+    });
+
+    it('shows check mark on selected color', () => {
+      resetStores({ color: 'indigo' });
+      const { container } = render(<ProjectSettings />);
+      const indigoBtn = screen.getByTitle('Indigo');
+      const svg = indigoBtn.querySelector('svg');
+      expect(svg).toBeTruthy();
+    });
+
+    it('defaults to indigo when no color is set', () => {
+      resetStores({ color: undefined });
+      const indigoBtn = render(<ProjectSettings />);
+      // Indigo should show check when no color set
+      const svg = screen.getByTitle('Indigo').querySelector('svg');
+      expect(svg).toBeTruthy();
+    });
+  });
+
+  describe('icon management', () => {
+    it('renders Choose Image button', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.getByText('Choose Image')).toBeInTheDocument();
+    });
+
+    it('opens image crop dialog when image is picked', async () => {
+      mockPickProjectImage.mockResolvedValue('data:image/png;base64,abc');
+      resetStores();
+      render(<ProjectSettings />);
+
+      fireEvent.click(screen.getByText('Choose Image'));
+
+      expect(await screen.findByTestId('image-crop-dialog')).toBeInTheDocument();
+    });
+
+    it('does not open crop dialog when no image selected', async () => {
+      mockPickProjectImage.mockResolvedValue(null);
+      resetStores();
+      render(<ProjectSettings />);
+
+      fireEvent.click(screen.getByText('Choose Image'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('image-crop-dialog')).toBeNull();
+      });
+    });
+
+    it('saves cropped icon on confirm', async () => {
+      mockPickProjectImage.mockResolvedValue('data:image/png;base64,abc');
+      resetStores();
+      render(<ProjectSettings />);
+
+      fireEvent.click(screen.getByText('Choose Image'));
+      const confirmBtn = await screen.findByTestId('crop-confirm');
+      fireEvent.click(confirmBtn);
+
+      await waitFor(() => {
+        expect(mockSaveCroppedProjectIcon).toHaveBeenCalledWith('proj-1', 'cropped-data-url');
+      });
+    });
+
+    it('shows Remove button when icon exists', () => {
+      resetStores({ icon: 'icon.png' });
+      useProjectStore.setState({
+        projectIcons: { 'proj-1': 'data:image/png;base64,xyz' },
+      });
+      render(<ProjectSettings />);
+      expect(screen.getByText('Remove')).toBeInTheDocument();
+    });
+
+    it('clicking Remove clears the icon', () => {
+      resetStores({ icon: 'icon.png' });
+      useProjectStore.setState({
+        projectIcons: { 'proj-1': 'data:image/png;base64,xyz' },
+      });
+      render(<ProjectSettings />);
+      fireEvent.click(screen.getByText('Remove'));
+      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { icon: '' });
+    });
+
+    it('shows initial letter when no icon exists', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.getByText('M')).toBeInTheDocument();
+    });
+  });
+
+  describe('danger zone', () => {
+    it('renders Close Project and Reset Project buttons', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.getByText('Close Project')).toBeInTheDocument();
+      expect(screen.getByText('Reset Project')).toBeInTheDocument();
+    });
+
+    it('clicking Close Project removes project and closes settings', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      fireEvent.click(screen.getByText('Close Project'));
+
+      expect(mockToggleSettings).toHaveBeenCalled();
+      expect(mockRemoveProject).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('clicking Reset Project shows confirmation dialog', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      fireEvent.click(screen.getByText('Reset Project'));
+      expect(screen.getByTestId('reset-dialog')).toBeInTheDocument();
+    });
+
+    it('confirming reset calls resetProject API', async () => {
+      resetStores();
+      render(<ProjectSettings />);
+      fireEvent.click(screen.getByText('Reset Project'));
+      fireEvent.click(screen.getByTestId('reset-confirm'));
+
+      await waitFor(() => {
+        expect(window.clubhouse.project.resetProject).toHaveBeenCalledWith('/home/user/my-project');
+      });
+      expect(mockToggleSettings).toHaveBeenCalled();
+      expect(mockRemoveProject).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('canceling reset closes dialog', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      fireEvent.click(screen.getByText('Reset Project'));
+      expect(screen.getByTestId('reset-dialog')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('reset-cancel'));
+      expect(screen.queryByTestId('reset-dialog')).toBeNull();
+    });
+
+    it('shows danger zone description', () => {
+      resetStores();
+      render(<ProjectSettings />);
+      expect(screen.getByText(/Close removes the project from Clubhouse/)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #230 — Adds comprehensive component test coverage for five high-visibility components that had **zero test coverage**.

- **SleepingAgent.tsx** (18 tests) — Canonical agent view; tests rendering for sleeping/error/quick states, wake button flow with IPC calls, retry behavior, branch display, and color indicator
- **ConfigChangesDialog.tsx** (25 tests) — New complex dialog; tests loading/empty/items states, checkbox toggle and select-all logic, save/discard/keep-for-agent actions, Escape key and backdrop dismissal, diff view expansion, and error handling
- **AgentTerminal.tsx** (20 tests) — Terminal rendering with PTY integration; tests xterm initialization with theme, FitAddon loading, PTY data forwarding (both directions), exit sequence handling, ResizeObserver cleanup, theme live-update, focus behavior, and clipboard handler attachment
- **ProjectSettings.tsx** (30 tests) — Main settings view; tests name editing with dirty state and Enter key, color picker selection, icon management (pick/crop/remove), danger zone (close project and reset project with confirmation dialog), and project fallback states
- **PopoutHubPane.tsx** (40 tests) — Pop-out hub leaf pane; tests content rendering (terminal/sleeping/ghost/picker), agent picker with durable/quick filtering, floating chip with expanded actions (View/Zoom/Stop/Remove), edge split indicators for all 4 directions, drag-and-drop pane swapping, border styles for permission/error/focused states, and completed agent ghost dismissal

**Total: 133 new tests** — all passing against full suite of 3228 tests.

## Test plan

- [x] All 133 new tests pass individually
- [x] Full test suite (3228 tests, 157 files) passes with 0 failures
- [x] No existing tests were modified or weakened
- [x] Test patterns follow established conventions (see `PopoutHubView.test.tsx`, `AgentListItem.test.tsx`)

## Notes

- AgentTerminal mocking uses `globalThis` pattern to work around vitest's `vi.mock` hoisting + `mockReset: true` config — classes defined inside factory functions survive mock resets
- Pre-existing typecheck failure (`adm-zip` types in `marketplace-service.ts`) is unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)