### PR TITLE
feat: log manifest source URL during update checks

### DIFF
--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -306,9 +306,14 @@ export function verifySHA256(filePath: string, expectedHash: string): Promise<bo
  * fetch both the stable and preview manifests and pick whichever reports the
  * newer version (stable wins on a tie).
  */
-async function fetchBestManifest(previewChannel: boolean): Promise<UpdateManifest> {
+interface ManifestResult {
+  manifest: UpdateManifest;
+  sourceUrl: string;
+}
+
+async function fetchBestManifest(previewChannel: boolean): Promise<ManifestResult> {
   if (!previewChannel) {
-    return fetchJSON(UPDATE_URL);
+    return { manifest: await fetchJSON(UPDATE_URL), sourceUrl: UPDATE_URL };
   }
 
   // Fetch both in parallel; preview may not exist yet so we tolerate failure.
@@ -317,14 +322,14 @@ async function fetchBestManifest(previewChannel: boolean): Promise<UpdateManifes
     fetchJSON(PREVIEW_UPDATE_URL).catch(() => null as UpdateManifest | null),
   ]);
 
-  if (!preview) return stable;
+  if (!preview) return { manifest: stable, sourceUrl: UPDATE_URL };
 
   // Pick whichever is newer. isNewerVersion handles prerelease suffixes
   // (rc, -beta.N) and considers a stable release newer than its prerelease.
   if (isNewerVersion(preview.version, stable.version)) {
-    return preview;
+    return { manifest: preview, sourceUrl: PREVIEW_UPDATE_URL };
   }
-  return stable;
+  return { manifest: stable, sourceUrl: UPDATE_URL };
 }
 
 export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
@@ -343,8 +348,12 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
   });
 
   try {
-    const manifest = await fetchBestManifest(settings.previewChannel);
+    const { manifest, sourceUrl } = await fetchBestManifest(settings.previewChannel);
     const currentVersion = app.getVersion();
+
+    appLog('update:check', 'info', 'Fetched manifest', {
+      meta: { sourceUrl, manifestVersion: manifest.version },
+    });
 
     if (!isNewerVersion(manifest.version, currentVersion)) {
       appLog('update:check', 'info', 'App is up to date', {
@@ -965,7 +974,7 @@ export function composeVersionHistoryMarkdown(entries: VersionHistoryEntry[]): s
 
 export async function getVersionHistory(): Promise<{ markdown: string; entries: VersionHistoryEntry[] }> {
   const currentVersion = app.getVersion();
-  appLog('update:history', 'info', 'Fetching version history', { meta: { currentVersion } });
+  appLog('update:history', 'info', 'Fetching version history', { meta: { currentVersion, historyUrl: HISTORY_URL } });
 
   try {
     const entries = await fetchJSON<VersionHistoryEntry[]>(HISTORY_URL);


### PR DESCRIPTION
Release: Update Manifest URL Logging

## Summary
- Log which manifest URL the client fetches during update checks, so we can verify v1→v2 migration in app logs
- Adds `sourceUrl` to the `update:check` log entry and `historyUrl` to the `update:history` log entry

## Changes
- **`src/main/services/auto-update-service.ts`**:
  - `fetchBestManifest` now returns `{ manifest, sourceUrl }` instead of just the manifest
  - New `ManifestResult` interface for the return type
  - Added `Fetched manifest` log line with `sourceUrl` and `manifestVersion`
  - Added `historyUrl` to the version history fetch log

## Why
After the v2 manifest URL fork (#459), we need a way to confirm clients are checking the correct path. With this change, app logs will show:
```
update:check | Fetched manifest | { sourceUrl: "https://...updates/v2/latest.json", manifestVersion: "0.35.0" }
```

## Test Plan
- [x] Typecheck passes
- [x] All 5366 tests pass
- [x] Lint: no new errors
- [ ] After deploying, check app logs to confirm URL appears in update check entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)