### PR TITLE
feat: add query params to update URLs

### DIFF
--- a/src/main/services/auto-update-service.test.ts
+++ b/src/main/services/auto-update-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { isNewerVersion, parseVersion, verifySHA256 } from './auto-update-service';
+import { isNewerVersion, parseVersion, verifySHA256, appendTelemetryParams } from './auto-update-service';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -164,6 +164,34 @@ describe('auto-update-service', () => {
       const url = 'https://example.com/artifacts/Clubhouse';
       const ext = path.extname(new URL(url).pathname) || '.zip';
       expect(ext).toBe('.zip');
+    });
+  });
+
+  describe('appendTelemetryParams', () => {
+    it('appends v, os, and arch query params to a plain URL', () => {
+      const result = appendTelemetryParams('https://example.com/latest.json');
+      expect(result).toMatch(/^https:\/\/example\.com\/latest\.json\?v=.+&os=.+&arch=.+$/);
+    });
+
+    it('uses & separator when URL already has query params', () => {
+      const result = appendTelemetryParams('https://example.com/latest.json?foo=bar');
+      expect(result).toMatch(/\?foo=bar&v=.+&os=.+&arch=.+$/);
+      // Should not have double ?
+      expect(result.split('?').length).toBe(2);
+    });
+
+    it('includes the current platform and arch', () => {
+      const result = appendTelemetryParams('https://example.com/file');
+      expect(result).toContain(`os=${process.platform}`);
+      expect(result).toContain(`arch=${process.arch}`);
+    });
+
+    it('does not alter the URL pathname (extension parsing still works)', () => {
+      const url = 'https://example.com/artifacts/Clubhouse-1.0.0-Setup.exe';
+      const result = appendTelemetryParams(url);
+      // pathname-based extension parsing should still yield .exe
+      const ext = path.extname(new URL(result).pathname);
+      expect(ext).toBe('.exe');
     });
   });
 

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -67,13 +67,25 @@ function platformKey(): string {
 }
 
 /**
+ * Append telemetry query params (version, os, arch) to a URL.
+ * Azure Blob Storage ignores unknown params but Log Analytics captures
+ * the full request URI, enabling stale-client monitoring.
+ */
+export function appendTelemetryParams(url: string): string {
+  const separator = url.includes('?') ? '&' : '?';
+  const version = app.getVersion();
+  return `${url}${separator}v=${encodeURIComponent(version)}&os=${encodeURIComponent(process.platform)}&arch=${encodeURIComponent(process.arch)}`;
+}
+
+/**
  * Build the Squirrel releases URL for the current platform and channel.
  * Convention: {SQUIRREL_BASE_URL}/{channel}/{platform-arch}/
  * e.g. https://.../squirrel/stable/win32-x64/
  */
 export function getSquirrelReleasesUrl(previewChannel: boolean): string {
   const channel = previewChannel ? 'preview' : 'stable';
-  return `${SQUIRREL_BASE_URL}/${channel}/${platformKey()}`;
+  const base = `${SQUIRREL_BASE_URL}/${channel}/${platformKey()}`;
+  return appendTelemetryParams(base);
 }
 
 /** Path to Squirrel's Update.exe — one directory above the app exe. */
