### PR TITLE
fix: pre-flight validation before Windows update apply (#432)

### DIFF
--- a/src/main/services/auto-update-service.test.ts
+++ b/src/main/services/auto-update-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isNewerVersion, parseVersion, verifySHA256 } from './auto-update-service';
+import { isNewerVersion, parseVersion, verifySHA256, validateWindowsUpdatePrerequisites } from './auto-update-service';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -164,6 +164,95 @@ describe('auto-update-service', () => {
       const url = 'https://example.com/artifacts/Clubhouse';
       const ext = path.extname(new URL(url).pathname) || '.zip';
       expect(ext).toBe('.zip');
+    });
+  });
+
+  describe('validateWindowsUpdatePrerequisites', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-preflight-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('passes when all prerequisites are met (with updateExePath)', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const updateExePath = path.join(tmpDir, 'Update.exe');
+      const scriptPath = path.join(tmpDir, 'update.cmd');
+
+      fs.writeFileSync(downloadPath, 'installer');
+      fs.writeFileSync(updateExePath, 'updater');
+
+      expect(() =>
+        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath, updateExePath }),
+      ).not.toThrow();
+    });
+
+    it('passes when all prerequisites are met (without updateExePath)', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const scriptPath = path.join(tmpDir, 'update.cmd');
+
+      fs.writeFileSync(downloadPath, 'installer');
+
+      expect(() =>
+        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath }),
+      ).not.toThrow();
+    });
+
+    it('throws when Update.exe is missing', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const scriptPath = path.join(tmpDir, 'update.cmd');
+      const updateExePath = path.join(tmpDir, 'Update.exe');
+
+      fs.writeFileSync(downloadPath, 'installer');
+
+      expect(() =>
+        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath, updateExePath }),
+      ).toThrow(/Update\.exe not found/);
+    });
+
+    it('throws when downloaded installer is missing', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const scriptPath = path.join(tmpDir, 'update.cmd');
+
+      expect(() =>
+        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath }),
+      ).toThrow(/Update file was removed/);
+    });
+
+    it('throws when temp directory is not writable', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const scriptPath = path.join(tmpDir, 'nonexistent-dir', 'nested', 'update.cmd');
+
+      fs.writeFileSync(downloadPath, 'installer');
+
+      expect(() =>
+        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath }),
+      ).toThrow(/Cannot write to temp directory/);
+    });
+
+    it('checks Update.exe before download path', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const scriptPath = path.join(tmpDir, 'update.cmd');
+      const updateExePath = path.join(tmpDir, 'Update.exe');
+
+      expect(() =>
+        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath, updateExePath }),
+      ).toThrow(/Update\.exe not found/);
+    });
+
+    it('does not leave temp files after writable check', () => {
+      const downloadPath = path.join(tmpDir, 'Setup.exe');
+      const scriptPath = path.join(tmpDir, 'update.cmd');
+
+      fs.writeFileSync(downloadPath, 'installer');
+
+      validateWindowsUpdatePrerequisites({ downloadPath, scriptPath });
+
+      expect(fs.existsSync(scriptPath)).toBe(false);
     });
   });
 

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -458,6 +458,47 @@ async function downloadUpdate(
 }
 
 // ---------------------------------------------------------------------------
