### PR TITLE
feat: add Codex CLI sleeping mascot with EVE-inspired design

### DIFF
--- a/src/renderer/features/agents/SleepingMascots.test.tsx
+++ b/src/renderer/features/agents/SleepingMascots.test.tsx
@@ -5,6 +5,7 @@ import {
   SleepingMascot,
   ClaudeCodeSleeping,
   CopilotSleeping,
+  CodexCliSleeping,
   GenericRobotSleeping,
 } from './SleepingMascots';
 
@@ -22,6 +23,13 @@ describe('SleepingMascots', () => {
       // Copilot mascot uses the dark body color
       const body = container.querySelector('rect[fill="#1e1e2e"]');
       expect(body).not.toBeNull();
+    });
+
+    it('renders CodexCliSleeping for codex-cli orchestrator', () => {
+      const { container } = render(<SleepingMascot orchestrator="codex-cli" />);
+      // Codex mascot uses the white/light body color in its head
+      const head = container.querySelector('ellipse[fill="#E8E8EC"]');
+      expect(head).not.toBeNull();
     });
 
     it('renders GenericRobotSleeping for opencode orchestrator', () => {
@@ -81,6 +89,48 @@ describe('SleepingMascots', () => {
 
     it('contains animated Zzz text elements', () => {
       const { container } = render(<CopilotSleeping />);
+      const zTexts = container.querySelectorAll('text tspan');
+      expect(zTexts.length).toBe(3);
+    });
+  });
+
+  describe('CodexCliSleeping', () => {
+    it('renders an SVG with 200x200 dimensions', () => {
+      const { container } = render(<CodexCliSleeping />);
+      const svg = container.querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg!.getAttribute('width')).toBe('200');
+      expect(svg!.getAttribute('height')).toBe('200');
+    });
+
+    it('has a smooth oval head and dark visor', () => {
+      const { container } = render(<CodexCliSleeping />);
+      const head = container.querySelector('ellipse[fill="#E8E8EC"]');
+      const visor = container.querySelector('ellipse[fill="#0a0a14"]');
+      expect(head).not.toBeNull();
+      expect(visor).not.toBeNull();
+    });
+
+    it('has leaf-shaped arms', () => {
+      const { container } = render(<CodexCliSleeping />);
+      const arms = container.querySelectorAll('ellipse[fill="#D0D0D8"]');
+      expect(arms.length).toBe(2);
+    });
+
+    it('has a tapered body', () => {
+      const { container } = render(<CodexCliSleeping />);
+      const body = container.querySelector('path[fill="#E0E0E8"]');
+      expect(body).not.toBeNull();
+    });
+
+    it('has a Codex indigo accent', () => {
+      const { container } = render(<CodexCliSleeping />);
+      const accent = container.querySelector('rect[fill="#6B6BDE"]');
+      expect(accent).not.toBeNull();
+    });
+
+    it('contains animated Zzz text elements', () => {
+      const { container } = render(<CodexCliSleeping />);
       const zTexts = container.querySelectorAll('text tspan');
       expect(zTexts.length).toBe(3);
     });

--- a/src/renderer/features/agents/SleepingMascots.tsx
+++ b/src/renderer/features/agents/SleepingMascots.tsx
@@ -241,6 +241,59 @@ export function GenericRobotSleeping() {
   );
 }
 
+/* ── Codex CLI mascot ────────────────────────────────────────────── */
+
+export function CodexCliSleeping() {
+  return (
+    <svg width="200" height="200" viewBox="0 0 100 100" className="drop-shadow-lg">
+      {/* Ground shadow */}
+      <ellipse cx="50" cy="90" rx="18" ry="2.5" fill="#181825" opacity="0.3" />
+
+      {/* Arms — smooth leaf/paddle shapes, behind body */}
+      <ellipse cx="20" cy="60" rx="7" ry="18" transform="rotate(-12, 20, 60)" fill="#D0D0D8" />
+      <ellipse cx="80" cy="60" rx="7" ry="18" transform="rotate(12, 80, 60)" fill="#D0D0D8" />
+
+      {/* Body — tapered cup shape (wide top, narrow bottom) */}
+      <path
+        d="M 30 46 Q 30 44 32 44 L 68 44 Q 70 44 70 46 L 63 82 Q 61 88 50 88 Q 39 88 37 82 Z"
+        fill="#E0E0E8"
+      />
+
+      {/* Body highlight */}
+      <path
+        d="M 33 46 L 67 46 L 65 52 L 35 52 Z"
+        fill="#EAEAF0"
+        opacity="0.4"
+      />
+
+      {/* Head — smooth oval */}
+      <ellipse cx="50" cy="28" rx="24" ry="20" fill="#E8E8EC" />
+
+      {/* Head highlight */}
+      <ellipse cx="44" cy="18" rx="14" ry="8" fill="#F0F0F6" opacity="0.35" />
+
+      {/* Visor / face panel */}
+      <ellipse cx="50" cy="32" rx="18" ry="12" fill="#0a0a14" />
+
+      {/* Sleeping eyes — dim blue crescents */}
+      <ellipse cx="40" cy="34" rx="5" ry="3" fill="#3a6a9a" opacity="0.4" />
+      <ellipse cx="60" cy="34" rx="5" ry="3" fill="#3a6a9a" opacity="0.4" />
+      {/* Eyelid overlay — visor covers top of eye */}
+      <ellipse cx="40" cy="32" rx="5.5" ry="3" fill="#0a0a14" />
+      <ellipse cx="60" cy="32" rx="5.5" ry="3" fill="#0a0a14" />
+
+      {/* Codex indigo accent at neck */}
+      <rect x="36" y="43" width="28" height="1.5" rx="0.75" fill="#6B6BDE" opacity="0.25" />
+
+      {/* Codex terminal prompt on chest >_ */}
+      <path d="M 44 60 L 48 63 L 44 66" stroke="#9898B0" strokeWidth="1.2" fill="none" strokeLinecap="round" strokeLinejoin="round" opacity="0.35" />
+      <line x1="50" y1="66" x2="56" y2="66" stroke="#9898B0" strokeWidth="1.2" strokeLinecap="round" opacity="0.35" />
+
+      <SleepingZzz x={68} y={8} />
+    </svg>
+  );
+}
+
 /* ── Mascot selector ──────────────────────────────────────────────── */
 
 export function SleepingMascot({ orchestrator }: { orchestrator?: OrchestratorId }) {
@@ -249,6 +302,8 @@ export function SleepingMascot({ orchestrator }: { orchestrator?: OrchestratorId
       return <ClaudeCodeSleeping />;
     case 'copilot-cli':
       return <CopilotSleeping />;
+    case 'codex-cli':
+      return <CodexCliSleeping />;
     default:
       return <GenericRobotSleeping />;
   }


### PR DESCRIPTION
## Summary
- Added a new `CodexCliSleeping` mascot for OpenAI's Codex CLI agent, inspired by EVE from Pixar
- Modern sleek robot design: smooth oval head with dark visor, tapered white body, leaf-shaped paddle arms
- Wired into `SleepingMascot` selector for `codex-cli` orchestrator ID

## Changes
- **`SleepingMascots.tsx`**: Added `CodexCliSleeping` component with:
  - Smooth oval head in clean white (#E8E8EC) with highlight
  - Dark wraparound visor (#0a0a14) with dim blue eye crescents (#3a6a9a) — half-closed for sleeping
  - Tapered cup-shaped body (#E0E0E8) narrowing toward the base
  - Two leaf-shaped paddle arms (#D0D0D8) at the sides
  - Codex terminal prompt `>_` on chest (subtle, from Codex branding)
  - Indigo accent line (#6B6BDE) at the neck (Codex brand color)
  - Zzz animation for sleeping state
  - Added `'codex-cli'` case to `SleepingMascot` selector switch
- **`SleepingMascots.test.tsx`**: Added 7 new tests:
  - Selector test for `codex-cli` orchestrator
  - SVG dimensions, head + visor, leaf arms, tapered body, indigo accent, Zzz animation

## Test Plan
- [x] All 20 SleepingMascots tests pass (7 new)
- [x] Typecheck passes
- [ ] Visual review: Codex mascot renders with correct EVE-like shape
- [ ] Verify mascot appears when a Codex CLI agent is in sleeping state
- [ ] Confirm existing Claude Code, Copilot, and generic mascots still render correctly

## Manual Validation
1. Open Clubhouse with a Codex CLI agent configured
2. Ensure the agent is in sleeping/idle state
3. Verify the mascot shows: white oval head, dark visor with dim blue eyes, tapered body, paddle arms, `>_` prompt, Zzz
4. Check other orchestrator mascots still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)