### PR TITLE
fix: keyboard navigation in Files tab tree (#511)

### DIFF
--- a/src/renderer/plugins/builtin/files/FileTree.test.tsx
+++ b/src/renderer/plugins/builtin/files/FileTree.test.tsx
@@ -200,9 +200,9 @@ describe('FileTree', () => {
     const treeContainer = container.querySelector('[tabindex="0"]')!;
     fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
 
-    // Focus should move to the first item
+    // Focus should move to the first item with the visible focus indicator
     await waitFor(() => {
-      const focused = container.querySelector('[class*="bg-ctp-surface0"]');
+      const focused = container.querySelector('[class*="ring-ctp-blue"]');
       expect(focused).not.toBeNull();
     });
   });
@@ -903,6 +903,331 @@ describe('FileTree — flicker prevention', () => {
     await waitFor(() => {
       expect(screen.getByText('src')).toBeInTheDocument();
       expect(screen.getByText('README.md')).toBeInTheDocument();
+    });
+  });
+});
+
+// ── Keyboard navigation ───────────────────────────────────────────────
+
+describe('FileTree — keyboard navigation', () => {
+  beforeEach(() => {
+    fileState.reset();
+  });
+
+  it('onFocus initializes focusedPath to first visible node', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+    fireEvent.focus(treeContainer);
+
+    // After focus, first ArrowDown should move to the second item (docs)
+    // because focus was initialized to the first item (src)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      const docsNode = container.querySelector('[data-path="/project/docs"]');
+      expect(docsNode?.className).toContain('ring-ctp-blue');
+    });
+  });
+
+  it('onFocus initializes focusedPath to selected item when one exists', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    // Click to select README.md
+    const readme = await screen.findByText('README.md');
+    fireEvent.click(readme);
+
+    // Clear focus by blurring, then refocus
+    const treeContainer = container.querySelector('[role="tree"]')!;
+    fireEvent.blur(treeContainer);
+    // Reset focusedPath — simulate losing focus state
+    fireEvent.keyDown(treeContainer, { key: 'Escape' }); // no-op key, just so handleFocus triggers fresh
+
+    fireEvent.focus(treeContainer);
+
+    // ArrowDown from selected README.md should move to package.json (next item)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      const pkgNode = container.querySelector('[data-path="/project/package.json"]');
+      expect(pkgNode?.className).toContain('ring-ctp-blue');
+    });
+  });
+
+  it('ArrowDown wraps around to first item at end of list', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Move to last item: src, docs, README.md, package.json (4 items)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → src
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → docs
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → README.md
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → package.json
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → wraps to src
+
+    await waitFor(() => {
+      const srcNode = container.querySelector('[data-path="/project/src"]');
+      expect(srcNode?.className).toContain('ring-ctp-blue');
+    });
+  });
+
+  it('ArrowUp wraps around to last item at beginning of list', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Move focus to first item, then up to wrap
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → src
+    fireEvent.keyDown(treeContainer, { key: 'ArrowUp' });   // → wraps to package.json
+
+    await waitFor(() => {
+      const pkgNode = container.querySelector('[data-path="/project/package.json"]');
+      expect(pkgNode?.className).toContain('ring-ctp-blue');
+    });
+  });
+
+  it('ArrowRight expands a collapsed directory', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Focus on src (first item)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+
+    // ArrowRight should expand src
+    fireEvent.keyDown(treeContainer, { key: 'ArrowRight' });
+
+    await waitFor(() => {
+      expect(screen.getByText('index.ts')).toBeInTheDocument();
+    });
+  });
+
+  it('ArrowLeft collapses an expanded directory', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Focus on src and expand it
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+    fireEvent.keyDown(treeContainer, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByText('index.ts')).toBeInTheDocument());
+
+    // ArrowLeft should collapse src
+    fireEvent.keyDown(treeContainer, { key: 'ArrowLeft' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('index.ts')).not.toBeInTheDocument();
+    });
+  });
+
+  it('ArrowRight does nothing on an already expanded directory', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Focus on src and expand it
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+    fireEvent.keyDown(treeContainer, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByText('index.ts')).toBeInTheDocument());
+
+    // ArrowRight again should do nothing (already expanded)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowRight' });
+
+    // Still expanded, children visible
+    expect(screen.getByText('index.ts')).toBeInTheDocument();
+  });
+
+  it('ArrowLeft does nothing on a collapsed directory', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Focus on src (collapsed by default)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+
+    // ArrowLeft should do nothing (already collapsed)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowLeft' });
+
+    expect(screen.queryByText('index.ts')).not.toBeInTheDocument();
+  });
+
+  it('Space key opens preview tab for focused file', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Navigate to README.md (3rd item: src, docs, README.md)
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → src
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → docs
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' }); // → README.md
+
+    // Space should open preview tab
+    fireEvent.keyDown(treeContainer, { key: ' ' });
+
+    await waitFor(() => {
+      const tab = fileState.getTabByPath('README.md');
+      expect(tab).toBeDefined();
+      expect(tab!.isPreview).toBe(true);
+    });
+  });
+
+  it('focus indicator is visually distinct from hover style', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+
+    // Focus on src
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      const srcNode = container.querySelector('[data-path="/project/src"]');
+      // Focus uses ring-ctp-blue, not just bg-ctp-surface0
+      expect(srcNode?.className).toContain('ring-ctp-blue');
+      expect(srcNode?.className).toContain('bg-ctp-surface1/60');
+    });
+
+    // Non-focused items should NOT have the focus ring
+    const docsNode = container.querySelector('[data-path="/project/docs"]');
+    expect(docsNode?.className).not.toContain('ring-ctp-blue');
+  });
+});
+
+// ── ARIA and accessibility ────────────────────────────────────────────
+
+describe('FileTree — accessibility', () => {
+  beforeEach(() => {
+    fileState.reset();
+  });
+
+  it('container has role="tree" and tabIndex', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]');
+    expect(treeContainer).not.toBeNull();
+    expect(treeContainer?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('container has focus ring classes', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    const treeContainer = container.querySelector('[role="tree"]');
+    expect(treeContainer?.className).toContain('focus:ring-1');
+    expect(treeContainer?.className).toContain('focus:ring-ctp-blue/50');
+  });
+
+  it('tree items have role="treeitem" and aria attributes', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    // Check directory node
+    const srcNode = container.querySelector('[data-path="/project/src"]');
+    expect(srcNode?.getAttribute('role')).toBe('treeitem');
+    expect(srcNode?.getAttribute('tabindex')).toBe('-1');
+    expect(srcNode?.getAttribute('aria-expanded')).toBe('false');
+    expect(srcNode?.getAttribute('aria-level')).toBe('1');
+    expect(srcNode?.getAttribute('aria-selected')).toBe('false');
+
+    // Check file node
+    const readmeNode = container.querySelector('[data-path="/project/README.md"]');
+    expect(readmeNode?.getAttribute('role')).toBe('treeitem');
+    expect(readmeNode?.getAttribute('aria-expanded')).toBeNull(); // files don't have aria-expanded
+    expect(readmeNode?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('expanded directory has aria-expanded="true"', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    // Expand src
+    fireEvent.click(screen.getByText('src'));
+
+    await waitFor(() => {
+      const srcNode = container.querySelector('[data-path="/project/src"]');
+      expect(srcNode?.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  it('selected file has aria-selected="true"', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    const readme = await screen.findByText('README.md');
+    fireEvent.click(readme);
+
+    await waitFor(() => {
+      const readmeNode = container.querySelector('[data-path="/project/README.md"]');
+      expect(readmeNode?.getAttribute('aria-selected')).toBe('true');
+    });
+  });
+
+  it('nested tree items have correct aria-level', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    // Expand src to see children
+    fireEvent.click(screen.getByText('src'));
+    await waitFor(() => expect(screen.getByText('index.ts')).toBeInTheDocument());
+
+    const indexNode = container.querySelector('[data-path="/project/src/index.ts"]');
+    expect(indexNode?.getAttribute('aria-level')).toBe('2');
+  });
+
+  it('scrollIntoView is called when focused path changes', async () => {
+    const api = createRealisticAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    await screen.findByText('src');
+
+    // Mock scrollIntoView on the target element
+    const srcNode = container.querySelector('[data-path="/project/src"]') as HTMLElement;
+    srcNode.scrollIntoView = vi.fn();
+
+    const treeContainer = container.querySelector('[role="tree"]')!;
+    fireEvent.keyDown(treeContainer, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(srcNode.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
     });
   });
 });

--- a/src/renderer/plugins/builtin/files/FileTree.ts
+++ b/src/renderer/plugins/builtin/files/FileTree.ts
@@ -194,7 +194,7 @@ const TreeNode = React.memo(function TreeNodeInner({ node, depth, expanded, onTo
   const relPath = getRelativePath(node.path, projectPath);
   const gitStatus = gitMap.get(relPath);
 
-  const bgClass = isSelected ? 'bg-ctp-surface1' : isFocused ? 'bg-ctp-surface0' : 'hover:bg-ctp-surface0';
+  const bgClass = isSelected ? 'bg-ctp-surface1' : isFocused ? 'bg-ctp-surface1/60 ring-1 ring-inset ring-ctp-blue' : 'hover:bg-ctp-surface0';
 
   const handleClick = () => {
     if (node.isDirectory) {
@@ -227,6 +227,11 @@ const TreeNode = React.memo(function TreeNodeInner({ node, depth, expanded, onTo
       onDoubleClick: handleDoubleClick,
       onContextMenu: (e: React.MouseEvent) => onContextMenu(e, node),
       'data-path': node.path,
+      role: 'treeitem',
+      tabIndex: -1,
+      'aria-expanded': node.isDirectory ? isExpanded : undefined,
+      'aria-selected': isSelected,
+      'aria-level': depth + 1,
     },
       chevron,
       icon,
@@ -727,6 +732,26 @@ export function FileTree({ api }: { api: PluginAPI }) {
         setFocusedPath(visible[prevIndex].path);
         break;
       }
+      case 'ArrowRight': {
+        e.preventDefault();
+        if (focusedPath) {
+          const node = visible.find((n) => n.path === focusedPath);
+          if (node?.isDirectory && !expanded.has(node.path)) {
+            toggleExpand(node.path);
+          }
+        }
+        break;
+      }
+      case 'ArrowLeft': {
+        e.preventDefault();
+        if (focusedPath) {
+          const node = visible.find((n) => n.path === focusedPath);
+          if (node?.isDirectory && expanded.has(node.path)) {
+            toggleExpand(node.path);
+          }
+        }
+        break;
+      }
       case 'Enter': {
         e.preventDefault();
         if (focusedPath) {
@@ -738,6 +763,16 @@ export function FileTree({ api }: { api: PluginAPI }) {
               // Enter opens permanently (like double-click)
               openFilePermanently(node.path);
             }
+          }
+        }
+        break;
+      }
+      case ' ': {
+        e.preventDefault();
+        if (focusedPath) {
+          const node = visible.find((n) => n.path === focusedPath);
+          if (node && !node.isDirectory) {
+            selectFile(node.path);
           }
         }
         break;
@@ -754,7 +789,23 @@ export function FileTree({ api }: { api: PluginAPI }) {
         break;
       }
     }
-  }, [focusedPath, getVisibleNodes, toggleExpand, selectFile, handleContextAction]);
+  }, [focusedPath, getVisibleNodes, toggleExpand, expanded, selectFile, openFilePermanently, handleContextAction]);
+
+  // Initialize focus on container focus
+  const handleFocus = useCallback(() => {
+    if (!focusedPath) {
+      const visible = getVisibleNodes();
+      setFocusedPath(selectedPath ?? visible[0]?.path ?? null);
+    }
+  }, [focusedPath, selectedPath, getVisibleNodes]);
+
+  // Scroll focused node into view
+  useEffect(() => {
+    if (focusedPath && containerRef.current) {
+      const el = containerRef.current.querySelector(`[data-path="${CSS.escape(focusedPath)}"]`);
+      el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [focusedPath]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent, node: FileNode) => {
     e.preventDefault();
@@ -763,9 +814,11 @@ export function FileTree({ api }: { api: PluginAPI }) {
 
   return React.createElement('div', {
     ref: containerRef,
-    className: 'flex flex-col h-full bg-ctp-mantle text-ctp-text select-none',
+    className: 'flex flex-col h-full bg-ctp-mantle text-ctp-text select-none focus:outline-none focus:ring-1 focus:ring-inset focus:ring-ctp-blue/50',
     tabIndex: 0,
+    role: 'tree',
     onKeyDown: handleKeyDown,
+    onFocus: handleFocus,
   },
     // Header
     React.createElement('div', {


### PR DESCRIPTION
## Summary
- Fixes keyboard navigation in the Files tab sidebar tree which was non-functional due to missing focus initialization, invisible focus indicators, and lack of scrollIntoView support
- Adds ArrowLeft/ArrowRight for expand/collapse, Space for preview, and full ARIA accessibility attributes
- Closes #511

## Changes

### Focus initialization (Issue 1 & 2)
- Added `onFocus` handler on the tree container that initializes `focusedPath` to the currently selected item or first visible node when the container receives focus

### Visible focus indicator (Issue 3)
- Changed focused node style from `bg-ctp-surface0` (nearly invisible) to `bg-ctp-surface1/60 ring-1 ring-inset ring-ctp-blue` — now visually distinct from both hover and selected states

### ScrollIntoView (Issue 4)
- Added `useEffect` that scrolls the focused node into view (`{ block: 'nearest', behavior: 'smooth' }`) whenever `focusedPath` changes, matching the pattern used in CommandPaletteItem and TabBar

### Container focus ring (Issue 5)
- Added `focus:outline-none focus:ring-1 focus:ring-inset focus:ring-ctp-blue/50` to the container div so Tab-focusing the tree shows a visible border

### ARIA attributes (Issue 6)
- Added `role="tree"` on the container
- Added `role="treeitem"`, `tabIndex={-1}`, `aria-expanded`, `aria-selected`, and `aria-level` on each tree node

### Additional keyboard bindings
- **ArrowRight**: Expands a collapsed directory (no-op if already expanded)
- **ArrowLeft**: Collapses an expanded directory (no-op if already collapsed)
- **Space**: Opens a preview tab for the focused file (like single-click)

## Test Plan
- [x] `onFocus` initializes focusedPath to first visible node
- [x] `onFocus` initializes focusedPath to selected item when one exists
- [x] ArrowDown wraps around to first item at end of list
- [x] ArrowUp wraps around to last item at beginning of list
- [x] ArrowRight expands a collapsed directory
- [x] ArrowLeft collapses an expanded directory
- [x] ArrowRight does nothing on an already expanded directory
- [x] ArrowLeft does nothing on a collapsed directory
- [x] Space key opens preview tab for focused file
- [x] Focus indicator uses distinct ring-ctp-blue style
- [x] Container has role="tree" and tabIndex
- [x] Container has focus ring classes
- [x] Tree items have role="treeitem" and correct ARIA attributes
- [x] Expanded directory has aria-expanded="true"
- [x] Selected file has aria-selected="true"
- [x] Nested tree items have correct aria-level
- [x] scrollIntoView is called when focused path changes
- [x] All 5604 existing tests pass
- [x] TypeScript typecheck passes
- [x] Lint passes (pre-existing error in unrelated file only)

## Manual Validation
1. Open the Files tab in the sidebar
2. Click inside the file tree — first item should get a visible blue ring focus indicator
3. Press ArrowDown/ArrowUp — focus highlight should move visibly through items
4. Press ArrowRight on a collapsed folder — it should expand
5. Press ArrowLeft on an expanded folder — it should collapse
6. Press Enter on a folder — it should toggle expand/collapse
7. Press Enter on a file — it should open as a permanent tab
8. Press Space on a file — it should open as a preview tab
9. Tab to the tree container — a subtle blue ring should appear around the container
10. Navigate to an item off-screen — it should auto-scroll into view