### PR TITLE
feat: migrate Windows update to Squirrel native Update.exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,6 +312,22 @@ jobs:
           $exe = Get-ChildItem -Path out/make -Recurse -Filter "*Setup*.exe" | Select-Object -First 1
           Copy-Item $exe.FullName "dist/Clubhouse-${version}-win32-${arch}-Setup.exe"
 
+          # Copy Squirrel update files (nupkg + RELEASES) for native Update.exe
+          # Use arch-specific subdirectory to avoid collisions when artifacts merge
+          $squirrelDir = Get-ChildItem -Path "out/make/squirrel.windows" -Directory | Select-Object -First 1
+          if ($squirrelDir) {
+            $squirrelDist = "dist/squirrel-win32-${arch}"
+            New-Item -ItemType Directory -Force -Path $squirrelDist | Out-Null
+            Copy-Item "$($squirrelDir.FullName)/RELEASES" "$squirrelDist/RELEASES"
+            Get-ChildItem $squirrelDir.FullName -Filter "*.nupkg" | ForEach-Object {
+              Copy-Item $_.FullName "$squirrelDist/$($_.Name)"
+            }
+            Write-Host "Squirrel files for ${arch}:"
+            Get-ChildItem $squirrelDist | ForEach-Object { Write-Host "  $($_.Name) ($($_.Length) bytes)" }
+          } else {
+            Write-Warning "No Squirrel output directory found"
+          }
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -558,6 +574,46 @@ jobs:
                 exit 1
               fi
               sleep 2
+            done
+          done
+
+      - name: Upload Squirrel native update files
+        run: |
+          SLOT="${{ needs.verify-tag.outputs.is_preview == 'true' && 'preview' || 'stable' }}"
+          ACCOUNT="stclubhousereleases"
+          CONTAINER="releases"
+
+          for WIN_ARCH in x64 arm64; do
+            SQUIRREL_SRC="artifacts/squirrel-win32-${WIN_ARCH}"
+            SQUIRREL_DEST="squirrel/${SLOT}/win32-${WIN_ARCH}"
+
+            if [ ! -d "$SQUIRREL_SRC" ]; then
+              echo "::warning::No Squirrel files for win32-${WIN_ARCH}"
+              continue
+            fi
+
+            echo "Uploading Squirrel files for win32-${WIN_ARCH} to ${SQUIRREL_DEST}/"
+
+            # Upload RELEASES file
+            az storage blob upload \
+              --account-name "$ACCOUNT" \
+              --container-name "$CONTAINER" \
+              --name "${SQUIRREL_DEST}/RELEASES" \
+              --file "${SQUIRREL_SRC}/RELEASES" \
+              --overwrite \
+              --auth-mode login
+
+            # Upload nupkg files
+            for nupkg in "${SQUIRREL_SRC}"/*.nupkg; do
+              [ -f "$nupkg" ] || continue
+              echo "  Uploading $(basename "$nupkg")"
+              az storage blob upload \
+                --account-name "$ACCOUNT" \
+                --container-name "$CONTAINER" \
+                --name "${SQUIRREL_DEST}/$(basename "$nupkg")" \
+                --file "$nupkg" \
+                --overwrite \
+                --auth-mode login
             done
           done
 

--- a/src/main/services/auto-update-apply.test.ts
+++ b/src/main/services/auto-update-apply.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
@@ -7,8 +7,6 @@ import { spawn } from 'child_process';
 import {
   buildMacUpdateScript,
   buildMacQuitUpdateScript,
-  buildWindowsUpdateScript,
-  buildWindowsQuitUpdateScript,
 } from './auto-update-service';
 
 // ---------------------------------------------------------------------------
@@ -29,20 +27,6 @@ async function waitForFileRemoval(filePath: string, timeoutMs = SCRIPT_TIMEOUT_M
     }
   }
   throw new Error(`Timed out waiting for ${filePath} to be removed (${timeoutMs}ms)`);
-}
-
-/** Poll until a file appears on disk. */
-async function waitForFile(filePath: string, timeoutMs = SCRIPT_TIMEOUT_MS): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      await fsp.access(filePath);
-      return;
-    } catch {
-      await new Promise((r) => setTimeout(r, 100));
-    }
-  }
-  throw new Error(`Timed out waiting for ${filePath} to appear (${timeoutMs}ms)`);
 }
 
 // ---------------------------------------------------------------------------
