### PR TITLE
chore: bump version to 0.35.0-beta.4 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.35.0-beta.3",
+  "version": "0.35.0-beta.4",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Bug Fixes & Update Reliability

**Windows users on v0.32–v0.34:** Auto-update is broken on these versions. Please download the latest installer manually from the [Releases page](https://github.com/Agent-Clubhouse/Clubhouse/releases) to update.

# Bug Fixes
- Fixed Windows auto-updater console window issue via PowerShell launcher
- Added pre-flight validation before Windows update apply to prevent silent failures
- Reverted gradient/font theme support to fix Windows background rendering artifacts