### PR TITLE
fix: remove opaque bg-ctp-base from root wrappers so body gradient renders

### DIFF
--- a/src/renderer/App.structural.test.ts
+++ b/src/renderer/App.structural.test.ts
@@ -299,7 +299,26 @@ describe('App.tsx – project switch handling', () => {
   });
 });
 
-// ─── 7. Import Verification ───────────────────────────────────────────────
+// ─── 7. Gradient Transparency ────────────────────────────────────────────
+
+describe('App.tsx – root wrapper must not occlude body gradient', () => {
+  const blocks = getJsxReturnBlocks();
+
+  it('should NOT use bg-ctp-base on root wrapper divs (body provides the background)', () => {
+    for (const { block, label } of blocks) {
+      // The first <div in each return block is the root wrapper
+      const firstDivMatch = block.match(/<div\s+className="([^"]+)"/);
+      expect(firstDivMatch, `${label}: could not find root wrapper div`).toBeTruthy();
+      const className = firstDivMatch![1];
+      expect(
+        className,
+        `${label} root wrapper has bg-ctp-base which occludes body gradient — remove it`,
+      ).not.toContain('bg-ctp-base');
+    }
+  });
+});
+
+// ─── 8. Import Verification ───────────────────────────────────────────────
 
 describe('App.tsx – required imports', () => {
   it('should import initApp and initAppEventBridge', () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -138,7 +138,7 @@ export function App() {
 
   if (isHome) {
     return (
-      <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
+      <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col">
         <div className={titleBarClass}>
           <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
         </div>
@@ -161,7 +161,7 @@ export function App() {
   if (isAppPlugin) {
     const appPluginId = explorerTab.slice('plugin:app:'.length);
     return (
-      <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
+      <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col">
         <div className={titleBarClass}>
           <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
         </div>
@@ -183,7 +183,7 @@ export function App() {
 
   if (isHelp) {
     return (
-      <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
+      <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col">
         <div className={titleBarClass}>
           <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
         </div>
@@ -204,7 +204,7 @@ export function App() {
   }
 
   return (
-    <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
+    <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col">
       {/* Title bar */}
       <div className={titleBarClass}>
         <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>

--- a/src/renderer/features/popout/PopoutWindow.tsx
+++ b/src/renderer/features/popout/PopoutWindow.tsx
@@ -143,14 +143,14 @@ export function PopoutWindow() {
   const params = window.clubhouse.window?.getPopoutParams();
   if (!params) {
     return (
-      <div className="h-screen w-screen bg-ctp-base text-ctp-text flex items-center justify-center">
+      <div className="h-screen w-screen text-ctp-text flex items-center justify-center">
         <span className="text-ctp-subtext0 text-sm">Invalid pop-out configuration</span>
       </div>
     );
   }
 
   return (
-    <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col" data-testid="popout-window">
+    <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col" data-testid="popout-window">
       {/* Title bar drag region */}
       <div className="h-[38px] flex-shrink-0 drag-region bg-ctp-mantle border-b border-surface-0 flex items-center justify-center" data-testid="popout-title-bar">
         <span className="text-xs text-ctp-subtext0 select-none" data-testid="popout-title">


### PR DESCRIPTION
## Summary
- PR #421 added `background-image: var(--theme-gradient-bg, none)` to `<body>` in CSS, but gradients were invisible because every App shell wrapper `<div>` used `bg-ctp-base`, painting an opaque background on top
- Removed `bg-ctp-base` from all 4 root wrapper divs in `App.tsx` and 2 in `PopoutWindow.tsx` — `<body>` already provides `background-color: rgb(var(--ctp-base))` so no visual change for non-gradient themes
- Added structural regression test to prevent re-introduction

## Changes
- **`src/renderer/App.tsx`** — Removed `bg-ctp-base` from all 4 root `h-screen w-screen` wrapper divs (Home, AppPlugin, Help, MainProject paths). Body already provides the base background color; removing it lets the body's `background-image` gradient show through.
- **`src/renderer/features/popout/PopoutWindow.tsx`** — Same fix for both popout wrapper divs.
- **`src/renderer/App.structural.test.ts`** — Added regression test verifying root wrapper divs do not use `bg-ctp-base`, preventing future re-introduction of the occlusion bug.

## Test Plan
- [x] All 5370 existing tests pass
- [x] TypeScript type check passes
- [x] Lint passes (no new errors)
- [x] New structural test verifies root wrappers don't use `bg-ctp-base`
- [ ] Manual: Apply a theme with `gradients.background` set — app background should show the gradient
- [ ] Manual: Apply a theme without gradients — app should look identical to before (body provides same `bg-ctp-base` color)
- [ ] Manual: Pop out an agent window — gradient should show there too

## Manual Validation
1. Install a plugin theme that defines `gradients: { background: 'linear-gradient(135deg, #1a1a2e, #16213e)' }` — the gradient should now be visible as the app background
2. Switch to a built-in theme (e.g. Catppuccin Mocha) — should look identical to before this fix (solid background, no gradient)
3. Pop out an agent to a separate window — gradient should render there as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)