### PR TITLE
fix: app-scoped plugins bypass project-level bilateral consent

### DIFF
--- a/src/renderer/plugins/plugin-api-factory.test.ts
+++ b/src/renderer/plugins/plugin-api-factory.test.ts
@@ -1299,7 +1299,32 @@ describe('plugin-api-factory', () => {
       });
 
       it('rejects when target project does not have the plugin enabled (bilateral consent)', async () => {
-        // proj-3 is not in projectEnabled
+        // proj-3 is not in projectEnabled, and plugin is NOT app-enabled
+        const { useProjectStore } = await import('../stores/projectStore');
+        useProjectStore.setState({
+          projects: [
+            { id: 'proj-1', name: 'Project A', path: '/projects/project-a' },
+            { id: 'proj-3', name: 'Project C', path: '/projects/project-c' },
+          ] as any,
+        });
+        usePluginStore.setState({
+          plugins: {},
+          projectEnabled: { 'proj-1': ['test-plugin'] },
+          appEnabled: [],
+          modules: {},
+          safeModeActive: false,
+          pluginSettings: {},
+        });
+
+        const api = createPluginAPI(makeCtx(), undefined, crossProjectManifest);
+
+        await expect(
+          api.agentConfig.injectSkill('x', 'y', { projectId: 'proj-3' }),
+        ).rejects.toThrow(/not enabled in target project/);
+      });
+
+      it('app-enabled plugins bypass project-level bilateral consent check', async () => {
+        // proj-3 is NOT in projectEnabled, but plugin IS in appEnabled
         const { useProjectStore } = await import('../stores/projectStore');
         useProjectStore.setState({
           projects: [
@@ -1318,9 +1343,14 @@ describe('plugin-api-factory', () => {
 
         const api = createPluginAPI(makeCtx(), undefined, crossProjectManifest);
 
-        await expect(
-          api.agentConfig.injectSkill('x', 'y', { projectId: 'proj-3' }),
-        ).rejects.toThrow(/not enabled in target project/);
+        // Should NOT throw — app-enabled plugins are implicitly enabled in all projects
+        await api.agentConfig.injectSkill('buddy-check', '# Check', { projectId: 'proj-3' });
+
+        expect(mockAgentSettings.writeSourceSkillContent).toHaveBeenCalledWith(
+          '/projects/project-c',
+          'plugin-test-plugin-buddy-check',
+          '# Check',
+        );
       });
 
       it('rejects when target project does not exist', async () => {
@@ -3777,6 +3807,25 @@ describe('plugin-api-factory', () => {
       expect(projectApi.projectId).toBe('proj-2');
       expect(projectApi.projectPath).toBe('/projects/other');
       expect(typeof projectApi.readFile).toBe('function');
+    });
+
+    it('workspace.forProject succeeds for app-enabled plugin without project-level enablement', async () => {
+      const { useProjectStore } = await import('../stores/projectStore');
+      useProjectStore.setState({
+        projects: [
+          { id: 'proj-2', name: 'Other Project', path: '/projects/other' },
+        ],
+      });
+      // Plugin is NOT in projectEnabled for proj-2, but IS app-enabled
+      usePluginStore.setState({
+        projectEnabled: {},
+        appEnabled: ['test-plugin'],
+      });
+      const api = createPluginAPI(makeCtx({ scope: 'app', projectId: undefined, projectPath: undefined }), undefined, workspaceManifest);
+      const projectApi = api.workspace.forProject('proj-2');
+      expect(projectApi).toBeDefined();
+      expect(projectApi.projectId).toBe('proj-2');
+      expect(projectApi.projectPath).toBe('/projects/other');
     });
 
     it('workspace.watch requires workspace.watch permission', () => {

--- a/src/renderer/plugins/plugin-api-factory.ts
+++ b/src/renderer/plugins/plugin-api-factory.ts
@@ -1260,13 +1260,16 @@ function createWorkspaceAPI(ctx: PluginContext, manifest?: PluginManifest): Work
       }
 
       // Bilateral consent: target project must have this plugin enabled
-      const { projectEnabled } = usePluginStore.getState();
-      const enabledInTarget = projectEnabled[projectId] || [];
-      if (!enabledInTarget.includes(ctx.pluginId)) {
-        throw new Error(
-          `Plugin '${ctx.pluginId}' is not enabled in target project '${project.name}'. ` +
-          'Cross-project workspace access requires the plugin to be enabled in both projects.',
-        );
+      // App-scoped plugins are implicitly enabled in all projects
+      const { projectEnabled, appEnabled } = usePluginStore.getState();
+      if (!appEnabled.includes(ctx.pluginId)) {
+        const enabledInTarget = projectEnabled[projectId] || [];
+        if (!enabledInTarget.includes(ctx.pluginId)) {
+          throw new Error(
+            `Plugin '${ctx.pluginId}' is not enabled in target project '${project.name}'. ` +
+            'Cross-project workspace access requires the plugin to be enabled in both projects.',
+          );
+        }
       }
 
       const projectRoot = `${project.path}/.clubhouse/plugin-data/${ctx.pluginId}`;
@@ -1431,13 +1434,16 @@ function resolveAgentConfigTarget(
   }
 
   // 3. Bilateral consent: target project must have this plugin enabled
-  const { projectEnabled } = usePluginStore.getState();
-  const enabledInTarget = projectEnabled[opts.projectId] || [];
-  if (!enabledInTarget.includes(pluginId)) {
-    throw new Error(
-      `Plugin '${pluginId}' is not enabled in target project '${project.name}'. ` +
-      'Cross-project agent config requires the plugin to be enabled in both projects.',
-    );
+  // App-scoped plugins are implicitly enabled in all projects
+  const { projectEnabled, appEnabled } = usePluginStore.getState();
+  if (!appEnabled.includes(pluginId)) {
+    const enabledInTarget = projectEnabled[opts.projectId] || [];
+    if (!enabledInTarget.includes(pluginId)) {
+      throw new Error(
+        `Plugin '${pluginId}' is not enabled in target project '${project.name}'. ` +
+        'Cross-project agent config requires the plugin to be enabled in both projects.',
+      );
+    }
   }
 
   return project.path;


### PR DESCRIPTION
## Summary
- App-scoped plugins (in `appEnabled`) are implicitly enabled in all projects, but `resolveAgentConfigTarget()` and `workspace.forProject()` only checked `projectEnabled` for bilateral consent
- This caused app-scoped plugins like `buddy-system` to hit "not enabled in target project" errors when doing cross-project operations
- Both functions now check `appEnabled` first and skip the project-level enablement check for app-enabled plugins

## Test plan
- [x] Existing bilateral consent test updated to correctly test project-scoped plugins (removed `appEnabled` from the rejection test)
- [x] New test: `app-enabled plugins bypass project-level bilateral consent check` for agentConfig
- [x] New test: `workspace.forProject succeeds for app-enabled plugin without project-level enablement`
- [x] All 5299 tests pass
- [x] Build succeeds
- [x] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)