### PR TITLE
feat: split wake button with Wake & Resume option

### DIFF
--- a/src/renderer/features/agents/AgentListItem.test.tsx
+++ b/src/renderer/features/agents/AgentListItem.test.tsx
@@ -139,6 +139,11 @@ describe('AgentListItem actions', () => {
     expect(screen.getByTestId('action-wake')).toBeInTheDocument();
   });
 
+  it('renders wake-resume button for sleeping durable agent', () => {
+    renderItem({ status: 'sleeping' });
+    expect(screen.getByTestId('action-wake-resume')).toBeInTheDocument();
+  });
+
   it('renders stop button for running agent', () => {
     renderItem({ status: 'running' });
     expect(screen.getByTestId('action-stop')).toBeInTheDocument();
@@ -178,12 +183,13 @@ describe('AgentListItem context menu', () => {
     expect(screen.getByTestId('agent-context-menu')).toBeInTheDocument();
   });
 
-  it('context menu shows all available actions', () => {
+  it('context menu shows all available actions including Wake & Resume', () => {
     renderItem({ status: 'sleeping' }, { onSpawnQuickChild: vi.fn() });
     const row = screen.getByTestId('agent-item-agent-1');
     fireEvent.contextMenu(row);
 
     expect(screen.getByTestId('ctx-wake')).toBeInTheDocument();
+    expect(screen.getByTestId('ctx-wake-resume')).toBeInTheDocument();
     expect(screen.getByTestId('ctx-popout')).toBeInTheDocument();
     expect(screen.getByTestId('ctx-spawn')).toBeInTheDocument();
     expect(screen.getByTestId('ctx-settings')).toBeInTheDocument();
@@ -219,5 +225,12 @@ describe('AgentListItem context menu', () => {
     expect(screen.getByTestId('agent-context-menu')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByTestId('agent-context-menu')).toBeNull();
+  });
+
+  it('does not show wake-resume in context menu for running agents', () => {
+    renderItem({ status: 'running' });
+    const row = screen.getByTestId('agent-item-agent-1');
+    fireEvent.contextMenu(row);
+    expect(screen.queryByTestId('ctx-wake-resume')).toBeNull();
   });
 });

--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -163,6 +163,15 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
     const configs = await window.clubhouse.agent.listDurable(activeProject.path);
     const config = configs.find((c: any) => c.id === agent.id);
     if (config) {
+      await spawnDurableAgent(activeProject.id, activeProject.path, config, false);
+    }
+  }, [activeProject, agent.status, agent.id, spawnDurableAgent]);
+
+  const handleWakeAndResume = useCallback(async () => {
+    if (!activeProject || agent.status === 'running') return;
+    const configs = await window.clubhouse.agent.listDurable(activeProject.path);
+    const config = configs.find((c: any) => c.id === agent.id);
+    if (config) {
       await spawnDurableAgent(activeProject.id, activeProject.path, config, true);
     }
   }, [activeProject, agent.status, agent.id, spawnDurableAgent]);
@@ -214,6 +223,19 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
         hoverColor: 'hover:text-green-400',
         visible: true,
         handler: handleWake,
+      });
+      list.push({
+        id: 'wake-resume',
+        label: 'Wake & Resume',
+        icon: (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M1 4v6h6" />
+            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+          </svg>
+        ),
+        hoverColor: 'hover:text-green-400',
+        visible: true,
+        handler: handleWakeAndResume,
       });
     }
 
@@ -282,7 +304,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
     }
 
     return list;
-  }, [agent.status, agent.kind, isDurable, isCreating, onSpawnQuickChild, handleStopOrRemove, handleWake, handlePopOut, handleSpawnChild, handleSettings, handleDelete]);
+  }, [agent.status, agent.kind, isDurable, isCreating, onSpawnQuickChild, handleStopOrRemove, handleWake, handleWakeAndResume, handlePopOut, handleSpawnChild, handleSettings, handleDelete]);
 
   // ── Responsive action collapse ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Default wake is now a clean session** — the main "Wake Up" button starts fresh (`resume=false`)
- **Split button dropdown** on SleepingAgent's wake button reveals a "Wake & Resume" option that continues the previous CLI session
- **"Wake & Resume" action** added to AgentListItem's action list, visible in both inline action buttons and the right-click context menu
- **Resume spinner overlay** — when resuming, a "Resuming session..." spinner covers the terminal while the CLI replays the conversation history, then auto-dismisses and re-fits the terminal to fix rendering glitches

## Changes

### Split button UI
- `SleepingAgent.tsx`: Converted the single wake button into a split button with a dropdown arrow. Main button wakes clean, dropdown contains "Wake & Resume" (`resume=true`). Includes click-outside and Escape to dismiss.
- `AgentListItem.tsx`: Changed `handleWake` to `resume=false`. Added `handleWakeAndResume` handler. Added "Wake & Resume" action (with refresh icon) to the actions list.

### Resume loading overlay
- `shared/types.ts`: Added `resuming?: boolean` to the `Agent` interface
- `agentStore.ts`: Sets `resuming: true` when spawning with `resume=true`. Added `clearResuming` action.
- `AgentTerminal.tsx`: Shows a spinner overlay when `agent.resuming` is true. Monitors PTY data with a 1.5s debounce — when output settles, clears the overlay and triggers `fitAddon.fit()` to fix rendering glitches from the replay burst. Includes a 10s safety fallback.

## Test plan
- [x] 177 test files pass (4518 tests, 10 new)
- [x] TypeScript typecheck passes
- [x] Lint passes on all changed files
- [x] SleepingAgent: "Wake Up" calls spawnDurableAgent with `resume=false`
- [x] SleepingAgent: Dropdown "Wake & Resume" calls with `resume=true`
- [x] SleepingAgent: Dropdown closes on Escape
- [x] AgentListItem: Context menu includes both "Wake" and "Wake & Resume"
- [x] AgentListItem: "Wake & Resume" not shown for running agents
- [x] AgentTerminal: Resume overlay renders when `resuming=true`
- [x] AgentTerminal: Overlay hidden when `resuming` is falsy
- [x] AgentTerminal: Overlay clears after PTY data settles (1.5s silence)
- [x] AgentTerminal: Fallback clears overlay after 10s with no data
- [x] AgentTerminal: Terminal re-fits after resume finishes
- [x] agentStore: `resuming=true` set on resume spawn, undefined otherwise
- [x] agentStore: `clearResuming` clears the flag, no-op for unknown agents
- [ ] **Manual**: Verify split button visual appearance and alignment
- [ ] **Manual**: Verify spinner overlay appearance during resume
- [ ] **Manual**: Verify terminal renders cleanly after overlay dismisses (no glitches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)