### PR TITLE
fix: prevent workspace search crash from V8 serializer stack overflow

### DIFF
--- a/src/main/services/search-service.test.ts
+++ b/src/main/services/search-service.test.ts
@@ -139,4 +139,46 @@ describe('search-service', () => {
       expect(fp.endsWith('.md')).toBe(false);
     }
   });
+
+  it('truncates long lineContent to prevent IPC serialization overflow', async () => {
+    // Create a file with a very long line (>500 chars)
+    const longLine = 'x'.repeat(1000) + ' findme ' + 'y'.repeat(1000);
+    await fs.writeFile(path.join(tmpDir, 'long-line.txt'), longLine);
+
+    const result = await searchFiles(tmpDir, 'findme');
+    const longFile = result.results.find(r => r.filePath.includes('long-line.txt'));
+    expect(longFile).toBeDefined();
+    expect(longFile!.matches.length).toBeGreaterThan(0);
+
+    // lineContent should be truncated to 501 chars (500 + ellipsis)
+    for (const match of longFile!.matches) {
+      expect(match.lineContent.length).toBeLessThanOrEqual(501);
+    }
+  });
+
+  it('does not truncate short lineContent', async () => {
+    const result = await searchFiles(tmpDir, 'greeting');
+    const helloFile = result.results.find(r => r.filePath.includes('hello.ts'));
+    expect(helloFile).toBeDefined();
+
+    for (const match of helloFile!.matches) {
+      // Short lines should not have the ellipsis truncation marker
+      expect(match.lineContent).not.toContain('…');
+    }
+  });
+
+  it('uses reduced default max results (1000) to prevent large payloads', async () => {
+    // Create many small files with matches
+    const dir = path.join(tmpDir, 'many');
+    await fs.mkdir(dir);
+    for (let i = 0; i < 20; i++) {
+      const lines = Array.from({ length: 100 }, (_, j) => `line ${j} match_token`);
+      await fs.writeFile(path.join(dir, `file${i}.txt`), lines.join('\n'));
+    }
+
+    // Search without explicit maxResults — should use the default (1000)
+    const result = await searchFiles(tmpDir, 'match_token');
+    expect(result.totalMatches).toBeLessThanOrEqual(1000);
+    expect(result.truncated).toBe(true);
+  });
 });

--- a/src/main/services/search-service.ts
+++ b/src/main/services/search-service.ts
@@ -6,8 +6,9 @@ const picomatch = require('picomatch') as (
 ) => (input: string) => boolean;
 import type { FileSearchOptions, FileSearchResult, FileSearchFileResult, FileSearchMatch } from '../../shared/types';
 
-const DEFAULT_MAX_RESULTS = 10_000;
+const DEFAULT_MAX_RESULTS = 1_000;
 const DEFAULT_CONTEXT_LINES = 0;
+const MAX_LINE_CONTENT_LENGTH = 500;
 
 /**
  * Try to locate the ripgrep binary. Returns the path or null if not found.
@@ -82,7 +83,7 @@ function buildRgArgs(query: string, rootPath: string, options?: FileSearchOption
 
   const args: string[] = [
     '--json',                        // JSON output for structured parsing
-    '--max-count', '1000',           // max matches per file
+    '--max-count', '100',            // max matches per file
     '--no-messages',                 // suppress file access error messages
   ];
 
@@ -159,7 +160,7 @@ function searchWithRipgrep(
     const child = execFile(
       rgPath,
       args,
-      { maxBuffer: 100 * 1024 * 1024, timeout: 30_000 },
+      { maxBuffer: 10 * 1024 * 1024, timeout: 30_000 },
       (error, stdout, _stderr) => {
         // ripgrep exits with code 1 when no matches found — not an error
         if (error && (error as NodeJS.ErrnoException).code !== null && !stdout) {
@@ -210,7 +211,7 @@ function parseRipgrepOutput(
 
     const data = parsed.data;
     const filePath = data.path?.text;
-    const lineContent = data.lines?.text?.replace(/\n$/, '') ?? '';
+    const lineContent = truncateLineContent(data.lines?.text?.replace(/\n$/, '') ?? '');
     const lineNumber = data.line_number ?? 0;
 
     if (!filePath) continue;
@@ -321,7 +322,7 @@ async function searchWithNodeFs(
             line: i + 1,
             column: match.index + 1,
             length: match[0].length,
-            lineContent: line,
+            lineContent: truncateLineContent(line),
           });
           totalMatches++;
 
@@ -344,6 +345,11 @@ async function searchWithNodeFs(
   }
 
   return { results, totalMatches, truncated };
+}
+
+function truncateLineContent(line: string): string {
+  if (line.length <= MAX_LINE_CONTENT_LENGTH) return line;
+  return line.slice(0, MAX_LINE_CONTENT_LENGTH) + '…';
 }
 
 function escapeRegex(s: string): string {


### PR DESCRIPTION
## Summary
- Fixes app crash (`EXC_BREAKPOINT`) when workspace search returns large result sets that overflow V8's structured clone serializer during IPC transfer
- Reduces payload size across four dimensions: max results, line content length, per-file match cap, and stdout buffer limit

Fixes #512

## Changes
- **`DEFAULT_MAX_RESULTS`**: 10,000 → 1,000 — limits total matches returned in a single IPC response
- **`lineContent` truncation**: Cap at 500 chars with ellipsis — prevents minified file lines (often 10k+ chars) from bloating the payload
- **`--max-count`**: 1,000 → 100 per file — reduces ripgrep output for files with many matches
- **`maxBuffer`**: 100MB → 10MB — prevents excessive memory allocation for ripgrep stdout

## Test Plan
- [x] New test: long lineContent (2000+ chars) is truncated to ≤501 chars
- [x] New test: short lineContent is not truncated (no false positives)
- [x] New test: default max results caps at 1,000 and sets `truncated: true`
- [x] Existing tests continue to pass (13 total)
- [x] TypeScript type check passes
- [x] Lint clean (pre-existing unrelated error only)

## Manual Validation
1. Open a large project with `node_modules` or minified files
2. Search for a very common string (e.g., `e`, `the`, `import`)
3. Verify app does not crash and results are returned with `truncated: true`
4. Verify long lines in results are truncated with `…` suffix