### PR TITLE
chore: bump version to 0.35.0-beta.3 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.35.0-beta.2",
+  "version": "0.35.0-beta.3",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Windows users — please reinstall from agent-clubhouse.com/reinstall

# Bug Fixes
- Fixed Windows update scripts hanging due to timeout command unavailability

# Improvements
- Enforced process execution policy server-side for security hardening
- Sanitized markdown rendering with DOMPurify to prevent XSS