+// Windows pre-flight validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate prerequisites for applying a Windows update via Squirrel.
+ * Throws with an actionable error message if any check fails.
+ */
+export function validateWindowsUpdatePrerequisites(opts: {
+  downloadPath: string;
+  scriptPath: string;
+  updateExePath?: string;
+}): void {
+  // Validate Update.exe exists (needed for relaunch after install)
+  if (opts.updateExePath && !fs.existsSync(opts.updateExePath)) {
+    appLog('update:apply', 'error', 'Update.exe not found — Squirrel installation may be corrupted', {
+      meta: { expectedPath: opts.updateExePath },
+    });
+    throw new Error('Cannot apply update: Update.exe not found. Please reinstall the app manually.');
+  }
+
+  // Validate downloaded installer still exists (AV could quarantine it)
+  if (!fs.existsSync(opts.downloadPath)) {
+    appLog('update:apply', 'error', 'Downloaded installer missing — may have been quarantined by antivirus', {
+      meta: { expectedPath: opts.downloadPath },
+    });
+    throw new Error('Update file was removed. Please check your antivirus settings and try again.');
+  }
+
+  // Validate temp directory is writable
+  try {
+    fs.writeFileSync(opts.scriptPath, '');
+    fs.unlinkSync(opts.scriptPath);
+  } catch (err) {
+    appLog('update:apply', 'error', 'Cannot write to temp directory', {
+      meta: { scriptPath: opts.scriptPath, error: err instanceof Error ? err.message : String(err) },
+    });
+    throw new Error('Cannot write to temp directory. Please check disk space and permissions.');
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Apply update (quit, replace, relaunch)
 // ---------------------------------------------------------------------------
 
@@ -562,30 +603,29 @@ export async function applyUpdate(): Promise<void> {
     // waits for the old process to fully exit, runs the installer, then
     // relaunches the app via Squirrel's Update.exe.
     try {
-      if (fs.existsSync(downloadPath)) {
-        const { spawn } = require('child_process');
-        const script = path.join(app.getPath('temp'), 'clubhouse-update.cmd');
-        const updateExe = path.resolve(path.dirname(app.getPath('exe')), '..', 'Update.exe');
-        const appExeName = path.basename(app.getPath('exe'));
+      const { spawn } = require('child_process');
+      const script = path.join(app.getPath('temp'), 'clubhouse-update.cmd');
+      const updateExe = path.resolve(path.dirname(app.getPath('exe')), '..', 'Update.exe');
+      const appExeName = path.basename(app.getPath('exe'));
 
-        // Pre-flight: verify Update.exe exists before writing the batch script
-        if (!fs.existsSync(updateExe)) {
-          const msg = `Squirrel Update.exe not found at ${updateExe}`;
-          appLog('update:apply', 'error', msg);
-          throw new Error(msg);
-        }
+      // Pre-flight validation: ensure all prerequisites are met before
+      // writing and spawning the batch script (see #432)
+      validateWindowsUpdatePrerequisites({
+        downloadPath,
+        scriptPath: script,
+        updateExePath: updateExe,
+      });
 
-        fs.writeFileSync(script, buildWindowsUpdateScript(downloadPath, updateExe, appExeName));
+      fs.writeFileSync(script, buildWindowsUpdateScript(downloadPath, updateExe, appExeName));
 
-        spawn('cmd.exe', ['/c', script], {
-          detached: true,
-          stdio: 'ignore',
-          windowsHide: true,
-        }).unref();
+      spawn('cmd.exe', ['/c', script], {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      }).unref();
 
-        app.exit(0);
-        return;
-      }
+      app.exit(0);
+      return;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       appLog('update:apply', 'error', `Failed to apply Windows update: ${msg}`);
@@ -679,18 +719,22 @@ export function applyUpdateOnQuit(): void {
     // fully exit before running the installer to avoid file-lock hangs.
     // No relaunch step since the user chose to quit.
     try {
-      if (fs.existsSync(downloadPath)) {
-        const { spawn } = require('child_process');
-        const script = path.join(app.getPath('temp'), 'clubhouse-update-quit.cmd');
+      const { spawn } = require('child_process');
+      const script = path.join(app.getPath('temp'), 'clubhouse-update-quit.cmd');
 
-        fs.writeFileSync(script, buildWindowsQuitUpdateScript(downloadPath));
+      // Pre-flight validation (no Update.exe needed — no relaunch)
+      validateWindowsUpdatePrerequisites({
+        downloadPath,
+        scriptPath: script,
+      });
 
-        spawn('cmd.exe', ['/c', script], {
-          detached: true,
-          stdio: 'ignore',
-          windowsHide: true,
-        }).unref();
-      }
+      fs.writeFileSync(script, buildWindowsQuitUpdateScript(downloadPath));
+
+      spawn('cmd.exe', ['/c', script], {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      }).unref();
     } catch (err) {
       appLog('update:apply-on-quit', 'error', `Failed to apply Windows update on quit: ${err instanceof Error ? err.message : String(err)}`);
     }


### PR DESCRIPTION
## Summary
- Adds comprehensive pre-flight validation before writing/spawning the Windows update batch script
- Extracts `validateWindowsUpdatePrerequisites()` — validates Update.exe, downloaded installer, and temp directory writability
- Applies validation to both `applyUpdate()` and `applyUpdateOnQuit()` win32 paths
- Errors propagate with actionable user-facing messages instead of failing silently

## Changes
- **`src/main/services/auto-update-service.ts`**
  - New exported `validateWindowsUpdatePrerequisites()` function with three checks:
    1. `Update.exe` exists (Squirrel installation not corrupted)
    2. Downloaded installer still on disk (not quarantined by AV)
    3. Temp directory is writable (batch script can be created)
  - `applyUpdate()` win32 path: replaced the inline `Update.exe` check (from #433) with the comprehensive validation function
  - `applyUpdateOnQuit()` win32 path: added pre-flight validation (previously had no checks at all)
  - Removed the outer `if (fs.existsSync(downloadPath))` guard in both paths — the validation function now handles this with a proper error message instead of silently skipping

- **`src/main/services/auto-update-service.test.ts`**
  - 7 new test cases for `validateWindowsUpdatePrerequisites()`:
    - Passes with all prerequisites met (with and without Update.exe)
    - Throws with actionable message when Update.exe is missing
    - Throws when downloaded installer is missing (AV quarantine scenario)
    - Throws when temp directory is not writable
    - Validates check ordering (Update.exe checked first)
    - Confirms no temp files are left behind after writable check

## Relationship to #433
PR #433 (merged) added an inline `Update.exe` check in `applyUpdate()`. This PR subsumes that check and adds the two missing validations (download path + temp writable) requested in #432, plus extends coverage to `applyUpdateOnQuit()`.

## Test Plan
- [x] All 5392 tests pass
- [x] Typecheck passes (`tsc --noEmit`)
- [x] 7 new unit tests for the validation function
- [ ] Manual: on Windows, corrupt Squirrel install (rename Update.exe) → verify actionable error
- [ ] Manual: on Windows, delete downloaded installer before applying → verify error message
- [ ] Manual: on Windows, make temp dir read-only → verify error message
- [ ] Manual: normal update flow still works end-to-end

## Manual Validation
1. Build and install on Windows
2. Download an update (state = "ready")
3. Test each failure mode:
   - Rename `Update.exe` → click "Restart to update" → expect "Update.exe not found" error in UI
   - Delete the downloaded Setup.exe → click update → expect "Update file was removed" error
   - Make `%TEMP%` read-only → click update → expect "Cannot write to temp directory" error
4. Verify normal update path still works when all prerequisites pass

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)