### PR TITLE
refactor: overhaul help content — concise, actionable, up-to-date

### DIFF
--- a/src/renderer/features/help/content/agents-clubhouse-mode.md
+++ b/src/renderer/features/help/content/agents-clubhouse-mode.md
@@ -1,0 +1,44 @@
+# Clubhouse Mode
+
+Clubhouse Mode keeps your durable agents in sync with project-level defaults. When enabled, changes to project settings (instructions, permissions, MCP config, skills, templates) are automatically pushed to agents on wake.
+
+## How It Works
+
+1. You configure project-level agent defaults (instructions, MCP, skills, etc.)
+2. Clubhouse Mode pushes these defaults to durable agent worktrees
+3. When an agent wakes and its config has drifted, a **Config Changes Dialog** appears
+
+## Config Changes Dialog
+
+When drift is detected, you see a diff grouped by category (instructions, permissions, MCP, skills, templates) with additions (+), removals (-), and modifications (~).
+
+Three options:
+
+| Action | Effect |
+|--------|--------|
+| **Save to Clubhouse** | Push selected changes back to project defaults |
+| **Keep for this agent** | Lock the agent to its own config (override) |
+| **Discard** | Ignore the changes |
+
+## Wildcard Substitutions
+
+Clubhouse Mode supports dynamic placeholders in instructions:
+
+| Placeholder | Resolves To |
+|------------|-------------|
+| `@@AgentName` | The agent's display name |
+| `@@StandbyBranch` | The agent's assigned branch |
+| `@@Path` | The agent's worktree path |
+
+> **Example:** An instruction file containing *"You are @@AgentName working on @@StandbyBranch"* resolves to *"You are feature-auth working on feature/auth-refactor"* for each agent.
+
+## Settings
+
+- **Global toggle:** **Settings > Clubhouse Mode** — enable/disable for all projects
+- **Per-project override:** **Project Settings > Clubhouse Mode** — override the global setting
+
+## When to Use
+
+- **Teams** — Ensure all agents follow the same coding standards and instructions
+- **Consistency** — Keep MCP servers, skills, and permissions uniform across agents
+- **Flexibility** — Individual agents can still override with "Keep for this agent"

--- a/src/renderer/features/help/content/agents-durable.md
+++ b/src/renderer/features/help/content/agents-durable.md
@@ -1,113 +1,49 @@
 # Durable Agents
 
-Durable agents are long-lived, persistent agents designed for ongoing work. Unlike quick agents, they survive app restarts, maintain their own configuration, and can be paused and resumed across multiple sessions. A durable agent is the right choice when you need an AI assistant that stays with a task over time — building a feature branch, performing iterative refactors, or acting as a dedicated reviewer.
+Durable agents are persistent, long-lived agents designed for ongoing work. They survive app restarts, maintain their own Git worktree, and can be paused and resumed across sessions.
 
 ## Creating a Durable Agent
 
-To create a durable agent:
+1. Select a project, open the Agents tab, click **New Agent**
+2. Configure: **Name**, **Color**, **Emoji**, **Branch**, **Model**, **Orchestrator**
+3. Click **Create** — the agent appears in the explorer immediately
+4. Give it a mission to start working, or leave it sleeping
 
-1. Select a project in the Project Rail (left sidebar).
-2. Click **New Agent** in the project's explorer panel.
-3. Fill in the configuration form:
-   - **Name** — a descriptive name for the agent (e.g., "feature-auth", "refactor-api").
-   - **Color** — choose from 10+ colors used for the agent's avatar ring and accent highlights.
-   - **Emoji / Avatar** — optionally pick an emoji to serve as the agent's visual avatar. If omitted, the agent uses the first letter of its name.
-   - **Branch** — the Git branch the agent will work on. You can select an existing branch or create a new one.
-   - **Model** — the AI model the agent will use, selected from the models available through the project's orchestrator.
-   - **Orchestrator** — the backend that powers the agent (e.g., Claude Code). This is typically inherited from the project configuration.
-4. Click **Create** to register the agent. It appears in the explorer list immediately.
-5. Give the agent an initial mission to start it working, or leave it sleeping to configure further before launching.
+> **Tip:** Use templates to pre-fill configuration for recurring agent types.
 
-## Customization
+## Git Worktree Isolation
 
-You can update a durable agent's appearance at any time from its configuration panel.
+Each durable agent operates in its own worktree on a dedicated branch:
+- Agent file operations are scoped to its worktree — your main checkout is unaffected
+- Multiple agents can work on different branches simultaneously
+- Merge agent work via standard Git (merge, PR, cherry-pick)
 
-- **Name** — rename the agent to reflect its current purpose.
-- **Color** — pick a new color from the palette. The color appears on the avatar ring, the explorer entry, and the terminal tab.
-- **Emoji / Avatar** — change or remove the emoji avatar.
+## Configuration
 
-These changes take effect immediately and do not interrupt a running agent.
-
-## Git Worktree
-
-Each durable agent can operate in its own Git worktree, giving it an isolated copy of the repository on a dedicated branch. This means the agent can make commits, create files, and run builds without affecting your main working tree or other agents.
-
-When you assign a branch to a durable agent, Clubhouse can automatically create a Git worktree for that branch. The worktree lives alongside your main repository checkout and is managed by Clubhouse. Benefits of worktree isolation include:
-
-- **No conflicts** — the agent's changes do not appear in your editor or interfere with other agents.
-- **Independent builds** — you can build and test the agent's branch without switching your own branch.
-- **Clean diffs** — each agent's work is scoped to its own branch, making pull requests straightforward.
-
-If you prefer not to use a worktree, the agent can work directly on the project's current branch, though this may lead to conflicts if multiple agents or manual edits are happening simultaneously.
-
-## Agent Instructions
-
-You can provide custom instructions that guide an agent's behavior. These instructions are stored in the `.clubhouse/` directory within the project and are loaded automatically when the agent starts.
-
-Agent instructions are written in Markdown and can include:
-
-- Coding style guidelines and conventions the agent should follow
-- Repository structure notes to help the agent navigate the codebase
-- Workflow rules such as "always write tests before implementation" or "commit frequently"
-- Restrictions such as "do not modify files outside of the `src/` directory"
-
-Instructions are per-agent, so different agents on the same project can have different behavioral guidelines.
-
-## MCP Configuration
-
-Each durable agent can have its own Model Context Protocol (MCP) configuration. MCP defines the set of tool servers and resources available to the agent during its session. You can configure MCP from the agent's settings panel to:
-
-- Add or remove MCP tool servers (e.g., file system, web search, database access)
-- Set server-specific parameters and environment variables
-- Control which tools the agent is allowed to invoke
-
-MCP configuration is stored per agent and does not affect other agents on the same project.
-
-## Skills
-
-Skills are reusable definitions that extend what an agent can do. A skill packages a prompt, a set of allowed tools, and optional configuration into a named unit that the agent can invoke during its session.
-
-You can attach skills to a durable agent from its configuration panel. Skills might include things like:
-
-- A "commit" skill that stages, commits, and pushes changes following your team's conventions
-- A "review-pr" skill that fetches a pull request and provides structured feedback
-- A "test" skill that runs the project's test suite and summarizes failures
-
-Skills are defined at the project level and can be shared across multiple agents.
-
-## Agent Templates
-
-Agent templates let you save a durable agent's configuration as a reusable starting point for new agents. A template captures:
-
-- Name pattern, color, and avatar
-- Branch naming convention
-- Model and orchestrator selection
-- Agent instructions
-- MCP configuration
-- Attached skills
-
-When creating a new durable agent, you can select a template to pre-fill the configuration form. This is useful for teams that want a consistent setup across agents or for quickly spinning up agents for recurring task types.
+| Feature | Description |
+|---------|-------------|
+| **Instructions** | Markdown files in `.clubhouse/` guiding agent behavior — coding style, restrictions, workflow rules |
+| **MCP** | Per-agent Model Context Protocol config — tool servers, resources, environment variables |
+| **Skills** | Reusable prompt + tool packages (e.g., "commit", "review-pr", "test") defined at the project level |
+| **Templates** | Save an agent's full config as a reusable starting point for new agents |
 
 ## Quick Agent Defaults
 
