### PR TITLE
chore: bump version to 0.33.1 (RC)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Bug Fixes & Improvements

# Bug Fixes
- Fixed shell environment not being passed to providers
- Prevented terminal focus theft with click-to-recover fallback
- Fixed Windows updater hang and added auto-relaunch after update

# Improvements
- Added spinner overlay during session resume with terminal re-fit
- Split wake button to offer both Wake and Resume options