### PR TITLE
fix: wire up theme fonts and gradients to render in UI

### DIFF
--- a/src/renderer/features/terminal/ShellTerminal.tsx
+++ b/src/renderer/features/terminal/ShellTerminal.tsx
@@ -16,6 +16,7 @@ export function ShellTerminal({ sessionId, focused }: Props) {
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const terminalColors = useThemeStore((s) => s.theme.terminal);
+  const monoFont = useThemeStore((s) => s.theme.fonts?.mono ?? s.theme.fontOverride);
   const clipboardCompat = useClipboardSettingsStore((s) => s.clipboardCompat);
   const loadClipboard = useClipboardSettingsStore((s) => s.loadSettings);
 
@@ -24,9 +25,10 @@ export function ShellTerminal({ sessionId, focused }: Props) {
   useEffect(() => {
     if (!containerRef.current) return;
 
+    const DEFAULT_MONO = '"SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace';
     const term = new Terminal({
       theme: terminalColors,
-      fontFamily: '"SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace',
+      fontFamily: monoFont || DEFAULT_MONO,
       fontSize: 13,
       lineHeight: 1.3,
       cursorBlink: true,
@@ -136,6 +138,13 @@ export function ShellTerminal({ sessionId, focused }: Props) {
       terminalRef.current.options.theme = terminalColors;
     }
   }, [terminalColors]);
+
+  useEffect(() => {
+    if (terminalRef.current) {
+      const DEFAULT_MONO = '"SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace';
+      terminalRef.current.options.fontFamily = monoFont || DEFAULT_MONO;
+    }
+  }, [monoFont]);
 
   useEffect(() => {
     if (focused && terminalRef.current) {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -65,27 +65,30 @@
 
   body {
     background-color: rgb(var(--ctp-base));
+    background-image: var(--theme-gradient-bg, none);
     color: rgb(var(--ctp-text));
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(--theme-font-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
     -webkit-font-smoothing: antialiased;
   }
 
-  /* Theme font overrides (v0.7+) */
-  .theme-font-ui {
-    font-family: var(--theme-font-ui) !important;
+  /* Monospace elements use theme mono font with fallback */
+  pre, code, kbd, samp {
+    font-family: var(--theme-font-mono, 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace);
   }
 
-  .theme-font-mono pre,
-  .theme-font-mono code,
-  .theme-font-mono .xterm,
-  .theme-font-mono .xterm * {
-    font-family: var(--theme-font-mono) !important;
-  }
-
-  /* Legacy full-override class (both ui + mono set) — backward compat with Terminal theme */
+  /* Full-mono override: theme sets both ui + mono, apply mono everywhere */
   .theme-mono,
   .theme-mono * {
-    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace !important;
+    font-family: var(--theme-font-mono, 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace) !important;
+  }
+
+  /* Theme gradient overlays for surface and accent elements */
+  .theme-gradient-surface {
+    background-image: var(--theme-gradient-surface, none);
+  }
+
+  .theme-gradient-accent {
+    background-image: var(--theme-gradient-accent, none);
   }
 
   /* Scrollbar styling — auto-hide: invisible by default, visible on hover */
@@ -401,7 +404,7 @@
   background-color: rgb(var(--ctp-surface0));
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
-  font-family: 'SF Mono', 'Fira Code', Menlo, monospace;
+  font-family: var(--theme-font-mono, 'SF Mono', 'Fira Code', Menlo, monospace);
   font-size: 0.8125rem;
 }
 

--- a/src/renderer/themes/apply-theme.test.ts
+++ b/src/renderer/themes/apply-theme.test.ts
@@ -147,21 +147,17 @@ describe('applyTheme', () => {
   });
 
   describe('font override (legacy)', () => {
-    it('adds theme-mono class and stores font when fontOverride is set', () => {
+    it('sets --theme-font-mono CSS variable when fontOverride is set', () => {
       const theme = makeTheme({ fontOverride: 'JetBrains Mono' });
       applyTheme(theme);
 
-      // Legacy fontOverride sets mono font but not theme-mono (needs both ui+mono for that)
-      expect(mockClassList.add).toHaveBeenCalledWith('theme-font-mono');
       expect(mockSetProperty).toHaveBeenCalledWith('--theme-font-mono', 'JetBrains Mono');
     });
 
-    it('removes font classes and clears font when no fontOverride', () => {
+    it('removes theme-mono class and clears font when no fontOverride', () => {
       applyTheme(makeTheme());
 
       expect(mockClassList.remove).toHaveBeenCalledWith('theme-mono');
-      expect(mockClassList.remove).toHaveBeenCalledWith('theme-font-ui');
-      expect(mockClassList.remove).toHaveBeenCalledWith('theme-font-mono');
       expect(mockLocalStorage.has('clubhouse-theme-font')).toBe(false);
     });
 
@@ -177,18 +173,16 @@ describe('applyTheme', () => {
   });
 
   describe('fonts (v0.7)', () => {
-    it('sets --theme-font-ui and adds class when fonts.ui is set', () => {
+    it('sets --theme-font-ui CSS variable when fonts.ui is set', () => {
       applyTheme(makeTheme({ fonts: { ui: 'Inter, sans-serif' } }));
 
       expect(mockSetProperty).toHaveBeenCalledWith('--theme-font-ui', 'Inter, sans-serif');
-      expect(mockClassList.add).toHaveBeenCalledWith('theme-font-ui');
     });
 
-    it('sets --theme-font-mono and adds class when fonts.mono is set', () => {
+    it('sets --theme-font-mono CSS variable when fonts.mono is set', () => {
       applyTheme(makeTheme({ fonts: { mono: "'JetBrains Mono', monospace" } }));
 
       expect(mockSetProperty).toHaveBeenCalledWith('--theme-font-mono', "'JetBrains Mono', monospace");
-      expect(mockClassList.add).toHaveBeenCalledWith('theme-font-mono');
     });
 
     it('adds theme-mono class when both ui and mono fonts are set', () => {
@@ -223,8 +217,14 @@ describe('applyTheme', () => {
 
       expect(mockRemoveProperty).toHaveBeenCalledWith('--theme-font-ui');
       expect(mockRemoveProperty).toHaveBeenCalledWith('--theme-font-mono');
-      expect(mockClassList.remove).toHaveBeenCalledWith('theme-font-ui');
-      expect(mockClassList.remove).toHaveBeenCalledWith('theme-font-mono');
+    });
+
+    it('caches font variables to localStorage', () => {
+      applyTheme(makeTheme({ fonts: { ui: 'Georgia, serif', mono: 'Fira Code' } }));
+
+      const cached = JSON.parse(mockLocalStorage.get('clubhouse-theme-vars')!);
+      expect(cached['--theme-font-ui']).toBe('Georgia, serif');
+      expect(cached['--theme-font-mono']).toBe('Fira Code');
     });
   });
 

--- a/src/renderer/themes/apply-theme.ts
+++ b/src/renderer/themes/apply-theme.ts
@@ -62,29 +62,27 @@ export function applyTheme(theme: ThemeDefinition): void {
     cache[varName] = hex;
   }
 
-  // Font overrides — new `fonts` field takes precedence over legacy `fontOverride`
+  // Font overrides — new `fonts` field takes precedence over legacy `fontOverride`.
+  // CSS variables are consumed directly via var() fallbacks in index.css, so we only
+  // need to set/remove the variables (no class toggling for individual font overrides).
   const uiFont = theme.fonts?.ui;
   const monoFont = theme.fonts?.mono ?? theme.fontOverride;
 
   if (uiFont) {
     s.setProperty('--theme-font-ui', uiFont);
-    document.documentElement.classList.add('theme-font-ui');
     cache['--theme-font-ui'] = uiFont;
   } else {
     s.removeProperty('--theme-font-ui');
-    document.documentElement.classList.remove('theme-font-ui');
   }
 
   if (monoFont) {
     s.setProperty('--theme-font-mono', monoFont);
-    document.documentElement.classList.add('theme-font-mono');
     cache['--theme-font-mono'] = monoFont;
   } else {
     s.removeProperty('--theme-font-mono');
-    document.documentElement.classList.remove('theme-font-mono');
   }
 
-  // Legacy class — maintained for backward compat (both ui + mono = full override)
+  // Full-mono class: when both ui + mono are set, apply mono everywhere
   if (uiFont && monoFont) {
     document.documentElement.classList.add('theme-mono');
     localStorage.setItem('clubhouse-theme-font', monoFont);


### PR DESCRIPTION
## Summary
- Theme fonts and gradients were half-implemented: CSS variables were set but no UI elements consumed them
- Fonts now use CSS variable fallbacks directly on `body` and mono elements, fixing custom font themes
- Gradients now render via `background-image` on body and utility classes for surfaces/accents

## Changes

### Font fixes
- `body` font-family now uses `var(--theme-font-ui, <system-stack>)` — previously the class-based override on `<html>` lost to body's own `font-family` declaration
- `pre`, `code`, `kbd`, `samp` elements now use `var(--theme-font-mono, <mono-stack>)` directly
- Legacy `.theme-mono` class now uses the CSS variable instead of a hardcoded font stack, so plugin themes with custom mono fonts actually work
- Removed broken `.theme-font-ui` / `.theme-font-mono` class toggling from `apply-theme.ts` (CSS variable fallbacks handle it)
- `ShellTerminal.tsx` reads mono font from theme store and updates xterm programmatically when theme changes (xterm uses canvas rendering, not CSS)
- Help content code blocks use the mono font variable

### Gradient fixes
- `body` now has `background-image: var(--theme-gradient-bg, none)` — gradient overlays the solid background color, defaults to `none`
- Added `.theme-gradient-surface` and `.theme-gradient-accent` utility classes for panel and accent elements

## Test Plan
- [x] All 5369 existing tests pass
- [x] TypeScript type check passes
- [x] Lint passes (no new errors)
- [x] `apply-theme.test.ts` updated: removed assertions for deleted class toggling, added font cache test
- [ ] Manual: Apply a theme with `fonts.ui` set to a serif font — body text should change
- [ ] Manual: Apply a theme with `fonts.mono` set to a named mono font — terminal and code blocks should use it
- [ ] Manual: Apply a theme with `gradients.background` — app background should show the gradient
- [ ] Manual: Switch between themes with and without fonts/gradients — should cleanly toggle

## Manual Validation
1. Install a plugin theme that defines `fonts: { ui: 'Georgia, serif' }` — all UI text should render in Georgia
2. Install a plugin theme with `fonts: { mono: "'JetBrains Mono', monospace" }` — terminal and code blocks should use JetBrains Mono
3. Install a plugin theme with `gradients: { background: 'linear-gradient(135deg, #1a1a2e, #16213e)' }` — app background should show gradient
4. Switch back to a built-in theme (e.g. Catppuccin Mocha) — fonts and gradients should cleanly reset to defaults