-A durable agent can also serve as a launchpad for quick agents. From the durable agent's configuration, you can set defaults that apply to any quick agent spawned from it:
+A durable agent can serve as a launchpad for quick agents, inheriting:
+- System prompt (prepended to the quick agent's mission)
+- Allowed tools (e.g., restrict to read-only access)
+- Default model
 
-- **System prompt** — a base prompt prepended to the quick agent's mission.
-- **Allowed tools** — restrict which tools the quick agent can use (e.g., read-only file access, no shell commands).
-- **Default model** — the model the quick agent will use, which may differ from the durable agent's own model.
+Configure under the durable agent's **Quick Agent Defaults** section.
 
-These defaults make it easy to run quick one-off tasks in the context of a durable agent's work without reconfiguring each time.
+## Deleting
 
-## Deleting a Durable Agent
+Delete from the context menu or config panel. Cleanup options:
 
-When you no longer need a durable agent, you can delete it from the explorer's context menu or the agent's configuration panel. Clubhouse offers multiple cleanup options to ensure no work is lost:
-
-| Option | What It Does |
+| Option | What Happens |
 |--------|-------------|
-| **Commit and push changes** | Commits any uncommitted work on the agent's branch and pushes to the remote, then removes the agent and its worktree. |
-| **Cleanup branch** | Deletes the agent's local and remote branch in addition to removing the agent registration. Use this when the branch has already been merged or is no longer needed. |
-| **Save as patch** | Exports the agent's uncommitted changes as a `.patch` file you can apply later, then removes the agent and worktree. |
-| **Force delete** | Removes the agent, its worktree, and all local changes immediately without saving anything. This is irreversible. |
-| **Just unregister** | Removes the agent from Clubhouse without touching the Git branch or worktree. The branch and files remain on disk for manual cleanup. |
-
-Choose the option that matches your situation. If you are unsure, **Save as patch** is the safest choice — it preserves the agent's work while cleaning up the Clubhouse registration.
+| **Commit and push** | Saves uncommitted work, pushes to remote, removes agent |
+| **Cleanup branch** | Deletes local and remote branch |
+| **Save as patch** | Exports changes as a `.patch` file (safest choice) |
+| **Force delete** | Removes everything immediately — irreversible |
+| **Just unregister** | Removes from Clubhouse, leaves branch and files on disk |

--- a/src/renderer/features/help/content/agents-overview.md
+++ b/src/renderer/features/help/content/agents-overview.md
@@ -1,61 +1,38 @@
-# Agents
+# Agent Overview
 
-Agents are AI-powered assistants that work directly on your code inside Clubhouse. Each agent is backed by an orchestrator — the CLI backend (such as Claude Code) that drives the AI model, manages tool calls, and handles file operations. Clubhouse provides the visual layer: you see what the agent is doing, approve or deny sensitive operations, and manage the agent's lifecycle from a unified desktop interface.
+Agents are AI assistants that work directly on your code. Each is backed by an orchestrator (e.g., Claude Code) that drives the AI model and handles tool calls.
 
 ## Agent Types
 
-Clubhouse supports two distinct types of agents, each suited to different workflows.
+| Type | Lifespan | Best For |
+|------|----------|----------|
+| **Durable** | Persistent — survives restarts, can be paused/resumed | Feature branches, multi-day refactors, ongoing work |
+| **Quick** | One-shot — runs a task and exits | Bug fixes, code generation, quick questions |
 
-| Type | Purpose | Lifespan | Use Cases |
-|------|---------|----------|-----------|
-| **Durable** | Long-lived, persistent agents with dedicated configuration | Survives app restarts; runs until you stop or delete it | Feature development, multi-day refactors, ongoing code review, complex research |
-| **Quick** | One-shot task runners that execute a single mission | Runs once and exits automatically | Small bug fixes, code generation, one-off questions, quick research tasks |
+## Lifecycle States
 
-Durable agents live in the explorer list under your project and can be paused, resumed, and reconfigured at any time. Quick agents are launched from a lightweight prompt, produce a summary when finished, and then appear as dismissible review cards.
+The explorer shows a colored ring around each agent's avatar:
 
-See the dedicated **Durable Agents** and **Quick Agents** help topics for full details on each type.
+| State | Ring | Meaning |
+|-------|------|---------|
+| **Working** | Green (pulsing) | Actively processing — reading files, writing code, running commands |
+| **Needs Permission** | Orange | Waiting for you to approve/deny a sensitive operation |
+| **Tool Error** | Yellow | A tool call failed; agent may recover on its own |
+| **Sleeping** | Gray | Paused or between missions — resume anytime |
+| **Error** | Red | Fatal error — check terminal output or transcript |
 
-## Agent Lifecycle
+## Dashboard Monitoring
 
-Every agent moves through a set of lifecycle states. The explorer list shows a colored ring around each agent's avatar to indicate its current state at a glance.
+The Dashboard home screen aggregates agent stats across all projects: working count, attention needed, and completed today. The **Needs Attention** box lists agents requiring action with clickable links.
 
-### Primary States
+## Agent Pop-Out
 
-| State | Visual Indicator | Description |
-|-------|-----------------|-------------|
-| **Running** | Green ring with pulse animation | The agent is actively processing its mission. The ring pulses to indicate ongoing activity. |
-| **Sleeping** | Gray ring (no animation) | The agent has finished its current work or was manually paused. It can be resumed at any time. Durable agents enter this state between missions. |
-| **Error** | Red ring | The agent encountered a fatal error and stopped. Check the terminal output or transcript for details. |
-
-### Detailed Status Indicators
-
-While an agent is running, Clubhouse monitors its activity in real time and may display more specific status indicators.
-
-| Status | Visual Indicator | Description |
-|--------|-----------------|-------------|
-| **Working** | Green ring with pulse | The agent is executing normally — reading files, writing code, running commands. |
-| **Needs Permission** | Orange ring | The agent is waiting for you to approve or deny a sensitive operation such as a file edit or shell command. An action prompt appears in the terminal view. |
-| **Tool Error** | Yellow ring | A tool call failed (for example, a shell command returned a non-zero exit code). The agent is still running and may recover on its own, but you may want to check the output. |
-
-These indicators update in real time as Clubhouse monitors the stream of tool calls, permission requests, and errors from the orchestrator.
-
-## Hook Events
-
-Clubhouse subscribes to events emitted by the orchestrator during an agent's session. These hook events power the real-time status indicators, permission prompts, and transcript logging. The events Clubhouse monitors include:
-
-- **Tool calls** — every file read, file write, shell command, or search the agent performs
-- **Permission requests** — when the agent wants to perform a sensitive operation and needs your approval
-- **Errors** — tool failures, orchestrator crashes, and other unexpected conditions
-- **Completion** — when the agent finishes its mission or exits
-
-You do not need to configure hook events manually. They are handled automatically by the integration between Clubhouse and the orchestrator.
+Any agent can be detached into an independent OS window for multi-monitor workflows. The pop-out stays fully synchronized with the main window.
 
 ## Model Selection
 
-Agents use AI models provided by the project's configured orchestrator. When you create or configure an agent, the model picker displays all models available through that orchestrator. The set of available models depends on your orchestrator setup and API keys.
+Models are provided by the project's orchestrator. Change an agent's model from its config panel — takes effect on next start or resume.
 
-You can change an agent's model at any time from the agent's configuration panel. The new model takes effect the next time the agent starts or resumes.
+## Reordering
 
-## Agent Reordering
-
-Durable agents appear in a list in the project explorer. You can drag agents up or down in this list to reorder them. The order is saved per project and persists across restarts. Use this to keep your most active agents at the top or group related agents together.
+Drag agents in the explorer list to reorder. The order persists per project across restarts.

--- a/src/renderer/features/help/content/agents-quick.md
+++ b/src/renderer/features/help/content/agents-quick.md
@@ -1,89 +1,57 @@
 # Quick Agents
 
-Quick agents are one-shot task runners. You give them a mission, they execute it, and they exit. There is no persistent state, no dedicated branch, and no configuration to maintain. Quick agents are ideal for tasks that can be completed in a single pass: small bug fixes, generating boilerplate, answering a question about the codebase, or running a one-off script.
+Quick agents are one-shot task runners. Give them a mission, they execute it, and they exit — no persistent state or dedicated branch.
 
-## Running a Quick Agent
+## Launching
 
-To launch a quick agent:
+1. Press `Cmd+Shift+N` (or click **Quick Agent** in the explorer)
+2. Type a mission description
+3. Optionally configure:
+   - **Model** — from the orchestrator's available models
+   - **Orchestrator** — when no parent agent is selected
+   - **Parent agent** — inherit a durable agent's context and defaults
+   - **Project** — if launching from outside a project context
+4. Press `Cmd+Enter` or click **Run**
 
-1. Select a project in the Project Rail.
-2. Open the quick agent launcher in the explorer panel (the text input at the top of the agent list, or the **Quick Agent** button).
-3. Type a mission description — a clear, concise statement of what you want the agent to do.
-4. Optionally select a model from the model picker. If you do not choose one, the default model from the project or parent durable agent is used.
-5. Press **Enter** or click **Run** to launch the agent.
+## Free Agent Mode
 
-The quick agent starts immediately. You can watch its progress in the terminal view or switch to other work while it runs.
+Check **Free Agent** to skip all permission prompts (`--dangerously-skip-permissions`). The agent runs fully autonomously without pausing for approvals.
+
+> **Use with caution:** Free Agent mode is best for trusted tasks in sandboxed environments. For destructive operations, keep it off.
+
+## Headless vs Interactive Mode
+
+| | Headless (default) | Interactive |
+|-|-------------------|-------------|
+| **Permissions** | Agent proceeds automatically | Pauses for each approval |
+| **File edits** | Applied immediately | Require approval |
+| **Shell commands** | Executed immediately | Require approval |
+| **Speed** | Faster | Slower (waits for input) |
+
+Switch mode in **Settings** (global) or **Project Settings** (per-project).
+
+**Note:** Headless mode controls output format. Free Agent mode controls permission handling. They are separate toggles.
 
 ## Completion Summary
 
-When a quick agent finishes its mission, Clubhouse displays a structured summary with the following information:
+When finished, a summary card shows:
 
 | Field | Description |
 |-------|-------------|
-| **Exit code** | The process exit code. `0` indicates success; any other value indicates an error. |
-| **Files modified** | A list of files the agent created, edited, or deleted during its run. |
-| **Duration** | How long the agent ran, from start to completion. |
-| **Cost (USD)** | The estimated API cost for the agent's session, based on token usage and the model's pricing. |
-| **Timestamp** | The date and time the agent finished. |
-| **Tools used** | A summary of the tools the agent invoked (e.g., file reads, file writes, shell commands, searches). |
+| **Exit code** | `0` = success |
+| **Files modified** | Created, edited, or deleted files |
+| **Duration** | Start to finish time |
+| **Cost** | Estimated API cost (USD) |
+| **Tools used** | Summary of tool invocations |
 
-The summary gives you a quick way to assess what happened without reading through the full terminal output.
+## Ghost Cards
 
-## Quick Agent Ghosts
-
-After a quick agent completes, it does not disappear from the interface immediately. Instead, it appears as a "ghost" — a review card in the explorer list. Ghost cards show the agent's mission, exit status, and a condensed summary.
-
-You can interact with a ghost card to:
-
-- **View the full summary** including all files modified and tools used.
-- **Open the transcript** to see a structured log of everything the agent did.
-- **Inspect file changes** to review diffs of modified files.
-- **Dismiss** the ghost card when you are done reviewing.
-
-Ghost cards remain until you dismiss them, so you can launch several quick agents and review their results later at your convenience.
-
-## Headless Mode
-
-By default, quick agents run in **headless mode**: the agent runs from start to finish without stopping for permission prompts, making it significantly faster for most tasks.
-
-**Interactive mode** is available as an alternative. In interactive mode, when the agent wants to perform a sensitive operation (such as editing a file or running a shell command), it pauses and asks for your permission. This is safer but requires you to stay attentive.
-
-### Switching to Interactive Mode
-
-You can switch to interactive mode in two ways:
-
-- **Globally** — go to **Settings** and disable the headless mode toggle. This applies to all quick agents across all projects.
-- **Per project** — open the project's settings and select interactive mode. This overrides the global setting for that project only.
-
-### How Headless Mode Works
-
-| Behavior | Headless Mode (default) | Interactive Mode |
-|----------|-------------------------|------------------|
-| Permission prompts | Agent proceeds automatically | Agent pauses and waits for approval |
-| File edits | Applied immediately | Require approval before writing |
-| Shell commands | Executed immediately | Require approval before executing |
-| Completion summary | Richer summary with full tool call details | Standard summary |
-| Speed | Faster (no interruptions) | Slower (waits for human input) |
-
-Interactive mode is best suited for tasks that involve destructive operations (deleting files, force-pushing branches, modifying production configuration), where the safety net of permission prompts is valuable.
-
-### Quick Agent Defaults
-
-If a quick agent is launched from a durable agent, it can inherit default settings configured on the durable agent:
-
-- **System prompt** — a base prompt that is prepended to the mission you type. Use this to provide standing instructions such as coding conventions, file restrictions, or output format requirements.
-- **Allowed tools** — a whitelist of tools the quick agent can use. For example, you might restrict a quick agent to read-only file access and search, preventing it from making edits.
-- **Default model** — the model the quick agent uses if you do not explicitly pick one in the launcher.
-
-These defaults are configured on the parent durable agent's settings panel under **Quick Agent Defaults**. They save time and enforce consistency when you frequently launch quick agents for similar tasks.
+Completed quick agents appear as dismissible review cards ("ghosts") in the explorer. From a ghost card you can:
+- View the full summary and file changes
+- Open the transcript (structured event log)
+- Inspect diffs of modified files
+- Dismiss when done reviewing
 
 ## Transcript
 
-Every quick agent (and durable agent) produces a transcript: a structured event log of everything the agent did during its session. The transcript is more organized than raw terminal output and includes:
-
-- **Tool calls** with their inputs and outputs (e.g., which file was read, what command was run)
-- **Permission events** showing what was approved or denied
-- **Errors** with timestamps and context
-- **Timing data** for each event
-
-You can open the transcript from the completion summary or from the ghost card's context menu. The transcript is useful for understanding what the agent did, debugging unexpected behavior, and auditing the agent's actions.
+Every agent produces a structured event log with tool calls, permission events, errors, and timing data. More organized than raw terminal output — useful for debugging and auditing.

--- a/src/renderer/features/help/content/agents-terminal.md
+++ b/src/renderer/features/help/content/agents-terminal.md
@@ -1,96 +1,56 @@
-# Agent Terminal and Output
+# Terminal & Transcripts
 
-Every running agent in Clubhouse has a terminal view that shows its real-time output. The terminal is the primary way to observe what an agent is doing, interact with permission prompts, and debug issues.
+Every agent has a terminal view showing real-time output, plus a structured transcript for organized review.
 
 ## Terminal View
 
-When you select a running agent in the explorer, the main content area displays its terminal. The terminal is built on xterm.js and behaves like a standard terminal emulator:
+The terminal (built on xterm.js) behaves like a standard terminal emulator:
+- Full ANSI color support and theme-aware colors
+- Scrollback buffer preserved for the session
+- Text selection and clipboard copy
+- Auto-resizes with window and panel changes
 
-- **ANSI color support** — output from the orchestrator, including syntax-highlighted diffs, colored status messages, and formatted tables, renders with full color.
-- **Theme-aware** — the terminal background, foreground, and color palette automatically match your Clubhouse theme (light or dark). If you switch themes, open terminals update immediately.
-- **Scrollback** — you can scroll up through the terminal history to review earlier output. The scrollback buffer is preserved for the duration of the agent's session.
-- **Text selection and copy** — select text in the terminal with your mouse and copy it to the clipboard.
+## User Input
 
-## User Input Forwarding
-
-You can type directly into the agent's terminal. Keystrokes are forwarded to the underlying orchestrator process. This is useful for:
-
-- Responding to interactive prompts from tools the agent invokes (e.g., a CLI tool that asks for confirmation).
-- Sending text input when the agent runs a command that reads from stdin.
-
-Note that in most cases, the agent handles its own input and output. User input forwarding is a fallback for situations where the orchestrator or a subprocess needs direct human input.
-
-## Terminal Resizing
-
-The terminal automatically resizes when:
-
-- You resize the Clubhouse window.
-- You drag the panel divider to make the terminal area wider or narrower.
-- You toggle the sidebar or other panels that affect available space.
-
-The resize signal is forwarded to the orchestrator process so that command output wraps correctly at the new width. You do not need to do anything manually.
+You can type directly into an agent's terminal. Keystrokes are forwarded to the orchestrator process — useful for responding to interactive prompts from tools the agent invokes.
 
 ## Output Buffering
 
-When you switch away from an agent (for example, by selecting a different agent or navigating to settings), the terminal output continues to be captured in the background. When you switch back, all buffered output is replayed into the terminal view so you see the complete history.
-
-This means you never lose output by switching between agents. Every agent's terminal maintains its full session history regardless of whether it is currently visible.
-
-## Transcript Viewer
-
-In addition to the raw terminal, Clubhouse provides a **transcript viewer** — a structured event log that organizes the agent's activity into discrete, readable entries. The transcript is available for both running and completed agents.
-
-Each transcript entry includes:
-
-| Field | Description |
-|-------|-------------|
-| **Timestamp** | When the event occurred, shown as a relative time (e.g., "2m ago") or absolute time. |
-| **Event type** | The kind of event: tool call, permission request, error, completion, or informational message. |
-| **Tool name** | For tool call events, the name of the tool that was invoked (e.g., Read, Edit, Bash). |
-| **Input** | The parameters passed to the tool (e.g., the file path for a Read, the command for a Bash call). |
-| **Output** | The result returned by the tool, which may be truncated for large outputs. |
-| **Status** | Whether the event succeeded, failed, or is still pending. |
-
-The transcript viewer is useful for quickly scanning what an agent did without reading through terminal output line by line. You can open it from the agent's toolbar or from a completed quick agent's ghost card.
+Switching away from an agent doesn't lose output. All data is captured in the background and replayed when you switch back.
 
 ## Permission Prompts
 
-When an agent running in interactive mode wants to perform a sensitive operation, it pauses and requests permission. Clubhouse surfaces these requests with clear visual indicators:
+When an agent in interactive mode needs approval for a sensitive operation:
 
-1. **Orange ring** — the agent's avatar ring in the explorer turns orange, signaling that attention is needed.
-2. **Permission banner** — inside the terminal view, a banner appears describing the operation the agent wants to perform (e.g., "Edit file: src/index.ts" or "Run command: npm test").
-3. **Approve / Deny buttons** — click **Approve** to let the agent proceed or **Deny** to reject the operation. The agent will attempt to continue its mission after a denial, possibly choosing an alternative approach.
+1. **Orange ring** appears on the agent's avatar in the explorer
+2. **Permission banner** describes the operation (e.g., "Edit file: src/index.ts")
+3. **Approve / Deny** buttons let you respond
 
-Operations that typically require permission include:
+Common permission requests: file edits, shell commands, file deletions, Git operations.
 
-- Writing or editing files
-- Running shell commands
-- Deleting files
-- Performing Git operations (committing, pushing, branch manipulation)
+**Batch approval** — When multiple similar requests queue up, you may see an option to approve all at once.
 
-In headless mode, these prompts are skipped and the agent proceeds automatically. See the **Quick Agents** help topic for details on headless mode.
+In headless mode, prompts are skipped automatically.
 
-### Batch Approval
+## Transcript Viewer
 
-If an agent requests permission for several similar operations in sequence (for example, editing multiple files as part of a refactor), you may see a batch approval option that lets you approve all pending operations at once rather than one at a time.
+A structured event log organizing agent activity into discrete entries:
+
+| Field | Description |
+|-------|-------------|
+| **Timestamp** | When the event occurred |
+| **Event type** | Tool call, permission request, error, or completion |
+| **Tool name** | e.g., Read, Edit, Bash |
+| **Input/Output** | Parameters and results |
+| **Status** | Succeeded, failed, or pending |
+
+Open from the agent toolbar or a ghost card's context menu.
 
 ## Utility Terminal
 
-Sometimes you need to do manual work in an agent's working directory — run a build, inspect files, test a command, or check Git status. Clubhouse provides a **utility terminal** for this purpose.
+Need to do manual work in an agent's worktree? Open a **Utility Terminal**:
 
-To open a utility terminal:
+1. Select the agent
+2. Click **Utility Terminal** in the toolbar
 
-1. Select the agent in the explorer.
-2. Click the **Utility Terminal** button in the agent's toolbar (or use the context menu).
-3. A new shell session opens in a tab, with the working directory set to the agent's worktree.
-
-The utility terminal is a standard shell session (your default shell, typically bash or zsh). It is completely independent of the agent's orchestrator process — commands you run here do not affect the agent, and the agent does not see your commands.
-
-Use the utility terminal to:
-
-- Run builds or tests against the agent's branch.
-- Inspect the file system to verify changes the agent made.
-- Run Git commands (check status, view diffs, create commits).
-- Debug issues by running the same commands the agent attempted.
-
-You can have multiple utility terminals open at the same time, and they persist until you close them or delete the agent.
+This opens a standard shell session (bash/zsh) in the agent's working directory — completely independent of the agent's process. Use it to run builds, inspect files, check Git status, or debug.

--- a/src/renderer/features/help/content/general-command-palette.md
+++ b/src/renderer/features/help/content/general-command-palette.md
@@ -1,0 +1,31 @@
+# Command Palette
+
+The Command Palette (`Cmd+K`) is a fuzzy-search launcher for navigating anywhere in Clubhouse. It works even when your cursor is in a text input.
+
+## Filter Modes
+
+Type a prefix to filter results:
+
+| Prefix | Filters To | Example |
+|--------|-----------|---------|
+| *(none)* | Everything | `auth` — finds agents, projects, commands matching "auth" |
+| `@` | Agents | `@feature` — jump to an agent named "feature-auth" |
+| `/` | Projects | `/my-app` — switch to a project |
+| `#` | Hubs | `#monitoring` — open a hub workspace |
+| `>` | Commands | `>theme` — navigate to settings, run actions |
+
+## Navigation
+
+- **Arrow keys** — move up/down through results
+- **Enter** — select the highlighted item
+- **Escape** — close the palette
+
+## Recently Used
+
+When you open the palette with no query, it shows your most recently used items (up to 20). Recent items also get a ranking boost in search results.
+
+## Shortcut Display
+
+Each result shows its keyboard shortcut (if one exists), so you can learn shortcuts as you use the palette.
+
+> **Example:** Type `Cmd+K` then `>key` to quickly jump to **Settings > Keyboard Shortcuts**.

--- a/src/renderer/features/help/content/general-dashboard.md
+++ b/src/renderer/features/help/content/general-dashboard.md
@@ -1,0 +1,39 @@
+# Dashboard
+
+The Dashboard is your home screen — a bird's-eye view of all projects and agent activity.
+
+## Overview Cards
+
+Four stat cards at the top summarize your workspace:
+
+| Card | Shows |
+|------|-------|
+| **Projects** | Total registered projects |
+| **Working** | Agents currently running |
+| **Attention** | Agents needing permission approval or in error state |
+| **Done Today** | Quick agents completed since midnight |
+
+## Needs Attention
+
+A highlighted section lists agents that require action (permission requests, errors). Click any entry to jump directly to that agent.
+
+## Project Cards
+
+Each project displays:
+- Status pills showing agent counts by state (working, idle, errored, sleeping)
+- Quick-action buttons for Hub and Settings
+- Durable agent list with current branch and status
+- Quick agent completion count
+
+## Recent Activity
+
+Shows up to 8 recently completed quick agents across all projects:
+- Status (success/failed/cancelled), agent name, project
+- Duration and cost (USD)
+- Click to review the full summary
+
+## Accessing the Dashboard
+
+- Click the **Home** icon in the Project Rail
+- Press `Cmd+Shift+H`
+- Toggle Dashboard visibility in **Settings > Display**

--- a/src/renderer/features/help/content/general-getting-started.md
+++ b/src/renderer/features/help/content/general-getting-started.md
@@ -1,66 +1,34 @@
 # Getting Started
 
-Welcome to Clubhouse -- a desktop environment for managing AI coding agents. Clubhouse lets you organize your software projects, launch AI agents to work on them, and monitor their progress in real time. Whether you need a long-running assistant for a complex feature or a quick one-shot task, Clubhouse provides the tools to manage it all from a single interface.
+Clubhouse is a desktop environment for managing AI coding agents. You organize projects, launch agents, and monitor their work from one interface.
 
 ## First Launch
 
-When you first open Clubhouse, you land on the **Home dashboard**. The Home dashboard provides an overview of all your projects and their agents. From here you can:
+On first launch, a short onboarding flow appears based on your experience level. After that, you land on the **Dashboard** — your home screen for all projects and agents.
 
-- See a summary of your registered projects and active agents
-- Add new projects
-- Jump into any project by clicking its icon in the Project Rail on the left
-- Access application settings via the gear icon at the bottom of the Project Rail
-- Open this help system via the `?` icon
+## Quick Start
 
-## Adding Your First Project
+1. **Add a project** — Click `+` in the Project Rail (left sidebar) and select a folder.
+2. **Create an agent** — Open the Agents tab, click **New Agent**, and choose Durable or Quick.
+3. **Give it a mission** — Describe what you want in natural language (e.g., *"Add input validation to the signup form"*).
+4. **Monitor progress** — Watch real-time terminal output, approve permissions, and review results.
 
-A project in Clubhouse represents a folder on your machine, typically a Git repository.
-
-1. Click the **+** button in the Project Rail (the leftmost column of the app).
-2. A folder picker dialog opens. Select the root folder of your project.
-3. Clubhouse detects the project name from the folder name and automatically identifies any Git configuration (branch, remotes, status).
-4. The project appears as an icon in the Project Rail. Click it to switch to that project.
-
-You can add as many projects as you need. Each project maintains its own set of agents, plugin configurations, and Git state independently.
-
-## Creating Your First Agent
-
-Once you have a project selected, you can create an agent to start working on it.
-
-1. Open the **Agents** tab in the Explorer Rail (second column).
-2. Click **New Agent**.
-3. Choose an agent type:
-
-| Type | Description |
-|------|-------------|
-| **Durable Agent** | A persistent, long-lived agent with its own name, color, Git worktree, and branch. Durable agents persist across app restarts and can be paused and resumed. Best for ongoing feature development, complex multi-step tasks, or work that spans multiple sessions. |
-| **Quick Agent** | A one-shot agent that runs a single task and exits. Results are captured as a summary with a list of modified files. Quick agents appear as completed entries for review after they finish. Best for small fixes, code generation, or research tasks. |
-
-## Giving the Agent a Mission
-
-After choosing the agent type and configuring it:
-
-1. Enter a **mission** -- a natural-language description of what you want the agent to accomplish (for example, "Refactor the authentication module to use JWT tokens").
-2. Select a **model** from the available options. The models available depend on your orchestrator configuration and API keys.
-3. Launch the agent. It begins working immediately, and its terminal output appears in the Main Content View (the largest pane on the right).
-
-For durable agents, you can also configure a name, accent color, and a dedicated Git branch before launching.
+> **Tip:** Use `Cmd+K` to open the Command Palette — the fastest way to navigate anywhere in the app.
 
 ## Key Concepts
 
-| Concept | Description |
-|---------|-------------|
-| **Project** | A folder on your machine, typically a Git repository. Each project has its own agents, plugins, and settings. |
-| **Durable Agent** | A long-lived agent with its own name, color, Git worktree, and branch. It persists across app restarts and can be paused (sleeping) or resumed. |
-| **Quick Agent** | A one-shot agent that runs a single task, produces a summary of its work, and exits. |
-| **Orchestrator** | The CLI backend that powers agents (for example, Claude Code). The orchestrator handles communication between Clubhouse and the AI model. |
-| **Plugin** | An extension that adds functionality to Clubhouse, such as file browsing, issue tracking, or kanban boards. Plugins can be app-scoped or project-scoped. |
-| **Worktree** | A separate Git working directory linked to the same repository. Durable agents can use their own worktree so they work in isolation without affecting your main checkout. |
+| Concept | What It Is |
+|---------|-----------|
+| **Project** | A folder on your machine (usually a Git repo). Each has its own agents, plugins, and settings. |
+| **Durable Agent** | A persistent agent with its own Git worktree and branch. Survives restarts. Best for complex, multi-session work. |
+| **Quick Agent** | A one-shot agent that runs a single task and exits. Best for small fixes and quick questions. |
+| **Orchestrator** | The CLI backend powering agents (e.g., Claude Code, Copilot CLI). Handles AI communication. |
+| **Plugin** | An extension adding features like file browsing, Hub workspaces, or custom tools. |
+| **Hub** | A split-pane workspace for monitoring multiple agents side-by-side. |
 
 ## Next Steps
 
-- **Navigation** -- Learn how the multi-pane layout works and how to move between projects and views.
-- **Keyboard Shortcuts** -- Discover shortcuts for common actions.
-- **Projects** -- Dive deeper into project configuration, display names, colors, and custom icons.
-- **Agents & Plugins** -- Explore agent lifecycle, orchestrator settings, and the plugin system.
-- **Updates** -- Understand how Clubhouse keeps itself up to date.
+- **Dashboard** — Learn about the home screen overview
+- **Command Palette** — Master the `Cmd+K` launcher
+- **Hub & Workspaces** — Set up multi-agent monitoring
+- **Keyboard Shortcuts** — Speed up your workflow

--- a/src/renderer/features/help/content/general-hub.md
+++ b/src/renderer/features/help/content/general-hub.md
@@ -1,0 +1,42 @@
+# Hub & Workspaces
+
+The Hub is a split-pane workspace for monitoring multiple agents side-by-side. Use it to watch several agents work simultaneously without switching tabs.
+
+## Two Modes
+
+| Mode | Scope | Access |
+|------|-------|--------|
+| **Per-Project Hub** | Shows agents from one project | Explorer Rail tab within a project |
+| **Cross-Project Hub** | Spans all projects | Project Rail icon (enable in **Settings > Display**) |
+
+## Working with Panes
+
+Each pane displays one agent's terminal. You can:
+
+- **Split** — Hover over pane edges to reveal split arrows (up/down/left/right)
+- **Assign an agent** — Select from the dropdown picker or drag an agent into a pane
+- **Swap** — Drag pane name chips to rearrange
+- **Zoom** — Maximize a single pane to full view; click again to restore
+- **Resize** — Drag dividers between panes
+- **Close** — Remove a pane (minimum 1 always remains)
+
+## Multiple Hub Tabs
+
+- Click `+` to create additional hub tabs within a workspace
+- Double-click a tab name to rename it
+- Click `x` on a tab to remove it
+
+## Pop-Out Windows
+
+Detach any hub tab or individual agent into a separate OS window:
+
+- **Hub pop-out:** Hover over a hub tab and click the pop-out icon
+- **Agent pop-out:** Use the pane menu or context menu on an agent
+
+Pop-out windows stay fully synchronized with the main window — changes in either are reflected in both. Useful for multi-monitor setups.
+
+## Layout Persistence
+
+Hub layouts save automatically and restore across app restarts.
+
+> **Example workflow:** Create a 2x2 hub grid with your 4 active agents. Pop it out to a second monitor. Continue working in the main window while monitoring all agents at a glance.

--- a/src/renderer/features/help/content/general-keyboard-shortcuts.md
+++ b/src/renderer/features/help/content/general-keyboard-shortcuts.md
@@ -1,78 +1,59 @@
 # Keyboard Shortcuts
 
-Clubhouse provides keyboard shortcuts for common actions. These shortcuts apply to the application frame. Agent terminal sessions handle their own keyboard input independently -- standard shortcuts like Cmd+C inside an agent terminal interact with the terminal, not the app.
+On macOS, shortcuts use `Cmd`. On Windows/Linux, substitute `Ctrl`.
 
-On macOS, shortcuts use the `Cmd` key. On Windows and Linux, substitute `Ctrl` for `Cmd`.
+All shortcuts are customizable in **Settings > Keyboard Shortcuts**.
 
-All shortcuts can be customized in **Settings > Keyboard Shortcuts**.
+## Global Shortcuts
 
-## General
+These work even when focus is in a text input:
 
 | Shortcut | Action |
 |----------|--------|
-| `Cmd+K` | Command Palette |
+| `Cmd+K` | Open Command Palette |
+| `Cmd+Shift+N` | New Quick Agent |
+
+## Command Palette Filters
+
+Open `Cmd+K`, then type a prefix:
+
+| Prefix | Filters To |
+|--------|-----------|
+| `@` | Agents |
+| `/` | Projects |
+| `#` | Hubs |
+| `>` | Commands & Settings |
+
+## App Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
 | `Cmd+,` | Toggle Settings |
 | `Cmd+Shift+/` | Toggle Help |
-
-## Navigation
-
-| Shortcut | Action |
-|----------|--------|
 | `Cmd+Shift+H` | Go to Home |
-
-## Panels
-
-| Shortcut | Action |
-|----------|--------|
 | `Cmd+B` | Toggle Sidebar |
 | `Cmd+Shift+B` | Toggle Accessory Panel |
 
-## Agents
+## Agents & Projects
 
 | Shortcut | Action |
 |----------|--------|
-| `Cmd+1` through `Cmd+9` | Switch to Agent 1–9 |
-| `Cmd+Shift+N` | New Quick Agent |
-
-## Projects
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd+Option+1` through `Cmd+Option+9` | Switch to Project 1–9 |
+| `Cmd+1` – `Cmd+9` | Switch to Agent 1–9 |
+| `Cmd+Option+1` – `Cmd+Option+9` | Switch to Project 1–9 |
 | `Cmd+Shift+O` | Add Project |
+| `Cmd+Enter` | Submit Quick Agent dialog |
 
-## Edit Menu Shortcuts
-
-These are standard system edit shortcuts provided by the application menu:
+## Standard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
-| `Cmd+Z` | Undo |
-| `Shift+Cmd+Z` | Redo |
-| `Cmd+X` | Cut |
-| `Cmd+C` | Copy |
-| `Cmd+V` | Paste |
+| `Cmd+Z` / `Shift+Cmd+Z` | Undo / Redo |
+| `Cmd+X` / `Cmd+C` / `Cmd+V` | Cut / Copy / Paste |
 | `Cmd+A` | Select All |
-
-## View Menu Shortcuts
-
-These are standard system view shortcuts provided by the application menu:
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd+R` | Reload the window |
-| `Cmd+Shift+I` | Toggle Developer Tools (available in development mode) |
-| `Ctrl+Cmd+F` | Toggle full screen |
-| `Cmd+M` | Minimize the window |
-
-## Window Menu Shortcuts
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd+W` | Close the window |
+| `Cmd+W` | Close Window |
+| `Ctrl+Cmd+F` | Toggle Fullscreen |
 
 ## Notes
 
-- **Agent terminals**: When an agent terminal has focus, keyboard input goes to the terminal process, not to Clubhouse. App-level shortcuts like `Cmd+K` still work because they are handled at the renderer level, but text input and editing shortcuts apply to the terminal.
-- **Platform differences**: On Windows and Linux, replace `Cmd` with `Ctrl` in all shortcuts listed above. Some view menu shortcuts may differ slightly based on the platform.
-- **Customization**: All app shortcuts can be rebound in **Settings > Keyboard Shortcuts**. Changes take effect immediately.
+- **Agent terminals** capture keyboard input — app shortcuts like `Cmd+K` still work, but typing goes to the terminal process.
+- Changes to keybindings take effect immediately.

--- a/src/renderer/features/help/content/general-navigation.md
+++ b/src/renderer/features/help/content/general-navigation.md
@@ -1,77 +1,38 @@
-# Navigation
+# Navigation & Layout
 
-Clubhouse uses a multi-pane layout to organize your workspace. The interface is divided into up to four columns, each serving a distinct purpose. The number of visible columns depends on context: the Home dashboard and Help view use a simplified two-column layout, while the main project view uses three or four columns.
+Clubhouse uses a multi-pane layout. The number of visible columns adapts to your current context.
 
-## Multi-Pane Layout Overview
+## Standard Layout
 
-From left to right, the standard project view contains:
+| Pane | Purpose |
+|------|---------|
+| **Project Rail** | Global nav: Home, project icons, `+` add, `?` help, gear for settings. Always visible. |
+| **Explorer Rail** | Agent list, plugin tabs for the active project. |
+| **Accessory Panel** | Agent config, file browsers, Git info, plugin sidebars. |
+| **Main Content View** | Terminal output, plugin panels, settings pages. |
 
-| Pane | Width | Purpose |
-|------|-------|---------|
-| **Project Rail** | 60px (fixed) | Global navigation: projects, home, help, settings |
-| **Explorer Rail** | 200px | Context-specific navigation: agent lists, plugin tabs |
-| **Accessory Panel** | 280px | Detail views: agent config, file browsers, sidebars |
-| **Main Content View** | Remaining space | Primary content: terminal output, plugin panels, settings |
-
-Some plugin layouts use a "full" mode that hides the Accessory Panel and gives the Main Content View more space.
+Some plugins use a "full" layout that hides the Accessory Panel for more space.
 
 ## Project Rail
 
-The Project Rail is the leftmost column (60px wide). It is always visible regardless of which view is active. It contains the following items from top to bottom:
+From top to bottom: **Home** (Dashboard), project icons, `+` (add project), `?` (help), gear (settings). App-scoped plugins also appear here.
 
-- **Home** -- Returns to the Home dashboard, which shows an overview of all projects and agents.
-- **Project icons** -- One icon per registered project. Click an icon to switch to that project. Icons can be **reordered by dragging and dropping** them within the rail.
-- **+ (Add project)** -- Opens a folder picker to register a new project.
-- **? (Help)** -- Opens this help system.
-- **Gear (Settings)** -- Opens the application settings panel.
-
-App-scoped plugins that contribute a rail item also appear in the Project Rail.
+- **Reorder** — Drag and drop project icons
+- **Switch projects** — Click an icon or press `Cmd+Option+1` through `Cmd+Option+9`
 
 ## Explorer Rail
 
-The Explorer Rail is the second column (200px wide). Its contents change depending on the active project and selected tab:
+Context-sensitive: shows the **Agents** tab by default, plus tabs for enabled project-scoped plugins. Hidden on the Dashboard and in app-scoped plugin views.
 
-- **Agents tab** -- Lists all durable agents and the quick agent launcher for the active project. This is the default tab when you select a project.
-- **Plugin tabs** -- Project-scoped plugins that contribute a tab appear here. For example, a file browser plugin gets its own tab in the Explorer Rail.
+## Quick Navigation
 
-The Explorer Rail does not appear on the Home dashboard or when viewing app-scoped plugin content.
+| Action | How |
+|--------|-----|
+| Switch project | `Cmd+Option+1–9` or click in Project Rail |
+| Switch agent | `Cmd+1–9` or click in Explorer |
+| Open anything | `Cmd+K` (Command Palette) |
+| Toggle sidebar | `Cmd+B` |
+| Toggle accessory panel | `Cmd+Shift+B` |
+| Go home | `Cmd+Shift+H` |
 
-## Accessory Panel
-
-The Accessory Panel is the third column (280px wide). It provides detail and configuration views related to the current selection in the Explorer Rail:
-
-- **Agent configuration and status** -- When an agent is selected, this panel shows its name, color, branch, model, mission, and current status.
-- **File browsers** -- Plugin-provided file tree views appear here.
-- **Git information** -- Branch status, uncommitted changes, and other Git details for the active project.
-- **Plugin sidebars** -- Plugins that contribute a sidebar panel render their content in this column.
-
-The Accessory Panel is hidden when a plugin uses "full" layout mode, giving the Main Content View the extra horizontal space.
-
-## Main Content View
-
-The Main Content View is the largest pane, occupying all remaining horizontal space. It displays the primary content for the current context:
-
-- **Agent terminal output** -- When a running or sleeping agent is selected, the Main Content View shows its terminal session with full scrollback.
-- **Plugin main panels** -- Plugins that contribute a main panel (such as a kanban board or document editor) render here.
-- **Settings pages** -- When settings is open, the various settings sub-pages (General, Updates, About, etc.) are displayed here.
-
-## Help View
-
-When help is open (via the `?` icon in the Project Rail), the Help View takes over the space to the right of the Project Rail. It replaces the Explorer Rail, Accessory Panel, and Main Content View with a three-column help layout:
-
-| Column | Width | Content |
-|--------|-------|---------|
-| **Section Nav** | 200px | Lists help sections (General, Projects, Agents & Plugins, plus any plugin help sections) |
-| **Topic List** | 240px | Lists topics within the selected section |
-| **Content Pane** | Remaining space | Displays the selected help topic content |
-
-Click any project icon or the Home button in the Project Rail to exit the Help View and return to the normal layout.
-
-## Switching Between Projects
-
-There are two ways to switch between projects:
-
-- **Click** a project icon in the Project Rail.
-- **Keyboard shortcut**: Press `Cmd+1` through `Cmd+9` (or `Ctrl+1` through `Ctrl+9` on non-Mac platforms) to switch to the first through ninth project in the rail, based on their current display order.
-
-When you switch projects, Clubhouse restores the navigation state you left off with, including which Explorer tab was active and which agent was selected.
+Project state (selected agent, scroll position) is preserved when switching — you pick up exactly where you left off.

--- a/src/renderer/features/help/content/general-updates.md
+++ b/src/renderer/features/help/content/general-updates.md
@@ -1,83 +1,29 @@
 # Updates
 
-Clubhouse includes a built-in update system that checks for new versions, downloads them in the background, and applies them with minimal disruption to your workflow.
+Clubhouse checks for updates automatically and applies them with minimal disruption.
 
-## Automatic Update Checking
+## How It Works
 
-When automatic updates are enabled (the default), Clubhouse checks for new versions:
+1. **Check** — On startup (after 30s) and every 4 hours. Toggle auto-check in **Settings > Updates**.
+2. **Download** — Happens in the background with SHA-256 verification.
+3. **Notify** — A blue banner shows the new version. Click **Restart to update** or dismiss.
+4. **Apply** — If agents are running, a confirmation dialog warns before restarting.
 
-- **On startup** -- After a 30-second delay to let the app settle.
-- **Periodically** -- Every 4 hours while the app is running.
+## After Updating
 
-Automatic checking can be toggled on or off in **Settings > Updates**.
-
-## Update Available Banner
-
-When a newer version is detected, a blue info banner appears at the top of the window. The banner displays:
-
-- The new version number (for example, "Update v0.28.0 is ready").
-- An optional release message from the developer, if one is included with the release.
-
-The banner provides two actions:
-
-- **Restart to update** -- Applies the update immediately (see below).
-- **Dismiss (x)** -- Hides the banner for this session.
-
-## Download and Verification
-
-When an update is found, Clubhouse automatically downloads the appropriate artifact for your platform and architecture. During the download:
-
-- A **progress percentage** is tracked and shown in the Settings > Updates status area.
-- If the file has already been downloaded from a previous check, Clubhouse verifies it before skipping the download.
-
-After the download completes, the file is verified using a **SHA-256 checksum** to ensure integrity. If verification fails, the file is deleted and the download is retried on the next check.
-
-## Applying an Update
-
-Click **Restart to update** in the banner to apply the downloaded update. If any agents are currently running, a confirmation dialog appears:
-
-- The dialog shows how many agents are running and warns that they will be stopped.
-- You can choose **Restart anyway** to proceed or **Cancel** to go back.
-
-On macOS, the update extracts the new application bundle, replaces the current one, and relaunches. On Windows, the installer runs automatically. On Linux, the app relaunches and expects a manual install.
-
-## Dismissing a Version
-
-If you dismiss the update banner using the **x** button, the banner hides for the current session. The update remains available and the banner reappears the next time the state transitions to "ready" (for example, on the next app launch).
-
-To skip a specific version entirely so it does not prompt you again, the dismissed version is tracked in update settings. A manually triggered check clears any previously dismissed version.
-
-## What's New Dialog
-
-After an update is installed and Clubhouse relaunches, a **"What's New"** dialog appears automatically. This dialog shows:
-
-- The newly installed version number in the header.
-- Release notes rendered as formatted text.
-
-Click **Got it** or press `Escape` to dismiss the dialog. The dialog only appears once per upgrade -- it does not show on fresh installs or when the version has not changed.
-
-## What's New Settings Page
-
-Navigate to **Settings > What's New** to view a complete history of recent release notes. This page shows release notes for versions up to your current build, including any versions you may have skipped. The history covers up to 5 versions or 3 months, whichever is fewer.
-
-Each version is displayed with its release title as a heading, followed by the full release notes, and separated by a horizontal rule from the next version. Versions are ordered newest-first so the most recent changes appear at the top.
+A **What's New** dialog shows release notes on first launch after an update. View past release notes anytime in **Settings > What's New**.
 
 ## Update Settings
 
-Navigate to **Settings > Updates** to manage update behavior. The settings page provides:
+Found in **Settings > Updates**:
 
 | Setting | Description |
 |---------|-------------|
-| **Automatic updates** toggle | Enable or disable background update checking (every 4 hours). |
-| **Status** | Shows the current update state: Up to date, Checking, Downloading (with progress percentage), Update ready (with version), or Error (with details). |
-| **Check now** button | Manually trigger an update check at any time, regardless of the auto-update setting. |
-| **Last checked** | Displays the timestamp of the most recent update check. |
+| **Auto-update toggle** | Enable/disable background checking |
+| **Status** | Current state: up to date, checking, downloading, ready, or error |
+| **Check now** | Trigger an immediate check |
+| **Last checked** | Timestamp of most recent check |
 
-## Architecture Information
+## Architecture
 
-The **Settings > About** page displays your current app version along with architecture details:
-
-- **Architecture**: Shows whether the app is running as `arm64` (native Apple Silicon) or `x64`.
-- **Rosetta indicator**: If the app is running under Rosetta translation on Apple Silicon hardware, a notice appears recommending the native arm64 build for better performance.
-
-This information is helpful for diagnosing performance issues. If you are on an Apple Silicon Mac and see the Rosetta indicator, switching to the arm64 build of Clubhouse improves performance.
+**Settings > About** shows your app version and architecture (arm64 or x64). If running under Rosetta on Apple Silicon, a notice recommends switching to the native arm64 build for better performance.

--- a/src/renderer/features/help/content/plugins-creating.md
+++ b/src/renderer/features/help/content/plugins-creating.md
@@ -1,258 +1,85 @@
 # Creating Plugins
 
-This guide covers how to create your own Clubhouse plugin. A plugin is a self-contained package that extends Clubhouse with custom views, commands, and integrations. The best way to learn is to study the built-in plugins that ship with Clubhouse -- they demonstrate all of the patterns described here.
+Build custom plugins to extend Clubhouse with new views, commands, and integrations. Study the built-in plugins (Hub, Terminal, Files) for working examples of all patterns.
 
 ## Plugin Structure
 
-A plugin is a directory containing at minimum a manifest file, and optionally a JavaScript entry point and any supporting assets.
-
 ```
 my-plugin/
-  manifest.json      # Required: plugin metadata and declarations
-  main.js            # Optional: entry point with activate/deactivate lifecycle
-  styles.css         # Optional: additional styles
-  assets/            # Optional: images, icons, etc.
+  manifest.json      # Required: metadata and declarations
+  main.js            # Optional: entry point with lifecycle hooks
+  styles.css         # Optional: custom styles
+  assets/            # Optional: images, icons
 ```
 
-For **built-in** plugins, the manifest is defined as a TypeScript file (`manifest.ts`) that exports a `PluginManifest` object, and the module is a TypeScript file (`main.ts`) that exports lifecycle hooks and React components. For **community** plugins installed in `~/.clubhouse/plugins/`, the manifest must be a `manifest.json` file.
+Community plugins use `manifest.json`. Built-in plugins use TypeScript (`manifest.ts`, `main.ts`).
 
-## Manifest
-
-The manifest is the most important file in a plugin. It tells Clubhouse everything it needs to know about the plugin: its identity, scope, permissions, UI contributions, and settings.
-
-### Required Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Unique identifier for the plugin (e.g., `"my-plugin"`). Must be unique across all installed plugins. |
-| `name` | string | Human-readable display name shown in the UI (e.g., `"My Plugin"`). |
-| `version` | string | Semantic version string (e.g., `"1.0.0"`). |
-| `engine.api` | number | The minimum Plugin API version required by this plugin. The current API version is **0.5**. |
-| `scope` | string | One of `"project"`, `"app"`, or `"dual"`. Determines where the plugin appears and how it is activated. |
-
-### Optional Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `description` | string | A short description of what the plugin does. Displayed in the plugin list and in the auto-generated About help topic. |
-| `author` | string | The plugin author's name. |
-| `main` | string | Path to the main JavaScript module, relative to the plugin directory. If omitted, the plugin contributes only declarative elements (settings, commands) with no runtime code. |
-| `permissions` | string[] | List of permissions the plugin requires (see the Permissions help topic). Required for API v0.5 and later. |
-| `settingsPanel` | string | Either `"declarative"` (auto-generated UI from settings declarations) or `"custom"` (plugin renders its own settings panel). |
-| `externalRoots` | array | Declares directories outside the project that the plugin can access. Requires the `files.external` permission. |
-| `allowedCommands` | string[] | Lists CLI commands the plugin is allowed to execute. Required when using the `process` permission. |
-| `contributes` | object | Declares the plugin's UI contributions (tabs, rail items, commands, settings, storage, help). See below. |
-
-### Example Manifest
+## Manifest (Required Fields)
 
 ```json
 {
   "id": "my-plugin",
   "name": "My Plugin",
   "version": "1.0.0",
-  "description": "A custom plugin for my workflow.",
-  "author": "Your Name",
   "engine": { "api": 0.5 },
-  "scope": "project",
-  "main": "main.js",
-  "permissions": ["files", "notifications", "commands"],
-  "settingsPanel": "declarative",
-  "contributes": {
-    "tab": {
-      "label": "My Plugin",
-      "icon": "<svg>...</svg>",
-      "layout": "sidebar-content"
-    },
-    "commands": [
-      { "id": "refresh", "title": "Refresh Data" }
-    ],
-    "settings": [
-      {
-        "key": "autoRefresh",
-        "type": "boolean",
-        "label": "Auto-refresh",
-        "description": "Automatically refresh data when files change.",
-        "default": true
-      }
-    ],
-    "storage": { "scope": "project" },
-    "help": {
-      "topics": [
-        { "id": "usage", "title": "Usage Guide", "content": "## Usage\n\nHow to use this plugin..." }
-      ]
-    }
-  }
+  "scope": "project"
 }
 ```
 
-## Contributes
+| Field | Description |
+|-------|-------------|
+| `id` | Unique identifier |
+| `name` | Display name |
+| `version` | Semver string |
+| `engine.api` | Minimum Plugin API version (current: **0.5**) |
+| `scope` | `"project"`, `"app"`, or `"dual"` |
 
-The `contributes` object declares everything the plugin adds to the Clubhouse UI.
+**Optional:** `description`, `author`, `main`, `permissions`, `settingsPanel`, `externalRoots`, `allowedCommands`, `contributes`
 
-### Tab (Project and Dual Scopes)
+## UI Contributions (`contributes`)
 
-A `tab` entry adds a tab to the Explorer Rail for project-scoped and dual-scoped plugins.
+| Key | What It Adds |
+|-----|-------------|
+| `tab` | Explorer Rail tab (`label`, `icon`, `layout`: `"sidebar-content"` or `"full"`) |
+| `railItem` | Project Rail icon (`label`, `icon`, `position`: `"top"` or `"bottom"`) |
+| `commands` | Command palette entries (`id`, `title`) |
+| `settings` | Auto-generated settings UI (boolean, string, number, select, directory) |
+| `storage` | Persistent data scope (`project`, `project-local`, `global`) |
+| `help.topics` | Help articles that appear in the help system |
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `label` | string | The text displayed on the tab. |
-| `icon` | string | An SVG string or icon name for the tab icon. |
-| `layout` | string | Either `"sidebar-content"` (default, two-column layout with sidebar and main panel) or `"full"` (single full-width panel). |
+## Module Exports
 
-### Rail Item (App and Dual Scopes)
+| Export | Purpose |
+|--------|---------|
+| `activate(ctx, api)` | Setup: register commands, event listeners, initialize state |
+| `deactivate()` | Cleanup: dispose resources |
+| `MainPanel` | React component for the main content area |
+| `SidebarPanel` | React component for the accessory panel |
+| `SettingsPanel` | Custom settings UI (when `settingsPanel: 'custom'`) |
+| `HubPanel` | Panel for Hub integration (dual-scoped plugins) |
 
-A `railItem` entry adds an icon to the Project Rail for app-scoped and dual-scoped plugins.
+All receive `{ api: PluginAPI }` as props (except `HubPanel` which gets `{ paneId, resourceId }`).
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `label` | string | Tooltip text shown when hovering over the rail icon. |
-| `icon` | string | An SVG string or icon name. |
-| `position` | string | Either `"top"` (default) or `"bottom"` to control placement in the rail. |
+## Key API Namespaces
 
-### Commands
-
-An array of command declarations. Each command has an `id` and a `title`. The `id` is used to register and execute the command programmatically. The `title` is the human-readable name shown in the UI.
-
-```json
-"commands": [
-  { "id": "refresh", "title": "Refresh Data" },
-  { "id": "export", "title": "Export Results" }
-]
-```
-
-### Settings (Declarative)
-
-An array of setting declarations. Each setting is automatically rendered in the plugin's settings panel.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `key` | string | Unique key for this setting within the plugin. |
-| `type` | string | One of `"boolean"`, `"string"`, `"number"`, `"select"`, or `"directory"`. |
-| `label` | string | Display label for the setting. |
-| `description` | string | Optional help text shown below the setting control. |
-| `default` | varies | Default value used when the setting has not been configured. |
-| `options` | array | Required for `"select"` type. An array of `{ "label": "...", "value": "..." }` objects defining the dropdown choices. |
-
-### Storage
-
-Declares a storage scope for the plugin.
-
-| Scope | Location | Git Behavior |
-|-------|----------|--------------|
-| `project` | `.clubhouse/plugin-data/{pluginId}/` | Committed to version control |
-| `project-local` | `.clubhouse/plugin-data-local/{pluginId}/` | Gitignored (local only) |
-| `global` | `~/.clubhouse/plugin-data/{pluginId}/` | Per-user, outside any project |
-
-### Help Topics
-
-Plugins can contribute markdown help topics that appear in the Clubhouse help system under the plugin's section.
-
-```json
-"help": {
-  "topics": [
-    {
-      "id": "getting-started",
-      "title": "Getting Started",
-      "content": "## Getting Started\n\nInstructions for using this plugin..."
-    }
-  ]
-}
-```
-
-Each plugin also receives an auto-generated **About** topic that displays the plugin name, version, author, API version, and scope. Custom topics are appended after the About topic.
-
-## Plugin API Namespaces
-
-When a plugin is activated, it receives a `PluginAPI` object with the following namespaces. Each namespace is only available if the plugin has declared the corresponding permission.
-
-| Namespace | Permission | Description |
+| Namespace | Permission | Key Methods |
 |-----------|------------|-------------|
-| `api.project` | files | Read and write files within the project. Provides `readFile`, `writeFile`, `deleteFile`, `fileExists`, `listDirectory`, and access to `projectPath` and `projectId`. |
-| `api.files` | files | Extended file operations: `readTree`, `readBinary`, `stat`, `rename`, `copy`, `mkdir`, `delete`, `showInFolder`. Use `forRoot(name)` for external roots. |
-| `api.git` | git | Query Git state: `status()`, `log()`, `currentBranch()`, `diff()`. |
-| `api.agents` | agents | Manage agents: `list()`, `runQuick()`, `kill()`, `resume()`, `listCompleted()`, `getDetailedStatus()`, `getModelOptions()`. Subscribe via `onStatusChange()` and `onAnyChange()`. |
-| `api.ui` | notifications | Show notifications and prompts: `showNotice()`, `showError()`, `showConfirm()`, `showInput()`, `openExternalUrl()`. |
-| `api.storage` | storage | Persistent storage with three scopes: `project`, `projectLocal`, `global`. Each scope supports `read()`, `write()`, `delete()`, `list()`. |
-| `api.terminal` | terminal | Shell sessions: `spawn()`, `write()`, `resize()`, `kill()`, `getBuffer()`, `onData()`, `onExit()`. Also provides the `ShellTerminal` React component. |
-| `api.navigation` | navigation | UI control: `focusAgent(agentId)`, `setExplorerTab(tabId)`. |
-| `api.process` | process | Execute CLI commands: `exec(command, args, options)`. Only commands listed in `allowedCommands` are permitted. |
-| `api.badges` | badges | Manage badge indicators: `set()`, `clear()`, `clearAll()`. |
-| `api.logging` | logging | Structured logging: `debug()`, `info()`, `warn()`, `error()`, `fatal()`. Each method accepts a message and an optional metadata object. |
-| `api.events` | events | Event bus: `on(event, handler)` returns a `Disposable` to unsubscribe. |
-| `api.commands` | commands | Command registry: `register(commandId, handler)`, `execute(commandId, ...args)`. |
-| `api.projects` | projects | Project information: `list()`, `getActive()`. |
-| `api.widgets` | widgets | Shared React components: `AgentTerminal`, `SleepingAgent`, `AgentAvatar`, `QuickAgentGhost`. |
-| `api.context` | -- | Always available. Provides `mode` (`"project"` or `"app"`), `projectId`, and `projectPath`. |
-| `api.settings` | -- | Always available. Provides `get(key)`, `getAll()`, and `onChange(callback)` to read and react to the plugin's settings. |
-
-## API Version Compatibility
-
-Plugins declare the minimum API version they require via the `engine.api` field in the manifest. The current API version is **0.5**. If a plugin requires an API version that is newer than what the running copy of Clubhouse supports, the plugin will be marked as **incompatible** and will not activate.
-
-When the API evolves, new permissions and namespaces may be added. Existing permissions and their behavior remain stable within a major version.
-
-## Plugin Module
-
-If the plugin specifies a `main` entry point, the module can export any of the following:
-
-| Export | Type | Description |
-|--------|------|-------------|
-| `activate` | function | Called when the plugin is activated. Receives `PluginContext` and `PluginAPI` as arguments. Use this to set up event listeners, register commands, and initialize state. May be async. |
-| `deactivate` | function | Called when the plugin is deactivated (e.g., the project is closed or the plugin is disabled). Use this to clean up resources. May be async. |
-| `MainPanel` | React component | Rendered in the main content area. Receives `{ api: PluginAPI }` as props. |
-| `SidebarPanel` | React component | Rendered in the sidebar/accessory panel (for `sidebar-content` layout). Receives `{ api: PluginAPI }` as props. |
-| `SettingsPanel` | React component | Custom settings UI (when `settingsPanel: 'custom'`). Receives `{ api: PluginAPI }` as props. |
-| `HubPanel` | React component | Special panel for dual-scoped plugins that integrate with the Hub. Receives `{ paneId, resourceId }` as props. |
-
-## Plugin Settings
-
-Settings can be accessed at runtime through the `api.settings` namespace, which is always available regardless of permissions.
-
-- `api.settings.get<T>(key)` -- Returns the current value for a setting key, or `undefined` if not set.
-- `api.settings.getAll()` -- Returns all settings as a key-value object.
-- `api.settings.onChange(callback)` -- Subscribes to setting changes. The callback receives the key and new value.
-
-## Plugin Storage
-
-The storage API provides persistent data storage at three scopes.
-
-| Scope | Location | Description |
-|-------|----------|-------------|
-| `project` | `.clubhouse/plugin-data/{pluginId}/` | Data committed to version control. Shared across team members who use the same repository. |
-| `projectLocal` | `.clubhouse/plugin-data-local/{pluginId}/` | Data that stays local to this machine. The path is automatically added to `.gitignore`. |
-| `global` | `~/.clubhouse/plugin-data/{pluginId}/` | Data stored in the user's home directory, shared across all projects. |
-
-Each scope provides four operations:
-
-- `read(key)` -- Read a value by key. Returns the stored value or `undefined`.
-- `write(key, value)` -- Write a value. The value is serialized as JSON.
-- `delete(key)` -- Delete a stored key.
-- `list()` -- List all keys in this scope.
-
-## Plugin File Access
-
-Plugins with the `files` permission can read and write files within the project directory. The primary file operations are:
-
-- `readFile(relativePath)` -- Read a file's text content.
-- `writeFile(relativePath, content)` -- Write text content to a file.
-- `deleteFile(relativePath)` -- Delete a file.
-- `fileExists(relativePath)` -- Check whether a file exists.
-- `listDirectory(relativePath)` -- List the contents of a directory. Returns an array of entries with `name`, `path`, and `isDirectory` properties.
-
-The extended files API (`api.files`) adds further capabilities: `readTree` (recursive directory listing), `readBinary` (base64-encoded binary content), `stat` (file metadata), `rename`, `copy`, `mkdir`, `delete`, and `showInFolder` (reveal in system file manager).
-
-All paths are relative to the project root. Attempting to access paths outside the project directory will fail unless the plugin has the `files.external` permission and has declared the appropriate external roots.
-
-## Gitignore Management
-
-Clubhouse provides internal gitignore management for plugins. When a plugin uses `project-local` storage, the storage path is automatically gitignored. Plugins can also programmatically add and remove `.gitignore` entries through the backend services. Each entry added by a plugin is tagged with a comment identifying the plugin, so entries can be cleanly removed when the plugin is uninstalled or deactivated.
+| `api.project` | files | `readFile`, `writeFile`, `deleteFile`, `listDirectory` |
+| `api.files` | files | `readTree`, `stat`, `rename`, `copy`, `showInFolder` |
+| `api.git` | git | `status`, `log`, `currentBranch`, `diff` |
+| `api.agents` | agents | `list`, `runQuick`, `kill`, `resume`, `onStatusChange` |
+| `api.ui` | notifications | `showNotice`, `showError`, `showConfirm`, `showInput` |
+| `api.storage` | storage | `read`, `write`, `delete`, `list` (3 scopes) |
+| `api.terminal` | terminal | `spawn`, `write`, `resize`, `kill`, `onData` |
+| `api.process` | process | `exec(command, args, options)` |
+| `api.context` | *(always)* | `mode`, `projectId`, `projectPath` |
+| `api.settings` | *(always)* | `get`, `getAll`, `onChange` |
 
 ## Best Practices
 
-- **Study the built-in plugins.** The Hub, Terminal, and Files plugins demonstrate all major plugin patterns: dual-scope rendering, external file access, process execution, declarative settings, custom help topics, badge indicators, and agent integration.
-- **Request only the permissions you need.** Each permission grants access to a specific API namespace. Requesting unnecessary permissions may cause users to hesitate before enabling your plugin.
-- **Declare allowed commands explicitly.** If your plugin uses the `process` permission, list every command it will run in the `allowedCommands` array. This gives users confidence in what the plugin will execute on their machine.
-- **Use declarative settings when possible.** Clubhouse generates a consistent settings UI automatically from your setting declarations. Use a custom settings panel only when you need UI that goes beyond simple toggles, text fields, and dropdowns.
-- **Provide help topics.** Add help content via `contributes.help.topics` so users can learn about your plugin without leaving the app. Clubhouse automatically generates an About topic from your manifest, but custom topics let you document features, keyboard shortcuts, and workflows.
-- **Clean up in `deactivate`.** If your `activate` function sets up event listeners, intervals, or other resources, dispose of them in `deactivate` to avoid leaks. Add disposables to `ctx.subscriptions` for automatic cleanup.
-- **Use storage scopes appropriately.** Use `project` storage for data that should be shared with teammates via version control. Use `project-local` for machine-specific data. Use `global` for user preferences that apply across all projects.
+- Request only the permissions you need
+- Declare `allowedCommands` explicitly for `process` permission
+- Use declarative settings when possible
+- Provide help topics via `contributes.help.topics`
+- Clean up resources in `deactivate` (or use `ctx.subscriptions`)
+- Use the right storage scope: `project` for shared, `project-local` for machine-specific, `global` for cross-project

--- a/src/renderer/features/help/content/plugins-overview.md
+++ b/src/renderer/features/help/content/plugins-overview.md
@@ -1,132 +1,66 @@
-# Plugins
+# Installing & Using Plugins
 
-Plugins are extensions that add custom views, commands, and integrations to Clubhouse. They allow you to tailor the application to your workflow by adding new tabs, sidebar panels, and capabilities beyond what ships out of the box.
+Plugins extend Clubhouse with custom views, commands, and integrations.
 
 ## Plugin Scopes
 
-Every plugin declares a scope that determines where it appears and how it runs.
-
-| Scope | Context | Where It Appears |
-|-------|---------|------------------|
-| **Project** | Activated per-project; operates on a single project at a time | Tab in the Explorer Rail (second column) |
-| **App** | Global; runs independently of any specific project | Icon in the Project Rail (leftmost column) |
-| **Dual** | Supports both project and app contexts | Tab in the Explorer Rail *and* icon in the Project Rail |
-
-A **project-scoped** plugin is activated separately for each project that enables it. It has access to that project's files, Git state, and agents. An **app-scoped** plugin runs once globally and is not tied to any particular project. A **dual-scoped** plugin can do both: it appears as a project tab for per-project work and as a rail icon for cross-project work.
+| Scope | Where It Appears | Context |
+|-------|------------------|---------|
+| **Project** | Tab in the Explorer Rail | Per-project; accesses that project's files, Git, and agents |
+| **App** | Icon in the Project Rail | Global; not tied to any project |
+| **Dual** | Both locations | Works in project and global contexts |
 
 ## Built-in Plugins
 
-Clubhouse ships with several built-in plugins. Three of them (Hub, Terminal, and Files) are enabled by default on a fresh install.
-
 | Plugin | Scope | Description |
 |--------|-------|-------------|
-| **Hub** | Dual | Split-pane agent monitoring dashboard. Per-project view shows agents for a single project; cross-project view spans all projects. |
-| **Terminal** | Project | Interactive terminal emulator scoped to each project's root directory. |
-| **Files** | Project | File browser with a built-in Monaco editor, markdown preview, and image display. |
+| **Hub** | Dual | Split-pane agent monitoring workspace |
+| **Terminal** | Project | Interactive terminal scoped to the project root |
+| **Files** | Project | File browser with Monaco editor, markdown preview, and image display |
 
-## Plugin Trust Levels
+## How to Enable Plugins
 
-Every plugin in Clubhouse carries a trust-level badge that helps you understand where it came from and how much vetting it has received.
+**Step 1: App-level** — **Settings > Plugins** — toggle on globally.
+
+**Step 2: Project-level** — **Project Settings > Plugins** — toggle on for specific projects. A plugin must be enabled at the app level first.
+
+## Installing External Plugins
+
+External plugins load from `~/.clubhouse/plugins/`. External loading is **disabled by default** for security.
+
+1. **Settings > Plugins** — Enable **External Plugins** in the External section
+2. Download or create a plugin directory
+3. Place it in `~/.clubhouse/plugins/`
+4. Restart Clubhouse
+5. Enable at app level, then per-project as needed
+
+To uninstall, remove the directory from `~/.clubhouse/plugins/` or use the uninstall option in plugin settings.
+
+## Trust Levels
 
 | Badge | Meaning |
 |-------|---------|
-| **Built-in** | Ships with Clubhouse. Maintained and tested by the Clubhouse team. Always available. |
-| **Official** | A community plugin that has been reviewed and endorsed by the Clubhouse team. Distributed via the external plugins directory. |
-| **Community** | A third-party plugin that has not been reviewed by the Clubhouse team. Use at your own discretion. |
+| **Built-in** | Ships with Clubhouse. Always available. |
+| **Official** | Community plugin reviewed by the Clubhouse team. |
+| **Community** | Third-party, unreviewed. Use at your own discretion. |
 
-Built-in plugins cannot be uninstalled. Official and Community plugins are loaded from `~/.clubhouse/plugins/` and can be added or removed freely.
-
-## Enabling Plugins
-
-Plugins can be enabled at two levels. A plugin must be enabled at the appropriate level before it will appear in the UI.
-
-### App-level
-
-Open **Settings** (gear icon in the Project Rail) and navigate to the **Plugins** section. Here you can enable or disable any registered plugin globally. Disabling a plugin at the app level prevents it from appearing in any project.
-
-### Project-level
-
-Open the settings for a specific project and toggle individual plugins on or off. This allows you to customize which plugins are active in each project. A plugin must first be enabled at the app level before it can be enabled for a project.
-
-## External Plugins
-
-External plugins are plugins that are not built into Clubhouse. They are loaded from the `~/.clubhouse/plugins/` directory on your machine.
-
-### Master Switch
-
-For security, external plugin loading is **disabled by default**. To enable it:
-
-1. Open **Settings** (gear icon in the Project Rail) and navigate to the **Plugins** section.
-2. Toggle **Enable External Plugins** on in the External section header.
-3. Restart Clubhouse. External plugins will now be discovered and appear in the plugin list.
-
-When external plugins are disabled, Clubhouse will not scan for or load any plugins outside of the built-in set. This provides a safe default for users who do not need third-party extensions.
-
-### Installing External Plugins
-
-To install an external plugin:
-
-1. Ensure the **Enable External Plugins** master switch is turned on (see above).
-2. Create or download the plugin directory.
-3. Place it inside `~/.clubhouse/plugins/` (create the directory if it does not exist).
-4. Restart Clubhouse or reload plugins. The plugin will appear in **Settings > Plugins** under the External section.
-5. Enable it at the app level and, if it is project-scoped, enable it in the desired projects.
-
-To uninstall an external plugin, remove its directory from `~/.clubhouse/plugins/` or use the uninstall option in plugin settings.
-
-## Plugin UI
-
-Where a plugin appears in the interface depends on its scope:
-
-- **Project plugins** appear as tabs in the **Explorer Rail** (the second column). Click a tab to open that plugin's sidebar panel and main content view. The Explorer Rail shows the Agents tab alongside tabs for each enabled project-scoped plugin.
-- **App plugins** appear as icons in the **Project Rail** (the leftmost column). Click an icon to open the plugin's global view.
-- **Dual plugins** appear in both locations. The Hub, for example, shows a tab in the Explorer Rail for per-project agent management and an icon in the Project Rail for cross-project agent management.
-
-## Plugin Status
-
-Each plugin goes through a lifecycle represented by its status.
+## Plugin Lifecycle
 
 | Status | Meaning |
 |--------|---------|
-| **Registered** | The plugin has been discovered and its manifest has been loaded, but it is not yet enabled. |
-| **Enabled** | The plugin is turned on at the app level and ready to be activated. |
-| **Activated** | The plugin is running. Its `activate` function has been called and its UI is available. |
-| **Deactivated** | The plugin was previously activated but has been shut down (e.g., the project was closed). |
-| **Disabled** | The plugin has been explicitly turned off by the user, or was disabled due to a permission violation. |
-| **Errored** | The plugin encountered an error during activation or runtime. Check the application logs for details. |
-| **Incompatible** | The plugin requires an API version that is newer than the version supported by this copy of Clubhouse. |
+| **Registered** | Discovered, manifest loaded, not yet enabled |
+| **Enabled** | Turned on at app level, ready to activate |
+| **Activated** | Running, UI available |
+| **Disabled** | Turned off by user or auto-disabled (permission violation) |
+| **Errored** | Failed during activation or runtime — check logs |
+| **Incompatible** | Requires a newer API version than your Clubhouse supports |
 
-## Plugin Badges
+## Badges
 
-Plugins can display indicator badges on their tabs and rail items to signal unread counts, status changes, or other notifications. Badges come in two types:
-
-- **Count** -- Displays a numeric value (e.g., the number of unresolved issues).
-- **Dot** -- Displays a simple indicator dot to flag that something needs attention.
-
-Badges appear on the plugin's tab in the Explorer Rail and, for app or dual-scoped plugins, on the plugin's icon in the Project Rail.
+Plugins can show indicator badges on their tabs/icons:
+- **Count** — numeric value (e.g., unresolved issues)
+- **Dot** — simple attention indicator
 
 ## Plugin Settings
 
-Some plugins expose configuration options that let you customize their behavior.
-
-### Declarative Settings
-
-Plugins can define settings in their manifest, and Clubhouse will automatically generate a settings UI for them. The following setting types are available:
-
-| Type | Description | Example |
-|------|-------------|---------|
-| **boolean** | A toggle switch for on/off options | "Show hidden files" |
-| **string** | A text input field | "API endpoint URL" |
-| **number** | A numeric input field | "Refresh interval (seconds)" |
-| **select** | A dropdown menu with predefined choices | "Output format: JSON / CSV" |
-| **directory** | A folder picker with browse button and path input | "Data directory" |
-
-Plugins with declarative settings display the `settingsPanel: 'declarative'` indicator in their manifest. Their settings appear automatically in the plugin's settings section.
-
-### Custom Settings Panels
-
-Some plugins provide a fully custom settings panel instead of (or in addition to) declarative settings. These plugins render their own settings UI with complete control over layout and behavior. Custom settings panels are indicated by `settingsPanel: 'custom'` in the manifest.
-
-### Accessing Plugin Settings
-
-To access a plugin's settings, open **Settings** (gear icon), navigate to **Plugins**, and select the plugin. If the plugin has configurable settings, they will appear in the plugin's detail panel.
+Some plugins expose settings (boolean, string, number, select, directory). Access via **Settings > Plugins > [Plugin Name]**.

--- a/src/renderer/features/help/content/projects-git.md
+++ b/src/renderer/features/help/content/projects-git.md
@@ -1,99 +1,46 @@
 # Git Integration
 
-Clubhouse provides deep, built-in Git awareness for your projects. It automatically detects repository status, tracks file changes, and surfaces relevant information throughout the interface — so you always know the state of your code without leaving the app.
+Clubhouse provides built-in Git awareness — branch tracking, file status, and worktree isolation for agents.
 
 ## Git Detection
 
-When you add a project, Clubhouse checks whether the folder is a Git repository. This detection happens automatically and requires no configuration.
+When you add a project, Clubhouse checks for a `.git` directory:
+- **Found** — Full Git features enabled automatically
+- **Not found** — A yellow banner appears with a one-click **git init** button. Dismiss if you prefer to work without Git.
 
-- If the folder is a Git repository (contains a `.git` directory), Clubhouse enables full Git integration features: branch display, file status tracking, stash indicators, and more.
-- If the folder is **not** a Git repository, Clubhouse displays a **yellow warning banner** at the top of the project view. This banner includes a one-click **"git init"** button that initializes a new Git repository in the project folder. You can dismiss the banner if you prefer to work without Git, but certain features (such as worktrees for durable agents) will not be available.
+## What Clubhouse Tracks
 
-## Branch Detection
-
-Clubhouse continuously monitors the current branch of your project and displays the branch name in the UI. When you switch branches outside of Clubhouse (for example, using the terminal or another Git client), Clubhouse detects the change and updates the display automatically.
-
-The branch name is visible in the project header area, giving you an at-a-glance view of which branch you are working on at all times.
-
-## File Status Tracking
-
-Clubhouse tracks the status of files in your working directory, mirroring the information you would see from `git status`. Files are categorized as:
-
-- **Staged** — Files that have been added to the Git index and are ready to be committed.
-- **Unstaged** — Files that have been modified but not yet staged.
-- **Untracked** — New files that Git is not yet tracking.
-
-These statuses are reflected in the Clubhouse interface, allowing you to see at a glance what has changed in your project — whether those changes were made by you, by an agent, or by an external tool.
-
-## Ahead/Behind Tracking
-
-When your local branch has an upstream remote configured, Clubhouse tracks how many commits you are **ahead** of or **behind** the remote branch.
-
-- **Ahead** indicates local commits that have not been pushed.
-- **Behind** indicates remote commits that have not been pulled.
-
-This information helps you stay aware of sync status without needing to run `git fetch` or `git log` manually. Clubhouse fetches remote status periodically in the background.
-
-## Stash Count
-
-If you have entries in your Git stash, Clubhouse displays a **stash indicator** showing the number of stashed entries. This is a quick visual reminder that you have saved work that has not been applied.
-
-## Conflict Detection
-
-Clubhouse detects **merge conflicts** in your working directory. When conflicts are present — for example, after a merge, rebase, or cherry-pick — Clubhouse highlights the conflicted state so you can resolve it before continuing.
-
-Conflict detection applies to both your main working directory and to agent worktrees. If an agent's worktree encounters a conflict during a Git operation, the conflict will be surfaced in the Clubhouse interface.
+| Feature | Description |
+|---------|-------------|
+| **Branch** | Current branch displayed in the UI; auto-updates on external changes |
+| **File status** | Staged, unstaged, and untracked files |
+| **Ahead/Behind** | Commit count relative to upstream remote |
+| **Stash count** | Visual indicator of stashed entries |
+| **Conflicts** | Merge conflict detection in working directory and agent worktrees |
 
 ## Git Operations
 
-Clubhouse provides access to common Git operations directly from the interface. Available operations include:
+Available through the project's Git UI:
 
-| Operation | Description |
-|-----------|-------------|
-| **Checkout** | Switch to a different branch or create a new branch |
-| **Stage / Unstage** | Add or remove files from the Git index |
-| **Commit** | Create a new commit with a message |
-| **Push** | Push local commits to the upstream remote |
-| **Pull** | Fetch and merge changes from the upstream remote |
-| **Diff** | View a diff of changes in the working directory |
-| **Stash / Pop** | Save or restore uncommitted changes |
-| **Create Branch** | Create a new branch from the current HEAD |
+Checkout, Stage/Unstage, Commit, Push, Pull, Diff, Stash/Pop, Create Branch
 
-These operations are available through the Git section of the project view. They execute standard Git commands under the hood, so the results are fully compatible with any other Git tooling you use.
+These execute standard Git commands — fully compatible with other Git tools.
 
 ## Worktrees
 
-**Git worktrees** are a core feature of Clubhouse's agent isolation model. A worktree is a separate working directory that shares the same underlying Git repository. Clubhouse uses worktrees to give durable agents their own isolated environment, so multiple agents can work on different branches simultaneously without interfering with each other or with your main checkout.
+Worktrees are central to how Clubhouse isolates agent work. Each durable agent gets its own Git worktree on a dedicated branch.
 
-### How Worktrees Work
+**How it works:**
+1. You assign a branch when creating a durable agent
+2. Clubhouse creates a worktree in the project's `.clubhouse/agents/` directory
+3. All agent file operations are scoped to its worktree
+4. Your main checkout stays untouched
 
-When you create a durable agent and assign it a branch, Clubhouse sets up a worktree for that agent:
+**Benefits:**
+- No conflicts between your work and agent work
+- Multiple agents can work on different branches simultaneously
+- Clean diffs make pull requests straightforward
 
-1. Clubhouse creates a `.worktrees/` directory inside the project root (if it does not already exist).
-2. A new worktree is created within `.worktrees/`, named after the agent.
-3. The worktree is checked out to the agent's assigned branch.
-4. All of the agent's file operations — reads, writes, terminal commands — are scoped to its worktree directory rather than your main project directory.
+**Merging agent work:** Use standard Git operations — merge, PR, or cherry-pick. Clubhouse doesn't merge automatically; you retain full control.
 
-This means your main checkout remains untouched while agents work. You can continue editing files, switching branches, and committing in your main working directory without any interference.
-
-### Branch Isolation
-
-Each agent worktree operates on its own branch. This provides several benefits:
-
-- **No conflicts with your work** — An agent modifying files on its branch does not affect the files you see in your main checkout.
-- **Parallel development** — Multiple agents can work on different features or bug fixes at the same time, each on its own branch.
-- **Safe experimentation** — If an agent's changes are not useful, you can simply delete the branch without affecting anything else.
-
-### Merging Changes Back
-
-Agent worktree changes are merged back into your codebase using standard Git operations. Common approaches include:
-
-- **Merge** — Merge the agent's branch into your main branch using `git merge`.
-- **Pull request** — Push the agent's branch to a remote and open a pull request for code review.
-- **Cherry-pick** — Select specific commits from the agent's branch to apply to your own.
-
-Clubhouse does not perform merges automatically. You retain full control over when and how agent changes are integrated into your codebase.
-
-### Worktree Lifecycle
-
-Worktrees persist as long as the durable agent exists. If you delete a durable agent, Clubhouse cleans up the associated worktree and branch (with a confirmation prompt). You can also manually manage worktrees using standard `git worktree` commands if needed.
+**Lifecycle:** Worktrees persist as long as the agent exists. Deleting an agent prompts cleanup options for the worktree and branch.

--- a/src/renderer/features/help/content/projects-overview.md
+++ b/src/renderer/features/help/content/projects-overview.md
@@ -1,76 +1,36 @@
-# Projects
+# Managing Projects
 
-A **project** in Clubhouse represents a folder on your machine — typically a Git repository — that serves as the workspace for your AI coding agents. Projects are the primary organizational unit in Clubhouse: everything you do, from launching agents to configuring plugins, happens within the context of a project.
-
-## What Is a Project?
-
-At its core, a project is simply a directory on your local filesystem. In most cases this will be a Git repository, but Clubhouse does not require Git. When you add a folder as a project, Clubhouse treats it as the root of all agent activity: file reads and writes, terminal commands, and Git operations are all scoped to that directory.
-
-Clubhouse creates a `.clubhouse/` directory inside the project root to store its own configuration and state. This includes:
-
-- **Agent definitions** — names, colors, branches, and other metadata for your durable agents
-- **Skills** — custom skill scripts and configuration files
-- **Templates** — reusable mission templates for agents
-- **Instructions** — project-level instructions (such as a `CLAUDE.md` file) that guide agent behavior
-- **Plugin configs** — per-project plugin enablement and settings
-
-The `.clubhouse/` directory is safe to commit to version control if you want to share project configuration with your team, or you can add it to `.gitignore` if you prefer to keep it local.
+A project is a folder on your machine — typically a Git repo — that serves as the workspace for your agents.
 
 ## Adding a Project
 
-To add a new project:
+1. Click `+` in the Project Rail (or `Cmd+Shift+O`)
+2. Select a folder in the file picker
+3. Clubhouse auto-detects the project name and Git configuration
 
-1. Click the `+` button at the bottom of the **Project Rail** (the vertical icon bar on the far left of the window).
-2. A system file picker dialog will open. Navigate to the folder you want to add and select it.
-3. Clubhouse will automatically detect:
-   - The **project name** from the folder name (e.g., a folder called `my-app` becomes the project name "my-app").
-   - **Git configuration**, if present — including the current branch, remotes, and repository status.
-4. The project appears as a new icon in the Project Rail, ready for use.
-
-There is no limit to the number of projects you can add. You can add any folder, whether it is a new empty directory, an existing codebase, or a monorepo.
+Add as many projects as you need. Each is fully independent — its own agents, plugins, Git state, and settings.
 
 ## The Project Rail
 
-The **Project Rail** is the vertical sidebar on the left edge of the Clubhouse window. Each project you have added is represented by an icon in this rail.
-
-### Switching Projects
-
-Click any project icon in the rail to switch to that project. The main content area — including the agent explorer, terminal views, and Git status — will update to reflect the selected project.
-
-### Reordering Projects
-
-Drag and drop project icons within the rail to reorder them. The order is saved automatically and persists across app restarts. Place your most-used projects at the top for quick access.
-
-### Project Icon Appearance
-
-By default, each project icon displays the first letter of the project name, styled with the project's accent color. You can customize both the color and the icon image in Project Settings (see the [Project Settings](projects-settings) help topic for details).
-
-## Working with Multiple Projects
-
-Clubhouse is designed for multi-project workflows. You can have many projects open at the same time, and each one is fully independent:
-
-- **Agents** — Each project maintains its own set of durable and quick agents. Agents in one project cannot access or modify files in another project.
-- **Plugin configurations** — Plugins can be enabled or disabled on a per-project basis. A plugin that is active in one project may be turned off in another.
-- **Git state** — Each project tracks its own Git branch, staged files, stash count, and remote status independently.
-- **Worktrees** — Durable agents within a project can each have their own Git worktree and branch, providing full isolation for parallel development.
-
-Switching between projects is instant. Clubhouse preserves the state of each project — including which agent is selected and the scroll position of terminal output — so you can pick up exactly where you left off.
+- **Switch** — Click a project icon or press `Cmd+Option+1–9`
+- **Reorder** — Drag and drop icons
+- **Customize** — Change color, name, or icon in Project Settings
 
 ## The .clubhouse/ Directory
 
-When you first interact with a project (for example, by creating an agent), Clubhouse creates a `.clubhouse/` directory at the project root. This directory is the single location for all Clubhouse-specific data tied to that project.
+Clubhouse creates a `.clubhouse/` folder in your project root to store its configuration:
 
-### Directory Structure
+| Path | Contents |
+|------|----------|
+| `agents/` | Agent definitions and per-agent config |
+| `skills/` | Custom skill scripts |
+| `templates/` | Reusable agent templates |
+| `instructions/` | Project-level instructions for agent behavior |
 
-| Path | Purpose |
-|------|---------|
-| `.clubhouse/agents/` | Agent definitions and per-agent configuration |
-| `.clubhouse/skills/` | Custom skill scripts available to agents in this project |
-| `.clubhouse/templates/` | Reusable mission templates |
-| `.clubhouse/instructions/` | Project-level instruction files for agent guidance |
+- Safe to commit to Git for team sharing, or add to `.gitignore` for local-only use
+- Deleting `.clubhouse/` resets all Clubhouse config for that project (your source code is unaffected)
+- Clubhouse never modifies your source files outside of agent-driven actions you initiate
 
-### Important Notes
+## Dashboard View
 
-- Clubhouse will never modify your source files outside of agent-driven actions that you initiate. The `.clubhouse/` directory is the only location Clubhouse writes to on its own.
-- Deleting the `.clubhouse/` directory resets all Clubhouse configuration for that project. Agents, skills, templates, and instructions will be lost. Your source code is not affected.
-- If you share a repository with teammates who also use Clubhouse, committing `.clubhouse/` allows you to share agent definitions, instructions, and templates across the team.
+Each project appears as a card on the Dashboard with agent status pills, quick-action buttons, and recent activity. See the **Dashboard** help topic for details.

--- a/src/renderer/features/help/content/projects-settings.md
+++ b/src/renderer/features/help/content/projects-settings.md
@@ -1,91 +1,41 @@
 # Project Settings
 
-Project settings allow you to customize how a project appears in Clubhouse, configure its AI backend, manage plugin enablement, and perform administrative actions like closing or resetting the project.
+Configure how a project appears, which orchestrator it uses, and manage plugins.
 
-## Accessing Project Settings
+**Access:** Click the gear icon in the project header, or open **Settings > Project**.
 
-There are two ways to open project settings:
+## Appearance
 
-1. **Gear icon** — Select a project in the Project Rail, then click the gear icon in the project header area.
-2. **Settings menu** — Open the application Settings panel and navigate to the **Project** section while the desired project is selected.
-
-Both paths open the same settings view. Changes are saved automatically as you make them.
-
-## Display Name
-
-By default, Clubhouse uses the folder name as the project's display name. You can override this with a custom name that better describes the project.
-
-- The display name appears in the Project Rail tooltip, the project header, and anywhere the project is referenced in the UI.
-- Changing the display name does not rename the folder on disk. It is purely a cosmetic setting within Clubhouse.
-- To revert to the folder name, clear the custom name field.
-
-## Color
-
-Each project has an **accent color** that is used for its icon in the Project Rail and for visual identification throughout the interface.
-
-- Choose from 10 or more preset accent colors.
-- The color is applied to the project icon background and is also used as a subtle tint in headers and borders when the project is selected.
-- Assigning distinct colors to your projects makes it easier to identify them at a glance, especially when you have many projects in the rail.
-
-## Icon
-
-You can upload a **custom icon image** to replace the default letter-based project icon.
-
-- Click the icon area in project settings to open a file picker dialog.
-- Select an image file (PNG, JPG, or SVG are supported).
-- A preview of the icon is shown in the settings view after upload.
-- To remove a custom icon and revert to the default letter icon, click the remove button next to the icon preview.
-
-Custom icons are displayed in the Project Rail and in the project header. They are stored within the `.clubhouse/` directory for the project.
+| Setting | Description |
+|---------|-------------|
+| **Display name** | Override the folder name. Cosmetic only — doesn't rename the folder. |
+| **Accent color** | Choose from 10+ colors for the project icon and UI accents. |
+| **Custom icon** | Upload a PNG, JPG, or SVG. Supports cropping during upload. Clear to revert to the default letter icon. |
 
 ## Orchestrator
 
-The **orchestrator** determines which AI backend powers the agents in this project. Clubhouse supports multiple orchestrators:
+Select which AI backend powers agents in this project:
 
-| Orchestrator | Description |
-|-------------|-------------|
-| **Claude Code** | Anthropic's Claude-powered coding CLI |
-| **Copilot CLI** | GitHub Copilot's command-line interface |
-| **OpenCode** | Open-source AI coding backend |
+| Orchestrator | Status |
+|-------------|--------|
+| **Claude Code** | Stable |
+| **Copilot CLI** | Stable |
+| **OpenCode** | Beta |
+| **Codex CLI** | Beta |
 
-- Select an orchestrator from the dropdown menu in project settings.
-- The chosen orchestrator applies to all agents created in this project, both durable and quick.
-- Changing the orchestrator does not affect agents that are already running. The new orchestrator will be used for agents created or restarted after the change.
-- Available orchestrators depend on which CLI tools are installed on your system and which API keys are configured in the global Clubhouse settings.
+The selected orchestrator applies to new and restarted agents. Only orchestrators enabled in global settings and detected on your system appear as options.
+
+## Clubhouse Mode
+
+When enabled, project-level agent defaults (instructions, permissions, MCP config, skills) are automatically synced to durable agents on wake. See the **Clubhouse Mode** help topic for details.
 
 ## Per-Project Plugin Enablement
 
-Plugins installed in Clubhouse can be enabled or disabled on a per-project basis. This is useful when certain plugins are relevant to some projects but not others.
-
-- The plugin enablement section lists all installed plugins with a toggle for each.
-- Enabling a plugin makes it available to agents working in this project. Disabling it prevents agents from using that plugin's capabilities.
-- Plugin toggles take effect immediately. Running agents will pick up the change the next time they interact with the plugin system.
-- Global plugin settings (such as API keys or configuration) are managed in the application-wide Settings panel, not in project settings.
+Toggle plugins on/off for this specific project. A plugin must first be enabled at the app level. Changes take effect immediately.
 
 ## Danger Zone
 
-The danger zone contains destructive actions that cannot be easily undone. Each action requires explicit confirmation before it is executed.
-
-### Close Project
-
-Closing a project removes it from Clubhouse. This means:
-
-- The project icon is removed from the Project Rail.
-- All agent definitions, worktrees, and Clubhouse-specific state for the project are discarded.
-- **Your files on disk are not affected.** The project folder and all source code remain exactly as they are.
-- You can re-add the folder as a project at any time, but previous agent definitions and Clubhouse configuration will not be restored (unless the `.clubhouse/` directory was preserved on disk).
-
-A confirmation dialog will appear with a clear warning before the project is closed.
-
-### Reset Project
-
-Resetting a project deletes all Clubhouse configuration data stored in the `.clubhouse/` directory within the project folder. This includes:
-
-- All agent definitions (durable and quick agent history)
-- Skills, templates, and instruction files
-- Plugin configuration specific to the project
-- Worktree metadata
-
-After a reset, the project remains in Clubhouse but returns to a clean state, as if it had just been added for the first time. **Your source code and Git history are not affected.**
-
-A confirmation dialog will appear with a detailed warning explaining what will be deleted. This action cannot be undone.
+| Action | Effect |
+|--------|--------|
+| **Close Project** | Removes from Clubhouse. Files on disk are untouched. Re-add anytime. |
+| **Reset Project** | Deletes the `.clubhouse/` directory — all agents, skills, templates, and plugin config. Source code is unaffected. Cannot be undone. |

--- a/src/renderer/features/help/content/settings-annex.md
+++ b/src/renderer/features/help/content/settings-annex.md
@@ -1,0 +1,36 @@
+# Annex (iOS Companion)
+
+Annex lets you monitor and interact with your agents from an iOS device on the same local network.
+
+## Setup
+
+1. Open **Settings > Annex**
+2. Toggle the local server **on**
+3. A 6-digit PIN is displayed
+4. On your iOS device, open the Annex app and enter the PIN to pair
+
+Devices are discovered automatically via Bonjour/mDNS on your local network.
+
+## What You Can Do from iOS
+
+- See agent status in real time (working, idle, error, needs permission)
+- **Approve or deny** permission requests remotely
+- View tool call details and agent activity
+
+> **Example:** Step away from your desk and approve a permission request from your phone when an agent is waiting.
+
+## Settings
+
+| Setting | Description |
+|---------|-------------|
+| **Server toggle** | Enable/disable the local Annex server |
+| **Status & port** | Shows whether the server is running and on which port |
+| **Connected devices** | Count of currently paired devices |
+| **PIN** | Display and regenerate the pairing PIN |
+| **Device name** | Custom name shown to iOS clients |
+
+## Security
+
+- All communication stays on your **local network** — nothing goes to external servers
+- PIN pairing prevents unauthorized device access
+- Regenerate the PIN anytime to revoke existing pairings

--- a/src/renderer/features/help/content/settings-logging.md
+++ b/src/renderer/features/help/content/settings-logging.md
@@ -1,74 +1,58 @@
-# Logging
+# Logging & Diagnostics
 
-Clubhouse includes a structured, namespace-based logging system that records application events, agent activity, and diagnostic information. Logs are stored locally on your machine and are never transmitted to any external service.
+Clubhouse includes structured, namespace-based logging. Logs are stored locally and never sent externally.
 
-## Enabling Logging
+## Quick Setup
 
-1. Open **Settings** (gear icon in the Project Rail, or press `Cmd+,`).
-2. Navigate to the **Logging** section.
-3. Use the **master toggle** to enable or disable logging.
-
-When logging is disabled, no new log entries are written. Existing log files are preserved until they expire according to the retention policy.
+**Settings > Logging** — Toggle logging on, set a level, and enable relevant namespaces.
 
 ## Log Levels
 
-Clubhouse uses a tiered severity system. You can set a **minimum log level** to control how much detail is captured. Only messages at or above the selected level are recorded.
+| Level | Use For |
+|-------|---------|
+| **Debug** | Maximum detail — internal state, timing, event traces |
+| **Info** | Standard operations — agent starts, project loads, plugin activations *(recommended default)* |
+| **Warn** | Potential issues — deprecated API calls, failed background fetches |
+| **Error** | Operation failures — crashed agents, plugin load errors |
+| **Fatal** | Critical failures that may require a restart |
 
-| Level | Description |
-|-------|-------------|
-| **Debug** | Verbose output useful for diagnosing issues. Includes internal state, timing data, and detailed event traces. Produces the most log volume. |
-| **Info** | Standard operational messages. Records key events such as agent starts, project loads, and plugin activations. This is the recommended default for normal use. |
-| **Warn** | Conditions that are not errors but may indicate a problem, such as a deprecated plugin API call or a failed background fetch. |
-| **Error** | Failures that prevented an operation from completing, such as a crashed agent or a plugin that failed to load. |
-| **Fatal** | Critical failures that may cause application instability or force a restart. These are rare but important to capture. |
+## Namespaces
 
-Setting the level to **Debug** captures everything. Setting it to **Error** captures only errors and fatal events, resulting in much smaller log files.
+Filter logs by feature area to reduce noise:
 
-## Namespace Control
+| Namespace | Covers |
+|-----------|--------|
+| `core:startup` | App launch and initialization |
+| `core:updates` | Auto-update checks |
+| `git:operations` | Git commands and monitoring |
+| `agents:lifecycle` | Agent create, start, stop, delete |
+| `agents:orchestrator` | Orchestrator CLI communication |
+| `plugins:loader` | Plugin discovery and loading |
+| `plugins:api` | Plugin API calls |
+| `ui:navigation` | View switches and layout changes |
 
-Logs are organized by **feature namespace**, allowing you to toggle logging on or off for specific areas of the application. This is particularly useful when you are investigating a specific issue and want to reduce noise from unrelated subsystems.
+Each namespace can be toggled independently.
 
-Example namespaces include:
+## Retention
 
-| Namespace | Area |
-|-----------|------|
-| `core:startup` | Application launch and initialization |
-| `core:updates` | Auto-update checks and installation |
-| `git:operations` | Git commands and repository monitoring |
-| `agents:lifecycle` | Agent creation, start, stop, and deletion events |
-| `agents:orchestrator` | Communication between Clubhouse and orchestrator CLIs |
-| `plugins:loader` | Plugin discovery, loading, and initialization |
-| `plugins:api` | Plugin API calls and responses |
-| `ui:navigation` | View switches, pane transitions, and layout changes |
+| Tier | Duration | Max Size |
+|------|----------|----------|
+| **Low** | 3 days | 50 MB |
+| **Medium** | 7 days | 200 MB |
+| **High** | 30 days | 500 MB |
+| **Unlimited** | No expiry | No cap |
 
-Each namespace can be individually enabled or disabled in the Logging settings. When a namespace is disabled, messages from that area are silently dropped regardless of their severity level.
+Oldest entries are pruned automatically when limits are reached.
 
-## Retention Policy
+## Log Files
 
-Log files accumulate over time. Clubhouse provides configurable retention tiers that control how long logs are kept and how much disk space they may consume.
+The full path to your log directory is shown in Settings with a direct **Open in Finder** link.
 
-| Tier | Duration | Max Size | Best For |
-|------|----------|----------|----------|
-| **Low** | 3 days | 50 MB | Minimal footprint. Suitable if you rarely need to check logs. |
-| **Medium** | 7 days | 200 MB | A balanced default. Keeps enough history to diagnose recent issues. |
-| **High** | 30 days | 500 MB | Extended history for ongoing debugging or monitoring. |
-| **Unlimited** | No expiry | No cap | Logs are never automatically deleted. Use with caution, as log files can grow large over time. |
+## Common Diagnostic Scenarios
 
-When logs exceed the configured duration or size limit, the oldest entries are pruned automatically. The **Unlimited** tier disables all automatic cleanup -- you are responsible for managing disk usage manually.
-
-## Log File Location
-
-The Logging settings display the **full path** to the log file directory on your system. A **direct link** is provided to open the log folder in Finder, making it easy to access log files for sharing or external analysis.
-
-## Privacy
-
-All logs are stored **locally on your machine**. Clubhouse does not transmit, upload, or share log data with any external service. Log files may contain project paths, file names, and agent activity details, so treat them with the same care you would give any local development data.
-
-## Use Cases
-
-| Scenario | Recommended Configuration |
-|----------|--------------------------|
-| **Debugging a startup crash** | Enable logging at **Debug** level with the `core:startup` namespace active. Check logs after reproducing the issue. |
-| **Monitoring agent behavior** | Enable **Info** level with `agents:lifecycle` and `agents:orchestrator` namespaces. Review logs to trace what the agent did and why. |
-| **Diagnosing a plugin problem** | Enable **Debug** level with `plugins:loader` and `plugins:api` namespaces. Look for errors during plugin initialization or API calls. |
-| **General background logging** | Use **Info** level with all namespaces enabled and **Medium** retention. Provides a reasonable history without excessive disk usage. |
+| Problem | Configuration |
+|---------|--------------|
+| Startup crash | Debug level + `core:startup` |
+| Agent misbehavior | Info level + `agents:lifecycle` + `agents:orchestrator` |
+| Plugin issue | Debug level + `plugins:loader` + `plugins:api` |
+| General monitoring | Info level + all namespaces + Medium retention |

--- a/src/renderer/features/help/content/settings-notifications.md
+++ b/src/renderer/features/help/content/settings-notifications.md
@@ -1,69 +1,45 @@
-# Notifications
+# Notifications & Badges
 
-Clubhouse provides a configurable notification system that keeps you informed about agent activity, permission requests, and other important events -- even when the app is in the background.
+Stay informed about agent activity even when Clubhouse is in the background.
 
 ## Notification Settings
 
-To configure notifications:
-
-1. Open **Settings** (gear icon in the Project Rail, or press `Cmd+,`).
-2. Navigate to the **Notifications** section.
+**Settings > Notifications**
 
 ### Master Toggle
 
-At the top of the Notifications settings is a **master enable/disable toggle**. When disabled, Clubhouse will not send any system notifications regardless of individual event settings. Badge indicators may still appear within the app.
+Disables all system notifications when off. Badge indicators within the app may still appear.
 
-### Event-Based Notifications
-
-Each notification event can be toggled independently. The available events are:
+### Event Notifications
 
 | Event | Description |
 |-------|-------------|
-| **Permission Request** | An agent is waiting for you to approve or deny a sensitive operation. This is often the most important notification to keep enabled, since a blocked permission request can stall an agent's progress. |
-| **Agent Stopped** | An agent has finished its mission or exited. Useful for knowing when a long-running task completes. |
-| **Agent Idle** | An agent has been idle for an extended period without producing output. May indicate the agent is stuck or waiting for input. |
-| **Agent Error** | An agent encountered a fatal error and stopped unexpectedly. |
+| **Permission Request** | Agent waiting for approval — keep this enabled to avoid stalling agents |
+| **Agent Stopped** | Agent finished or exited |
+| **Agent Idle** | Agent idle for an extended period — may be stuck |
+| **Agent Error** | Agent crashed unexpectedly |
 
-### Sound Control
+Each event can be toggled independently.
 
-Notification sounds can be toggled independently from visual notifications. Use the **Enable notification sounds** toggle to control whether Clubhouse plays an audio alert when a notification fires. When disabled, notifications still appear as system banners but without sound.
+### macOS Permissions
 
-## macOS Notification Permission
+If notifications aren't appearing: **System Settings > Notifications > Clubhouse**. Use the **Test Notification** button in Clubhouse settings to verify.
 
-Clubhouse uses the macOS notification system to deliver alerts. On first launch, macOS may prompt you to grant notification permission. If you dismissed this prompt or need to change the setting later:
+## Badges
 
-1. Open **System Settings > Notifications** on your Mac.
-2. Find **Clubhouse** in the application list.
-3. Enable or configure notifications as desired.
+Badges are indicator dots/counts on icons and tabs signaling pending items.
 
-A **Test Notification** button is available in Clubhouse's notification settings. Use it to verify that notifications are working correctly and that macOS permissions are properly configured.
-
-## Badge Settings
-
-Badges are small indicator dots that appear on icons in the Clubhouse interface to signal pending items or activity. Badge settings are located in **Settings > Notifications**, under the **Badges** section.
-
-### Plugin Badges
-
-Plugins can generate badge indicators to draw your attention -- for example, a plugin might show a badge when there is unread content. Use the **Show plugin badges** toggle to enable or disable badge indicators from all plugins.
-
-### Project Rail Badges
-
-When enabled, **project rail badges** appear as small indicators on project icons in the Project Rail sidebar. These badges aggregate information from all sources within that project (agents, plugins, and other events), giving you an at-a-glance summary of which projects need attention.
-
-### Per-Project Badge Overrides
-
-You can customize badge behavior for individual projects:
-
-1. Right-click a project icon in the Project Rail, or open the project's settings.
-2. Find the **Badge** configuration.
-3. Override the default badge behavior for that specific project -- for example, you may want to suppress badges for a project you are not actively working on.
-
-### Clear All Badges
-
-If badge indicators have accumulated and you want a fresh start, use the **Clear All Badges** button in the badge settings. This resets all badge indicators across all projects and plugins. It is a one-time action; new badges will appear again as events occur.
+| Setting | Controls |
+|---------|----------|
+| **Plugin badges** | Show/hide badges from all plugins |
+| **Project Rail badges** | Show/hide aggregate badges on project icons |
+| **Per-project overrides** | Customize badge behavior per project (right-click project icon) |
+| **Clear All Badges** | Reset all badges across projects and plugins |
 
 ## Dock Badge
 
-Clubhouse displays a **dock badge** on the application icon in the macOS Dock. The badge shows a count of pending items that need your attention, such as permission requests waiting for approval. This allows you to see at a glance whether any agents need input, even when Clubhouse is not the foreground application.
+The macOS Dock icon shows a count of pending items (e.g., permission requests). Updates in real time, clears when addressed.
 
-The dock badge count updates in real time and clears automatically when you address the pending items.
+## Sound
+
+Notification sounds are configured separately in **Settings > Sound**. See the **Sound & Audio** help topic.

--- a/src/renderer/features/help/content/settings-orchestrators.md
+++ b/src/renderer/features/help/content/settings-orchestrators.md
@@ -1,76 +1,44 @@
 # Orchestrators
 
-An **orchestrator** is the CLI backend that powers your agents. It handles communication between Clubhouse and the AI model -- sending prompts, executing tool calls, managing file operations, and streaming output back to the Clubhouse interface. Clubhouse uses an orchestrator provider system that supports multiple backends, so you can choose the CLI that best fits your workflow.
+An orchestrator is the CLI backend powering your agents — it handles AI communication, tool calls, file operations, and output streaming.
 
 ## Available Orchestrators
 
 | Orchestrator | Description | Status |
 |-------------|-------------|--------|
-| **Claude Code** | Anthropic's official CLI for Claude. This is the default orchestrator and provides the most complete integration with Clubhouse. | Stable |
-| **Copilot CLI** | GitHub Copilot's CLI interface. Use this if your workflow is centered on GitHub's ecosystem. | Stable |
-| **OpenCode** | An open-source orchestrator alternative. Community-maintained with growing feature support. | Beta |
+| **Claude Code** | Anthropic's CLI for Claude. Most complete Clubhouse integration. | Stable |
+| **Copilot CLI** | GitHub Copilot's CLI. Best for GitHub-centric workflows. | Stable |
+| **OpenCode** | Open-source AI coding backend. Community-maintained. | Beta |
+| **Codex CLI** | OpenAI's Codex CLI. Sandbox-based permissions, `--full-auto` mode. | Beta |
 
-## Configuring Orchestrators
+## Setup
 
-1. Open **Settings** (gear icon in the Project Rail, or press `Cmd+,`).
-2. Navigate to the **Orchestrators** section.
-3. Each orchestrator is listed with a toggle to **enable** or **disable** it.
+1. Open **Settings > Orchestrators**
+2. Enable/disable orchestrators with toggles
+3. Clubhouse auto-detects installed binaries via PATH
 
-You can enable multiple orchestrators simultaneously. Different projects can use different orchestrators, so having several enabled gives you flexibility.
+**Status indicators:**
+- **Green checkmark** — Binary found, ready to use
+- **Red indicator** — Binary not found. Follow the setup prompt to install.
 
-**Important:** You cannot disable the last remaining enabled orchestrator. At least one orchestrator must be active at all times for Clubhouse to function.
+You cannot disable the last remaining orchestrator.
 
-## Binary Detection
+## Capability Matrix
 
-Clubhouse automatically searches for orchestrator binaries in common installation locations when the app starts and when you enable an orchestrator. The detection covers:
+| Capability | Claude Code | Copilot CLI | OpenCode | Codex CLI |
+|-----------|:-----------:|:-----------:|:--------:|:---------:|
+| Headless mode | Yes | Yes | Yes | Yes |
+| Structured output | Yes | — | — | — |
+| Hooks | Yes | Yes | — | — |
+| Session resume | Yes | — | — | Yes |
+| Permissions | Yes | Yes | Yes | Yes (sandbox) |
 
-- Standard PATH locations
-- Common installation directories (e.g., `/usr/local/bin`, `~/.local/bin`, Homebrew paths)
-- Version-managed tool directories (e.g., npm global, Cargo bin)
+## Per-Project Selection
 
-### Status Indicators
-
-Each orchestrator displays a status indicator in the settings:
-
-| Indicator | Meaning |
-|-----------|---------|
-| **Green checkmark** | The orchestrator binary was found and is available for use. |
-| **Red indicator** | The orchestrator binary was not found. A setup prompt will guide you through installation or manual path configuration. |
-
-If an orchestrator's binary is not found, Clubhouse displays a setup prompt with instructions for installing the required CLI tool.
-
-## Per-Project Orchestrator
-
-Each project can use a different orchestrator, allowing you to tailor the AI backend to the needs of each codebase:
-
-1. Select the project in the Project Rail.
-2. Open the project's settings.
-3. Choose the desired orchestrator from the dropdown.
-
-Only orchestrators that are enabled in the global settings and have their binary detected will appear as options.
+Each project can use a different orchestrator: **Project Settings > Orchestrator**. Only enabled orchestrators with detected binaries appear as options.
 
 ## Model Selection
 
-Each orchestrator provides its own set of available AI models. When you create or configure an agent, the **model picker** displays the models from the project's configured orchestrator.
-
-The models available depend on:
-
-- Which orchestrator the project is using
-- The orchestrator CLI version installed on your system
-- Your API key configuration and account permissions
-
-If you do not see expected models, check that your orchestrator CLI is up to date and that your API keys are valid.
-
-## Orchestrator Capabilities
-
-Different orchestrators support different feature sets. Clubhouse adapts its interface based on the capabilities reported by each orchestrator.
-
-| Capability | Description |
-|-----------|-------------|
-| **Headless mode** | Running the agent without an interactive terminal, using structured input/output instead. Required for background agent operation. |
-| **Structured output** | The orchestrator can emit structured JSON events (tool calls, permission requests, errors) that Clubhouse uses to power real-time status indicators and the transcript view. |
-| **Hooks** | Event hooks that allow Clubhouse to subscribe to agent lifecycle events such as tool calls, permission requests, and completion. |
-| **Session resume** | The ability to pause an agent session and resume it later, preserving conversation context. Essential for durable agents. |
-| **Permissions** | Support for permission-gated operations where the agent must request approval before performing sensitive actions like file writes or shell commands. |
-
-Not all orchestrators support every capability. The orchestrator settings page indicates which capabilities each orchestrator provides.
+Each orchestrator provides its own model list. If models are missing:
+- Update the orchestrator CLI to the latest version
+- Check that API keys are valid and have the required permissions

--- a/src/renderer/features/help/content/settings-sound.md
+++ b/src/renderer/features/help/content/settings-sound.md
@@ -1,0 +1,43 @@
+# Sound & Audio
+
+Configure notification sounds with sound packs, per-event controls, and per-project overrides.
+
+## Sound Packs
+
+A sound pack is a set of audio files for notification events. Types:
+
+| Source | Description |
+|--------|-------------|
+| **OS Default** | System notification sounds |
+| **User-created** | Import a folder of audio files from `~/.clubhouse/sounds/` |
+| **Plugin-provided** | Packs contributed by plugins (cannot be deleted) |
+
+Supported formats: `.mp3`, `.wav`, `.ogg`
+
+## Per-Event Controls
+
+Four sound events, each with independent settings:
+
+| Event | Triggers When |
+|-------|--------------|
+| **Agent Finished** | An agent completes its mission |
+| **Error** | An agent encounters a fatal error |
+| **Permission Request** | An agent is waiting for approval |
+| **General Notification** | Other notification events |
+
+For each event:
+- **Enable/disable** toggle
+- **Volume slider** (0–100%)
+- **Preview button** — plays the sound at current settings
+
+## Per-Project Overrides
+
+Each project can use a different sound pack: **Project Settings > Sound Pack**.
+
+## Managing Packs
+
+- Import folders from `~/.clubhouse/sounds/`
+- Delete user-created packs from Settings
+- Plugin-provided packs show a "Plugin" badge and cannot be removed
+
+**Access:** **Settings > Sound**

--- a/src/renderer/features/help/content/settings-themes.md
+++ b/src/renderer/features/help/content/settings-themes.md
@@ -1,45 +1,31 @@
-# Themes & Display
+# Display & Themes
 
-Clubhouse offers a selection of built-in themes that control the visual appearance of the entire application, including the editor interface and terminal colors. You can switch themes at any time from the Display settings.
+Customize how Clubhouse looks: themes, terminal colors, and display preferences.
 
 ## Changing Your Theme
 
-1. Open **Settings** (gear icon in the Project Rail, or press `Cmd+,`).
-2. Navigate to the **Display** section.
-3. Select a theme from the list.
+**Settings > Display** — Select a theme. Applied immediately, no restart needed.
 
-The new theme is applied immediately across the entire application. There is no need to restart Clubhouse.
+## Built-in Themes
 
-## Available Themes
+| Theme | Style |
+|-------|-------|
+| **Catppuccin Mocha** | Dark, warm pastels *(default)* |
+| **Catppuccin Latte** | Light, soft pastels |
+| **Solarized Dark** | Dark, precision contrast |
+| **Terminal** | Dark, green-on-black CRT |
+| **Nord** | Dark, arctic blue tones |
+| **Dracula** | Dark, vivid purples and pinks |
+| **Tokyo Night** | Dark, cool blue tones |
+| **Gruvbox Dark** | Dark, warm retro earth tones |
 
-Clubhouse ships with eight built-in themes.
+## Terminal Colors
 
-| Theme | Style | Description |
-|-------|-------|-------------|
-| **Catppuccin Mocha** | Dark | A warm, pastel-toned dark theme. This is the default theme for new installations. |
-| **Catppuccin Latte** | Light | The light counterpart to Catppuccin Mocha, with soft pastel tones on a light background. |
-| **Solarized Dark** | Dark | Ethan Schoonover's precision-engineered color scheme, dark variant. Designed for long reading sessions with carefully balanced contrast. |
-| **Terminal** | Dark | A classic green-on-black aesthetic inspired by vintage CRT terminals. |
-| **Nord** | Dark | An arctic, north-bluish color palette with muted tones. Clean and minimal. |
-| **Dracula** | Dark | A popular dark theme with vivid purples, pinks, and greens on a dark background. |
-| **Tokyo Night** | Dark | Inspired by the vibrant lights of downtown Tokyo. Balanced contrast with cool blue tones. |
-| **Gruvbox Dark** | Dark | A retro-inspired theme with warm, earthy tones of orange, yellow, and aqua on a dark background. |
+Each theme includes a complete terminal color scheme (16 ANSI colors, cursor, selection highlight). Terminal colors update immediately across all open sessions when you switch themes.
 
-## Terminal Color Integration
+## Display Options
 
-Each theme defines its own complete terminal color scheme. This includes:
-
-- **16 ANSI colors** -- the standard set of 8 normal colors and 8 bright variants used by terminal applications, shell prompts, and syntax highlighting in CLI tools.
-- **Cursor color** -- the color of the blinking cursor in terminal views.
-- **Selection color** -- the background color used when you highlight text in the terminal.
-
-When you switch themes, terminal colors update immediately in all open terminal sessions. This ensures a consistent visual experience between the Clubhouse interface and the terminal output from your agents.
-
-## Home Dashboard Toggle
-
-The Display settings also include a toggle to **show or hide the Home dashboard**.
-
-- **Enabled (default)** -- Clicking the Home button in the Project Rail opens the Home dashboard, which shows an overview of all your projects and active agents.
-- **Disabled** -- The Home dashboard is hidden. Clicking the Home button has no effect, and Clubhouse opens directly to the last active project on launch.
-
-This is useful if you prefer a minimal workflow and do not need the overview screen.
+| Setting | Description |
+|---------|-------------|
+| **Home Dashboard** | Toggle visibility of the Dashboard home screen |
+| **Cross-Project Hub** | Show/hide the global Hub icon in the Project Rail |

--- a/src/renderer/features/help/content/troubleshooting-common.md
+++ b/src/renderer/features/help/content/troubleshooting-common.md
@@ -1,82 +1,74 @@
 # Common Issues
 
-This page covers frequently encountered problems in Clubhouse and how to resolve them. For each issue, the symptoms are described first, followed by the likely cause and the steps to fix it.
+Quick fixes for frequently encountered problems.
 
 ## Agent Won't Start
 
-**Symptoms:** You click to start or resume an agent, but nothing happens, or the agent immediately enters an error state.
+**Check these in order:**
+1. **Orchestrator installed?** — **Settings > Orchestrators** — look for a green checkmark. Red = not found; follow the setup prompt.
+2. **API keys configured?** — Most orchestrators need an API key (e.g., `ANTHROPIC_API_KEY` env var). See orchestrator docs.
+3. **Orchestrator enabled?** — Ensure it's toggled on in **Settings > Orchestrators**.
 
-**Possible causes and fixes:**
+## Agent Stuck (Orange Ring)
 
-1. **Orchestrator not installed.** Open **Settings > Orchestrators** and check the status indicator for the orchestrator your project is configured to use. If the indicator is red, the orchestrator CLI binary was not found on your system. Install the required CLI tool and restart Clubhouse, or click the setup prompt in the orchestrator settings.
-2. **API keys not configured.** Most orchestrators require an API key to communicate with the AI model provider. Verify that your API key is set up correctly according to the orchestrator's documentation. Some orchestrators use environment variables (e.g., `ANTHROPIC_API_KEY`), while others use configuration files.
-3. **Orchestrator disabled.** Ensure the orchestrator is enabled in **Settings > Orchestrators**. If it is disabled, agents using that orchestrator cannot start.
+The orange ring means the agent is **waiting for permission approval**. Open the agent's terminal, review the request, and click **Approve** or **Deny**.
 
-## Agent Stuck on Permission
-
-**Symptoms:** An agent appears to be running but is not making progress. The agent's status ring shows an orange indicator.
-
-**Fix:** The orange ring means the agent is waiting for you to **approve or deny a permission request**. Open the agent's terminal view to see the pending request. The agent cannot proceed until you respond. Common permission requests include file writes, shell command execution, and access to sensitive directories.
-
-If you want agents to run with fewer interruptions, check whether the orchestrator supports an auto-approve mode for certain low-risk operations.
+To reduce interruptions: enable headless mode or Free Agent mode for quick agents.
 
 ## Plugin Not Appearing
 
-**Symptoms:** A plugin you expect to see is missing from the Explorer Rail or the Project Rail.
-
-**Possible causes and fixes:**
-
-1. **Plugin not enabled at app level.** Open **Settings > Plugins** and verify the plugin is enabled globally.
-2. **Plugin not enabled at project level.** Even if a plugin is enabled globally, project-scoped plugins must also be enabled for the specific project. Open the project's settings and check the plugin list.
-3. **Incompatible API version.** If the plugin was built for an older version of the Clubhouse plugin API, it may fail to load. Check **Settings > Logging** for error messages from the `plugins:loader` namespace. The plugin author may need to update the plugin for compatibility.
+1. **App-level enabled?** — **Settings > Plugins** — toggle on.
+2. **Project-level enabled?** — **Project Settings > Plugins** — toggle on for this project.
+3. **API version compatible?** — Check `plugins:loader` logs for version mismatch errors.
+4. **External plugins enabled?** — **Settings > Plugins > External Plugins** master switch must be on.
 
 ## Git Not Detected
 
-**Symptoms:** A yellow warning banner appears at the top of the project view stating that Git is not detected.
-
-**Fix:** This means the project folder does not contain a `.git` directory. You have two options:
-
-1. **Initialize Git.** Click the **"git init"** button in the yellow banner. Clubhouse will run `git init` in the project folder and enable full Git integration.
-2. **Dismiss the banner.** If you intentionally work without Git, dismiss the warning. Note that some features -- such as Git worktrees for durable agents, branch tracking, and file status indicators -- will not be available.
+Yellow banner = no `.git` directory found. Options:
+- Click **git init** in the banner to initialize
+- Dismiss if you don't need Git (worktrees and branch tracking won't be available)
 
 ## Slow Performance
 
-**Symptoms:** The application feels sluggish, animations stutter, or terminal output renders slowly.
+**Check:** **Settings > About** — if it shows x64 on Apple Silicon, you're running under Rosetta.
 
-**Possible cause:** You may be running the **x64 (Intel) build** of Clubhouse on an Apple Silicon Mac via Rosetta 2 translation. This significantly degrades performance.
-
-**How to check:** Open the **About** page (accessible from the application menu or the Project Rail). The About page displays your system architecture. If it shows that you are running x64 on an arm64 system, you are using the wrong build.
-
-**Fix:** Download the **arm64 (Apple Silicon) build** of Clubhouse from the official download page and install it. The native arm64 build provides substantially better performance on Apple Silicon hardware.
+**Fix:** Download and install the **arm64 (Apple Silicon)** build for significantly better performance.
 
 ## Updates Not Working
 
-**Symptoms:** Clubhouse does not update automatically, or the update process appears stuck.
-
-**Possible causes and fixes:**
-
-1. **Check update status.** Open **Settings > Updates**. The settings page displays the current update state, including any error messages. Common errors include network timeouts and failed signature verification.
-2. **Manual check.** Click the **"Check now"** button to force an immediate update check.
-3. **Internet connectivity.** Ensure your machine has a working internet connection. Clubhouse downloads updates from a remote server and cannot proceed without network access.
-4. **Firewall or proxy.** If you are behind a corporate firewall or proxy, update downloads may be blocked. Check with your network administrator.
+1. Check status in **Settings > Updates** for error messages
+2. Click **Check now** to force a manual check
+3. Verify internet connectivity and firewall/proxy settings
 
 ## Terminal Not Responding
 
-**Symptoms:** The terminal view for an agent is frozen or not displaying new output.
-
-**Possible causes and fixes:**
-
-1. **Agent in error state.** Check the agent's status indicator. If the ring is red, the agent has crashed. Try stopping and restarting the agent.
-2. **Hung process.** The agent's underlying orchestrator process may be stuck. Use the **Kill** or **Stop** button to terminate the agent, then restart it.
-3. **Large output buffer.** If the agent has produced an extremely large volume of terminal output, the renderer may struggle. Stopping and restarting the agent clears the buffer.
+1. **Red ring?** — Agent crashed. Stop and restart.
+2. **No output?** — Process may be hung. Use **Kill/Stop**, then restart.
+3. **Rendering slow?** — Large output buffer. Restart the agent to clear it.
 
 ## Missing Models
 
-**Symptoms:** The model picker shows fewer models than expected, or no models at all.
+Models come from the orchestrator, not Clubhouse. If models are missing:
+- Update your orchestrator CLI to the latest version
+- Verify API keys are valid with the required permissions
+- Check **Settings > Orchestrators** for status indicators
 
-**Possible causes and fixes:**
+## Command Palette Not Opening
 
-1. **Models come from the orchestrator.** The model list is provided by the orchestrator CLI, not by Clubhouse itself. If models are missing, the issue is on the orchestrator side.
-2. **Outdated orchestrator CLI.** Newer models may require a newer version of the orchestrator CLI. Update the CLI to the latest version.
-3. **Invalid or expired API keys.** Some models are gated behind specific API key tiers or account permissions. Verify that your API key is valid and that your account has access to the models you expect.
-4. **Orchestrator not responding.** If the orchestrator binary is not running correctly, it may fail to report its model list. Check **Settings > Orchestrators** for status indicators.
+If `Cmd+K` doesn't work:
+- Ensure focus is on the Clubhouse window (not a pop-out terminal's native input)
+- Check **Settings > Keyboard Shortcuts** for conflicts
+- Try `Cmd+K` from a non-text-input area first
+
+## Clubhouse Mode Dialog Keeps Appearing
+
+The Config Changes dialog appears when an agent's config has drifted from project defaults. To stop it:
+- Click **Keep for this agent** to lock the agent to its own config
+- Or **Save to Clubhouse** to sync changes back to defaults
+
+## Still Stuck?
+
+Report issues at [github.com/Agent-Clubhouse/Clubhouse/issues](https://github.com/Agent-Clubhouse/Clubhouse/issues). Include:
+- Steps to reproduce
+- Log output (**Settings > Logging** — enable Debug level, reproduce, share the log file)
+- Clubhouse version (**Settings > About**)

--- a/src/renderer/features/help/content/troubleshooting-safe-mode.md
+++ b/src/renderer/features/help/content/troubleshooting-safe-mode.md
@@ -1,74 +1,58 @@
-# Safe Mode
+# Safe Mode & Recovery
 
-Safe mode is an emergency startup option that disables all plugins, allowing you to diagnose and recover from problems that prevent Clubhouse from starting normally.
-
-## What Is Safe Mode?
-
-When Clubhouse starts in safe mode, **all plugins are disabled**. The core application loads normally -- you can access your projects, agents, and settings -- but no plugin code is executed. This isolates plugin-related issues from the rest of the application.
-
-Safe mode is designed for situations where a plugin causes Clubhouse to crash or behave incorrectly during startup. By removing plugins from the equation, you can determine whether a plugin is the root cause of the problem and take corrective action.
+Safe mode disables all plugins so you can diagnose and fix startup problems.
 
 ## When Safe Mode Triggers
 
-Clubhouse includes **crash loop detection** that monitors startup behavior. Each time Clubhouse launches, it writes a startup marker to track whether the application initialized successfully. If Clubhouse detects repeated startup failures -- meaning the app crashed before it could fully start multiple times in a row -- it triggers the safe mode prompt on the next launch.
+Clubhouse detects **crash loops** — repeated startup failures. When detected, a dialog appears:
 
-### The Safe Mode Dialog
+| Option | Effect |
+|--------|--------|
+| **Start in Safe Mode** | Launch with all plugins disabled |
+| **Try Again Normally** | Attempt normal startup (use if crash was one-time) |
 
-When crash loop detection activates, Clubhouse presents a dialog with two options:
-
-| Option | Description |
-|--------|-------------|
-| **Start in Safe Mode** | Launches Clubhouse with all plugins disabled. The application will start without loading any plugin code. |
-| **Try Again Normally** | Attempts a normal startup with all plugins enabled. Use this if you believe the crash was a one-time issue (e.g., caused by a transient system condition). |
-
-The dialog also displays a **list of plugins that were enabled at the time of the last crash**. This information helps you identify which plugin may be causing the problem.
+The dialog lists plugins that were enabled at the time of the last crash.
 
 ## Working in Safe Mode
 
-Once Clubhouse is running in safe mode:
+1. All plugins are disabled — no plugin tabs, sidebars, or badges
+2. Core features work normally (projects, agents, Git, settings)
+3. Open **Settings > Plugins** — identify the suspect plugin (recently installed/updated, or listed in the crash dialog)
+4. Disable the problematic plugin
+5. Restart Clubhouse normally
 
-1. **All plugins are disabled.** Plugin tabs, sidebar panels, and plugin-generated badges will not appear.
-2. **Core features work normally.** You can open projects, start agents, use Git integration, and access settings.
-3. **Investigate the problem.** Open **Settings > Plugins** and review the list of plugins. Look for any plugin that was recently installed, updated, or that appeared in the safe mode dialog's crash list.
-4. **Disable the problematic plugin.** Toggle off the plugin you suspect is causing the crash. You can disable plugins one at a time to isolate the issue.
-5. **Restart normally.** Close and reopen Clubhouse. With the problematic plugin disabled, the app should start without triggering safe mode.
+**Not sure which plugin?** Disable all, restart, then re-enable one at a time until the crash reoccurs.
 
-If you are unsure which plugin is at fault, disable all plugins, restart, and then re-enable them one at a time until the crash reoccurs.
+## Recovery Options
 
-## Reset Project
+### Reset Project
 
-If a project's `.clubhouse/` configuration directory has become corrupted -- for example, due to a failed write, a version mismatch, or manual editing -- you can reset it.
+Deletes the `.clubhouse/` directory for a project — all agent definitions, skills, templates, and plugin config are removed. Source code is unaffected.
 
-1. Open **Settings > Project** (within the affected project).
-2. Click **Reset Project**.
-3. Confirm the action.
+**Project Settings > Danger Zone > Reset Project**
 
-**What this does:**
+Use as a last resort when project configuration is corrupted.
 
-- Deletes the `.clubhouse/` directory for that project, removing all Clubhouse-specific configuration, agent definitions, plugin settings, and cached data.
-- Your **source files on disk are not touched**. Only the `.clubhouse/` metadata is removed.
-- The project will appear as a fresh addition the next time you interact with it. You will need to reconfigure agents, plugins, and project-level settings.
+### Close Project
 
-Use this as a last resort when project-level configuration is in a broken state and other troubleshooting steps have not resolved the issue.
+Removes a project from Clubhouse without touching files on disk. The `.clubhouse/` directory stays intact. Re-add anytime with the `+` button.
 
-## Close Project
+**Right-click project icon > Close Project**
 
-If you want to remove a project from Clubhouse without affecting the files on disk:
+## Using Logs
 
-1. Right-click the project icon in the Project Rail.
-2. Select **Close Project**.
+When troubleshooting:
+1. **Settings > Logging** — enable logging
+2. Set level to **Debug**
+3. Enable `core:startup`, `plugins:loader`, `plugins:api` namespaces
+4. Reproduce the problem
+5. Open the log file (link in Logging settings) and look for errors
 
-This removes the project from the Clubhouse sidebar and stops tracking it. The project folder and all its files -- including the `.clubhouse/` directory -- remain untouched on disk. You can re-add the project at any time by using the `+` button in the Project Rail and selecting the same folder.
+Logs reveal which plugin failed, which API call caused an exception, and where in the startup sequence the crash occurred.
 
-## Using Logs for Diagnosis
+## Reporting Issues
 
-When troubleshooting startup problems or plugin issues, Clubhouse's logging system is your primary diagnostic tool.
-
-1. Open **Settings > Logging**.
-2. Ensure logging is **enabled**.
-3. Set the log level to **Debug** for maximum detail.
-4. Enable relevant namespaces, particularly `core:startup`, `plugins:loader`, and `plugins:api`.
-5. Restart Clubhouse and reproduce the problem.
-6. Open the log file (the path is shown in the Logging settings with a direct link) and look for error messages, stack traces, or warnings that indicate the cause of the failure.
-
-Logs can reveal which plugin failed to load, which API call caused an exception, or where in the startup sequence the crash occurred. This information is invaluable when reporting issues or deciding which plugin to disable.
+If you can't resolve the problem, report it at [github.com/Agent-Clubhouse/Clubhouse/issues](https://github.com/Agent-Clubhouse/Clubhouse/issues) with:
+- Steps to reproduce
+- Relevant log output
+- Clubhouse version (**Settings > About**)

--- a/src/renderer/features/help/help-content.test.ts
+++ b/src/renderer/features/help/help-content.test.ts
@@ -11,9 +11,9 @@ describe('help-content', () => {
     expect(ids).toEqual(['general', 'projects', 'agents', 'plugins', 'settings', 'troubleshooting']);
   });
 
-  it('has 20 total topics', () => {
+  it('has 26 total topics', () => {
     const total = HELP_SECTIONS.reduce((sum, s) => sum + s.topics.length, 0);
-    expect(total).toBe(20);
+    expect(total).toBe(26);
   });
 
   it('each section has at least 1 topic', () => {
@@ -38,5 +38,31 @@ describe('help-content', () => {
         expect(topic.content.length).toBeGreaterThan(0);
       }
     }
+  });
+
+  it('General section has 7 topics', () => {
+    const general = HELP_SECTIONS.find((s) => s.id === 'general');
+    expect(general?.topics).toHaveLength(7);
+  });
+
+  it('Agents & Orchestrators section has 6 topics', () => {
+    const agents = HELP_SECTIONS.find((s) => s.id === 'agents');
+    expect(agents?.topics).toHaveLength(6);
+  });
+
+  it('Settings section has 5 topics', () => {
+    const settings = HELP_SECTIONS.find((s) => s.id === 'settings');
+    expect(settings?.topics).toHaveLength(5);
+  });
+
+  it('includes key new topics', () => {
+    const allTopicIds = HELP_SECTIONS.flatMap((s) => s.topics.map((t) => t.id));
+    expect(allTopicIds).toContain('command-palette');
+    expect(allTopicIds).toContain('hub');
+    expect(allTopicIds).toContain('dashboard');
+    expect(allTopicIds).toContain('agents-clubhouse-mode');
+    expect(allTopicIds).toContain('settings-sound');
+    expect(allTopicIds).toContain('settings-annex');
+    expect(allTopicIds).toContain('orchestrators');
   });
 });

--- a/src/renderer/features/help/help-content.ts
+++ b/src/renderer/features/help/help-content.ts
@@ -1,4 +1,7 @@
 import gettingStarted from './content/general-getting-started.md';
+import dashboard from './content/general-dashboard.md';
+import commandPalette from './content/general-command-palette.md';
+import hub from './content/general-hub.md';
 import navigation from './content/general-navigation.md';
 import keyboardShortcuts from './content/general-keyboard-shortcuts.md';
 import updates from './content/general-updates.md';
@@ -8,13 +11,16 @@ import projectsSettings from './content/projects-settings.md';
 import agentsOverview from './content/agents-overview.md';
 import agentsDurable from './content/agents-durable.md';
 import agentsQuick from './content/agents-quick.md';
+import agentsClubhouseMode from './content/agents-clubhouse-mode.md';
 import agentsTerminal from './content/agents-terminal.md';
+import settingsOrchestrators from './content/settings-orchestrators.md';
 import pluginsOverview from './content/plugins-overview.md';
 import pluginsPermissions from './content/plugins-permissions.md';
 import pluginsCreating from './content/plugins-creating.md';
 import settingsThemes from './content/settings-themes.md';
+import settingsSound from './content/settings-sound.md';
 import settingsNotifications from './content/settings-notifications.md';
-import settingsOrchestrators from './content/settings-orchestrators.md';
+import settingsAnnex from './content/settings-annex.md';
 import settingsLogging from './content/settings-logging.md';
 import troubleshootingCommon from './content/troubleshooting-common.md';
 import troubleshootingSafeMode from './content/troubleshooting-safe-mode.md';
@@ -37,9 +43,12 @@ export const HELP_SECTIONS: HelpSection[] = [
     title: 'General',
     topics: [
       { id: 'getting-started', title: 'Getting Started', content: gettingStarted },
+      { id: 'dashboard', title: 'Dashboard', content: dashboard },
+      { id: 'command-palette', title: 'Command Palette', content: commandPalette },
+      { id: 'hub', title: 'Hub & Workspaces', content: hub },
       { id: 'navigation', title: 'Navigation & Layout', content: navigation },
       { id: 'keyboard-shortcuts', title: 'Keyboard Shortcuts', content: keyboardShortcuts },
-      { id: 'updates', title: 'Automatic Updates', content: updates },
+      { id: 'updates', title: 'Updates', content: updates },
     ],
   },
   {
@@ -53,19 +62,21 @@ export const HELP_SECTIONS: HelpSection[] = [
   },
   {
     id: 'agents',
-    title: 'Agents',
+    title: 'Agents & Orchestrators',
     topics: [
-      { id: 'agents-overview', title: 'Agent Types & Lifecycle', content: agentsOverview },
+      { id: 'agents-overview', title: 'Agent Overview', content: agentsOverview },
       { id: 'agents-durable', title: 'Durable Agents', content: agentsDurable },
-      { id: 'agents-quick', title: 'Quick Agents & Headless Mode', content: agentsQuick },
+      { id: 'agents-quick', title: 'Quick Agents', content: agentsQuick },
+      { id: 'agents-clubhouse-mode', title: 'Clubhouse Mode', content: agentsClubhouseMode },
       { id: 'agents-terminal', title: 'Terminal & Transcripts', content: agentsTerminal },
+      { id: 'orchestrators', title: 'Orchestrators', content: settingsOrchestrators },
     ],
   },
   {
     id: 'plugins',
     title: 'Plugins',
     topics: [
-      { id: 'plugins-overview', title: 'Using Plugins', content: pluginsOverview },
+      { id: 'plugins-overview', title: 'Installing & Using Plugins', content: pluginsOverview },
       { id: 'plugins-permissions', title: 'Plugin Permissions', content: pluginsPermissions },
       { id: 'plugins-creating', title: 'Creating Plugins', content: pluginsCreating },
     ],
@@ -74,9 +85,10 @@ export const HELP_SECTIONS: HelpSection[] = [
     id: 'settings',
     title: 'Settings',
     topics: [
-      { id: 'settings-themes', title: 'Themes & Appearance', content: settingsThemes },
+      { id: 'settings-themes', title: 'Display & Themes', content: settingsThemes },
+      { id: 'settings-sound', title: 'Sound & Audio', content: settingsSound },
       { id: 'settings-notifications', title: 'Notifications & Badges', content: settingsNotifications },
-      { id: 'settings-orchestrators', title: 'Orchestrators', content: settingsOrchestrators },
+      { id: 'settings-annex', title: 'Annex (iOS Companion)', content: settingsAnnex },
       { id: 'settings-logging', title: 'Logging & Diagnostics', content: settingsLogging },
     ],
   },


### PR DESCRIPTION
## Summary

Complete rewrite of all in-app help content to be significantly more concise, useful, and actionable. Added documentation for 6 previously undocumented features.

**Key changes:**
- Rewrote all 20 existing help topics — removed wordiness, added practical examples, fixed inaccuracies
- Added 6 new help topics: Dashboard, Command Palette, Hub & Workspaces, Clubhouse Mode, Sound & Audio, Annex (iOS Companion)
- Restructured "Agents" section → "Agents & Orchestrators" (moved Orchestrators from Settings)
- Total topics: 20 → 26 across 6 sections
- Net content: **877 insertions, 1425 deletions** — shorter but covers more features

**Content improvements:**
- Added Codex CLI as 4th orchestrator with capability matrix
- Added Free Agent mode documentation to Quick Agents
- Added Command Palette filter modes (`@`, `/`, `#`, `>`) and global shortcut docs
- Fixed project switching shortcut (`Cmd+Option+1-9`)
- Added GitHub issues link to Troubleshooting section
- Included practical examples and use cases throughout
- Incorporated upstream `agents.free-agent-mode` plugin permission

**Section breakdown (before → after):**
| Section | Before | After |
|---------|--------|-------|
| General | 4 topics | 7 topics (+Dashboard, Command Palette, Hub) |
| Projects | 3 topics | 3 topics (rewritten) |
| Agents & Orchestrators | 4 topics | 6 topics (+Clubhouse Mode, Orchestrators moved here) |
| Plugins | 3 topics | 3 topics (rewritten, +free-agent-mode permission) |
| Settings | 4 topics | 5 topics (+Sound & Audio, +Annex, Orchestrators moved out) |
| Troubleshooting | 2 topics | 2 topics (rewritten, +GH issues link, +new FAQ entries) |

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] All 4328 tests pass including 11 help-content tests (`npm test`)
- [x] Help-content test updated: validates 26 topics, 6 sections, new topic IDs
- [ ] **Manual:** Open Help view → verify all 6 sections render in nav
- [ ] **Manual:** Click through all 26 topics → verify markdown renders correctly
- [ ] **Manual:** Verify plugin help sections still appear for enabled plugins
- [ ] **Manual:** Verify Troubleshooting links to GitHub issues page open correctly
- [ ] **CI/CD:** Playwright e2e tests (not run locally per instruction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)