### PR TITLE
chore: bump version to 0.35.0-beta.5 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.35.0-beta.4",
+  "version": "0.35.0-beta.5",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Squirrel Native Windows Updates

**Windows users on v0.32–v0.34:** Auto-update is broken on these versions. Please download the latest installer manually from the [Releases page](https://github.com/Agent-Clubhouse/Clubhouse/releases) to update.

# Bug Fixes
- Migrated Windows update to Squirrel native Update.exe flow, replacing fragile batch script mechanism that was broken since v0.33