### PR TITLE
fix: explorer panel scroll overflow (#275)

### DIFF
--- a/src/renderer/panels/AccessoryPanel.test.tsx
+++ b/src/renderer/panels/AccessoryPanel.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUIStore } from '../stores/uiStore';
+import { AccessoryPanel } from './AccessoryPanel';
+
+function resetStores() {
+  useUIStore.setState({
+    explorerTab: 'settings',
+    settingsContext: 'app',
+    settingsSubPage: 'about',
+  });
+}
+
+describe('SettingsCategoryNav (via AccessoryPanel)', () => {
+  beforeEach(resetStores);
+
+  it('settings category nav is scrollable when content overflows', () => {
+    const { container } = render(<AccessoryPanel />);
+    const nav = container.querySelector('nav');
+    expect(nav).toBeInTheDocument();
+    expect(nav!.className).toContain('overflow-y-auto');
+    expect(nav!.className).toContain('min-h-0');
+  });
+});

--- a/src/renderer/panels/AccessoryPanel.tsx
+++ b/src/renderer/panels/AccessoryPanel.tsx
@@ -35,7 +35,7 @@ function SettingsCategoryNav() {
           {isApp ? 'App Settings' : 'Project Settings'}
         </span>
       </div>
-      <nav className="py-1 flex-1 flex flex-col">
+      <nav className="py-1 flex-1 flex flex-col min-h-0 overflow-y-auto">
         {isApp ? (
           <>
             {navButton('About', 'about')}

--- a/src/renderer/panels/ExplorerRail.test.tsx
+++ b/src/renderer/panels/ExplorerRail.test.tsx
@@ -85,4 +85,39 @@ describe('SettingsContextPicker (via ExplorerRail)', () => {
     expect(screen.getByText('C')).toBeInTheDocument();
     expect(screen.getByText('Custom Name')).toBeInTheDocument();
   });
+
+  it('settings context picker nav is scrollable when content overflows', () => {
+    useProjectStore.setState({
+      projects: Array.from({ length: 20 }, (_, i) =>
+        makeProject({ id: `p${i}`, name: `Project ${i}` }),
+      ),
+      projectIcons: {},
+    });
+
+    const { container } = render(<ExplorerRail />);
+    const nav = container.querySelector('nav');
+    expect(nav).toBeInTheDocument();
+    expect(nav!.className).toContain('overflow-y-auto');
+    expect(nav!.className).toContain('min-h-0');
+  });
+});
+
+describe('ExplorerRail tabs nav', () => {
+  beforeEach(() => {
+    resetStores();
+    useUIStore.setState({ explorerTab: 'agents' });
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'TestProj' })],
+      activeProjectId: 'p1',
+      projectIcons: {},
+    });
+  });
+
+  it('tabs nav is scrollable when content overflows', () => {
+    const { container } = render(<ExplorerRail />);
+    const nav = container.querySelector('nav');
+    expect(nav).toBeInTheDocument();
+    expect(nav!.className).toContain('overflow-y-auto');
+    expect(nav!.className).toContain('min-h-0');
+  });
 });

--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -57,11 +57,11 @@ function SettingsContextPicker() {
   const projectIcons = useProjectStore((s) => s.projectIcons);
 
   return (
-    <div className="flex flex-col bg-ctp-mantle border-r border-surface-0 h-full">
+    <div className="flex flex-col bg-ctp-mantle border-r border-surface-0 h-full min-h-0">
       <div className="px-3 py-3 border-b border-surface-0">
         <h2 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Settings</h2>
       </div>
-      <nav className="flex-1 py-1 flex flex-col">
+      <nav className="flex-1 py-1 flex flex-col min-h-0 overflow-y-auto">
         <button
           onClick={() => setSettingsContext('app')}
           className={`
@@ -288,7 +288,7 @@ export function ExplorerRail() {
           {activeProject?.displayName || activeProject?.name || 'No Project'}
         </h2>
       </div>
-      <nav className="flex-1 py-1 flex flex-col">
+      <nav className="flex-1 py-1 flex flex-col min-h-0 overflow-y-auto">
         {orderedTabs.map((tab, i) => (
           <div
             key={tab.id}


### PR DESCRIPTION
## Summary

Fixes #275 — the explorer panel (ExplorerRail and AccessoryPanel) did not scroll when content overflowed the visible area, causing items below the fold to be clipped and inaccessible.

### Root Cause

Three `<nav>` containers were missing `overflow-y-auto` and `min-h-0` CSS classes:

1. **`ExplorerRail.tsx` — SettingsContextPicker nav** (line 64): The project list in Settings mode had no scroll capability
2. **`ExplorerRail.tsx` — tabs nav** (line 291): The explorer tab list had no scroll capability
3. **`AccessoryPanel.tsx` — SettingsCategoryNav nav** (line 38): The settings category menu had no scroll capability

### Fix

Added `min-h-0 overflow-y-auto` to all three `<nav>` elements and `min-h-0` to the SettingsContextPicker parent div. This matches the established pattern in `ProjectRail.tsx` which already handles overflow correctly.

### Changes

- `src/renderer/panels/ExplorerRail.tsx` — Added `min-h-0 overflow-y-auto` to both nav containers; added `min-h-0` to SettingsContextPicker parent div
- `src/renderer/panels/AccessoryPanel.tsx` — Added `min-h-0 overflow-y-auto` to SettingsCategoryNav nav
- `src/renderer/panels/ExplorerRail.test.tsx` — Added tests verifying scroll overflow classes on both nav containers
- `src/renderer/panels/AccessoryPanel.test.tsx` — New test file verifying scroll overflow classes on SettingsCategoryNav

### Test Plan

- [x] Unit tests verify `overflow-y-auto` and `min-h-0` classes are present on all nav containers
- [x] All 4320 existing tests pass
- [x] TypeScript typecheck passes
- [x] Build succeeds

### Manual Validation

1. Open the Settings view with enough projects to overflow the ExplorerRail sidebar
2. Verify the project list scrolls when content overflows
3. Open Settings with enough category items to overflow the AccessoryPanel
4. Verify the settings category nav scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)