### PR TITLE
fix: isolate hub stores per project to prevent cross-project state leaks

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,7 +41,7 @@ import { initPluginUpdateListener } from './stores/pluginUpdateStore';
 import { PluginUpdateBanner } from './features/plugins/PluginUpdateBanner';
 import { useClubhouseModeStore } from './stores/clubhouseModeStore';
 import { ConfigChangesDialog } from './features/agents/ConfigChangesDialog';
-import { useProjectHubStore, useAppHubStore } from './plugins/builtin/hub/main';
+import { getProjectHubStore, useAppHubStore } from './plugins/builtin/hub/main';
 import { applyHubMutation } from './plugins/builtin/hub/hub-sync';
 import type { HubMutation } from '../shared/types';
 
@@ -180,8 +180,8 @@ export function App() {
   // Respond to hub state requests from pop-out windows
   useEffect(() => {
     const remove = window.clubhouse.window.onRequestHubState(
-      (requestId: string, hubId: string, scope: string) => {
-        const store = scope === 'global' ? useAppHubStore : useProjectHubStore;
+      (requestId: string, hubId: string, scope: string, projectId?: string) => {
+        const store = scope === 'global' ? useAppHubStore : getProjectHubStore(projectId ?? null);
         const state = store.getState();
         const hub = state.hubs.find((h) => h.id === hubId);
         if (hub) {
@@ -202,8 +202,8 @@ export function App() {
   // Apply hub mutations forwarded from pop-out windows
   useEffect(() => {
     const remove = window.clubhouse.window.onHubMutation(
-      (hubId: string, scope: string, mutation: unknown) => {
-        const store = scope === 'global' ? useAppHubStore : useProjectHubStore;
+      (hubId: string, scope: string, mutation: unknown, projectId?: string) => {
+        const store = scope === 'global' ? useAppHubStore : getProjectHubStore(projectId ?? null);
         applyHubMutation(store, hubId, mutation as HubMutation);
       },
     );

--- a/src/renderer/features/command-palette/use-command-source.test.ts
+++ b/src/renderer/features/command-palette/use-command-source.test.ts
@@ -101,11 +101,21 @@ const appHubState = {
   setActiveHub: mockSetAppActiveHub,
 };
 
+const mockProjectHubStore = Object.assign(
+  (selector: any) => selector(projectHubState),
+  { getState: () => projectHubState, subscribe: () => () => {}, destroy: () => {} },
+);
+
+vi.mock('zustand', async () => {
+  const actual = await vi.importActual('zustand');
+  return {
+    ...(actual as any),
+    useStore: (store: any, selector: any) => selector(store.getState()),
+  };
+});
+
 vi.mock('../../plugins/builtin/hub/main', () => ({
-  useProjectHubStore: Object.assign(
-    (selector: any) => selector(projectHubState),
-    { getState: () => projectHubState },
-  ),
+  getProjectHubStore: () => mockProjectHubStore,
   useAppHubStore: Object.assign(
     (selector: any) => selector(appHubState),
     { getState: () => appHubState },

--- a/src/renderer/features/command-palette/use-command-source.ts
+++ b/src/renderer/features/command-palette/use-command-source.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect } from 'react';
+import { useStore } from 'zustand';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAgentStore } from '../../stores/agentStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -6,7 +7,7 @@ import { usePanelStore } from '../../stores/panelStore';
 import { usePluginStore } from '../../plugins/plugin-store';
 import { useKeyboardShortcutsStore, formatBinding } from '../../stores/keyboardShortcutsStore';
 import { useAnnexStore } from '../../stores/annexStore';
-import { useProjectHubStore, useAppHubStore } from '../../plugins/builtin/hub/main';
+import { getProjectHubStore, useAppHubStore } from '../../plugins/builtin/hub/main';
 import { pluginHotkeyRegistry } from '../../plugins/plugin-hotkeys';
 import { pluginCommandRegistry } from '../../plugins/plugin-commands';
 import { CommandItem, SETTINGS_PAGES } from './command-registry';
@@ -47,8 +48,9 @@ export function useCommandSource(): CommandItem[] {
   const toggleAccessoryCollapse = usePanelStore((s) => s.toggleAccessoryCollapse);
   const annexSettings = useAnnexStore((s) => s.settings);
   const annexStatus = useAnnexStore((s) => s.status);
-  const projectHubs = useProjectHubStore((s) => s.hubs);
-  const projectActiveHubId = useProjectHubStore((s) => s.activeHubId);
+  const currentProjectStore = getProjectHubStore(activeProjectId);
+  const projectHubs = useStore(currentProjectStore, (s) => s.hubs);
+  const projectActiveHubId = useStore(currentProjectStore, (s) => s.activeHubId);
   const appHubs = useAppHubStore((s) => s.hubs);
   const appActiveHubId = useAppHubStore((s) => s.activeHubId);
 
@@ -152,7 +154,7 @@ export function useCommandSource(): CommandItem[] {
           execute: () => {
             setActiveProject(activeProjectId);
             setExplorerTab(HUB_TAB, activeProjectId);
-            useProjectHubStore.getState().setActiveHub(hub.id);
+            getProjectHubStore(activeProjectId).getState().setActiveHub(hub.id);
           },
         });
       }

--- a/src/renderer/plugins/builtin/hub/hub-sync.ts
+++ b/src/renderer/plugins/builtin/hub/hub-sync.ts
@@ -2,8 +2,8 @@
  * Hub state synchronisation between main window (leader) and pop-out
  * windows (followers).
  *
- * The main window's hub stores (`useProjectHubStore` / `useAppHubStore`)
- * are the single source of truth.  Pop-outs forward mutations here;
+ * The main window's hub stores (per-project via `getProjectHubStore()` /
+ * `useAppHubStore`) are the single source of truth.  Pop-outs forward mutations here;
  * this module applies them and broadcasts the resulting state to all
  * pop-out windows via IPC.
  */

--- a/src/renderer/plugins/builtin/hub/main.test.ts
+++ b/src/renderer/plugins/builtin/hub/main.test.ts
@@ -41,4 +41,35 @@ describe('hub main', () => {
     expect(hubModule.MainPanel).toBeDefined();
     expect(typeof hubModule.MainPanel).toBe('function');
   });
+
+  it('exports getProjectHubStore function', () => {
+    expect(hubModule.getProjectHubStore).toBeDefined();
+    expect(typeof hubModule.getProjectHubStore).toBe('function');
+  });
+
+  it('getProjectHubStore returns the same store for the same projectId', () => {
+    const store1 = hubModule.getProjectHubStore('proj-1');
+    const store2 = hubModule.getProjectHubStore('proj-1');
+    expect(store1).toBe(store2);
+  });
+
+  it('getProjectHubStore returns different stores for different projectIds', () => {
+    const storeA = hubModule.getProjectHubStore('proj-a');
+    const storeB = hubModule.getProjectHubStore('proj-b');
+    expect(storeA).not.toBe(storeB);
+  });
+
+  it('per-project stores have isolated state', () => {
+    const storeA = hubModule.getProjectHubStore('proj-iso-a');
+    const storeB = hubModule.getProjectHubStore('proj-iso-b');
+
+    // Modify store A
+    const paneId = storeA.getState().paneTree.id;
+    storeA.getState().assignAgent(paneId, 'agent-1', 'proj-iso-a');
+
+    // Store B should be unaffected
+    const leafB = storeB.getState().paneTree;
+    expect(leafB.type).toBe('leaf');
+    expect((leafB as any).agentId).toBeNull();
+  });
 });

--- a/src/renderer/plugins/builtin/hub/manifest.test.ts
+++ b/src/renderer/plugins/builtin/hub/manifest.test.ts
@@ -55,9 +55,9 @@ describe('hub manifest', () => {
     expect(cmds.some((c) => c.id === 'split-pane')).toBe(true);
   });
 
-  it('contributes global storage scope', () => {
+  it('contributes project-local storage scope', () => {
     expect(manifest.contributes?.storage).toBeDefined();
-    expect(manifest.contributes!.storage!.scope).toBe('global');
+    expect(manifest.contributes!.storage!.scope).toBe('project-local');
   });
 
   it('contributes cross-project-hub boolean setting with default true', () => {

--- a/src/renderer/plugins/builtin/hub/manifest.ts
+++ b/src/renderer/plugins/builtin/hub/manifest.ts
@@ -19,7 +19,7 @@ export const manifest: PluginManifest = {
     tab: { label: 'Hub', icon: GRID_ICON, layout: 'full' },
     railItem: { label: 'Hub', icon: SPOKE_ICON, position: 'top' },
     commands: [{ id: 'split-pane', title: 'Split Pane' }],
-    storage: { scope: 'global' },
+    storage: { scope: 'project-local' },
     settings: [
       {
         key: 'cross-project-hub',

--- a/src/renderer/plugins/builtin/hub/pane-tree.ts
+++ b/src/renderer/plugins/builtin/hub/pane-tree.ts
@@ -137,6 +137,16 @@ export function validateAgents(tree: PaneNode, knownIds: Set<string>): PaneNode 
   );
 }
 
+/** Strip cross-project references: clear panes whose projectId doesn't match the current project. */
+export function sanitizeProjectIds(tree: PaneNode, currentProjectId: string): PaneNode {
+  return mapLeaves(tree, (leaf) => {
+    if (leaf.projectId && leaf.projectId !== currentProjectId) {
+      return { ...leaf, agentId: null, projectId: undefined };
+    }
+    return leaf;
+  });
+}
+
 export function findLeaf(tree: PaneNode, paneId: string): LeafPane | null {
   if (tree.type === 'leaf') {
     return tree.id === paneId ? tree : null;

--- a/src/renderer/stores/notificationStore.ts
+++ b/src/renderer/stores/notificationStore.ts
@@ -3,7 +3,7 @@ import { NotificationSettings } from '../../shared/types';
 import { useAgentStore } from './agentStore';
 import { useUIStore } from './uiStore';
 import { useProjectStore } from './projectStore';
-import { useProjectHubStore, useAppHubStore } from '../plugins/builtin/hub/main';
+import { getProjectHubStore, useAppHubStore } from '../plugins/builtin/hub/main';
 import { collectLeaves } from '../plugins/builtin/hub/pane-tree';
 import { useSoundStore, mapNotificationToSoundEvent } from './soundStore';
 
@@ -21,7 +21,7 @@ function isAgentVisible(agentId: string, projectId: string): boolean {
 
   // Agent is in a visible hub pane
   if (explorerTab === 'plugin:hub' && activeProjectId === projectId) {
-    const leaves = collectLeaves(useProjectHubStore.getState().paneTree);
+    const leaves = collectLeaves(getProjectHubStore(projectId).getState().paneTree);
     if (leaves.some((l) => l.agentId === agentId)) return true;
   }
   if (explorerTab === 'plugin:app:hub' || explorerTab.startsWith('plugin:app:hub')) {


### PR DESCRIPTION
## Summary

Fixes #277. Project-level hub pane trees were leaking between projects because a single shared Zustand store (`useProjectHubStore`) was reused across all projects in the same renderer process.

- **Per-project store isolation** — Replaced the static `useProjectHubStore` singleton with a `Map<projectId, store>` via `getProjectHubStore(projectId)`. Each project now gets its own independent hub store instance with isolated in-memory state, counters, and lifecycle.
- **Manifest storage scope fix** — Changed `contributes.storage.scope` from `'global'` to `'project-local'` to match the runtime behavior of using `api.storage.projectLocal`.
- **Cross-project reference sanitization** — Added `sanitizeProjectIds()` in `pane-tree.ts` that strips panes with stale cross-project `projectId` references during hub load. Integrated into `loadHub()` when a `currentProjectId` is provided.
- **Consumer updates** — Updated `App.tsx` (pop-out window handlers now use the `projectId` parameter from IPC), `notificationStore.ts`, and `use-command-source.ts` to use the new `getProjectHubStore()` API.

## Files changed

| File | Change |
|------|--------|
| `src/renderer/plugins/builtin/hub/main.ts` | Replace static store with per-project Map + `getProjectHubStore()` |
| `src/renderer/plugins/builtin/hub/manifest.ts` | `storage.scope: 'global'` → `'project-local'` |
| `src/renderer/plugins/builtin/hub/useHubStore.ts` | `loadHub()` accepts `currentProjectId` for sanitization |
| `src/renderer/plugins/builtin/hub/pane-tree.ts` | New `sanitizeProjectIds()` function |
| `src/renderer/plugins/builtin/hub/hub-sync.ts` | Comment update |
| `src/renderer/App.tsx` | Pop-out handlers use `projectId` param |
| `src/renderer/stores/notificationStore.ts` | Use `getProjectHubStore(projectId)` |
| `src/renderer/features/command-palette/use-command-source.ts` | Use `useStore()` + `getProjectHubStore()` |

## Test plan

- [x] **Unit: per-project store isolation** — `getProjectHubStore` returns same store for same ID, different stores for different IDs, with isolated state
- [x] **Unit: sanitizeProjectIds** — Clears mismatched cross-project references, keeps matching ones, handles split trees recursively
- [x] **Unit: loadHub sanitization** — Cross-project panes are stripped when `currentProjectId` is provided; no sanitization when omitted; works for both multi-hub and legacy migration paths
- [x] **Unit: manifest scope** — Verifies `contributes.storage.scope` is `'project-local'`
- [x] **Unit: all existing tests pass** — 4328 tests, 171 test files, all green
- [x] **TypeScript** — Clean `tsc --noEmit`
- [ ] **Manual: project switching** — Open Project A with hub agents, switch to Project B, verify B has its own empty hub; switch back to A, verify A's state is intact
- [ ] **Manual: pop-out windows** — Pop out a hub from Project A, verify mutations round-trip correctly and don't leak to Project B
- [ ] **E2E (CI/CD)** — Playwright tests to be validated in CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)