### PR TITLE
fix: add release environment to build jobs for Azure OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
     name: Build macOS (${{ matrix.arch }})
     needs: verify-tag
     runs-on: ${{ matrix.runner }}
+    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -214,6 +215,7 @@ jobs:
     name: Build Windows (${{ matrix.arch }})
     needs: verify-tag
     runs-on: windows-latest
+    environment: release
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Added `environment: release` to both `build-macos` and `build-windows` jobs in the release workflow
- The `build-windows` job requires Azure OIDC for code signing via Trusted Signing, but the federated credential only matches jobs scoped to the `release` environment
- Without this, Azure login fails for any tag ref that doesn't have an explicit federated credential (discovered when pushing the first RC tag `v0.33.0rc`)
- Added to `build-macos` as well for consistency, even though it doesn't currently use Azure

## Note
You may also need to add/update the Azure AD federated identity credential to use entity type **Environment** with value `release` (instead of ref-based matching) if it isn't already configured that way.