### PR TITLE
fix: make plugin uninstall async and symlink-safe

### DIFF
--- a/src/main/ipc/plugin-handlers.ts
+++ b/src/main/ipc/plugin-handlers.ts
@@ -80,7 +80,7 @@ export function registerPluginHandlers(): void {
     await pluginStorage.mkdirPlugin(pluginId, scope as 'project' | 'global', relativePath, projectPath);
   });
 
-  ipcMain.handle(IPC.PLUGIN.UNINSTALL, (_event, pluginId: string) => {
-    pluginDiscovery.uninstallPlugin(pluginId);
+  ipcMain.handle(IPC.PLUGIN.UNINSTALL, async (_event, pluginId: string) => {
+    await pluginDiscovery.uninstallPlugin(pluginId);
   });
 }


### PR DESCRIPTION
## Summary
- Convert `uninstallPlugin` from synchronous `fs.rmSync` to async `fs.promises.rm` to avoid blocking the main process
- Add symlink detection: if the plugin path is a symlink, remove only the link (`fs.promises.unlink`) instead of recursively deleting the target directory
- Fixes #329

## Changes
- **`src/main/services/plugin-discovery.ts`**: `uninstallPlugin` is now `async`, uses `lstat` to detect symlinks and branches accordingly
- **`src/main/ipc/plugin-handlers.ts`**: UNINSTALL handler now `await`s the async function
- **`src/main/services/plugin-discovery.test.ts`**: Updated mocks for `fs.promises` (lstat, unlink, rm); added test cases for regular directory removal, symlink-only removal, and missing plugin no-op

## Test Plan
- [x] Regular plugin directory is removed with async `fs.promises.rm({ recursive: true })`
- [x] Symlinked plugin removes only the symlink via `fs.promises.unlink`, not the target
- [x] Missing plugin path is a no-op (no error thrown)
- [x] TypeScript type check passes
- [x] All 4706 tests pass
- [x] No new lint errors

## Manual Validation
1. Install a plugin normally, uninstall it — verify the directory is removed
2. Symlink a local plugin into `~/.clubhouse/plugins/`, uninstall it — verify the symlink is removed but the original directory remains intact