### PR TITLE
fix: handle missing v2/latest.json in update checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,6 +517,25 @@ jobs:
               --content-type "application/json" \
               --auth-mode login
 
+            # Seed v2/latest.json from the legacy path if it doesn't exist yet.
+            # This is needed because no stable release may have shipped since the
+            # v2 migration, and clients check both manifests in parallel.
+            EXISTS=$(az storage blob exists \
+              --account-name "$ACCOUNT" \
+              --container-name "$CONTAINER" \
+              --name "updates/v2/latest.json" \
+              --auth-mode login \
+              --query "exists" --output tsv)
+            if [ "$EXISTS" != "true" ]; then
+              echo "Seeding v2/latest.json from legacy latest.json"
+              az storage blob copy start \
+                --account-name "$ACCOUNT" \
+                --destination-container "$CONTAINER" \
+                --destination-blob "updates/v2/latest.json" \
+                --source-uri "https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}/updates/latest.json" \
+                --auth-mode login
+            fi
+
             # Copy installers to the preview/ slot (constantly overwritten)
             SLOT="preview"
           else

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -218,7 +218,9 @@ function fetchJSON<T = UpdateManifest>(url: string): Promise<T> {
     const mod = url.startsWith('https') ? https : http;
     const req = mod.get(url, { timeout: 15_000 }, (res) => {
       if (res.statusCode !== 200) {
-        reject(new Error(`HTTP ${res.statusCode}`));
+        const err = new Error(`HTTP ${res.statusCode} fetching ${url}`);
+        appLog('update:fetch', 'error', err.message);
+        reject(err);
         res.resume();
         return;
       }
@@ -319,13 +321,18 @@ async function fetchBestManifest(previewChannel: boolean): Promise<ManifestResul
     return { manifest: await fetchJSON(UPDATE_URL), sourceUrl: UPDATE_URL };
   }
 
-  // Fetch both in parallel; preview may not exist yet so we tolerate failure.
+  // Fetch both in parallel; either may be missing (e.g. v2/latest.json
+  // didn't exist until the first stable release after the v2 migration).
   const [stable, preview] = await Promise.all([
-    fetchJSON(UPDATE_URL),
+    fetchJSON(UPDATE_URL).catch(() => null as UpdateManifest | null),
     fetchJSON(PREVIEW_UPDATE_URL).catch(() => null as UpdateManifest | null),
   ]);
 
-  if (!preview) return { manifest: stable, sourceUrl: UPDATE_URL };
+  if (!stable && !preview) {
+    throw new Error('Both stable and preview manifests unavailable');
+  }
+  if (!preview) return { manifest: stable!, sourceUrl: UPDATE_URL };
+  if (!stable) return { manifest: preview, sourceUrl: PREVIEW_UPDATE_URL };
 
   // Pick whichever is newer. isNewerVersion handles prerelease suffixes
   // (rc, -beta.N) and considers a stable release newer than its prerelease.


### PR DESCRIPTION
## Summary
- **Root cause**: `v2/latest.json` was never created because no stable release shipped after the v2 manifest migration. All beta.10+ clients hit a 404 on this URL, breaking update checks on both macOS and Windows.
- **Code fix**: Add `.catch()` to the stable manifest fetch in `fetchBestManifest` so a missing `v2/latest.json` doesn't break preview channel update checks. If only one manifest is available, use it; throw only if both fail.
- **Pipeline fix**: Preview releases now seed `v2/latest.json` from the legacy `v1/latest.json` if it doesn't exist yet (one-time bootstrap). This unblocks existing beta.10 clients that don't have the code fix.
- **Logging**: `fetchJSON` now includes the URL in error messages for faster 404 diagnosis.

## Deployment plan
Shipping as beta.12 triggers the release pipeline → pipeline seeds `v2/latest.json` → existing beta.10 clients get unblocked (blob exists) → new beta.12 clients are protected by the resilient code.

## Test plan
- [ ] Verify `v2/latest.json` gets seeded during the beta.12 release pipeline run
- [ ] Verify beta.10 clients can check for updates after `v2/latest.json` exists
- [ ] Verify beta.12 clients handle a missing stable manifest gracefully (preview-only fallback)
- [ ] Verify update checks still work normally when both manifests exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)