### PR TITLE
feat: show agent worktree branch in file picker

### DIFF
--- a/src/renderer/plugins/builtin/files/FileTree.test.tsx
+++ b/src/renderer/plugins/builtin/files/FileTree.test.tsx
@@ -216,6 +216,70 @@ describe('FileTree', () => {
     });
   });
 
+  it('shows worktree branch when an agent worktree is selected', async () => {
+    const currentBranch = vi.fn(async (subPath?: string) => {
+      if (subPath === '.clubhouse/agents/my-agent') return 'my-agent/standby';
+      return 'main';
+    });
+    const readTree = vi.fn(async (path: string) => {
+      if (path === '.clubhouse/agents') {
+        return [{ name: 'my-agent', path: '/project/.clubhouse/agents/my-agent', isDirectory: true }];
+      }
+      if (path === '.' || path === '.clubhouse/agents/my-agent') return MOCK_TREE;
+      return [];
+    });
+    const api = createFilesAPI({
+      files: { ...createMockAPI().files, readTree },
+      git: { ...createMockAPI().git, currentBranch, status: vi.fn(async () => []) },
+    });
+
+    render(<FileTree api={api} />);
+
+    // Wait for worktree selector to appear, then switch to agent worktree
+    await waitFor(() => {
+      expect(screen.getByTitle('Switch worktree root')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTitle('Switch worktree root'), {
+      target: { value: '.clubhouse/agents/my-agent' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('my-agent/standby')).toBeInTheDocument();
+    });
+    expect(currentBranch).toHaveBeenCalledWith('.clubhouse/agents/my-agent');
+  });
+
+  it('shows "No Worktree" when agent directory has no git info', async () => {
+    const currentBranch = vi.fn(async (subPath?: string) => {
+      if (subPath === '.clubhouse/agents/no-wt-agent') return '';
+      return 'main';
+    });
+    const readTree = vi.fn(async (path: string) => {
+      if (path === '.clubhouse/agents') {
+        return [{ name: 'no-wt-agent', path: '/project/.clubhouse/agents/no-wt-agent', isDirectory: true }];
+      }
+      if (path === '.' || path === '.clubhouse/agents/no-wt-agent') return MOCK_TREE;
+      return [];
+    });
+    const api = createFilesAPI({
+      files: { ...createMockAPI().files, readTree },
+      git: { ...createMockAPI().git, currentBranch, status: vi.fn(async () => []) },
+    });
+
+    render(<FileTree api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Switch worktree root')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTitle('Switch worktree root'), {
+      target: { value: '.clubhouse/agents/no-wt-agent' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('No Worktree')).toBeInTheDocument();
+    });
+  });
+
   it('persists selected path to storage on file select', async () => {
     const write = vi.fn(async () => {});
     const api = createFilesAPI({

--- a/src/renderer/plugins/builtin/files/FileTree.ts
+++ b/src/renderer/plugins/builtin/files/FileTree.ts
@@ -378,15 +378,15 @@ export function FileTree({ api }: { api: PluginAPI }) {
     }
   }, [api]);
 
-  // Load current branch
+  // Load current branch — when viewing a worktree, resolve branch from that directory
   const loadBranch = useCallback(async () => {
     try {
-      const branch = await api.git.currentBranch();
+      const branch = await api.git.currentBranch(rootPath !== '.' ? rootPath : undefined);
       setCurrentBranch(branch);
     } catch {
       setCurrentBranch('');
     }
-  }, [api]);
+  }, [api, rootPath]);
 
   // Load worktree list
   const loadWorktrees = useCallback(async () => {
@@ -722,14 +722,15 @@ export function FileTree({ api }: { api: PluginAPI }) {
       React.createElement('div', {
         className: 'flex items-center gap-2 px-3 py-1',
       },
-        // Branch indicator
-        currentBranch
+        // Branch indicator — show worktree branch or "No Worktree" for agent dirs without one
+        (currentBranch || rootPath !== '.')
           ? React.createElement('div', {
               className: 'flex items-center gap-1 text-[10px] text-ctp-subtext0 flex-shrink-0',
-              title: `Branch: ${currentBranch}`,
+              title: currentBranch ? `Branch: ${currentBranch}` : 'No worktree',
             },
               GitBranchIcon,
-              React.createElement('span', { className: 'truncate max-w-[80px]' }, currentBranch),
+              React.createElement('span', { className: 'truncate max-w-[80px]' },
+                currentBranch || 'No Worktree'),
             )
           : null,
 

--- a/src/renderer/plugins/plugin-api-factory.ts
+++ b/src/renderer/plugins/plugin-api-factory.ts
@@ -271,8 +271,9 @@ function createGitAPI(ctx: PluginContext): GitAPI {
         date: e.date,
       }));
     },
-    async currentBranch(): Promise<string> {
-      const info = await window.clubhouse.git.info(projectPath);
+    async currentBranch(subPath?: string): Promise<string> {
+      const dirPath = subPath && subPath !== '.' ? `${projectPath}/${subPath}` : projectPath;
+      const info = await window.clubhouse.git.info(dirPath);
       return info.branch;
     },
     async diff(filePath: string, staged = false): Promise<string> {

--- a/src/renderer/plugins/testing.ts
+++ b/src/renderer/plugins/testing.ts
@@ -35,7 +35,7 @@ export function createMockAPI(overrides?: Partial<PluginAPI>): PluginAPI {
     git: {
       status: async () => [],
       log: async () => [],
-      currentBranch: async () => 'main',
+      currentBranch: async (_subPath?: string) => 'main',
       diff: async () => '',
     },
     storage: {

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -492,7 +492,7 @@ export interface ProjectsAPI {
 export interface GitAPI {
   status(): Promise<GitStatus[]>;
   log(limit?: number): Promise<GitCommit[]>;
-  currentBranch(): Promise<string>;
+  currentBranch(subPath?: string): Promise<string>;
   diff(filePath: string, staged?: boolean): Promise<string>;
 }
 


### PR DESCRIPTION
## Summary
- File picker branch indicator now shows the **worktree branch** when an agent worktree is selected, instead of always showing the root project branch (e.g., `main`)
- Agents without a worktree display "No Worktree" instead of a blank/missing branch indicator

## Changes
- **`plugin-types.ts`**: Added optional `subPath` parameter to `GitAPI.currentBranch(subPath?: string)`
- **`plugin-api-factory.ts`**: When `subPath` is provided, resolves it against `projectPath` and queries git info for that directory
- **`FileTree.ts`**: `loadBranch` now passes the current `rootPath` to `currentBranch()` when viewing a worktree; branch indicator shows "No Worktree" for agent directories without git info
- **`testing.ts`**: Updated mock signature to match new optional parameter

## Test Plan
- [x] Branch indicator shows root branch (`main`) when root is selected
- [x] Branch indicator updates to show worktree branch (e.g., `my-agent/standby`) when switching to an agent worktree via the dropdown
- [x] "No Worktree" is displayed when the selected agent directory has no `.git`
- [x] All existing FileTree tests continue to pass (31 tests)
- [x] Full test suite passes (5467 tests)
- [x] Type check and lint clean

## Manual Validation
1. Open the files plugin sidebar
2. Use the worktree dropdown to select a durable agent that has a worktree — branch indicator should show that agent's branch (e.g., `agent-name/standby`)
3. Switch back to `/ (root)` — branch should revert to the root branch
4. If an agent directory exists without a worktree, it should show "No Worktree"

🤖 Generated with [Claude Code](https://claude.com/claude-code)