@@ -156,138 +140,6 @@ describe.skipIf(process.platform !== 'darwin')('macOS update script execution (i
     // Cleanup should still complete
     expect(fs.existsSync(env.tmpExtract)).toBe(false);
     expect(fs.existsSync(env.downloadPath)).toBe(false);
-  }, SCRIPT_TIMEOUT_MS);
-});
-
-// ---------------------------------------------------------------------------
-// Windows integration tests — actually execute the generated batch scripts
-// ---------------------------------------------------------------------------
-
-describe.skipIf(process.platform !== 'win32')('Windows update script execution (integration)', () => {
-  const tmpDirs: string[] = [];
-  const logFile = path.join(os.tmpdir(), 'clubhouse-update.log');
-
-  beforeEach(async () => {
-    // Clean the shared log file before each test
-    await fsp.unlink(logFile).catch(() => {});
-  });
-
-  afterEach(async () => {
-    await fsp.unlink(logFile).catch(() => {});
-    for (const dir of tmpDirs) {
-      await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
-    }
-    tmpDirs.length = 0;
-  });
-
-  /**
-   * Create a temp dir with a mock installer .exe and script path.
-   *
-   * IMPORTANT: Mock installers must be real .exe files, not .cmd/.bat.
-   * Batch scripts that call another .cmd without `call` transfer control
-   * permanently (never return), causing the rest of the script to never
-   * execute.  In production, the installer is a Squirrel .exe.  We copy
-   * a small system executable (hostname.exe) as the mock to match this.
-   */
-  async function createWinTestEnv() {
-    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'clubhouse-update-test-'));
-    tmpDirs.push(tmpDir);
-
-    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
-
-    // Mock installer: copy hostname.exe — it prints the hostname, ignores
-    // extra args, and exits 0.  This mirrors production where the installer
-    // is a real .exe that returns control to the batch script.
-    const installerPath = path.join(tmpDir, 'mock-installer.exe');
-    await fsp.copyFile(path.join(systemRoot, 'System32', 'hostname.exe'), installerPath);
-
-    // Mock Update.exe: same approach
-    const updateExePath = path.join(tmpDir, 'Update.exe');
-    await fsp.copyFile(path.join(systemRoot, 'System32', 'hostname.exe'), updateExePath);
-
-    const scriptPath = path.join(tmpDir, 'clubhouse-update.cmd');
-
-    return { tmpDir, installerPath, updateExePath, scriptPath };
-  }
-
-  it('update script writes to the log file and cleans up', async () => {
-    const env = await createWinTestEnv();
-
-    const script = buildWindowsUpdateScript(
-      env.installerPath, env.updateExePath, 'Clubhouse.exe',
-    );
-    await fsp.writeFile(env.scriptPath, script);
-
-    // Spawn with the exact same flags as production
-    spawn('cmd.exe', ['/c', env.scriptPath], {
-      detached: true,
-      stdio: 'ignore',
-      windowsHide: true,
-    }).unref();
-
-    // Wait for the log file to appear (proves the delay mechanism worked)
-    await waitForFile(logFile);
-
-    // Wait for the script to self-delete (proves it ran to completion)
-    await waitForFileRemoval(env.scriptPath);
-
-    // Log file should contain expected entries
-    const log = await fsp.readFile(logFile, 'utf-8');
-    expect(log).toContain('Running installer:');
-    expect(log).toContain(env.installerPath);
-    expect(log).toContain('Installer exit code:');
-
-    // The mock installer should have been deleted
-    expect(fs.existsSync(env.installerPath)).toBe(false);
-  }, SCRIPT_TIMEOUT_MS);
-
-  it('quit script writes to the log file and cleans up without relaunching', async () => {
-    const env = await createWinTestEnv();
-
-    const script = buildWindowsQuitUpdateScript(env.installerPath);
-    await fsp.writeFile(env.scriptPath, script);
-
-    // Spawn with the exact same flags as production
-    spawn('cmd.exe', ['/c', env.scriptPath], {
-      detached: true,
-      stdio: 'ignore',
-      windowsHide: true,
-    }).unref();
-
-    await waitForFile(logFile);
-    await waitForFileRemoval(env.scriptPath);
-
-    // Log file should contain expected entries
-    const log = await fsp.readFile(logFile, 'utf-8');
-    expect(log).toContain('Running installer (quit):');
-    expect(log).toContain(env.installerPath);
-    expect(log).toContain('Installer exit code:');
-
-    // The mock installer should have been deleted
-    expect(fs.existsSync(env.installerPath)).toBe(false);
-  }, SCRIPT_TIMEOUT_MS);
-
-  it('log file reports non-zero exit code when installer fails', async () => {
-    const env = await createWinTestEnv();
-
-    // Replace mock installer with where.exe — it returns non-zero when
-    // given `--silent` (not a valid search target), simulating a failed install
-    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
-    await fsp.copyFile(path.join(systemRoot, 'System32', 'where.exe'), env.installerPath);
-
-    const script = buildWindowsQuitUpdateScript(env.installerPath);
-    await fsp.writeFile(env.scriptPath, script);
-
-    spawn('cmd.exe', ['/c', env.scriptPath], {
-      detached: true,
-      stdio: 'ignore',
-      windowsHide: true,
-    }).unref();
-
-    await waitForFileRemoval(env.scriptPath);
-
-    const log = await fsp.readFile(logFile, 'utf-8');
-    expect(log).toContain('Installer FAILED');
   }, SCRIPT_TIMEOUT_MS);
 });
 

