### PR TITLE
fix: remove 'sdk' and 'app-server' from structuredProtocol type

### DIFF
--- a/src/main/orchestrators/claude-code-provider.ts
+++ b/src/main/orchestrators/claude-code-provider.ts
@@ -85,7 +85,7 @@ export class ClaudeCodeProvider implements OrchestratorProvider {
       sessionResume: true,
       permissions: true,
       structuredMode: false, // adapter not yet implemented
-      structuredProtocol: 'sdk',
+      structuredProtocol: 'acp',
     };
   }
 

--- a/src/main/orchestrators/opencode-provider.ts
+++ b/src/main/orchestrators/opencode-provider.ts
@@ -88,7 +88,6 @@ export class OpenCodeProvider implements OrchestratorProvider {
       sessionResume: true,
       permissions: false,
       structuredMode: false,
-      structuredProtocol: 'app-server',
     };
   }
 

--- a/src/main/orchestrators/provider-integration.test.ts
+++ b/src/main/orchestrators/provider-integration.test.ts
@@ -800,7 +800,7 @@ describe('Provider integration tests', () => {
         sessionResume: true,
         permissions: true,
         structuredMode: false,
-        structuredProtocol: 'sdk',
+        structuredProtocol: 'acp',
       });
     });
 

--- a/src/main/orchestrators/types.ts
+++ b/src/main/orchestrators/types.ts
@@ -66,7 +66,7 @@ export interface ProviderCapabilities {
   sessionResume: boolean;
   permissions: boolean;
   structuredMode: boolean;
-  structuredProtocol?: 'sdk' | 'acp' | 'app-server';
+  structuredProtocol?: 'acp';
 }
 
 export interface OrchestratorProvider {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,7 +15,7 @@ export interface ProviderCapabilities {
   sessionResume: boolean;
   permissions: boolean;
   structuredMode: boolean;
-  structuredProtocol?: 'sdk' | 'acp' | 'app-server';
+  structuredProtocol?: 'acp';
 }
 
 export interface OrchestratorInfo {


### PR DESCRIPTION
## Summary
- Narrow `structuredProtocol` type union to just `'acp'` per the ACP-only structured mode decision
- Update provider capabilities to reflect the sole ACP protocol path

## Changes
- **`src/main/orchestrators/types.ts`**: `structuredProtocol?: 'sdk' | 'acp' | 'app-server'` → `structuredProtocol?: 'acp'`
- **`src/shared/types.ts`**: Same type narrowing in the shared `ProviderCapabilities` interface
- **`src/main/orchestrators/claude-code-provider.ts`**: Changed capability value from `'sdk'` to `'acp'`
- **`src/main/orchestrators/opencode-provider.ts`**: Removed `structuredProtocol: 'app-server'` (OpenCode has no ACP support)
- **`src/main/orchestrators/provider-integration.test.ts`**: Updated expected value from `'sdk'` to `'acp'`

## Test Plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] All 5055 tests pass across 200 test files (`npm test`)
- [x] Integration test for Claude Code capabilities asserts `structuredProtocol: 'acp'`
- [x] No new lint errors introduced

## Context
Closes #401. The `'sdk'` (Claude Agent SDK, #393) and `'app-server'` (Codex App-Server, #394) adapters were closed. ACP (#395) is the sole structured mode path per the final decision in `research/structured-mode-design-critique.md`.