### PR TITLE
feat: add Windows code signing via Azure Trusted Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,26 @@ jobs:
       - name: Build Windows installer
         run: npx electron-forge make --arch=${{ matrix.arch }}
 
+      - name: Authenticate to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows executables
+        uses: azure/trusted-signing-action@v0
+        with:
+          endpoint: https://wus2.codesigning.azure.net/
+          signing-account-name: Clubhouse-Win-Signing
+          certificate-profile-name: clubhouse-win-codesign
+          files-folder: out/make
+          files-folder-filter: exe
+          files-folder-depth: 10
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Compute artifact hashes
         id: hash
         shell: pwsh


### PR DESCRIPTION
Release: Windows code signing via Azure Trusted Signing

## Summary
- Adds Azure OIDC login + `azure/trusted-signing-action` to the `build-windows` job in the release workflow
- Signs all `.exe` files after build, before hash computation — so published hashes reflect the signed binaries
- Uses the `Clubhouse-Win-Signing` account and `clubhouse-win-codesign` certificate profile (set up today in Azure)

## Azure Setup (already done)
- Created `gh-clubhouse-release` app registration with OIDC federation for `Agent-Clubhouse/Clubhouse`
- Assigned `Artifact Signing Certificate Profile Signer` role on the Trusted Signing account
- Assigned `Storage Blob Data Contributor` for blob uploads
- Updated `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID` GitHub secrets

## Test plan
- [ ] Merge and trigger a preview release (`v*rc` tag) to validate signing end-to-end
- [ ] Download the signed `.exe` on a clean Windows machine
- [ ] Right-click > Properties > Digital Signatures — verify certificate shows "Mason Allen" under Microsoft's Trusted Signing CA
- [ ] Verify SmartScreen does not show "Unknown publisher" warning

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)