### PR TITLE
fix: prevent Windows updater hang and add auto-relaunch after update

### DIFF
--- a/src/main/services/auto-update-windows.test.ts
+++ b/src/main/services/auto-update-windows.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { buildWindowsUpdateScript, buildWindowsQuitUpdateScript } from './auto-update-service';
+
+describe('auto-update-service: Windows batch script builders', () => {
+  const downloadPath = 'C:\\Users\\test\\AppData\\Local\\Temp\\clubhouse-updates\\Clubhouse-0.26.0.exe';
+  const updateExePath = 'C:\\Users\\test\\AppData\\Local\\Clubhouse\\Update.exe';
+  const appExeName = 'Clubhouse.exe';
+
+  describe('buildWindowsUpdateScript', () => {
+    it('starts with @echo off', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script.startsWith('@echo off')).toBe(true);
+    });
+
+    it('waits before running installer to avoid file-lock contention', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain('timeout /t 2 /nobreak >nul');
+    });
+
+    it('runs the installer silently', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain(`"${downloadPath}" --silent`);
+    });
+
+    it('relaunches the app via Update.exe --processStart', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain(`"${updateExePath}" --processStart "${appExeName}"`);
+    });
+
+    it('cleans up the downloaded installer', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain(`del /f "${downloadPath}" 2>nul`);
+    });
+
+    it('self-deletes the batch script', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain('del "%~f0"');
+    });
+
+    it('uses CRLF line endings', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      const lines = script.split('\r\n');
+      expect(lines.length).toBe(6);
+    });
+
+    it('executes steps in correct order: wait, install, relaunch, cleanup', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      const lines = script.split('\r\n');
+      expect(lines[0]).toBe('@echo off');
+      expect(lines[1]).toContain('timeout');
+      expect(lines[2]).toContain('--silent');
+      expect(lines[3]).toContain('--processStart');
+      expect(lines[4]).toContain('del /f');
+      expect(lines[5]).toContain('del "%~f0"');
+    });
+  });
+
+  describe('buildWindowsQuitUpdateScript', () => {
+    it('starts with @echo off', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script.startsWith('@echo off')).toBe(true);
+    });
+
+    it('waits before running installer to avoid file-lock contention', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).toContain('timeout /t 2 /nobreak >nul');
+    });
+
+    it('runs the installer silently', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).toContain(`"${downloadPath}" --silent`);
+    });
+
+    it('does NOT relaunch the app', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).not.toContain('processStart');
+      expect(script).not.toContain('Update.exe');
+    });
+
+    it('cleans up the downloaded installer', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).toContain(`del /f "${downloadPath}" 2>nul`);
+    });
+
+    it('self-deletes the batch script', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).toContain('del "%~f0"');
+    });
+
+    it('uses CRLF line endings', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      const lines = script.split('\r\n');
+      expect(lines.length).toBe(5);
+    });
+
+    it('has one fewer line than the update script (no relaunch)', () => {
+      const updateScript = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      const quitScript = buildWindowsQuitUpdateScript(downloadPath);
+      expect(quitScript.split('\r\n').length).toBe(updateScript.split('\r\n').length - 1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Fixes the ~10 second hang** when applying Windows updates by using a batch script wrapper that waits for the app to fully exit before running the Squirrel installer, avoiding file-lock contention
- **Fixes missing auto-relaunch** after update by explicitly launching the updated app via `Update.exe --processStart` after the installer completes
- Applies the same batch-script pattern to the `applyUpdateOnQuit()` path (without relaunch) to prevent potential lock issues there too

## Root Cause
1. **Slow installer**: The app called `app.exit(0)` immediately after spawning `Setup.exe --silent`, but Electron doesn't release file locks instantly. The Squirrel installer stalls waiting for locks to be freed (~10s).
2. **No relaunch**: When `Setup.exe --silent` updates an existing install, Squirrel fires `--squirrel-updated` on the new app. `electron-squirrel-startup` handles this by updating shortcuts and **quitting immediately** — so the app never stays open for the user.

## Changes
- Extracted `buildWindowsUpdateScript()` and `buildWindowsQuitUpdateScript()` as pure, testable helper functions
- `applyUpdate()` Windows path: writes a `.cmd` batch script that waits 2s, runs installer, relaunches via `Update.exe --processStart`, and cleans up
- `applyUpdateOnQuit()` Windows path: same batch script pattern but without the relaunch step

## Test plan
- [x] New unit tests for `buildWindowsUpdateScript` (8 tests) — verifies correct script content, ordering, CRLF line endings, and relaunch step
- [x] New unit tests for `buildWindowsQuitUpdateScript` (8 tests) — verifies correct script content and absence of relaunch step
- [x] All existing auto-update tests continue to pass
- [x] TypeScript typecheck passes
- [ ] **Manual validation needed**: Test on Windows with an actual update to verify the installer runs without hanging and the app relaunches

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)