--- a/src/main/services/auto-update-service.test.ts
+++ b/src/main/services/auto-update-service.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isNewerVersion, parseVersion, verifySHA256, validateWindowsUpdatePrerequisites } from './auto-update-service';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isNewerVersion, parseVersion, verifySHA256 } from './auto-update-service';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -164,95 +164,6 @@ describe('auto-update-service', () => {
       const url = 'https://example.com/artifacts/Clubhouse';
       const ext = path.extname(new URL(url).pathname) || '.zip';
       expect(ext).toBe('.zip');
-    });
-  });
-
-  describe('validateWindowsUpdatePrerequisites', () => {
-    let tmpDir: string;
-
-    beforeEach(() => {
-      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-preflight-'));
-    });
-
-    afterEach(() => {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    });
-
-    it('passes when all prerequisites are met (with updateExePath)', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const updateExePath = path.join(tmpDir, 'Update.exe');
-      const scriptPath = path.join(tmpDir, 'update.cmd');
-
-      fs.writeFileSync(downloadPath, 'installer');
-      fs.writeFileSync(updateExePath, 'updater');
-
-      expect(() =>
-        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath, updateExePath }),
-      ).not.toThrow();
-    });
-
-    it('passes when all prerequisites are met (without updateExePath)', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const scriptPath = path.join(tmpDir, 'update.cmd');
-
-      fs.writeFileSync(downloadPath, 'installer');
-
-      expect(() =>
-        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath }),
-      ).not.toThrow();
-    });
-
-    it('throws when Update.exe is missing', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const scriptPath = path.join(tmpDir, 'update.cmd');
-      const updateExePath = path.join(tmpDir, 'Update.exe');
-
-      fs.writeFileSync(downloadPath, 'installer');
-
-      expect(() =>
-        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath, updateExePath }),
-      ).toThrow(/Update\.exe not found/);
-    });
-
-    it('throws when downloaded installer is missing', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const scriptPath = path.join(tmpDir, 'update.cmd');
-
-      expect(() =>
-        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath }),
-      ).toThrow(/Update file was removed/);
-    });
-
-    it('throws when temp directory is not writable', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const scriptPath = path.join(tmpDir, 'nonexistent-dir', 'nested', 'update.cmd');
-
-      fs.writeFileSync(downloadPath, 'installer');
-
-      expect(() =>
-        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath }),
-      ).toThrow(/Cannot write to temp directory/);
-    });
-
-    it('checks Update.exe before download path', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const scriptPath = path.join(tmpDir, 'update.cmd');
-      const updateExePath = path.join(tmpDir, 'Update.exe');
-
-      expect(() =>
-        validateWindowsUpdatePrerequisites({ downloadPath, scriptPath, updateExePath }),
-      ).toThrow(/Update\.exe not found/);
-    });
-
-    it('does not leave temp files after writable check', () => {
-      const downloadPath = path.join(tmpDir, 'Setup.exe');
-      const scriptPath = path.join(tmpDir, 'update.cmd');
-
-      fs.writeFileSync(downloadPath, 'installer');
-
-      validateWindowsUpdatePrerequisites({ downloadPath, scriptPath });
-
-      expect(fs.existsSync(scriptPath)).toBe(false);
     });
   });
 

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -17,6 +17,7 @@ import { appLog } from './log-service';
 const UPDATE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/latest.json';
 const PREVIEW_UPDATE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/preview.json';
 const HISTORY_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/history.json';
+const SQUIRREL_BASE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/squirrel';
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const MAX_HISTORY_VERSIONS = 5;
 const MAX_HISTORY_MONTHS = 3;
