### PR TITLE
test: plugin system E2E tests — built-in loading, marketplace, settings (#235)

### DIFF
--- a/e2e/plugin-system.spec.ts
+++ b/e2e/plugin-system.spec.ts
@@ -80,9 +80,10 @@ async function getTitleBarText(): Promise<string> {
 async function openSettings() {
   const settingsBtn = window.locator('[data-testid="nav-settings"]');
   await settingsBtn.click();
-  await window.waitForTimeout(500);
-  const title = await getTitleBarText();
-  expect(title).toContain('Settings');
+  // Use a retry-capable assertion instead of a fixed wait — CI machines can be slow
+  await expect(window.locator('[data-testid="title-bar"]').first()).toContainText('Settings', {
+    timeout: 5_000,
+  });
 }
 
 /** Navigate to the Plugins settings sub-page (within settings view). */
@@ -108,7 +109,10 @@ async function ensureProjectView() {
 async function closeSettings() {
   const settingsBtn = window.locator('[data-testid="nav-settings"]');
   await settingsBtn.click();
-  await window.waitForTimeout(500);
+  // Wait until Settings is no longer in the title bar — ensures close is complete before proceeding
+  await expect(window.locator('[data-testid="title-bar"]').first()).not.toContainText('Settings', {
+    timeout: 5_000,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -333,7 +337,8 @@ test.describe('Plugin Settings', () => {
 
   test('External plugins section shows toggle switch', async () => {
     // The external plugins master switch should be visible
-    const externalLabel = window.locator('text=Enable External Plugins');
+    // Use exact match to avoid hitting the paragraph "Enable external plugins above to discover..."
+    const externalLabel = window.getByText('Enable External Plugins', { exact: true });
     await expect(externalLabel).toBeVisible({ timeout: 3_000 });
   });
 


### PR DESCRIPTION
## Summary
- Adds comprehensive E2E test suite for the Plugin System covering 33 test cases across 5 areas
- Fixes selector ambiguity and view state issues discovered during test development
- Closes #235

## Test Coverage

### Part A: Built-in Plugin Loading (8 tests)
- Verifies all 3 built-in plugins (hub, terminal, files) are registered and active in the Zustand store
- Validates explorer rail renders plugin tabs with correct `data-testid` and `data-active` attributes
- Confirms default hub tab is active on launch
- Tests tab switching between plugin tabs

### Part B: Plugin Settings (10 tests)
- Navigates to Settings → Plugins sub-page
- Verifies built-in plugins section header and individual plugin entries (hub, terminal, files)
- Checks toggle switches default to enabled for all built-in plugins
- Tests plugin disable/re-enable round-trip preserves state
- Validates Workshop link and Marketplace button are present
- Confirms external plugins toggle defaults to off

### Part C: Plugin Marketplace Dialog (9 tests)
- Opens marketplace dialog via settings button
- Verifies dialog structure: search input, filter tabs (All/Featured/Official), close button
- Tests filter tab switching and active state tracking
- Tests search input accepts text
- Validates overlay click closes dialog
- Confirms close button dismisses dialog

### Part D: Plugin Store State Integrity (3 tests)
- Verifies Zustand store `plugins` object contains all 3 built-in plugins after settings round-trip
- Checks `modules` record has loaded modules for all built-in plugins
- Validates no duplicate plugin IDs exist in the store

### Part E: Console Error Monitoring (2 tests)
- Monitors browser console for plugin-related errors throughout the test session
- Verifies no unhandled promise rejections from plugin system

## Bugs Found & Fixed
1. **Selector ambiguity**: `button:has-text("Plugins")` matched multiple elements when the fixture project name contained "Plugins" — fixed with exact regex match `(/^Plugins$/)`
2. **View state after settings toggle**: After toggling settings, ExplorerRail renders `SettingsContextPicker` instead of plugin tabs — added `ensureProjectView()` helper to restore project context before asserting plugin tabs

## Validation Results
- **33/33 plugin E2E tests pass** (isolated run: ~1.2 min)
- **Full validation**: 183 passed, 7 failed — all 7 failures are pre-existing in other test files (`rail-hover-flyout.spec.ts` rail width assertion, `smoke.spec.ts` Agent Lifecycle durable agent issues)
- Unit tests (vitest): all pass
- TypeScript compilation: clean
- Build (npm run make): clean

## Files Changed
- `e2e/plugin-system.spec.ts` — new E2E test suite (33 tests)
- `e2e/fixtures/project-plugins/.clubhouse/` — dedicated fixture directory for plugin tests

## Manual Validation
1. `npm run validate` — full build + test suite
2. `npx playwright test e2e/plugin-system.spec.ts` — isolated plugin test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)