### PR TITLE
Fix terminal focus not restoring on project switch

### DIFF
--- a/src/renderer/panels/MainContentView.test.tsx
+++ b/src/renderer/panels/MainContentView.test.tsx
@@ -9,7 +9,7 @@ import type { CompletedQuickAgent } from '../../shared/types';
 
 // Mock child components to isolate MainContentView logic
 vi.mock('../features/agents/AgentTerminal', () => ({
-  AgentTerminal: () => <div data-testid="agent-terminal" />,
+  AgentTerminal: (props: any) => <div data-testid="agent-terminal" data-focused={String(!!props.focused)} />,
 }));
 vi.mock('../features/agents/SleepingAgent', () => ({
   SleepingAgent: () => <div data-testid="sleeping-agent" />,
@@ -181,5 +181,87 @@ describe('MainContentView selectedCompleted derivation', () => {
     rerender(<MainContentView />);
     // selectedCompletedId still set but no matching record => no-active-agent
     expect(screen.getByTestId('no-active-agent')).toBeInTheDocument();
+  });
+});
+
+describe('MainContentView terminal focus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+  });
+
+  it('passes focused=true to AgentTerminal when on agents tab', async () => {
+    useAgentStore.setState({
+      agents: { 'a-1': { id: 'a-1', projectId: 'proj-1', status: 'running', kind: 'durable' } as any },
+      activeAgentId: 'a-1',
+    });
+
+    render(<MainContentView />);
+
+    // Allow the useEffect + rAF to settle
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByTestId('agent-terminal')).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('passes focused=false when switching away from agents tab', async () => {
+    useAgentStore.setState({
+      agents: { 'a-1': { id: 'a-1', projectId: 'proj-1', status: 'running', kind: 'durable' } as any },
+      activeAgentId: 'a-1',
+    });
+
+    const { rerender } = render(<MainContentView />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByTestId('agent-terminal')).toHaveAttribute('data-focused', 'true');
+
+    // Switch to settings tab
+    act(() => {
+      useUIStore.setState({ explorerTab: 'settings' });
+    });
+
+    rerender(<MainContentView />);
+
+    // AgentTerminal should no longer be rendered at all
+    expect(screen.queryByTestId('agent-terminal')).not.toBeInTheDocument();
+  });
+
+  it('re-focuses terminal after project switch', async () => {
+    useAgentStore.setState({
+      agents: {
+        'a-1': { id: 'a-1', projectId: 'proj-1', status: 'running', kind: 'durable' } as any,
+        'a-2': { id: 'a-2', projectId: 'proj-2', status: 'running', kind: 'durable' } as any,
+      },
+      activeAgentId: 'a-1',
+    });
+
+    const { rerender } = render(<MainContentView />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByTestId('agent-terminal')).toHaveAttribute('data-focused', 'true');
+
+    // Switch to project 2
+    act(() => {
+      useProjectStore.setState({ activeProjectId: 'proj-2' });
+      useAgentStore.setState({ activeAgentId: 'a-2' });
+    });
+
+    rerender(<MainContentView />);
+
+    // The effect sets focused=false first, then rAF sets true
+    // After rAF settles, focused should be true again
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByTestId('agent-terminal')).toHaveAttribute('data-focused', 'true');
   });
 });

--- a/src/renderer/panels/MainContentView.tsx
+++ b/src/renderer/panels/MainContentView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useUIStore } from '../stores/uiStore';
 import { useAgentStore } from '../stores/agentStore';
 import { useQuickAgentStore } from '../stores/quickAgentStore';
@@ -37,6 +37,32 @@ export function MainContentView() {
   const selectCompleted = useQuickAgentStore((s) => s.selectCompleted);
   const dismissCompleted = useQuickAgentStore((s) => s.dismissCompleted);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
+
+  // Track whether the agent terminal should receive focus.
+  // Must transition false→true to trigger AgentTerminal's focus useEffect,
+  // including on project switches where explorerTab stays 'agents'.
+  const isAgentView = explorerTab === 'agents';
+  const [terminalFocused, setTerminalFocused] = useState(false);
+  const prevProjectIdRef = useRef(activeProjectId);
+
+  useEffect(() => {
+    if (!isAgentView) {
+      setTerminalFocused(false);
+      return;
+    }
+
+    const projectChanged = prevProjectIdRef.current !== activeProjectId;
+    prevProjectIdRef.current = activeProjectId;
+
+    if (projectChanged) {
+      // Force a false→true transition so AgentTerminal re-focuses
+      setTerminalFocused(false);
+      const raf = requestAnimationFrame(() => setTerminalFocused(true));
+      return () => cancelAnimationFrame(raf);
+    }
+
+    setTerminalFocused(true);
+  }, [isAgentView, activeProjectId]);
 
   const selectedCompleted = useMemo(() => {
     if (!selectedCompletedId) return null;
@@ -95,7 +121,7 @@ export function MainContentView() {
 
     return (
       <div className="h-full bg-ctp-base" data-testid="agent-terminal-view">
-        <AgentTerminal agentId={activeAgentId!} />
+        <AgentTerminal agentId={activeAgentId!} focused={terminalFocused} />
       </div>
     );
   }


### PR DESCRIPTION
Fixes #428 - When switching away from an agent while it's thinking and returning, the terminal input becomes unresponsive because xterm.js never re-receives focus

## Changes
- Track agent view visibility in `MainContentView.tsx` via `explorerTab` and `activeProjectId`
- Pass computed `focused` prop to `<AgentTerminal>`, matching the pattern already used by `HubPane` and `PopoutAgentView`
- Use `requestAnimationFrame` to force a false→true transition on project switches where `explorerTab` stays `'agents'`
- Add 3 tests covering: focus on agents tab, unfocus on tab switch, re-focus after project switch

## Testing
- `npm run typecheck` passes
- All existing tests pass (3 pre-existing env-specific failures unrelated)
- New tests in `MainContentView.test.tsx` validate the focus behavior