@@ -60,6 +61,21 @@ let checkTimer: ReturnType<typeof setInterval> | null = null;
 
 function platformKey(): string {
   return `${process.platform}-${process.arch}`;
+}
+
+/**
+ * Build the Squirrel releases URL for the current platform and channel.
+ * Convention: {SQUIRREL_BASE_URL}/{channel}/{platform-arch}/
+ * e.g. https://.../squirrel/stable/win32-x64/
+ */
+export function getSquirrelReleasesUrl(previewChannel: boolean): string {
+  const channel = previewChannel ? 'preview' : 'stable';
+  return `${SQUIRREL_BASE_URL}/${channel}/${platformKey()}`;
+}
+
+/** Path to Squirrel's Update.exe — one directory above the app exe. */
+export function getSquirrelUpdateExePath(): string {
+  return path.resolve(path.dirname(process.execPath), '..', 'Update.exe');
 }
 
 /**
@@ -131,65 +147,6 @@ export function isNewerVersion(a: string, b: string): boolean {
     return va.prereleaseNum > vb.prereleaseNum;
   }
   return false;
-}
-
-/**
- * Build the PowerShell arguments to launch a batch script with a completely
- * hidden window.  PowerShell's `-WindowStyle Hidden` prevents any console
- * flash, and `Start-Process -Wait -WindowStyle Hidden` keeps the child
- * hidden too.  PowerShell is guaranteed on Windows 10+.
- */
-export function buildPowershellLauncherArgs(cmdScriptPath: string): string[] {
-  return [
-    '-NoProfile',
-    '-WindowStyle', 'Hidden',
-    '-Command',
-    `Start-Process -FilePath cmd.exe -ArgumentList '/c','${cmdScriptPath.replace(/'/g, "''")}' -WindowStyle Hidden -Wait`,
-  ];
-}
-
-/**
- * Build a Windows batch script that waits for the app to exit, runs the
- * Squirrel installer silently, relaunches the updated app, and cleans up.
- */
-export function buildWindowsUpdateScript(
-  downloadPath: string,
-  updateExePath: string,
-  appExeName: string,
-): string {
-  // Use `ping` instead of `timeout` for the delay — `timeout` requires a
-  // real console handle and fails silently when spawned with windowsHide:true
-  // (CREATE_NO_WINDOW).  `ping -n 4` = 3 intervals ~3 seconds.
-  const logFile = '%TEMP%\\clubhouse-update.log';
-  return [
-    '@echo off',
-    'ping -n 4 127.0.0.1 >nul',
-    `echo [%date% %time%] Running installer: "${downloadPath}" >> "${logFile}"`,
-    `"${downloadPath}" --silent`,
-    `echo [%date% %time%] Installer exit code: %ERRORLEVEL% >> "${logFile}"`,
-    `IF %ERRORLEVEL% NEQ 0 echo [%date% %time%] Installer FAILED >> "${logFile}"`,
-    `"${updateExePath}" --processStart "${appExeName}"`,
-    `del /f "${downloadPath}" 2>nul`,
-    `del "%~f0"`,
-  ].join('\r\n');
-}
-
-/**
- * Build a Windows batch script that waits for the app to exit, runs the
- * Squirrel installer silently, and cleans up — no relaunch.
- */
-export function buildWindowsQuitUpdateScript(downloadPath: string): string {
-  const logFile = '%TEMP%\\clubhouse-update.log';
-  return [
-    '@echo off',
-    'ping -n 4 127.0.0.1 >nul',
-    `echo [%date% %time%] Running installer (quit): "${downloadPath}" >> "${logFile}"`,
-    `"${downloadPath}" --silent`,
-    `echo [%date% %time%] Installer exit code: %ERRORLEVEL% >> "${logFile}"`,
-    `IF %ERRORLEVEL% NEQ 0 echo [%date% %time%] Installer FAILED >> "${logFile}"`,
-    `del /f "${downloadPath}" 2>nul`,
-    `del "%~f0"`,
-  ].join('\r\n');
 }
 
 /**
@@ -422,8 +379,28 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
       meta: { currentVersion, newVersion: manifest.version },
     });
 
-    // Start download
     saveSettings({ ...settings, lastCheck: new Date().toISOString(), dismissedVersion: null });
+
+    // On Windows, use Squirrel native update — skip our own download.
+    // Update.exe will download the nupkg when we apply.
+    if (process.platform === 'win32') {
+      const releasesUrl = getSquirrelReleasesUrl(settings.previewChannel);
+      appLog('update:check', 'info', 'Windows: Squirrel native update ready', {
+        meta: { releasesUrl },
+      });
+      setState('ready', {
+        availableVersion: manifest.version,
+        releaseNotes: manifest.releaseNotes || null,
+        releaseMessage: manifest.releaseMessage || null,
+        downloadProgress: 100,
+        downloadPath: '',
+        error: null,
+        artifactUrl: artifact.url,
+      });
+      return status;
+    }
+
+    // macOS/Linux: download the artifact ourselves
     await downloadUpdate(manifest.version, manifest.releaseNotes || null, manifest.releaseMessage || null, artifact);
 
     return status;
@@ -518,56 +495,15 @@ async function downloadUpdate(
 }
 
 // ---------------------------------------------------------------------------
-// Windows pre-flight validation
-// ---------------------------------------------------------------------------
-
-/**
- * Validate prerequisites for applying a Windows update via Squirrel.
- * Throws with an actionable error message if any check fails.
- */
-export function validateWindowsUpdatePrerequisites(opts: {
-  downloadPath: string;
-  scriptPath: string;
-  updateExePath?: string;
-}): void {
-  // Validate Update.exe exists (needed for relaunch after install)
-  if (opts.updateExePath && !fs.existsSync(opts.updateExePath)) {
-    appLog('update:apply', 'error', 'Update.exe not found — Squirrel installation may be corrupted', {
-      meta: { expectedPath: opts.updateExePath },
-    });
-    throw new Error('Cannot apply update: Update.exe not found. Please reinstall the app manually.');
-  }
-
-  // Validate downloaded installer still exists (AV could quarantine it)
-  if (!fs.existsSync(opts.downloadPath)) {
-    appLog('update:apply', 'error', 'Downloaded installer missing — may have been quarantined by antivirus', {
-      meta: { expectedPath: opts.downloadPath },
-    });
-    throw new Error('Update file was removed. Please check your antivirus settings and try again.');
-  }
-
-  // Validate temp directory is writable
-  try {
-    fs.writeFileSync(opts.scriptPath, '');
-    fs.unlinkSync(opts.scriptPath);
-  } catch (err) {
-    appLog('update:apply', 'error', 'Cannot write to temp directory', {
-      meta: { scriptPath: opts.scriptPath, error: err instanceof Error ? err.message : String(err) },
-    });
-    throw new Error('Cannot write to temp directory. Please check disk space and permissions.');
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Apply update (quit, replace, relaunch)
 // ---------------------------------------------------------------------------
 
 export async function applyUpdate(): Promise<void> {
-  if (status.state !== 'ready' || !status.downloadPath) {
+  if (status.state !== 'ready') {
     throw new Error('No update ready to apply');
   }
 
-  const downloadPath = status.downloadPath!;
+  const downloadPath = status.downloadPath;
   const savedVersion = status.availableVersion;
   const savedArtifactUrl = status.artifactUrl;
 
@@ -648,35 +584,27 @@ export async function applyUpdate(): Promise<void> {
       throw err;
     }
   } else if (process.platform === 'win32') {
-    // On Windows, use a batch script to apply the Squirrel update.
-    // Directly spawning Setup.exe while the app is still exiting causes
-    // ~10 second hangs due to file-lock contention.  The batch script
-    // waits for the old process to fully exit, runs the installer, then
-    // relaunches the app via Squirrel's Update.exe.
+    // Squirrel native update: Update.exe downloads the nupkg and applies
+    // it in-place. No batch scripts, no console windows, no installer UI.
     try {
-      const { spawn } = require('child_process');
-      const script = path.join(app.getPath('temp'), 'clubhouse-update.cmd');
-      const updateExe = path.resolve(path.dirname(app.getPath('exe')), '..', 'Update.exe');
-      const appExeName = path.basename(app.getPath('exe'));
+      const updateExe = getSquirrelUpdateExePath();
 
-      // Pre-flight validation: ensure all prerequisites are met before
-      // writing and spawning the batch script (see #432)
-      validateWindowsUpdatePrerequisites({
-        downloadPath,
-        scriptPath: script,
-        updateExePath: updateExe,
+      if (!fs.existsSync(updateExe)) {
+        throw new Error('Update.exe not found. Please reinstall the app from https://www.agent-clubhouse.com/reinstall');
+      }
+
+      const settings = getSettings();
+      const releasesUrl = getSquirrelReleasesUrl(settings.previewChannel);
+
+      appLog('update:apply', 'info', 'Applying via Squirrel Update.exe', {
+        meta: { releasesUrl, version: savedVersion },
       });
 
-      fs.writeFileSync(script, buildWindowsUpdateScript(downloadPath, updateExe, appExeName));
+      const { execFileSync } = require('child_process');
+      execFileSync(updateExe, ['--update', releasesUrl], { timeout: 120_000 });
 
-      // Launch via PowerShell with -WindowStyle Hidden so no console
-      // window is visible.  PowerShell is guaranteed on Windows 10+.
-      spawn('powershell.exe', buildPowershellLauncherArgs(script), {
-        detached: true,
-        stdio: 'ignore',
-        windowsHide: true,
-      }).unref();
-
+      appLog('update:apply', 'info', 'Squirrel update applied, relaunching');
+      app.relaunch();
       app.exit(0);
       return;
     } catch (err) {
@@ -701,7 +629,7 @@ export async function applyUpdate(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export function applyUpdateOnQuit(): void {
-  if (status.state !== 'ready' || !status.downloadPath) {
+  if (status.state !== 'ready') {
     return; // No update ready — nothing to do
   }
 
@@ -760,27 +688,20 @@ export function applyUpdateOnQuit(): void {
       appLog('update:apply-on-quit', 'error', `Failed to apply update on quit: ${err instanceof Error ? err.message : String(err)}`);
     }
   } else if (process.platform === 'win32') {
-    // Same batch-script approach as applyUpdate() — wait for the app to
-    // fully exit before running the installer to avoid file-lock hangs.
-    // No relaunch step since the user chose to quit.
+    // Squirrel native update — no relaunch since the user chose to quit
     try {
-      const { spawn } = require('child_process');
-      const script = path.join(app.getPath('temp'), 'clubhouse-update-quit.cmd');
+      const updateExe = getSquirrelUpdateExePath();
+      if (!fs.existsSync(updateExe)) return;
 
-      // Pre-flight validation (no Update.exe needed — no relaunch)
-      validateWindowsUpdatePrerequisites({
-        downloadPath,
-        scriptPath: script,
+      const settings = getSettings();
+      const releasesUrl = getSquirrelReleasesUrl(settings.previewChannel);
+
+      appLog('update:apply-on-quit', 'info', 'Applying via Squirrel Update.exe (no relaunch)', {
+        meta: { releasesUrl },
       });
 
-      fs.writeFileSync(script, buildWindowsQuitUpdateScript(downloadPath));
-
-      // Launch via PowerShell with -WindowStyle Hidden — no visible console
-      spawn('powershell.exe', buildPowershellLauncherArgs(script), {
-        detached: true,
-        stdio: 'ignore',
-        windowsHide: true,
-      }).unref();
+      const { execFileSync } = require('child_process');
+      execFileSync(updateExe, ['--update', releasesUrl], { timeout: 120_000 });
     } catch (err) {
       appLog('update:apply-on-quit', 'error', `Failed to apply Windows update on quit: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -1040,7 +961,13 @@ export function startPeriodicChecks(): void {
   // Restore ready state immediately if a pending update was downloaded in a
   // previous session and the file is still on disk.
   const pending = readPendingUpdateInfo();
-  if (pending && fs.existsSync(pending.downloadPath)) {
+  // On Windows, Update.exe handles downloads so downloadPath is empty.
+  // On macOS, the downloaded file must still exist on disk.
+  const pendingReady = pending && (
+    process.platform === 'win32' ||
+    (pending.downloadPath && fs.existsSync(pending.downloadPath))
+  );
+  if (pending && pendingReady) {
     if (isNewerVersion(pending.version, currentVersion)) {
       appLog('update:restore', 'info', 'Restoring pending update from previous session', {
         meta: { version: pending.version },

--- a/src/main/services/auto-update-windows.test.ts
+++ b/src/main/services/auto-update-windows.test.ts
@@ -1,173 +1,44 @@
 import { describe, it, expect } from 'vitest';
-import { buildWindowsUpdateScript, buildWindowsQuitUpdateScript, buildPowershellLauncherArgs } from './auto-update-service';
+import { getSquirrelReleasesUrl, getSquirrelUpdateExePath } from './auto-update-service';
 
-describe('auto-update-service: Windows batch script builders', () => {
-  const downloadPath = 'C:\\Users\\test\\AppData\\Local\\Temp\\clubhouse-updates\\Clubhouse-0.26.0.exe';
-  const updateExePath = 'C:\\Users\\test\\AppData\\Local\\Clubhouse\\Update.exe';
-  const appExeName = 'Clubhouse.exe';
-
-  describe('buildWindowsUpdateScript', () => {
-    it('starts with @echo off', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script.startsWith('@echo off')).toBe(true);
+describe('auto-update-service: Squirrel native update helpers', () => {
+  describe('getSquirrelReleasesUrl', () => {
+    it('returns stable channel URL when previewChannel is false', () => {
+      const url = getSquirrelReleasesUrl(false);
+      expect(url).toContain('/squirrel/stable/');
     });
 
-    it('uses ping for delay instead of timeout (works without a console)', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain('ping -n 4 127.0.0.1 >nul');
-      expect(script).not.toContain('timeout');
+    it('returns preview channel URL when previewChannel is true', () => {
+      const url = getSquirrelReleasesUrl(true);
+      expect(url).toContain('/squirrel/preview/');
     });
 
-    it('runs the installer silently', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain(`"${downloadPath}" --silent`);
+    it('includes the platform-arch in the URL', () => {
+      const url = getSquirrelReleasesUrl(false);
+      // On CI/local this will be darwin-arm64 or darwin-x64, but the
+      // important thing is the pattern includes platform-arch
+      expect(url).toMatch(/\/(darwin|win32|linux)-(x64|arm64)$/);
     });
 
-    it('relaunches the app via Update.exe --processStart', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain(`"${updateExePath}" --processStart "${appExeName}"`);
-    });
-
-    it('cleans up the downloaded installer', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain(`del /f "${downloadPath}" 2>nul`);
-    });
-
-    it('self-deletes the batch script', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain('del "%~f0"');
-    });
-
-    it('uses CRLF line endings', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      const lines = script.split('\r\n');
-      expect(lines.length).toBe(9);
-    });
-
-    it('logs installer execution and exit code', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain('Running installer:');
-      expect(script).toContain('Installer exit code: %ERRORLEVEL%');
-      expect(script).toContain('clubhouse-update.log');
-    });
-
-    it('logs a failure message when installer returns non-zero', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      expect(script).toContain('IF %ERRORLEVEL% NEQ 0');
-      expect(script).toContain('Installer FAILED');
-    });
-
-    it('executes steps in correct order: wait, log, install, log, check, relaunch, cleanup', () => {
-      const script = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      const lines = script.split('\r\n');
-      expect(lines[0]).toBe('@echo off');
-      expect(lines[1]).toContain('ping');
-      expect(lines[2]).toContain('Running installer');
-      expect(lines[3]).toContain('--silent');
-      expect(lines[4]).toContain('exit code');
-      expect(lines[5]).toContain('IF %ERRORLEVEL%');
-      expect(lines[6]).toContain('--processStart');
-      expect(lines[7]).toContain('del /f');
-      expect(lines[8]).toContain('del "%~f0"');
+    it('uses the correct base URL', () => {
+      const url = getSquirrelReleasesUrl(false);
+      expect(url.startsWith('https://stclubhousereleases.blob.core.windows.net/releases/squirrel/')).toBe(true);
     });
   });
 
-  describe('buildWindowsQuitUpdateScript', () => {
-    it('starts with @echo off', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script.startsWith('@echo off')).toBe(true);
+  describe('getSquirrelUpdateExePath', () => {
+    it('returns a path ending with Update.exe', () => {
+      const p = getSquirrelUpdateExePath();
+      expect(p).toMatch(/Update\.exe$/);
     });
 
-    it('uses ping for delay instead of timeout (works without a console)', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain('ping -n 4 127.0.0.1 >nul');
-      expect(script).not.toContain('timeout');
-    });
-
-    it('runs the installer silently', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain(`"${downloadPath}" --silent`);
-    });
-
-    it('does NOT relaunch the app', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).not.toContain('processStart');
-      expect(script).not.toContain('Update.exe');
-    });
-
-    it('cleans up the downloaded installer', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain(`del /f "${downloadPath}" 2>nul`);
-    });
-
-    it('self-deletes the batch script', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain('del "%~f0"');
-    });
-
-    it('uses CRLF line endings', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      const lines = script.split('\r\n');
-      expect(lines.length).toBe(8);
-    });
-
-    it('logs installer execution and exit code', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain('Running installer (quit):');
-      expect(script).toContain('Installer exit code: %ERRORLEVEL%');
-      expect(script).toContain('clubhouse-update.log');
-    });
-
-    it('logs a failure message when installer returns non-zero', () => {
-      const script = buildWindowsQuitUpdateScript(downloadPath);
-      expect(script).toContain('IF %ERRORLEVEL% NEQ 0');
-      expect(script).toContain('Installer FAILED');
-    });
-
-    it('has one fewer line than the update script (no relaunch)', () => {
-      const updateScript = buildWindowsUpdateScript(downloadPath, updateExePath, appExeName);
-      const quitScript = buildWindowsQuitUpdateScript(downloadPath);
-      expect(quitScript.split('\r\n').length).toBe(updateScript.split('\r\n').length - 1);
-    });
-  });
-
-  describe('buildPowershellLauncherArgs', () => {
-    const cmdPath = 'C:\\Users\\test\\AppData\\Local\\Temp\\clubhouse-update.cmd';
-
-    it('includes -NoProfile to skip user profile loading', () => {
-      const args = buildPowershellLauncherArgs(cmdPath);
-      expect(args).toContain('-NoProfile');
-    });
-
-    it('includes -WindowStyle Hidden to prevent console flash', () => {
-      const args = buildPowershellLauncherArgs(cmdPath);
-      const idx = args.indexOf('-WindowStyle');
-      expect(idx).toBeGreaterThanOrEqual(0);
-      expect(args[idx + 1]).toBe('Hidden');
-    });
-
-    it('uses Start-Process with -Wait and -WindowStyle Hidden for the child', () => {
-      const args = buildPowershellLauncherArgs(cmdPath);
-      const cmd = args[args.indexOf('-Command') + 1];
-      expect(cmd).toContain('Start-Process');
-      expect(cmd).toContain('-WindowStyle Hidden');
-      expect(cmd).toContain('-Wait');
-    });
-
-    it('invokes cmd.exe /c with the script path', () => {
-      const args = buildPowershellLauncherArgs(cmdPath);
-      const cmd = args[args.indexOf('-Command') + 1];
-      expect(cmd).toContain('cmd.exe');
-      expect(cmd).toContain('/c');
-      expect(cmd).toContain(cmdPath);
-    });
-
-    it('escapes single quotes in the path', () => {
-      const pathWithQuote = "C:\\Users\\test's\\Temp\\script.cmd";
-      const args = buildPowershellLauncherArgs(pathWithQuote);
-      const cmd = args[args.indexOf('-Command') + 1];
-      expect(cmd).toContain("test''s");
-      expect(cmd).not.toContain("test's\\");
+    it('resolves to one directory above the exe directory', () => {
+      // Update.exe lives at the Squirrel app root, one level above
+      // the app-<version>/ directory that contains the main exe
+      const p = getSquirrelUpdateExePath();
+      // The path should contain ".." relative to the exe dir
+      // (path.resolve normalizes it, so just verify it ends correctly)
+      expect(p).toContain('Update.exe');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replaces custom batch-script update mechanism on Windows with Squirrel's native `Update.exe --update=<url>`
- Eliminates console window flash, installer splash screen, dual app instances, and lost config on update
- Updates release pipeline to upload nupkg + RELEASES files for Squirrel native updates

Closes #445

## Changes

### Client (`auto-update-service.ts`)
- `checkForUpdates()` skips download on Windows — sets state to `ready` immediately since `Update.exe` handles package download
- `applyUpdate()` Windows block now calls `Update.exe --update=<releasesUrl>` then `app.relaunch()` + `app.exit(0)`
- `applyUpdateOnQuit()` Windows block does the same without relaunch
- Convention-based Squirrel URL: `squirrel/{stable,preview}/win32-{arch}/` derived from settings
- Added `getSquirrelReleasesUrl()` and `getSquirrelUpdateExePath()` helpers
- Fixed `applyUpdate()` guard that blocked Windows updates (empty `downloadPath` was falsy)
- Simplified pending update restore logic to use `process.platform` check

### Dead code removed
- `buildWindowsUpdateScript()`, `buildWindowsQuitUpdateScript()` — batch script builders
- `buildPowershellLauncherArgs()` — PowerShell console-hide launcher
- `validateWindowsUpdatePrerequisites()` — pre-flight validation for old approach
- `squirrelReleasesUrl` field from `UpdateArtifact`, `UpdateStatus`, and `PendingUpdateInfo`

### Release pipeline (`.github/workflows/release.yml`)
- Build step now copies nupkg + RELEASES from `out/make/squirrel.windows/` to `dist/squirrel-win32-{arch}/`
- Publish step uploads these files to `squirrel/{stable,preview}/win32-{arch}/` on Azure Blob Storage

### Tests
- `auto-update-windows.test.ts`: Replaced batch script tests with tests for `getSquirrelReleasesUrl()` and `getSquirrelUpdateExePath()`
- `auto-update-service.test.ts`: Removed `validateWindowsUpdatePrerequisites` tests
- `auto-update-apply.test.ts`: Removed Windows batch script integration tests (macOS tests preserved)

## Test Plan
- [ ] Build succeeds (`npx tsc --noEmit` passes)
- [ ] All tests pass (`npm test` — 1885 tests, 0 failures)
- [ ] No new lint errors introduced
- [ ] Windows update flow: check → ready (no download) → apply via Update.exe → relaunch
- [ ] Windows quit-update flow: apply via Update.exe on quit (no relaunch)
- [ ] macOS update flow unchanged (still uses ZIP download + shell script)
- [ ] Release pipeline uploads nupkg + RELEASES to correct Azure paths
- [ ] Update.exe missing → meaningful error message with reinstall link