### PR TITLE
feat: support pack plugin activation with theme registration

### DIFF
--- a/src/renderer/plugins/manifest-validator.test.ts
+++ b/src/renderer/plugins/manifest-validator.test.ts
@@ -807,7 +807,7 @@ describe('manifest-validator', () => {
     });
 
     it('rejects pack without contributes object', () => {
-      const { contributes, ...rest } = validPack;
+      const { contributes: _contributes, ...rest } = validPack;
       const result = validateManifest(rest);
       expect(result.valid).toBe(false);
       expect(result.errors.some((e: string) => e.includes('must contribute at least one of'))).toBe(true);

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { usePluginStore } from './plugin-store';
 import type { PluginManifest, PluginModule } from '../../shared/plugin-types';
 

--- a/src/renderer/plugins/plugin-loader.ts
+++ b/src/renderer/plugins/plugin-loader.ts
@@ -4,7 +4,7 @@ import { usePluginStore } from './plugin-store';
 import { validateManifest } from './manifest-validator';
 import { createPluginAPI } from './plugin-api-factory';
 import { pluginHotkeyRegistry } from './plugin-hotkeys';
-import { injectStyles, removeStyles } from './plugin-styles';
+import { removeStyles } from './plugin-styles';
 import { getBuiltinPlugins, getDefaultEnabledIds } from './builtin';
 import { rendererLog } from './renderer-logger';
 import { dynamicImportModule } from './dynamic-import';

--- a/src/renderer/themes/themes.test.ts
+++ b/src/renderer/themes/themes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { THEMES, THEME_IDS, registerTheme, unregisterTheme, getTheme, getAllThemeIds, BUILTIN_THEMES, onRegistryChange } from './index';
+import { THEMES, THEME_IDS, registerTheme, unregisterTheme, getTheme, getAllThemeIds, onRegistryChange } from './index';
 import { ThemeId, ThemeDefinition } from '../../shared/types';
 
 /**


### PR DESCRIPTION
## Summary
- Add pack plugin support to the plugin loader so declarative-only plugins (kind: "pack") can contribute themes without a main.js module
- Pack plugins skip dynamic import, register contributed themes into the theme registry on activation, and unregister them on deactivation
- Theme IDs are namespaced as `plugin:{pluginId}:{themeId}` for isolation

## Changes
- **src/renderer/plugins/plugin-loader.ts**:
  - Added `registerPackThemes()` / `unregisterPackThemes()` helpers that convert `PluginThemeDeclaration` to `ThemeDefinition` and manage the theme registry
  - `activatePlugin()` now detects `kind === 'pack'` and skips dynamic import, using a synthetic empty module instead; registers contributed themes
  - `deactivatePlugin()` now unregisters pack themes when the last context is removed
  - Removed unused `injectStyles` import
- **src/renderer/plugins/plugin-loader.test.ts**: 6 new tests for pack plugin activation, theme registration, deactivation cleanup, and edge cases (no themes, synthetic module)
- **src/renderer/plugins/manifest-validator.test.ts**: 15 new tests for v0.7 pack plugin validation (kind, API version, forbidden fields, required contributions, contributes.themes structure)
- **src/renderer/themes/themes.test.ts**: 6 new tests for dynamic theme registry (registerTheme, unregisterTheme, builtin protection, onRegistryChange)

## Context
The existing codebase already had most infrastructure for plugin-contributed themes:
- Manifest validator already supports API 0.7, `kind: "pack"`, and `contributes.themes` validation
- `ThemeId` is already extensible (`BuiltinThemeId | (string & {})`)
- Theme registry already has `registerTheme()`/`unregisterTheme()`/`onRegistryChange()`
- Theme store already tracks `availableThemeIds` and auto-refreshes on registry changes
- DisplaySettingsView already uses dynamic `availableThemeIds`

The only missing piece was the plugin loader, which always tried to dynamically import a JS module for community plugins — failing for pack plugins that have no main.js.

## Test Plan
- [x] Pack plugin activates without dynamic import (no main.js needed)
- [x] Contributed themes are registered in the theme registry on activation
- [x] Theme IDs are namespaced as `plugin:{pluginId}:{themeId}`
- [x] Themes are unregistered on deactivation
- [x] Synthetic empty module is stored for pack plugins
- [x] Pack plugins with no themes activate gracefully
- [x] Manifest validation rejects packs with API < 0.7, main entry, settingsPanel, UI contributions
- [x] Manifest validation requires at least one pack contribution (themes, sounds, agentConfig)
- [x] Dynamic theme registry correctly adds/removes plugin themes
- [x] Builtin themes cannot be unregistered
- [x] Registry change listeners fire on register/unregister
- [x] All 4945 existing tests pass
- [x] TypeScript type check passes
- [x] Lint passes on changed files (pre-existing lint errors elsewhere are unrelated)

## Manual Validation
1. Install the spring-themes plugin at `~/.clubhouse/plugins/spring-themes/` with its manifest.json
2. Enable external plugins in Settings > Plugins
3. Enable the Spring Themes plugin
4. Navigate to Settings > Display & UI > Color Theme
5. Verify all 5 spring themes (Cherry Blossom, Spring Meadow, Wisteria, Daffodil, Moonlit Garden) appear in the theme picker
6. Select each theme and verify colors apply correctly
7. Disable the plugin and verify themes are removed from the picker