### PR TITLE
fix: replace timeout with ping in Windows update batch scripts

### DIFF
--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -140,10 +140,17 @@ export function buildWindowsUpdateScript(
   updateExePath: string,
   appExeName: string,
 ): string {
+  // Use `ping` instead of `timeout` for the delay — `timeout` requires a
+  // real console handle and fails silently when spawned with windowsHide:true
+  // (CREATE_NO_WINDOW).  `ping -n 4` = 3 intervals ~3 seconds.
+  const logFile = '%TEMP%\\clubhouse-update.log';
   return [
     '@echo off',
-    'timeout /t 2 /nobreak >nul',
+    'ping -n 4 127.0.0.1 >nul',
+    `echo [%date% %time%] Running installer: "${downloadPath}" >> "${logFile}"`,
     `"${downloadPath}" --silent`,
+    `echo [%date% %time%] Installer exit code: %ERRORLEVEL% >> "${logFile}"`,
+    `IF %ERRORLEVEL% NEQ 0 echo [%date% %time%] Installer FAILED >> "${logFile}"`,
     `"${updateExePath}" --processStart "${appExeName}"`,
     `del /f "${downloadPath}" 2>nul`,
     `del "%~f0"`,
@@ -155,10 +162,14 @@ export function buildWindowsUpdateScript(
  * Squirrel installer silently, and cleans up — no relaunch.
  */
 export function buildWindowsQuitUpdateScript(downloadPath: string): string {
+  const logFile = '%TEMP%\\clubhouse-update.log';
   return [
     '@echo off',
-    'timeout /t 2 /nobreak >nul',
+    'ping -n 4 127.0.0.1 >nul',
+    `echo [%date% %time%] Running installer (quit): "${downloadPath}" >> "${logFile}"`,
     `"${downloadPath}" --silent`,
+    `echo [%date% %time%] Installer exit code: %ERRORLEVEL% >> "${logFile}"`,
+    `IF %ERRORLEVEL% NEQ 0 echo [%date% %time%] Installer FAILED >> "${logFile}"`,
     `del /f "${downloadPath}" 2>nul`,
     `del "%~f0"`,
   ].join('\r\n');
@@ -530,6 +541,13 @@ export async function applyUpdate(): Promise<void> {
         const script = path.join(app.getPath('temp'), 'clubhouse-update.cmd');
         const updateExe = path.resolve(path.dirname(app.getPath('exe')), '..', 'Update.exe');
         const appExeName = path.basename(app.getPath('exe'));
+
+        // Pre-flight: verify Update.exe exists before writing the batch script
+        if (!fs.existsSync(updateExe)) {
+          const msg = `Squirrel Update.exe not found at ${updateExe}`;
+          appLog('update:apply', 'error', msg);
+          throw new Error(msg);
+        }
 
         fs.writeFileSync(script, buildWindowsUpdateScript(downloadPath, updateExe, appExeName));
 

--- a/src/main/services/auto-update-windows.test.ts
+++ b/src/main/services/auto-update-windows.test.ts
@@ -12,9 +12,10 @@ describe('auto-update-service: Windows batch script builders', () => {
       expect(script.startsWith('@echo off')).toBe(true);
     });
 
-    it('waits before running installer to avoid file-lock contention', () => {
+    it('uses ping for delay instead of timeout (works without a console)', () => {
       const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain('timeout /t 2 /nobreak >nul');
+      expect(script).toContain('ping -n 4 127.0.0.1 >nul');
+      expect(script).not.toContain('timeout');
     });
 
     it('runs the installer silently', () => {
@@ -40,18 +41,34 @@ describe('auto-update-service: Windows batch script builders', () => {
     it('uses CRLF line endings', () => {
       const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
       const lines = script.split('\r\n');
-      expect(lines.length).toBe(6);
+      expect(lines.length).toBe(9);
     });
 
-    it('executes steps in correct order: wait, install, relaunch, cleanup', () => {
+    it('logs installer execution and exit code', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain('Running installer:');
+      expect(script).toContain('Installer exit code: %ERRORLEVEL%');
+      expect(script).toContain('clubhouse-update.log');
+    });
+
+    it('logs a failure message when installer returns non-zero', () => {
+      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
+      expect(script).toContain('IF %ERRORLEVEL% NEQ 0');
+      expect(script).toContain('Installer FAILED');
+    });
+
+    it('executes steps in correct order: wait, log, install, log, check, relaunch, cleanup', () => {
       const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
       const lines = script.split('\r\n');
       expect(lines[0]).toBe('@echo off');
-      expect(lines[1]).toContain('timeout');
-      expect(lines[2]).toContain('--silent');
-      expect(lines[3]).toContain('--processStart');
-      expect(lines[4]).toContain('del /f');
-      expect(lines[5]).toContain('del "%~f0"');
+      expect(lines[1]).toContain('ping');
+      expect(lines[2]).toContain('Running installer');
+      expect(lines[3]).toContain('--silent');
+      expect(lines[4]).toContain('exit code');
+      expect(lines[5]).toContain('IF %ERRORLEVEL%');
+      expect(lines[6]).toContain('--processStart');
+      expect(lines[7]).toContain('del /f');
+      expect(lines[8]).toContain('del "%~f0"');
     });
   });
 
@@ -61,9 +78,10 @@ describe('auto-update-service: Windows batch script builders', () => {
       expect(script.startsWith('@echo off')).toBe(true);
     });
 
-    it('waits before running installer to avoid file-lock contention', () => {
+    it('uses ping for delay instead of timeout (works without a console)', () => {
       const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain('timeout /t 2 /nobreak >nul');
+      expect(script).toContain('ping -n 4 127.0.0.1 >nul');
+      expect(script).not.toContain('timeout');
     });
 
     it('runs the installer silently', () => {
@@ -90,7 +108,20 @@ describe('auto-update-service: Windows batch script builders', () => {
     it('uses CRLF line endings', () => {
       const script = buildWindowsQuitUpdateScript(downloadPath);
       const lines = script.split('\r\n');
-      expect(lines.length).toBe(5);
+      expect(lines.length).toBe(8);
+    });
+
+    it('logs installer execution and exit code', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).toContain('Running installer (quit):');
+      expect(script).toContain('Installer exit code: %ERRORLEVEL%');
+      expect(script).toContain('clubhouse-update.log');
+    });
+
+    it('logs a failure message when installer returns non-zero', () => {
+      const script = buildWindowsQuitUpdateScript(downloadPath);
+      expect(script).toContain('IF %ERRORLEVEL% NEQ 0');
+      expect(script).toContain('Installer FAILED');
     });
 
     it('has one fewer line than the update script (no relaunch)', () => {


### PR DESCRIPTION
## Summary
- Fixes #427 — Windows auto-updater broken across all versions (v0.32–v0.34) because `timeout` command fails silently when spawned without a console window
- Replaces `timeout` with `ping` (works in any context), adds diagnostic logging, and adds pre-flight validation for `Update.exe`

## Changes
- **`src/main/services/auto-update-service.ts`**
  - `buildWindowsUpdateScript()`: replaced `timeout /t 2 /nobreak >nul` with `ping -n 4 127.0.0.1 >nul` (~3s delay that works without a console handle)
  - `buildWindowsQuitUpdateScript()`: same `timeout` → `ping` replacement
  - Both scripts now log installer path, exit code, and failure status to `%TEMP%\clubhouse-update.log`
  - Added pre-flight check in `applyUpdate()` win32 path: verifies `Update.exe` exists before writing the batch script, throws a clear error instead of silently failing
- **`src/main/services/auto-update-windows.test.ts`**
  - Updated all tests to expect `ping` instead of `timeout`
  - Added tests for diagnostic logging lines (installer path, exit code, failure flag)
  - Added tests verifying `timeout` is NOT present in generated scripts
  - Updated line count expectations to reflect new logging lines
  - Updated step-order test to verify the full 9-line (update) / 8-line (quit) script structure

## Root Cause
The `timeout` command requires a real console handle. When the batch script is spawned with `windowsHide: true`, Node.js passes `CREATE_NO_WINDOW` to `CreateProcess` — no console is allocated. `timeout` fails immediately with "Input redirection is not supported", the delay never happens, and the installer runs while the app still holds file locks. The Squirrel installer fails silently.

## Test Plan
- [x] All 5374 existing tests pass
- [x] Windows batch script builder tests updated and passing (18 test cases)
- [x] Typecheck passes
- [x] No new lint errors introduced
- [ ] Manual: install on Windows, trigger update, verify app relaunches on new version
- [ ] Manual: verify `%TEMP%\clubhouse-update.log` is written with installer status
- [ ] Manual: verify quit-and-update path also works (close app with update pending)

## Manual Validation
1. Build and install on Windows
2. Have an older version installed, trigger update check
3. Click "Restart to update" — app should quit, wait ~3s, install silently, and relaunch
4. Check `%TEMP%\clubhouse-update.log` for diagnostic output
5. Test the quit path: with an update downloaded, simply close the app — next launch should be on the new version

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)