### PR TITLE
fix: intercept markdown link clicks to prevent blank screen crash

### DIFF
--- a/src/renderer/features/help/HelpContentPane.tsx
+++ b/src/renderer/features/help/HelpContentPane.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 import { marked } from 'marked';
+import { useSafeMarkdownLinks } from '../../utils/safe-markdown-links';
 
 interface HelpContentPaneProps {
   markdown: string | null;
 }
 
 export function HelpContentPane({ markdown }: HelpContentPaneProps) {
+  const handleClick = useSafeMarkdownLinks();
   const html = useMemo(() => {
     if (!markdown) return null;
     return marked.parse(markdown, { async: false }) as string;
@@ -24,6 +26,7 @@ export function HelpContentPane({ markdown }: HelpContentPaneProps) {
       <div
         className="help-content max-w-3xl"
         dangerouslySetInnerHTML={{ __html: html }}
+        onClick={handleClick}
       />
     </div>
   );

--- a/src/renderer/plugins/builtin/files/MarkdownPreview.ts
+++ b/src/renderer/plugins/builtin/files/MarkdownPreview.ts
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { marked } from 'marked';
+import { useSafeMarkdownLinks } from '../../../utils/safe-markdown-links';
 import hljs from 'highlight.js/lib/core';
 
 // Register languages selectively to keep bundle small
@@ -97,6 +98,7 @@ function injectHljsStyle(): void {
 
 export function MarkdownPreview({ content }: { content: string }) {
   injectHljsStyle();
+  const handleClick = useSafeMarkdownLinks();
 
   const html = useMemo(() => {
     return marked.parse(content) as string;
@@ -105,5 +107,6 @@ export function MarkdownPreview({ content }: { content: string }) {
   return React.createElement('div', {
     className: 'help-content p-4 overflow-auto h-full',
     dangerouslySetInnerHTML: { __html: html },
+    onClick: handleClick,
   });
 }

--- a/src/renderer/utils/safe-markdown-links.test.ts
+++ b/src/renderer/utils/safe-markdown-links.test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSafeMarkdownLinks } from './safe-markdown-links';
+
+const mockOpenExternalUrl = vi.fn().mockResolvedValue(undefined);
+
+Object.defineProperty(globalThis, 'window', {
+  value: {
+    clubhouse: {
+      app: {
+        openExternalUrl: mockOpenExternalUrl,
+      },
+    },
+  },
+  writable: true,
+});
+
+function makeClickEvent(anchorAttrs?: { href?: string } | null) {
+  const anchor = anchorAttrs
+    ? Object.assign(document.createElement('a'), anchorAttrs)
+    : null;
+
+  const target = anchor || document.createElement('span');
+  // If anchor, wrap in a div so closest('a') still works via DOM
+  const container = document.createElement('div');
+  container.appendChild(target);
+
+  const preventDefault = vi.fn();
+  return {
+    target,
+    preventDefault,
+    // Minimal React.MouseEvent shape
+  } as unknown as React.MouseEvent<HTMLDivElement>;
+}
+
+describe('useSafeMarkdownLinks', () => {
+  beforeEach(() => {
+    mockOpenExternalUrl.mockClear();
+  });
+
+  it('returns a stable callback', () => {
+    const { result, rerender } = renderHook(() => useSafeMarkdownLinks());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('does nothing when clicking a non-anchor element', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const event = makeClickEvent(null);
+    result.current(event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('prevents default and opens external URL for https links', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', 'https://example.com');
+    const preventDefault = vi.fn();
+    const event = {
+      target: anchor,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('prevents default and opens external URL for http links', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', 'http://example.com');
+    const preventDefault = vi.fn();
+    const event = {
+      target: anchor,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('http://example.com');
+  });
+
+  it('prevents default and opens external URL for mailto links', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', 'mailto:test@example.com');
+    const preventDefault = vi.fn();
+    const event = {
+      target: anchor,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('mailto:test@example.com');
+  });
+
+  it('prevents default but does NOT open external URL for relative links', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', './other-file.md');
+    const preventDefault = vi.fn();
+    const event = {
+      target: anchor,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('prevents default but does NOT open external URL for anchor links', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', '#section');
+    const preventDefault = vi.fn();
+    const event = {
+      target: anchor,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('prevents default but does nothing when anchor has no href', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    // No href attribute
+    const preventDefault = vi.fn();
+    const event = {
+      target: anchor,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('finds anchor via closest() when clicking child of anchor', () => {
+    const { result } = renderHook(() => useSafeMarkdownLinks());
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', 'https://example.com/nested');
+    const span = document.createElement('span');
+    span.textContent = 'click me';
+    anchor.appendChild(span);
+    // Attach to document so closest() works
+    document.body.appendChild(anchor);
+
+    const preventDefault = vi.fn();
+    const event = {
+      target: span,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://example.com/nested');
+
+    document.body.removeChild(anchor);
+  });
+});

--- a/src/renderer/utils/safe-markdown-links.ts
+++ b/src/renderer/utils/safe-markdown-links.ts
@@ -1,0 +1,24 @@
+import React, { useCallback } from 'react';
+
+/**
+ * Click handler that intercepts anchor clicks in rendered markdown HTML.
+ * - External URLs (http/https/mailto) are opened via shell.openExternal
+ * - All other links (relative, anchor, etc.) are suppressed to prevent
+ *   Electron renderer navigation which causes blank screen crashes.
+ */
+export function useSafeMarkdownLinks(): React.MouseEventHandler<HTMLDivElement> {
+  return useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = (e.target as HTMLElement).closest('a');
+    if (!target) return;
+
+    e.preventDefault();
+
+    const href = target.getAttribute('href');
+    if (!href) return;
+
+    if (/^https?:\/\//.test(href) || href.startsWith('mailto:')) {
+      window.clubhouse.app.openExternalUrl(href);
+    }
+    // Internal/relative links are silently ignored to prevent navigation
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Fixes #315 — clicking markdown links in the files plugin preview or help pane caused the Electron renderer to navigate away, resulting in a blank screen crash
- Adds a shared `useSafeMarkdownLinks()` hook that intercepts `<a>` clicks: external URLs (http/https/mailto) open via `shell.openExternal`, internal/relative links are silently suppressed
- Applied to both `MarkdownPreview` (files plugin) and `HelpContentPane` (help feature)

## Changes
- **New**: `src/renderer/utils/safe-markdown-links.ts` — `useSafeMarkdownLinks()` hook using click event delegation on the container div
- **New**: `src/renderer/utils/safe-markdown-links.test.ts` — 8 test cases covering external URLs, mailto, relative links, anchor links, no-href anchors, nested elements, and non-anchor clicks
- **Modified**: `src/renderer/plugins/builtin/files/MarkdownPreview.ts` — wires `onClick={handleClick}` to the rendered markdown container
- **Modified**: `src/renderer/features/help/HelpContentPane.tsx` — wires `onClick={handleClick}` to the help content container

## Test Plan
- [x] `useSafeMarkdownLinks` returns a stable callback reference across re-renders
- [x] Non-anchor element clicks are ignored (no preventDefault, no openExternal)
- [x] https links call preventDefault and openExternalUrl
- [x] http links call preventDefault and openExternalUrl
- [x] mailto links call preventDefault and openExternalUrl
- [x] Relative links (e.g. `./other.md`) call preventDefault but do NOT call openExternalUrl
- [x] Anchor links (e.g. `#section`) call preventDefault but do NOT call openExternalUrl
- [x] Anchors with no href call preventDefault but do NOT call openExternalUrl
- [x] Clicking a child element inside an anchor (e.g. `<a><span>text</span></a>`) correctly finds the anchor via `closest()`
- [x] TypeScript type check passes
- [x] All 4796 tests pass
- [x] No new lint errors

## Manual Validation
1. Open a project with `.md` files
2. Open the files plugin → select a markdown file → switch to preview
3. Click an external link → should open in system browser
4. Click a relative/anchor link → nothing should happen (no blank screen)
5. Open Help → navigate to a topic with links → repeat steps 3-4