### PR TITLE
fix: use correct param name for Azure trusted signing action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
         uses: azure/trusted-signing-action@v0
         with:
           endpoint: https://wus2.codesigning.azure.net/
-          signing-account-name: Clubhouse-Win-Signing
+          trusted-signing-account-name: Clubhouse-Win-Signing
           certificate-profile-name: clubhouse-win-codesign
           files-folder: out/make
           files-folder-filter: exe


### PR DESCRIPTION
## Summary
- Renamed `signing-account-name` to `trusted-signing-account-name` in the Windows code signing step
- The `azure/trusted-signing-action@v0` action expects `trusted-signing-account-name`, not `signing-account-name`