### PR TITLE
feat: seamless plugin hot-reload and check for updates UI

### DIFF
--- a/src/renderer/features/settings/PluginListSettings.test.tsx
+++ b/src/renderer/features/settings/PluginListSettings.test.tsx
@@ -4,6 +4,7 @@ import { PluginListSettings } from './PluginListSettings';
 import { usePluginStore } from '../../plugins/plugin-store';
 import { useUIStore } from '../../stores/uiStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { usePluginUpdateStore } from '../../stores/pluginUpdateStore';
 
 // Mock plugin-loader to avoid side effects
 const mockDiscoverNewPlugins = vi.fn(async () => [] as string[]);
@@ -55,6 +56,17 @@ beforeEach(() => {
     activeProjectId: null,
     projects: [],
   } as any);
+
+  usePluginUpdateStore.setState({
+    updates: [],
+    incompatibleUpdates: [],
+    checking: false,
+    lastCheck: null,
+    updating: {},
+    error: null,
+    updateErrors: {},
+    dismissed: false,
+  });
 });
 
 describe('PluginListSettings', () => {
@@ -174,5 +186,123 @@ describe('PluginListSettings', () => {
     fireEvent.click(screen.getByTestId('scan-plugins-button'));
 
     await screen.findByText('No new plugins found.');
+  });
+
+  describe('check for updates UI', () => {
+    it('renders "Check for Updates" button in app context with external plugins enabled', () => {
+      usePluginStore.setState({
+        externalPluginsEnabled: true,
+      } as any);
+      render(<PluginListSettings />);
+      expect(screen.getByTestId('check-updates-button')).toBeInTheDocument();
+      expect(screen.getByText('Check for Updates')).toBeInTheDocument();
+    });
+
+    it('shows "Checking..." when check is in progress', () => {
+      usePluginStore.setState({
+        externalPluginsEnabled: true,
+      } as any);
+      usePluginUpdateStore.setState({ checking: true });
+      render(<PluginListSettings />);
+      expect(screen.getByText('Checking...')).toBeInTheDocument();
+    });
+
+    it('shows last check time when available', () => {
+      usePluginStore.setState({
+        externalPluginsEnabled: true,
+      } as any);
+      usePluginUpdateStore.setState({ lastCheck: '2026-03-01T12:00:00Z' });
+      render(<PluginListSettings />);
+      expect(screen.getByTestId('last-check-time')).toBeInTheDocument();
+    });
+
+    it('shows "Update All" button when multiple updates available', () => {
+      usePluginStore.setState({
+        plugins: {
+          'plug-a': {
+            manifest: { id: 'plug-a', name: 'Plugin A', version: '1.0.0', engine: { api: 0.5 }, scope: 'app' },
+            status: 'activated', source: 'community', pluginPath: '/plugins/plug-a',
+          },
+          'plug-b': {
+            manifest: { id: 'plug-b', name: 'Plugin B', version: '1.0.0', engine: { api: 0.5 }, scope: 'app' },
+            status: 'activated', source: 'community', pluginPath: '/plugins/plug-b',
+          },
+        },
+        appEnabled: ['plug-a', 'plug-b'],
+        externalPluginsEnabled: true,
+      } as any);
+      usePluginUpdateStore.setState({
+        updates: [
+          { pluginId: 'plug-a', pluginName: 'Plugin A', currentVersion: '1.0.0', latestVersion: '2.0.0', assetUrl: '', sha256: '', size: 0, api: 0.5 },
+          { pluginId: 'plug-b', pluginName: 'Plugin B', currentVersion: '1.0.0', latestVersion: '2.0.0', assetUrl: '', sha256: '', size: 0, api: 0.5 },
+        ],
+      });
+      render(<PluginListSettings />);
+      expect(screen.getByTestId('update-all-button')).toBeInTheDocument();
+    });
+
+    it('shows per-plugin update badge and button when update available', () => {
+      usePluginStore.setState({
+        plugins: {
+          'updatable': {
+            manifest: { id: 'updatable', name: 'Updatable Plugin', version: '1.0.0', engine: { api: 0.5 }, scope: 'app' },
+            status: 'activated', source: 'marketplace', pluginPath: '/plugins/updatable',
+          },
+        },
+        appEnabled: ['updatable'],
+        externalPluginsEnabled: true,
+      } as any);
+      usePluginUpdateStore.setState({
+        updates: [
+          { pluginId: 'updatable', pluginName: 'Updatable Plugin', currentVersion: '1.0.0', latestVersion: '2.0.0', assetUrl: '', sha256: '', size: 0, api: 0.5 },
+        ],
+      });
+      render(<PluginListSettings />);
+      expect(screen.getByTestId('update-badge-updatable')).toBeInTheDocument();
+      expect(screen.getByTestId('update-btn-updatable')).toBeInTheDocument();
+      expect(screen.getByText('v2.0.0 available')).toBeInTheDocument();
+    });
+
+    it('shows update phase badge when plugin is being updated', () => {
+      usePluginStore.setState({
+        plugins: {
+          'updating-plug': {
+            manifest: { id: 'updating-plug', name: 'Updating Plugin', version: '1.0.0', engine: { api: 0.5 }, scope: 'app' },
+            status: 'activated', source: 'community', pluginPath: '/plugins/updating-plug',
+          },
+        },
+        appEnabled: ['updating-plug'],
+        externalPluginsEnabled: true,
+      } as any);
+      usePluginUpdateStore.setState({
+        updates: [
+          { pluginId: 'updating-plug', pluginName: 'Updating Plugin', currentVersion: '1.0.0', latestVersion: '2.0.0', assetUrl: '', sha256: '', size: 0, api: 0.5 },
+        ],
+        updating: { 'updating-plug': 'downloading' },
+      });
+      render(<PluginListSettings />);
+      expect(screen.getByTestId('update-phase-updating-plug')).toBeInTheDocument();
+      expect(screen.getByText('Downloading...')).toBeInTheDocument();
+      // Update button should be hidden during update
+      expect(screen.queryByTestId('update-btn-updating-plug')).not.toBeInTheDocument();
+    });
+
+    it('shows update error inline on the plugin row', () => {
+      usePluginStore.setState({
+        plugins: {
+          'error-plug': {
+            manifest: { id: 'error-plug', name: 'Error Plugin', version: '1.0.0', engine: { api: 0.5 }, scope: 'app' },
+            status: 'activated', source: 'community', pluginPath: '/plugins/error-plug',
+          },
+        },
+        appEnabled: ['error-plug'],
+        externalPluginsEnabled: true,
+      } as any);
+      usePluginUpdateStore.setState({
+        updateErrors: { 'error-plug': 'Module syntax error' },
+      });
+      render(<PluginListSettings />);
+      expect(screen.getByText(/Update failed: Module syntax error/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { usePluginStore } from '../../plugins/plugin-store';
 import { useUIStore } from '../../stores/uiStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { usePluginUpdateStore } from '../../stores/pluginUpdateStore';
 import { activatePlugin, deactivatePlugin, discoverNewPlugins } from '../../plugins/plugin-loader';
 import type { PluginPermission, PermissionRiskLevel, PluginRegistryEntry } from '../../../shared/plugin-types';
 import { PERMISSION_DESCRIPTIONS, PERMISSION_RISK_LEVELS } from '../../../shared/plugin-types';
@@ -106,23 +107,39 @@ function SourceBadge({ entry }: { entry: PluginRegistryEntry }) {
   return null;
 }
 
+/** Phase label for inline update progress. */
+const UPDATE_PHASE_LABELS: Record<string, string> = {
+  downloading: 'Downloading...',
+  installing: 'Installing...',
+  reloading: 'Reloading...',
+};
+
 function PluginRow({
   entry,
   enabled,
   onToggle,
   onOpenSettings,
   onUninstall,
+  onUpdate,
   hasSettings,
+  updateVersion,
+  updatePhase,
+  updateError,
 }: {
   entry: PluginRegistryEntry;
   enabled: boolean;
   onToggle: () => void;
   onOpenSettings: () => void;
   onUninstall?: () => void;
+  onUpdate?: () => void;
   hasSettings: boolean;
+  updateVersion?: string;
+  updatePhase?: string;
+  updateError?: string;
 }) {
   const isIncompatible = entry.status === 'incompatible';
   const isErrored = entry.status === 'errored';
+  const isUpdating = !!updatePhase;
 
   return (
     <div className="flex items-center justify-between py-3 px-4 rounded-lg bg-ctp-mantle border border-surface-0">
@@ -139,9 +156,22 @@ function PluginRow({
           {isErrored && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">Error</span>
           )}
+          {updateVersion && !isUpdating && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success" data-testid={`update-badge-${entry.manifest.id}`}>
+              v{updateVersion} available
+            </span>
+          )}
+          {isUpdating && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent animate-pulse" data-testid={`update-phase-${entry.manifest.id}`}>
+              {UPDATE_PHASE_LABELS[updatePhase] || 'Updating...'}
+            </span>
+          )}
         </div>
         {entry.manifest.description && (
           <p className="text-xs text-ctp-subtext0 mt-0.5 truncate">{entry.manifest.description}</p>
+        )}
+        {updateError && (
+          <p className="text-xs text-ctp-peach mt-0.5">Update failed: {updateError}</p>
         )}
         {entry.error && (() => {
           const newlineIdx = entry.error.indexOf('\n');
@@ -161,6 +191,16 @@ function PluginRow({
         })()}
       </div>
       <div className="flex items-center gap-2 ml-3">
+        {onUpdate && updateVersion && !isUpdating && (
+          <button
+            onClick={onUpdate}
+            className="text-[11px] px-2 py-1 rounded bg-ctp-success/20 text-ctp-success hover:bg-ctp-success/30 cursor-pointer"
+            title={`Update to v${updateVersion}`}
+            data-testid={`update-btn-${entry.manifest.id}`}
+          >
+            Update
+          </button>
+        )}
         {enabled && hasSettings && (
           <button
             onClick={onOpenSettings}
@@ -407,6 +447,16 @@ export function PluginListSettings() {
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const projects = useProjectStore((s) => s.projects);
 
+  // Plugin update state
+  const updates = usePluginUpdateStore((s) => s.updates);
+  const updating = usePluginUpdateStore((s) => s.updating);
+  const updateErrors = usePluginUpdateStore((s) => s.updateErrors);
+  const checking = usePluginUpdateStore((s) => s.checking);
+  const lastCheck = usePluginUpdateStore((s) => s.lastCheck);
+  const checkForUpdates = usePluginUpdateStore((s) => s.checkForUpdates);
+  const updatePlugin = usePluginUpdateStore((s) => s.updatePlugin);
+  const updateAll = usePluginUpdateStore((s) => s.updateAll);
+
   const [restartHint, setRestartHint] = useState(false);
   const [marketplaceOpen, setMarketplaceOpen] = useState(false);
   const [scanning, setScanning] = useState(false);
@@ -568,19 +618,30 @@ export function PluginListSettings() {
     return !!(entry.manifest.settingsPanel || (entry.manifest.contributes?.settings && entry.manifest.contributes.settings.length > 0));
   };
 
+  const getUpdateInfo = (pluginId: string) => updates.find((u) => u.pluginId === pluginId);
+
   const renderPluginList = (entries: PluginRegistryEntry[], showUninstall: boolean) => (
     <div className="space-y-2">
-      {entries.map((entry) => (
-        <PluginRow
-          key={entry.manifest.id}
-          entry={entry}
-          enabled={isEnabled(entry.manifest.id)}
-          onToggle={() => handleToggle(entry.manifest.id)}
-          onOpenSettings={() => openPluginSettings(entry.manifest.id)}
-          onUninstall={showUninstall ? () => handleUninstall(entry.manifest.id) : undefined}
-          hasSettings={hasSettings(entry)}
-        />
-      ))}
+      {entries.map((entry) => {
+        const updateInfo = getUpdateInfo(entry.manifest.id);
+        const phase = updating[entry.manifest.id];
+        const error = updateErrors[entry.manifest.id];
+        return (
+          <PluginRow
+            key={entry.manifest.id}
+            entry={entry}
+            enabled={isEnabled(entry.manifest.id)}
+            onToggle={() => handleToggle(entry.manifest.id)}
+            onOpenSettings={() => openPluginSettings(entry.manifest.id)}
+            onUninstall={showUninstall ? () => handleUninstall(entry.manifest.id) : undefined}
+            onUpdate={updateInfo ? () => updatePlugin(entry.manifest.id) : undefined}
+            hasSettings={hasSettings(entry)}
+            updateVersion={updateInfo?.latestVersion}
+            updatePhase={phase}
+            updateError={error}
+          />
+        );
+      })}
     </div>
   );
 
@@ -665,7 +726,25 @@ export function PluginListSettings() {
               {restartHint && (
                 <p className="text-xs text-ctp-peach mb-3">Restart Clubhouse for this change to take full effect.</p>
               )}
-              <div className="flex items-center gap-2 mb-3">
+              <div className="flex items-center gap-2 mb-3 flex-wrap">
+                <button
+                  onClick={checkForUpdates}
+                  disabled={checking}
+                  className="text-[11px] px-2 py-1 rounded border border-ctp-success/30 text-ctp-success hover:bg-ctp-success/10 cursor-pointer disabled:opacity-50"
+                  data-testid="check-updates-button"
+                >
+                  {checking ? 'Checking...' : 'Check for Updates'}
+                </button>
+                {updates.length > 1 && (
+                  <button
+                    onClick={updateAll}
+                    disabled={Object.keys(updating).length > 0}
+                    className="text-[11px] px-2 py-1 rounded border border-ctp-success/30 text-ctp-success hover:bg-ctp-success/10 cursor-pointer disabled:opacity-50"
+                    data-testid="update-all-button"
+                  >
+                    Update All ({updates.length})
+                  </button>
+                )}
                 <button
                   onClick={handleScanNewPlugins}
                   disabled={scanning}
@@ -683,6 +762,11 @@ export function PluginListSettings() {
                   </button>
                 )}
               </div>
+              {lastCheck && (
+                <p className="text-[10px] text-ctp-subtext0/70 mb-2" data-testid="last-check-time">
+                  Last checked: {new Date(lastCheck).toLocaleString()}
+                </p>
+              )}
               {scanResult && (
                 <p className="text-xs text-ctp-subtext0 mb-3">{scanResult}</p>
               )}

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -1112,6 +1112,9 @@ describe('plugin-loader', () => {
 
       const manifest = makeManifest({ id: 'multi-ctx', scope: 'project' });
       usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/multi-ctx', 'registered');
+      usePluginStore.getState().enableApp('multi-ctx');
+      usePluginStore.getState().enableForProject('proj-1', 'multi-ctx');
+      usePluginStore.getState().enableForProject('proj-2', 'multi-ctx');
 
       // Activate in two projects
       await activatePlugin('multi-ctx', 'proj-1', '/p1');
@@ -1200,6 +1203,107 @@ describe('plugin-loader', () => {
 
       expect(getActiveContext('app-reactivate')).toBeDefined();
       expect(usePluginStore.getState().plugins['app-reactivate'].status).toBe('activated');
+    });
+
+    it('restores project-enabled contexts from store state, not just active contexts', async () => {
+      const mod: PluginModule = { activate: vi.fn(), deactivate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      // Set up a dual-scoped plugin enabled at app and project level
+      const manifest = makeManifest({ id: 'dual-reload', scope: 'dual' });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/dual-reload', 'registered');
+      usePluginStore.getState().enableApp('dual-reload');
+      usePluginStore.getState().enableForProject('proj-1', 'dual-reload');
+
+      // Activate at both levels
+      await activatePlugin('dual-reload');
+      await activatePlugin('dual-reload', 'proj-1', '/path/to/proj-1');
+      expect(getActiveContext('dual-reload')).toBeDefined();
+      expect(getActiveContext('dual-reload', 'proj-1')).toBeDefined();
+
+      // Mock re-discovery
+      mockPlugin.discoverCommunity.mockResolvedValue([
+        { manifest: makeManifest({ id: 'dual-reload', scope: 'dual', version: '2.0.0' }), pluginPath: '/plugins/dual-reload', fromMarketplace: false },
+      ]);
+
+      await hotReloadPlugin('dual-reload');
+
+      // Both app and project contexts should be restored
+      expect(getActiveContext('dual-reload')).toBeDefined();
+      expect(getActiveContext('dual-reload', 'proj-1')).toBeDefined();
+      expect(usePluginStore.getState().plugins['dual-reload'].manifest.version).toBe('2.0.0');
+    });
+
+    it('preserves plugin settings across hot-reload', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      const manifest = makeManifest({ id: 'settings-persist', scope: 'app' });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/settings-persist', 'registered');
+      usePluginStore.getState().enableApp('settings-persist');
+      usePluginStore.getState().setPluginSetting('app', 'settings-persist', 'theme', 'dark');
+
+      await activatePlugin('settings-persist');
+
+      // Mock re-discovery
+      mockPlugin.discoverCommunity.mockResolvedValue([
+        { manifest: makeManifest({ id: 'settings-persist', scope: 'app', version: '2.0.0' }), pluginPath: '/plugins/settings-persist', fromMarketplace: false },
+      ]);
+
+      await hotReloadPlugin('settings-persist');
+
+      // Settings should still be in the store
+      const settings = usePluginStore.getState().pluginSettings['app:settings-persist'];
+      expect(settings).toEqual({ theme: 'dark' });
+    });
+
+    it('retries discovery when plugin not found on first attempt', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      const manifest = makeManifest({ id: 'retry-discover', scope: 'app' });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/retry-discover', 'registered');
+      usePluginStore.getState().enableApp('retry-discover');
+      await activatePlugin('retry-discover');
+
+      // First call returns empty (files still being written), second succeeds
+      mockPlugin.discoverCommunity
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { manifest: makeManifest({ id: 'retry-discover', scope: 'app', version: '2.0.0' }), pluginPath: '/plugins/retry-discover', fromMarketplace: false },
+        ]);
+
+      await hotReloadPlugin('retry-discover');
+
+      // Should have retried and succeeded
+      expect(mockPlugin.discoverCommunity).toHaveBeenCalledTimes(2);
+      expect(getActiveContext('retry-discover')).toBeDefined();
+      expect(usePluginStore.getState().plugins['retry-discover'].manifest.version).toBe('2.0.0');
+    });
+
+    it('preserves app-enabled and project-enabled lists across hot-reload', async () => {
+      const mod: PluginModule = { activate: vi.fn(), deactivate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      const manifest = makeManifest({ id: 'enabled-persist', scope: 'dual' });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/enabled-persist', 'registered');
+      usePluginStore.getState().enableApp('enabled-persist');
+      usePluginStore.getState().enableForProject('proj-a', 'enabled-persist');
+      usePluginStore.getState().enableForProject('proj-b', 'enabled-persist');
+
+      await activatePlugin('enabled-persist');
+
+      mockPlugin.discoverCommunity.mockResolvedValue([
+        { manifest: makeManifest({ id: 'enabled-persist', scope: 'dual', version: '3.0.0' }), pluginPath: '/plugins/enabled-persist', fromMarketplace: false },
+      ]);
+
+      await hotReloadPlugin('enabled-persist');
+
+      // Enabled lists should be preserved
+      const store = usePluginStore.getState();
+      expect(store.appEnabled).toContain('enabled-persist');
+      expect(store.projectEnabled['proj-a']).toContain('enabled-persist');
+      expect(store.projectEnabled['proj-b']).toContain('enabled-persist');
     });
   });
 });

--- a/src/renderer/plugins/plugin-loader.ts
+++ b/src/renderer/plugins/plugin-loader.ts
@@ -451,7 +451,8 @@ export function getActiveContext(pluginId: string, projectId?: string): PluginCo
  * Hot-reload a community plugin after its files have been updated on disk.
  * This tears down the running plugin instance (all contexts), re-reads the
  * manifest, clears the cached module, and re-activates the plugin in all
- * scopes where it was previously active.
+ * scopes where it was enabled — preserving app/project enabled state and
+ * plugin settings across the reload.
  *
  * Built-in plugins cannot be hot-reloaded.
  */
@@ -471,32 +472,46 @@ export async function hotReloadPlugin(pluginId: string): Promise<void> {
 
   rendererLog('core:plugins', 'info', `Hot-reloading plugin: ${pluginId}`);
 
-  // 1. Collect all active contexts for this plugin so we can re-activate them
-  const contextsToRestore: Array<{ projectId?: string; projectPath?: string }> = [];
-  for (const [key, ctx] of activeContexts.entries()) {
-    if (key === pluginId || key.startsWith(`${pluginId}:`)) {
-      contextsToRestore.push({
-        projectId: ctx.projectId,
-        projectPath: ctx.projectPath,
-      });
+  // 1. Snapshot the full enabled state BEFORE deactivation so we can restore
+  //    all scopes — not just the ones that happened to be active in memory.
+  const wasAppEnabled = store.appEnabled.includes(pluginId);
+  const enabledProjectIds: Array<{ projectId: string; projectPath?: string }> = [];
+  for (const [projectId, enabledIds] of Object.entries(store.projectEnabled)) {
+    if (enabledIds.includes(pluginId)) {
+      // Try to get the project path from the active context if available
+      const ctxKey = `${pluginId}:${projectId}`;
+      const ctx = activeContexts.get(ctxKey);
+      enabledProjectIds.push({ projectId, projectPath: ctx?.projectPath });
     }
   }
 
-  // 2. Deactivate all contexts for this plugin
-  for (const ctx of contextsToRestore) {
-    await deactivatePlugin(pluginId, ctx.projectId);
+  // 2. Deactivate all active contexts for this plugin
+  const activeKeys = [...activeContexts.keys()].filter(
+    (key) => key === pluginId || key.startsWith(`${pluginId}:`)
+  );
+  for (const key of activeKeys) {
+    const ctx = activeContexts.get(key);
+    await deactivatePlugin(pluginId, ctx?.projectId);
   }
 
-  // If the plugin had no active contexts, ensure full deactivation and module cleanup
-  if (contextsToRestore.length === 0) {
+  // If the plugin had no active contexts, ensure module cleanup
+  if (activeKeys.length === 0) {
     store.removePluginModule(pluginId);
   }
 
-  // 3. Re-read manifest from disk
-  const communityPlugins = await window.clubhouse.plugin.discoverCommunity();
-  const discovered = communityPlugins.find(
-    (p: { pluginPath: string }) => p.pluginPath === entry.pluginPath
-  );
+  // 3. Re-read manifest from disk (with retry for in-flight file writes)
+  let discovered: { manifest: unknown; pluginPath: string; fromMarketplace: boolean } | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const communityPlugins = await window.clubhouse.plugin.discoverCommunity();
+    discovered = communityPlugins.find(
+      (p: { pluginPath: string }) => p.pluginPath === entry.pluginPath
+    );
+    if (discovered) break;
+    // Brief pause before retry in case files are still being written
+    if (attempt === 0) {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
 
   if (!discovered) {
     rendererLog('core:plugins', 'error', `Plugin ${pluginId} no longer found at ${entry.pluginPath}`);
@@ -516,33 +531,35 @@ export async function hotReloadPlugin(pluginId: string): Promise<void> {
   // 4. Re-register with updated manifest (preserve original source)
   store.registerPlugin(validation.manifest, entry.source, entry.pluginPath, 'registered');
 
-  // 5. Re-activate in all contexts where it was previously active.
-  //    activatePlugin catches its own errors internally and sets status to
-  //    'errored', so we check the plugin status after each attempt rather
-  //    than using try/catch.  We continue through all contexts so that a
-  //    failure in one doesn't prevent the others from being restored.
+  // 5. Re-activate in all enabled scopes. We use the snapshotted enabled
+  //    state rather than just activeContexts, so project-scoped contexts
+  //    that were enabled but not yet activated also get restored.
   const activationErrors: string[] = [];
-  for (const ctx of contextsToRestore) {
-    await activatePlugin(pluginId, ctx.projectId, ctx.projectPath);
+
+  // Helper to attempt activation and track errors
+  const tryActivate = async (projectId?: string, projectPath?: string) => {
+    await activatePlugin(pluginId, projectId, projectPath);
     const postEntry = usePluginStore.getState().plugins[pluginId];
     if (postEntry?.status === 'errored') {
-      const label = ctx.projectId ? `project ${ctx.projectId}` : 'app';
+      const label = projectId ? `project ${projectId}` : 'app';
       activationErrors.push(`${label}: ${postEntry.error || 'unknown error'}`);
-      // Reset status to 'registered' so the next context attempt isn't skipped
-      // (activatePlugin skips plugins with 'errored' status).
+      // Reset status so subsequent activations aren't skipped
       usePluginStore.getState().setPluginStatus(pluginId, 'registered');
     }
+  };
+
+  // Re-activate app-level context if it was enabled
+  const updatedManifest = validation.manifest;
+  if (wasAppEnabled && (updatedManifest.scope === 'app' || updatedManifest.scope === 'dual')) {
+    await tryActivate();
   }
 
-  // If the plugin had no project contexts but was app-enabled, re-activate at app level
-  if (contextsToRestore.length === 0 && store.appEnabled.includes(pluginId)) {
-    const updatedEntry = usePluginStore.getState().plugins[pluginId];
-    if (updatedEntry && (updatedEntry.manifest.scope === 'app' || updatedEntry.manifest.scope === 'dual')) {
-      await activatePlugin(pluginId);
-      const postEntry = usePluginStore.getState().plugins[pluginId];
-      if (postEntry?.status === 'errored') {
-        activationErrors.push(`app: ${postEntry.error || 'unknown error'}`);
-      }
+  // Re-activate project-level contexts for all projects where the plugin was enabled
+  if (updatedManifest.scope === 'project' || updatedManifest.scope === 'dual') {
+    for (const { projectId, projectPath } of enabledProjectIds) {
+      // Only activate if still app-enabled (app-first gate)
+      if (!wasAppEnabled) continue;
+      await tryActivate(projectId, projectPath);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes the broken plugin update flow — plugins no longer require manual toggle off/on after updates
- Adds "Check for Updates" button and per-plugin inline update controls to plugin settings
- Hot-reload now restores ALL enabled scopes (app + project) using store state, not just in-memory active contexts

## Changes

### Hot-reload improvements (`plugin-loader.ts`)
- Snapshot full enabled state (`appEnabled` + `projectEnabled`) before deactivation, then restore all enabled scopes after re-registration
- Add retry with 500ms delay when plugin files not found during manifest re-read (handles in-flight file writes during updates)
- Plugin settings preserved across hot-reload (settings remain in Zustand store)
- Project-enabled contexts now properly restored even if they weren't active in memory

### Plugin settings UI (`PluginListSettings.tsx`)
- Add "Check for Updates" button for manual update checks (next to existing "Reload Local Plugins")
- Add per-plugin "Update" button with inline version badge (`v2.0.0 available`)
- Add "Update All" button when multiple updates are available
- Show update progress phase per-plugin (Downloading/Installing/Reloading) with animated badge
- Show update errors inline on the plugin row
- Display last check timestamp

### Tests
- New tests for dual-scoped plugin hot-reload restoring both app and project contexts
- Test for plugin settings persistence across hot-reload
- Test for discovery retry when files not found on first attempt
- Test for enabled list preservation across hot-reload
- Tests for check for updates button, per-plugin update badge/button, update phase indicators, and inline errors

## Test Plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] All 5332 tests pass (`npm test`)
- [x] Lint clean on changed files (pre-existing lint errors only)
- [ ] Manual: Install an external plugin, trigger an update, verify it hot-reloads seamlessly without needing toggle off/on
- [ ] Manual: Verify "Check for Updates" button appears and works in plugin settings
- [ ] Manual: Verify per-plugin "Update" button shows when update is available
- [ ] Manual: Verify plugin list doesn't go empty after update

## Manual Validation
1. Open Settings > Plugins with external plugins enabled
2. Verify "Check for Updates" button is visible next to "Reload Local Plugins"
3. Click it — should show "Checking..." then display last check time
4. If updates are available, each plugin row should show a version badge and "Update" button
5. Click "Update" on a plugin — should show progress phases (Downloading → Installing → Reloading)
6. Plugin should seamlessly reload without needing to toggle off/on at app or project level
7. Plugin settings and permissions should be preserved after update