### PR TITLE
fix: add missing SettingsAPI.set() method to plugin SDK

### DIFF
--- a/src/renderer/plugins/plugin-api-factory.test.ts
+++ b/src/renderer/plugins/plugin-api-factory.test.ts
@@ -464,6 +464,24 @@ describe('plugin-api-factory', () => {
       expect(api.settings.getAll()).toEqual({});
     });
 
+    it('set writes a setting to the store', () => {
+      const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+      api.settings.set('color', 'blue');
+      expect(usePluginStore.getState().pluginSettings['proj-1:test-plugin']?.color).toBe('blue');
+    });
+
+    it('set for app-scoped plugin writes to app: prefix', () => {
+      const api = createPluginAPI(makeCtx({ scope: 'app', projectId: undefined }), undefined, allPermsManifest);
+      api.settings.set('mode', 'zen');
+      expect(usePluginStore.getState().pluginSettings['app:test-plugin']?.mode).toBe('zen');
+    });
+
+    it('set value is readable via get', () => {
+      const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+      api.settings.set('size', 42);
+      expect(api.settings.get('size')).toBe(42);
+    });
+
     it('uses app: prefix for app-scoped plugins', () => {
       usePluginStore.setState({
         pluginSettings: { 'app:test-plugin': { mode: 'zen' } },

--- a/src/renderer/plugins/plugin-api-factory.ts
+++ b/src/renderer/plugins/plugin-api-factory.ts
@@ -416,9 +416,10 @@ function createEventsAPI(): EventsAPI {
 }
 
 function createSettingsAPI(ctx: PluginContext): SettingsAPI {
-  const settingsKey = (ctx.scope === 'project' || ctx.scope === 'dual') && ctx.projectId
-    ? `${ctx.projectId}:${ctx.pluginId}`
-    : `app:${ctx.pluginId}`;
+  const settingsScope = (ctx.scope === 'project' || ctx.scope === 'dual') && ctx.projectId
+    ? ctx.projectId
+    : 'app';
+  const settingsKey = `${settingsScope}:${ctx.pluginId}`;
   const changeHandlers = new Set<(key: string, value: unknown) => void>();
 
   // Subscribe to store changes and dispatch to changeHandlers
@@ -445,6 +446,9 @@ function createSettingsAPI(ctx: PluginContext): SettingsAPI {
     },
     getAll(): Record<string, unknown> {
       return usePluginStore.getState().pluginSettings[settingsKey] || {};
+    },
+    set(key: string, value: unknown): void {
+      usePluginStore.getState().setPluginSetting(settingsScope, ctx.pluginId, key, value);
     },
     onChange(callback: (key: string, value: unknown) => void): Disposable {
       changeHandlers.add(callback);

--- a/src/renderer/plugins/plugin-api-version-contracts.test.ts
+++ b/src/renderer/plugins/plugin-api-version-contracts.test.ts
@@ -69,7 +69,7 @@ const COMMANDS_API_METHODS: (keyof CommandsAPI)[] = [
 
 const EVENTS_API_METHODS: (keyof EventsAPI)[] = ['on'];
 
-const SETTINGS_API_METHODS: (keyof SettingsAPI)[] = ['get', 'getAll', 'onChange'];
+const SETTINGS_API_METHODS: (keyof SettingsAPI)[] = ['get', 'getAll', 'set', 'onChange'];
 
 const AGENTS_API_METHODS: (keyof AgentsAPI)[] = [
   'list', 'runQuick', 'kill', 'resume', 'listCompleted', 'dismissCompleted',
@@ -908,6 +908,10 @@ describe('§4 Mock API safe return values', () => {
 
   it('api.settings.getAll() returns empty object', () => {
     expect(api.settings.getAll()).toEqual({});
+  });
+
+  it('api.settings.set() is a no-op (returns undefined)', () => {
+    expect(api.settings.set('k', 'v')).toBeUndefined();
   });
 
   it('api.agents.list() returns empty array', () => {

--- a/src/renderer/plugins/testing.ts
+++ b/src/renderer/plugins/testing.ts
@@ -79,6 +79,7 @@ export function createMockAPI(overrides?: Partial<PluginAPI>): PluginAPI {
     settings: {
       get: (): undefined => undefined,
       getAll: () => ({}),
+      set: noop,
       onChange: () => ({ dispose: noop }),
     },
     agents: {

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -368,6 +368,7 @@ export interface EventsAPI {
 export interface SettingsAPI {
   get<T = unknown>(key: string): T | undefined;
   getAll(): Record<string, unknown>;
+  set(key: string, value: unknown): void;
   onChange(callback: (key: string, value: unknown) => void): Disposable;
 }
 


### PR DESCRIPTION
## Summary

- Adds the missing `set(key: string, value: unknown): void` method to the `SettingsAPI` interface, factory implementation, mock API, and contract tests
- The plugin store already had `setPluginSetting()` — this just wires it through the plugin API surface

## Context

The wiki plugin (and any plugin with inline config like "Browse" buttons that write back to a directory-type setting) depends on `api.settings.set('wikiPath', path)`. The method was missing from the type interface, factory, and mock, making it impossible for plugins to programmatically update their own declared settings.

## Files changed

| File | Change |
|------|--------|
| `src/shared/plugin-types.ts` | Add `set(key, value): void` to `SettingsAPI` |
| `src/renderer/plugins/plugin-api-factory.ts` | Implement `set()` via `pluginStore.setPluginSetting()` |
| `src/renderer/plugins/testing.ts` | Add `set: noop` to mock |
| `src/renderer/plugins/plugin-api-version-contracts.test.ts` | Add `set` to `SETTINGS_API_METHODS`, add return value test |
| `src/renderer/plugins/plugin-api-factory.test.ts` | Add 3 tests: store write, app-scope prefix, round-trip |

## Test plan

- [x] Typecheck passes
- [x] Contract tests pass (265 tests)
- [x] Factory tests pass (357 tests)
- [ ] Full `npm run validate` (CI)
- [ ] Manual: plugin calling `api.settings.set('key', value)` updates the setting and is readable via `api.settings.get('key')`
- [ ] Manual: `onChange` callback fires when `set()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)