### PR TITLE
fix: prevent badge dot clipping in Project Rail

### DIFF
--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../stores/projectStore';
+import { useUIStore } from '../stores/uiStore';
+import { useBadgeStore } from '../stores/badgeStore';
+import { useBadgeSettingsStore } from '../stores/badgeSettingsStore';
+import { usePluginStore } from '../plugins/plugin-store';
+import { ProjectRail } from './ProjectRail';
+import type { Project } from '../../shared/types';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-1',
+    name: 'test-project',
+    path: '/home/user/test-project',
+    ...overrides,
+  };
+}
+
+function resetStores() {
+  useProjectStore.setState({
+    projects: [],
+    activeProjectId: null,
+    projectIcons: {},
+  });
+  useUIStore.setState({
+    explorerTab: 'agents',
+    showHome: false,
+  });
+  usePluginStore.setState({
+    plugins: {},
+    appEnabled: [],
+    pluginSettings: {},
+  });
+  useBadgeStore.setState({ badges: {} });
+  useBadgeSettingsStore.setState({
+    enabled: true,
+    pluginBadges: true,
+    projectRailBadges: true,
+    projectOverrides: {},
+  });
+}
+
+describe('ProjectRail badge clipping', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(_cb: () => void) {}
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+    resetStores();
+  });
+
+  it('rail container uses asymmetric padding so badges are not clipped', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+    });
+
+    const { container } = render(<ProjectRail />);
+    // The rail container is the inner div with width transition
+    const railContainer = container.querySelector('[style*="width"]');
+    expect(railContainer).toBeTruthy();
+    // Should have pr-[10px] (not pr-[14px]) to give badges room
+    expect(railContainer!.className).toContain('pr-[10px]');
+    expect(railContainer!.className).toContain('pl-[14px]');
+  });
+
+  it('scroll container has top padding to prevent first badge from being clipped', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+    });
+
+    const { container } = render(<ProjectRail />);
+    // The scroll container holds the project list with overflow-y-auto
+    const scrollContainer = container.querySelector('.overflow-y-auto');
+    expect(scrollContainer).toBeTruthy();
+    expect(scrollContainer!.className).toContain('pt-1');
+  });
+
+  it('renders badge dot on project icon when badges are enabled', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+    });
+    useBadgeStore.setState({
+      badges: {
+        'test::explorer-tab:p1:agents': {
+          id: 'test::explorer-tab:p1:agents',
+          source: 'test',
+          type: 'dot',
+          value: 1,
+          target: { kind: 'explorer-tab', projectId: 'p1', tabId: 'agents' },
+        },
+      },
+    });
+
+    render(<ProjectRail />);
+    expect(screen.getByTestId('badge-dot')).toBeInTheDocument();
+  });
+
+  it('badge wrapper uses negative positioning that requires adequate container space', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+    });
+    useBadgeStore.setState({
+      badges: {
+        'test::explorer-tab:p1:agents': {
+          id: 'test::explorer-tab:p1:agents',
+          source: 'test',
+          type: 'dot',
+          value: 1,
+          target: { kind: 'explorer-tab', projectId: 'p1', tabId: 'agents' },
+        },
+      },
+    });
+
+    render(<ProjectRail />);
+    const badgeDot = screen.getByTestId('badge-dot');
+    const badgeWrapper = badgeDot.parentElement!;
+    // Badge wrapper uses -top-1 -right-1 to position outside icon bounds
+    expect(badgeWrapper.className).toContain('-top-1');
+    expect(badgeWrapper.className).toContain('-right-1');
+  });
+});

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -313,7 +313,7 @@ export function ProjectRail() {
       <div
         className={`
           flex flex-col py-3 gap-2 bg-ctp-mantle border-r border-surface-0 h-full
-          transition-[width] duration-200 ease-in-out overflow-hidden pl-[14px] pr-[14px]
+          transition-[width] duration-200 ease-in-out overflow-hidden pl-[14px] pr-[10px]
           ${overlaying ? 'absolute inset-y-0 left-0 z-30 shadow-xl shadow-black/20' : ''}
         `}
         style={{ width: expanded ? 200 : collapsedWidth }}
@@ -367,7 +367,7 @@ export function ProjectRail() {
           <div className="border-t border-surface-2 my-1 flex-shrink-0" />
         )}
 
-        <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col gap-2">
+        <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col gap-2 pt-1">
           {projects.map((p, i) => (
             <div
               key={p.id}


### PR DESCRIPTION
## Summary
- Fix badge dots being visually clipped in the collapsed Project Rail (Fixes #414)
- Reduce right padding from 14px to 10px so badge overhang fits within the scroll container
- Add top padding to the scroll container to prevent vertical clipping of the first item's badge

## Changes
- **`src/renderer/panels/ProjectRail.tsx`**: Changed rail container `pr-[14px]` → `pr-[10px]` to widen the content area from 42px to 46px, accommodating the 4px badge overhang from `-right-1` positioning. Added `pt-1` to the scroll container so the first project's badge (positioned at `-top-1`) isn't clipped at the scroll viewport edge.
- **`src/renderer/panels/ProjectRail.test.tsx`**: New test file verifying the padding fix, scroll container padding, badge rendering, and badge positioning classes.

## Test Plan
- [x] Rail container uses `pr-[10px]` (not `pr-[14px]`) for adequate badge space
- [x] Scroll container includes `pt-1` to prevent top-edge clipping
- [x] Badge dot renders on project icons when badges are enabled
- [x] Badge wrapper uses `-top-1 -right-1` positioning (confirming the layout assumption)
- [x] All 5414 existing tests continue to pass
- [x] Typecheck and lint pass clean

## Manual Validation
1. Open the app with at least one project that has an active badge (e.g. agent permission request)
2. Verify the badge dot in the collapsed Project Rail is fully visible — not clipped on the right or top edge
3. Expand the rail on hover and confirm badges still render correctly
4. Scroll through a long project list and verify badges on all items are fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)