### PR TITLE
feat: fork update manifest URLs to v2 paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,7 @@ jobs:
           az storage blob download \
             --account-name "$ACCOUNT" \
             --container-name "$CONTAINER" \
-            --name "updates/history.json" \
+            --name "updates/v2/history.json" \
             --file history-existing.json \
             --auth-mode login 2>/dev/null || echo '[]' > history-existing.json
 
@@ -495,7 +495,19 @@ jobs:
           done
 
           if [ "$IS_PREVIEW" = "true" ]; then
-            # Preview release: upload preview.json manifest
+            # Preview release: upload preview.json manifest to v2 path
+            az storage blob upload \
+              --account-name "$ACCOUNT" \
+              --container-name "$CONTAINER" \
+              --name "updates/v2/preview.json" \
+              --file artifacts/preview.json \
+              --overwrite \
+              --content-type "application/json" \
+              --auth-mode login
+
+            # Dual-publish to legacy path so clients on old URLs can bridge
+            # to this version, which knows how to check v2 paths.
+            # Remove this once legacy paths are pinned with static message (#458).
             az storage blob upload \
               --account-name "$ACCOUNT" \
               --container-name "$CONTAINER" \
@@ -508,7 +520,28 @@ jobs:
             # Copy installers to the preview/ slot (constantly overwritten)
             SLOT="preview"
           else
-            # Stable release: upload latest.json and history.json
+            # Stable release: upload latest.json and history.json to v2 paths
+            az storage blob upload \
+              --account-name "$ACCOUNT" \
+              --container-name "$CONTAINER" \
+              --name "updates/v2/latest.json" \
+              --file artifacts/latest.json \
+              --overwrite \
+              --content-type "application/json" \
+              --auth-mode login
+
+            az storage blob upload \
+              --account-name "$ACCOUNT" \
+              --container-name "$CONTAINER" \
+              --name "updates/v2/history.json" \
+              --file artifacts/history.json \
+              --overwrite \
+              --content-type "application/json" \
+              --auth-mode login
+
+            # Dual-publish to legacy paths so clients on old URLs can bridge
+            # to this version, which knows how to check v2 paths.
+            # Remove this once legacy paths are pinned with static message (#458).
             az storage blob upload \
               --account-name "$ACCOUNT" \
               --container-name "$CONTAINER" \

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -14,9 +14,12 @@ import { appLog, flush as flushLogs } from './log-service';
 // Config
 // ---------------------------------------------------------------------------
 
-const UPDATE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/latest.json';
-const PREVIEW_UPDATE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/preview.json';
-const HISTORY_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/history.json';
+// Manifest paths moved to v2/ to decouple from legacy clients (≤v0.34.0) whose
+// Windows update scripts are broken.  The old updates/*.json paths will be pinned
+// with a static "reinstall" message (see #458).
+const UPDATE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/v2/latest.json';
+const PREVIEW_UPDATE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/v2/preview.json';
+const HISTORY_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/updates/v2/history.json';
 const SQUIRREL_BASE_URL = 'https://stclubhousereleases.blob.core.windows.net/releases/squirrel';
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const MAX_HISTORY_VERSIONS = 5;


### PR DESCRIPTION
Release: Update Manifest URL Fork

## Summary
- Move update manifest checks from `updates/*.json` to `updates/v2/*.json` to decouple new clients from legacy clients (≤v0.34.0) whose Windows update scripts are broken
- Release workflow dual-publishes to both v2 and legacy paths during the transition so existing clients can bridge to the new URLs
- References #458 for the eventual legacy path static pin

## Changes
- **`src/main/services/auto-update-service.ts`**: Changed `UPDATE_URL`, `PREVIEW_UPDATE_URL`, and `HISTORY_URL` constants to point to `updates/v2/` paths, with comment explaining why
- **`.github/workflows/release.yml`**:
  - History download now reads from `updates/v2/history.json`
  - Primary manifest uploads go to `updates/v2/` paths
  - Added dual-publish to legacy `updates/` paths (with `#458` removal markers) so clients on old URLs can discover this version and migrate

## Upgrade Path
| Client | Behavior |
|--------|----------|
| ≤v0.34.0 (old URLs) | Polls old `latest.json` / `preview.json` → sees this release via dual-publish → updates → now on v2 URLs |
| ≥ this version (v2 URLs) | Polls `v2/latest.json` / `v2/preview.json` → normal flow |
| Broken Windows ≤v0.34.0 | Polls old path → sees update → can't apply (broken scripts) → banner visible. Later pinned via #458 |

Worst case: a long-dormant client updates twice quickly (→ bridge version → latest) but ends up fully current.

## Sequence: dual → single → static pin
1. **This release**: dual-publish (bridge existing clients)
2. **Next release**: remove dual-publish (all updatable clients have migrated)
3. **Eventually (#458)**: pin old paths with static reinstall message

## Test Plan
- [x] Typecheck passes
- [x] All 5366 tests pass (211 test files)
- [x] Lint: no new errors (all 91 are pre-existing)
- [ ] Deploy as beta, verify v2 manifests appear in Azure at `updates/v2/preview.json`
- [ ] Verify legacy `updates/preview.json` also updated (dual-publish)
- [ ] Verify client on previous beta sees update via old URL path
- [ ] After updating, verify new client checks `v2/` path on next cycle
- [ ] Test on both Mac and Windows

## Manual Validation
1. After merging and tagging a beta release, confirm both `updates/v2/preview.json` and `updates/preview.json` exist in Azure with matching content
2. On a client running the previous beta (old URLs), trigger update check — should discover the new version
3. After updating, inspect logs to confirm the client now fetches from `updates/v2/preview.json`
4. On Windows, confirm the update banner shows with the release message

🤖 Generated with [Claude Code](https://claude.com/claude-code)