### PR TITLE
feat: permission escalation gate for plugin updates

### DIFF
--- a/src/renderer/features/settings/PluginListSettings.test.tsx
+++ b/src/renderer/features/settings/PluginListSettings.test.tsx
@@ -305,4 +305,29 @@ describe('PluginListSettings', () => {
       expect(screen.getByText(/Update failed: Module syntax error/)).toBeInTheDocument();
     });
   });
+
+  describe('permission approval UI', () => {
+    it('shows pending-approval badge and approve/reject buttons', () => {
+      usePluginStore.setState({
+        plugins: {
+          'pending-plug': {
+            manifest: { id: 'pending-plug', name: 'Pending Plugin', version: '2.0.0', engine: { api: 0.5 }, scope: 'app', permissions: ['storage', 'process'] },
+            status: 'pending-approval' as const,
+            source: 'community',
+            pluginPath: '/plugins/pending-plug',
+            pendingPermissions: ['process'] as any,
+          },
+        },
+        appEnabled: ['pending-plug'],
+        externalPluginsEnabled: true,
+      } as any);
+      render(<PluginListSettings />);
+      expect(screen.getByTestId('pending-badge-pending-plug')).toBeInTheDocument();
+      expect(screen.getByText('New permissions')).toBeInTheDocument();
+      expect(screen.getByTestId('pending-approval-pending-plug')).toBeInTheDocument();
+      expect(screen.getByTestId('approve-btn-pending-plug')).toBeInTheDocument();
+      expect(screen.getByTestId('reject-btn-pending-plug')).toBeInTheDocument();
+      expect(screen.getByText('process')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -3,7 +3,7 @@ import { usePluginStore } from '../../plugins/plugin-store';
 import { useUIStore } from '../../stores/uiStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { usePluginUpdateStore } from '../../stores/pluginUpdateStore';
-import { activatePlugin, deactivatePlugin, discoverNewPlugins } from '../../plugins/plugin-loader';
+import { activatePlugin, deactivatePlugin, discoverNewPlugins, approvePluginPermissions, rejectPluginPermissions } from '../../plugins/plugin-loader';
 import type { PluginPermission, PermissionRiskLevel, PluginRegistryEntry } from '../../../shared/plugin-types';
 import { PERMISSION_DESCRIPTIONS, PERMISSION_RISK_LEVELS } from '../../../shared/plugin-types';
 import type { CustomMarketplace } from '../../../shared/marketplace-types';
@@ -139,10 +139,11 @@ function PluginRow({
 }) {
   const isIncompatible = entry.status === 'incompatible';
   const isErrored = entry.status === 'errored';
+  const isPendingApproval = entry.status === 'pending-approval';
   const isUpdating = !!updatePhase;
 
   return (
-    <div className="flex items-center justify-between py-3 px-4 rounded-lg bg-ctp-mantle border border-surface-0">
+    <div className={`flex items-center justify-between py-3 px-4 rounded-lg bg-ctp-mantle border ${isPendingApproval ? 'border-ctp-peach/40' : 'border-surface-0'}`}>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-ctp-text">{entry.manifest.name}</span>
@@ -155,6 +156,11 @@ function PluginRow({
           )}
           {isErrored && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">Error</span>
+          )}
+          {isPendingApproval && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach" data-testid={`pending-badge-${entry.manifest.id}`}>
+              New permissions
+            </span>
           )}
           {updateVersion && !isUpdating && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success" data-testid={`update-badge-${entry.manifest.id}`}>
@@ -189,6 +195,46 @@ function PluginRow({
             </div>
           );
         })()}
+        {isPendingApproval && entry.pendingPermissions && (
+          <div className="mt-2 p-2 rounded bg-ctp-peach/5 border border-ctp-peach/20" data-testid={`pending-approval-${entry.manifest.id}`}>
+            <p className="text-xs text-ctp-peach font-medium mb-1">
+              This update requires new permissions:
+            </p>
+            <div className="flex flex-wrap gap-1 mb-2">
+              {entry.pendingPermissions.map((perm) => {
+                const risk = PERMISSION_RISK_LEVELS[perm];
+                return (
+                  <span
+                    key={perm}
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${
+                      risk === 'dangerous'
+                        ? 'bg-red-500/20 text-red-400'
+                        : 'bg-yellow-500/20 text-yellow-400'
+                    }`}
+                  >
+                    {perm}
+                  </span>
+                );
+              })}
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={() => approvePluginPermissions(entry.manifest.id)}
+                className="text-[11px] px-2 py-1 rounded bg-ctp-accent/20 text-ctp-accent hover:bg-ctp-accent/30 cursor-pointer"
+                data-testid={`approve-btn-${entry.manifest.id}`}
+              >
+                Approve & Activate
+              </button>
+              <button
+                onClick={() => rejectPluginPermissions(entry.manifest.id)}
+                className="text-[11px] px-2 py-1 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 cursor-pointer"
+                data-testid={`reject-btn-${entry.manifest.id}`}
+              >
+                Reject
+              </button>
+            </div>
+          </div>
+        )}
       </div>
       <div className="flex items-center gap-2 ml-3">
         {onUpdate && updateVersion && !isUpdating && (

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -67,6 +67,8 @@ import {
   getActiveContext,
   discoverNewPlugins,
   hotReloadPlugin,
+  approvePluginPermissions,
+  rejectPluginPermissions,
   _resetActiveContexts,
 } from './plugin-loader';
 import { dynamicImportModule } from './dynamic-import';
@@ -1304,6 +1306,143 @@ describe('plugin-loader', () => {
       expect(store.appEnabled).toContain('enabled-persist');
       expect(store.projectEnabled['proj-a']).toContain('enabled-persist');
       expect(store.projectEnabled['proj-b']).toContain('enabled-persist');
+    });
+
+    it('blocks activation when update adds elevated permissions', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      // Original plugin with only safe permissions
+      const manifest = makeManifest({ id: 'perm-escalate', scope: 'app', permissions: ['storage', 'commands'] });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/perm-escalate', 'registered');
+      usePluginStore.getState().enableApp('perm-escalate');
+      await activatePlugin('perm-escalate');
+
+      // Update adds 'process' (elevated) and 'terminal' (elevated)
+      mockPlugin.discoverCommunity.mockResolvedValue([
+        {
+          manifest: makeManifest({
+            id: 'perm-escalate', scope: 'app', version: '2.0.0',
+            permissions: ['storage', 'commands', 'process', 'terminal'],
+            allowedCommands: ['node'],
+          }),
+          pluginPath: '/plugins/perm-escalate',
+          fromMarketplace: false,
+        },
+      ]);
+
+      await hotReloadPlugin('perm-escalate');
+
+      // Plugin should be in pending-approval state, NOT activated
+      const entry = usePluginStore.getState().plugins['perm-escalate'];
+      expect(entry.status).toBe('pending-approval');
+      expect(entry.pendingPermissions).toEqual(['process', 'terminal']);
+      expect(getActiveContext('perm-escalate')).toBeUndefined();
+    });
+
+    it('allows activation when update only adds safe permissions', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      const manifest = makeManifest({ id: 'safe-update', scope: 'app', permissions: ['storage'] });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/safe-update', 'registered');
+      usePluginStore.getState().enableApp('safe-update');
+      await activatePlugin('safe-update');
+
+      // Update adds only safe permissions
+      mockPlugin.discoverCommunity.mockResolvedValue([
+        {
+          manifest: makeManifest({
+            id: 'safe-update', scope: 'app', version: '2.0.0',
+            permissions: ['storage', 'commands', 'events'],
+          }),
+          pluginPath: '/plugins/safe-update',
+          fromMarketplace: false,
+        },
+      ]);
+
+      await hotReloadPlugin('safe-update');
+
+      // Should proceed without blocking
+      const entry = usePluginStore.getState().plugins['safe-update'];
+      expect(entry.status).toBe('activated');
+      expect(entry.pendingPermissions).toBeUndefined();
+    });
+
+    it('blocks on dangerous permissions', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      const manifest = makeManifest({ id: 'danger-update', scope: 'app', permissions: ['agents'] });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/danger-update', 'registered');
+      usePluginStore.getState().enableApp('danger-update');
+      await activatePlugin('danger-update');
+
+      // Update adds 'agents.free-agent-mode' (dangerous)
+      mockPlugin.discoverCommunity.mockResolvedValue([
+        {
+          manifest: makeManifest({
+            id: 'danger-update', scope: 'app', version: '2.0.0',
+            permissions: ['agents', 'agents.free-agent-mode'],
+          }),
+          pluginPath: '/plugins/danger-update',
+          fromMarketplace: false,
+        },
+      ]);
+
+      await hotReloadPlugin('danger-update');
+
+      const entry = usePluginStore.getState().plugins['danger-update'];
+      expect(entry.status).toBe('pending-approval');
+      expect(entry.pendingPermissions).toContain('agents.free-agent-mode');
+    });
+  });
+
+  // ── approvePluginPermissions / rejectPluginPermissions ─────────────
+
+  describe('approvePluginPermissions()', () => {
+    const mockDynamicImport = dynamicImportModule as ReturnType<typeof vi.fn>;
+
+    it('activates plugin after approval', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      const manifest = makeManifest({ id: 'approve-me', scope: 'app', permissions: ['process'] });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/approve-me', 'pending-approval');
+      usePluginStore.getState().enableApp('approve-me');
+      usePluginStore.getState().setPendingPermissions('approve-me', ['process']);
+
+      await approvePluginPermissions('approve-me');
+
+      const entry = usePluginStore.getState().plugins['approve-me'];
+      expect(entry.status).toBe('activated');
+      expect(entry.pendingPermissions).toBeUndefined();
+      expect(getActiveContext('approve-me')).toBeDefined();
+    });
+
+    it('does nothing for non-pending plugin', async () => {
+      const manifest = makeManifest({ id: 'not-pending', scope: 'app' });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/not-pending', 'activated');
+
+      await approvePluginPermissions('not-pending');
+
+      // Status unchanged
+      expect(usePluginStore.getState().plugins['not-pending'].status).toBe('activated');
+    });
+  });
+
+  describe('rejectPluginPermissions()', () => {
+    it('disables plugin on rejection', () => {
+      const manifest = makeManifest({ id: 'reject-me', scope: 'app', permissions: ['process'] });
+      usePluginStore.getState().registerPlugin(manifest, 'community', '/plugins/reject-me', 'pending-approval');
+      usePluginStore.getState().setPendingPermissions('reject-me', ['process']);
+
+      rejectPluginPermissions('reject-me');
+
+      const entry = usePluginStore.getState().plugins['reject-me'];
+      expect(entry.status).toBe('disabled');
+      expect(entry.error).toContain('not approved');
+      expect(entry.pendingPermissions).toBeUndefined();
     });
   });
 });

--- a/src/renderer/plugins/plugin-loader.ts
+++ b/src/renderer/plugins/plugin-loader.ts
@@ -1,4 +1,5 @@
-import type { PluginContext, PluginModule, PluginManifest, PluginThemeDeclaration } from '../../shared/plugin-types';
+import type { PluginContext, PluginModule, PluginManifest, PluginThemeDeclaration, PluginPermission } from '../../shared/plugin-types';
+import { PERMISSION_RISK_LEVELS } from '../../shared/plugin-types';
 import type { ThemeDefinition, ThemeColors, HljsColors, TerminalColors } from '../../shared/types';
 import { usePluginStore } from './plugin-store';
 import { validateManifest } from './manifest-validator';
@@ -175,7 +176,7 @@ export async function activatePlugin(
     return;
   }
 
-  if (entry.status === 'incompatible' || entry.status === 'errored' || entry.status === 'disabled') {
+  if (entry.status === 'incompatible' || entry.status === 'errored' || entry.status === 'disabled' || entry.status === 'pending-approval') {
     rendererLog('core:plugins', 'warn', `Skipping activation of ${pluginId}: ${entry.status}`, {
       meta: { pluginId, status: entry.status, error: entry.error },
     });
@@ -528,10 +529,31 @@ export async function hotReloadPlugin(pluginId: string): Promise<void> {
     return;
   }
 
-  // 4. Re-register with updated manifest (preserve original source)
+  // 4. Check for permission escalation — new elevated/dangerous permissions
+  //    require user approval before re-activation.
+  const oldPerms = new Set(entry.manifest.permissions || []);
+  const newPerms = validation.manifest.permissions || [];
+  const addedPerms = newPerms.filter((p) => !oldPerms.has(p));
+  const escalatedPerms = addedPerms.filter(
+    (p) => PERMISSION_RISK_LEVELS[p] === 'elevated' || PERMISSION_RISK_LEVELS[p] === 'dangerous'
+  );
+
+  if (escalatedPerms.length > 0) {
+    rendererLog('core:plugins', 'warn', `Plugin ${pluginId} update requires new permissions`, {
+      meta: { pluginId, newVersion: validation.manifest.version, addedPermissions: escalatedPerms },
+    });
+
+    // Register the updated manifest but set status to pending-approval
+    // so the plugin doesn't activate until the user approves.
+    store.registerPlugin(validation.manifest, entry.source, entry.pluginPath, 'pending-approval');
+    store.setPendingPermissions(pluginId, escalatedPerms);
+    return;
+  }
+
+  // 5. Re-register with updated manifest (preserve original source)
   store.registerPlugin(validation.manifest, entry.source, entry.pluginPath, 'registered');
 
-  // 5. Re-activate in all enabled scopes. We use the snapshotted enabled
+  // 6. Re-activate in all enabled scopes. We use the snapshotted enabled
   //    state rather than just activeContexts, so project-scoped contexts
   //    that were enabled but not yet activated also get restored.
   const activationErrors: string[] = [];
@@ -575,6 +597,56 @@ export async function hotReloadPlugin(pluginId: string): Promise<void> {
   rendererLog('core:plugins', 'info', `Plugin ${pluginId} hot-reloaded successfully`, {
     meta: { newVersion: finalEntry?.manifest.version, status: finalEntry?.status },
   });
+}
+
+/**
+ * Approve pending permissions for a plugin that was updated with new
+ * elevated/dangerous permissions. This clears the pending-approval state
+ * and activates the plugin in all enabled scopes.
+ */
+export async function approvePluginPermissions(pluginId: string): Promise<void> {
+  const store = usePluginStore.getState();
+  const entry = store.plugins[pluginId];
+
+  if (!entry || entry.status !== 'pending-approval') {
+    rendererLog('core:plugins', 'warn', `Cannot approve permissions for ${pluginId}: not pending`);
+    return;
+  }
+
+  store.setPendingPermissions(pluginId, undefined);
+  store.setPluginStatus(pluginId, 'registered');
+
+  rendererLog('core:plugins', 'info', `Permissions approved for ${pluginId}, activating`);
+
+  // Activate in all enabled scopes
+  const wasAppEnabled = store.appEnabled.includes(pluginId);
+  if (wasAppEnabled && (entry.manifest.scope === 'app' || entry.manifest.scope === 'dual')) {
+    await activatePlugin(pluginId);
+  }
+
+  if (entry.manifest.scope === 'project' || entry.manifest.scope === 'dual') {
+    for (const [projectId, enabledIds] of Object.entries(store.projectEnabled)) {
+      if (enabledIds.includes(pluginId) && wasAppEnabled) {
+        await activatePlugin(pluginId, projectId);
+      }
+    }
+  }
+}
+
+/**
+ * Reject pending permissions for a plugin that was updated with new
+ * elevated/dangerous permissions. This disables the plugin.
+ */
+export function rejectPluginPermissions(pluginId: string): void {
+  const store = usePluginStore.getState();
+  const entry = store.plugins[pluginId];
+
+  if (!entry || entry.status !== 'pending-approval') return;
+
+  store.setPendingPermissions(pluginId, undefined);
+  store.setPluginStatus(pluginId, 'disabled', 'New permissions were not approved');
+
+  rendererLog('core:plugins', 'info', `Permissions rejected for ${pluginId}, plugin disabled`);
 }
 
 /**

--- a/src/renderer/plugins/plugin-store.ts
+++ b/src/renderer/plugins/plugin-store.ts
@@ -48,6 +48,7 @@ interface PluginState {
   removePlugin: (pluginId: string) => void;
   recordPermissionViolation: (violation: PermissionViolation) => void;
   clearPermissionViolation: (pluginId: string) => void;
+  setPendingPermissions: (pluginId: string, permissions: PluginPermission[] | undefined) => void;
 }
 
 export const usePluginStore = create<PluginState>((set) => ({
@@ -195,4 +196,16 @@ export const usePluginStore = create<PluginState>((set) => ({
     set((s) => ({
       permissionViolations: s.permissionViolations.filter((v) => v.pluginId !== pluginId),
     })),
+
+  setPendingPermissions: (pluginId, permissions) =>
+    set((s) => {
+      const entry = s.plugins[pluginId];
+      if (!entry) return s;
+      return {
+        plugins: {
+          ...s.plugins,
+          [pluginId]: { ...entry, pendingPermissions: permissions },
+        },
+      };
+    }),
 }));

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -338,7 +338,8 @@ export type PluginStatus =
   | 'deactivated'
   | 'disabled'
   | 'errored'
-  | 'incompatible';
+  | 'incompatible'
+  | 'pending-approval';
 
 export type PluginSource = 'builtin' | 'community' | 'marketplace';
 
@@ -348,6 +349,8 @@ export interface PluginRegistryEntry {
   error?: string;
   source: PluginSource;
   pluginPath: string;
+  /** New permissions added by an update that require user approval before re-activation. */
+  pendingPermissions?: PluginPermission[];
 }
 
 // ── Plugin context (per-activation) ────────────────────────────────────


### PR DESCRIPTION
## Summary
- When a plugin update introduces new **elevated** or **dangerous** permissions, the hot-reload flow now blocks activation and enters a `pending-approval` state
- Users see the specific new permissions with risk-level badges and can **approve** (activates the plugin) or **reject** (disables the plugin with an error message)
- Safe permission additions (e.g., `storage`, `commands`, `events`) proceed automatically without interruption

## Changes
- **`src/shared/plugin-types.ts`**: Added `'pending-approval'` to `PluginStatus` union; added `pendingPermissions?: PluginPermission[]` to `PluginRegistryEntry`
- **`src/renderer/plugins/plugin-store.ts`**: Added `setPendingPermissions()` action
- **`src/renderer/plugins/plugin-loader.ts`**: 
  - Permission escalation check in `hotReloadPlugin()` — compares old/new manifest permissions, blocks on elevated/dangerous additions
  - New `approvePluginPermissions()` — clears pending state and activates
  - New `rejectPluginPermissions()` — sets disabled status with error message
  - `activatePlugin()` now skips plugins in `pending-approval` status
- **`src/renderer/features/settings/PluginListSettings.tsx`**: Pending-approval UI with orange border, permission badges colored by risk level, "Approve & Activate" and "Reject" buttons
- **Tests**: 6 new test cases in plugin-loader, 1 new test case in PluginListSettings covering all permission gate scenarios

## Test Plan
- [x] `blocks activation when update adds elevated permissions` — verifies `process` + `terminal` additions trigger pending-approval
- [x] `allows activation when update only adds safe permissions` — verifies `commands` + `events` additions proceed normally
- [x] `blocks on dangerous permissions` — verifies `agents.free-agent-mode` triggers pending-approval
- [x] `activates plugin after approval` — verifies approve flow clears pending state and activates
- [x] `does nothing for non-pending plugin` — verifies approve is a no-op for already active plugins
- [x] `disables plugin on rejection` — verifies reject sets disabled status with error message
- [x] `shows pending-approval badge and approve/reject buttons` — verifies settings UI renders correctly
- [x] All 5339 tests pass, typecheck clean

## Manual Validation
1. Install a community plugin with only `storage` permission
2. Update the plugin's manifest to add `process` permission with `allowedCommands`
3. Hot-reload the plugin — should show pending-approval state with the new permission listed
4. Click "Approve & Activate" — plugin should activate normally
5. Repeat but click "Reject" — plugin should show disabled state

🤖 Generated with [Claude Code](https://claude.com/claude-code)