@@ -318,14 +330,14 @@ interface ManifestResult {
 
 async function fetchBestManifest(previewChannel: boolean): Promise<ManifestResult> {
   if (!previewChannel) {
-    return { manifest: await fetchJSON(UPDATE_URL), sourceUrl: UPDATE_URL };
+    return { manifest: await fetchJSON(appendTelemetryParams(UPDATE_URL)), sourceUrl: UPDATE_URL };
   }
 
   // Fetch both in parallel; either may be missing (e.g. v2/latest.json
   // didn't exist until the first stable release after the v2 migration).
   const [stable, preview] = await Promise.all([
-    fetchJSON(UPDATE_URL).catch(() => null as UpdateManifest | null),
-    fetchJSON(PREVIEW_UPDATE_URL).catch(() => null as UpdateManifest | null),
+    fetchJSON(appendTelemetryParams(UPDATE_URL)).catch(() => null as UpdateManifest | null),
+    fetchJSON(appendTelemetryParams(PREVIEW_UPDATE_URL)).catch(() => null as UpdateManifest | null),
   ]);
 
   if (!stable && !preview) {
@@ -485,7 +497,7 @@ async function downloadUpdate(
   });
 
   try {
-    await downloadFile(artifact.url, destPath, artifact.size, (percent) => {
+    await downloadFile(appendTelemetryParams(artifact.url), destPath, artifact.size, (percent) => {
       status = { ...status, downloadProgress: percent };
       broadcastStatus();
     });
@@ -987,7 +999,7 @@ export async function getVersionHistory(): Promise<{ markdown: string; entries: 
   appLog('update:history', 'info', 'Fetching version history', { meta: { currentVersion, historyUrl: HISTORY_URL } });
 
   try {
-    const entries = await fetchJSON<VersionHistoryEntry[]>(HISTORY_URL);
+    const entries = await fetchJSON<VersionHistoryEntry[]>(appendTelemetryParams(HISTORY_URL));
     if (!Array.isArray(entries)) {
       appLog('update:history', 'warn', 'Invalid history.json format');
       return { markdown: '', entries: [] };

--- a/src/main/services/auto-update-windows.test.ts
+++ b/src/main/services/auto-update-windows.test.ts
@@ -14,16 +14,24 @@ describe('auto-update-service: Squirrel native update helpers', () => {
       expect(url).toContain('/squirrel/preview/');
     });
 
-    it('includes the platform-arch in the URL', () => {
+    it('includes the platform-arch in the URL path', () => {
       const url = getSquirrelReleasesUrl(false);
-      // On CI/local this will be darwin-arm64 or darwin-x64, but the
-      // important thing is the pattern includes platform-arch
-      expect(url).toMatch(/\/(darwin|win32|linux)-(x64|arm64)$/);
+      // The path segment should include platform-arch (query params follow)
+      const urlPath = new URL(url).pathname;
+      expect(urlPath).toMatch(/\/(darwin|win32|linux)-(x64|arm64)$/);
     });
 
     it('uses the correct base URL', () => {
       const url = getSquirrelReleasesUrl(false);
       expect(url.startsWith('https://stclubhousereleases.blob.core.windows.net/releases/squirrel/')).toBe(true);
+    });
+
+    it('includes telemetry query params', () => {
+      const url = getSquirrelReleasesUrl(false);
+      const parsed = new URL(url);
+      expect(parsed.searchParams.has('v')).toBe(true);
+      expect(parsed.searchParams.get('os')).toBe(process.platform);
+      expect(parsed.searchParams.get('arch')).toBe(process.arch);
     });
   });
 


### PR DESCRIPTION
## Summary
- Appends `?v=<version>&os=<platform>&arch=<arch>` query params to all outgoing update URLs
- Azure Blob Storage ignores unknown query params (files still served normally), but Log Analytics captures the full request URI
- Enables monitoring of client version distribution and stale client detection with zero infra changes

## Changes
- Added `appendTelemetryParams(url)` helper in `auto-update-service.ts` that appends `v`, `os`, and `arch` query params
- Applied to all outgoing URLs: manifest fetches (stable + preview), artifact downloads, version history, and Squirrel releases URLs
- Updated existing `getSquirrelReleasesUrl` tests to account for query params in URL
- Added new test suite for `appendTelemetryParams` covering plain URLs, URLs with existing params, platform/arch values, and pathname preservation

## Test Plan
- [x] `appendTelemetryParams` appends v/os/arch to plain URLs
- [x] Uses `&` separator when URL already has query params
- [x] Includes correct `process.platform` and `process.arch` values
- [x] Does not affect URL pathname (file extension parsing still works for `.exe`, `.zip`, etc.)
- [x] `getSquirrelReleasesUrl` includes telemetry params
- [x] All 5366 existing tests pass
- [x] Typecheck passes
- [x] Lint has no new errors

## Manual Validation
- After deploying, check Azure Log Analytics for request URIs containing `?v=...&os=...&arch=...` on blob storage requests
- Verify updates still download and apply correctly on macOS, Windows, and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)