### PR TITLE
fix: move module-level mock return values into beforeEach blocks

### DIFF
--- a/src/renderer/features/agents/SleepingAgent.test.tsx
+++ b/src/renderer/features/agents/SleepingAgent.test.tsx
@@ -37,7 +37,7 @@ const baseAgent: Agent = {
   color: 'indigo',
 };
 
-const mockSpawnDurableAgent = vi.fn().mockResolvedValue(undefined);
+const mockSpawnDurableAgent = vi.fn();
 
 function resetStores(agentOverrides: Partial<Agent> = {}) {
   const agent = { ...baseAgent, ...agentOverrides };
@@ -60,6 +60,7 @@ function renderComponent(agentOverrides: Partial<Agent> = {}) {
 describe('SleepingAgent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSpawnDurableAgent.mockResolvedValue(undefined);
     window.clubhouse.agent.listDurable = vi.fn().mockResolvedValue([]);
   });
 

--- a/src/renderer/features/popout/PopoutHubPane.test.tsx
+++ b/src/renderer/features/popout/PopoutHubPane.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../agents/QuickAgentGhost', () => ({
   ),
 }));
 
-const mockKillAgent = vi.fn().mockResolvedValue(undefined);
+const mockKillAgent = vi.fn();
 
 const defaultPane: LeafPane = {
   type: 'leaf',
@@ -74,6 +74,7 @@ function renderPane(overrides: Partial<typeof defaultProps> = {}) {
 describe('PopoutHubPane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockKillAgent.mockResolvedValue(undefined);
     useAgentStore.setState({ killAgent: mockKillAgent });
     window.clubhouse.window.focusMain = vi.fn().mockResolvedValue(undefined);
   });

--- a/src/renderer/features/popout/PopoutHubView.test.tsx
+++ b/src/renderer/features/popout/PopoutHubView.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../agents/QuickAgentGhost', () => ({
 
 const mockAgents: Record<string, any> = {};
 let mockDetailedStatuses: Record<string, any> = {};
-const mockLoadDurableAgents = vi.fn().mockResolvedValue(undefined);
+const mockLoadDurableAgents = vi.fn();
 
 vi.mock('../../stores/agentStore', () => ({
   useAgentStore: (selector: (s: any) => any) => selector({
@@ -42,7 +42,7 @@ vi.mock('../../stores/agentStore', () => ({
   }),
 }));
 
-const mockLoadProjects = vi.fn().mockResolvedValue(undefined);
+const mockLoadProjects = vi.fn();
 let mockProjects: any[] = [];
 
 vi.mock('../../stores/projectStore', () => {
@@ -139,6 +139,8 @@ describe('PopoutHubView', () => {
     mockLoadCompleted.mockClear();
     mockDismissCompleted.mockClear();
     mockLoadDurableAgents.mockClear();
+    mockLoadDurableAgents.mockResolvedValue(undefined);
+    mockLoadProjects.mockResolvedValue(undefined);
 
     window.clubhouse.pty.onExit = vi.fn().mockReturnValue(noop);
     window.clubhouse.agent.onHookEvent = vi.fn().mockReturnValue(noop);

--- a/src/renderer/features/settings/NotificationSettingsView.test.tsx
+++ b/src/renderer/features/settings/NotificationSettingsView.test.tsx
@@ -12,12 +12,12 @@ vi.mock('../../stores/badgeStore', () => ({
   }),
 }));
 
-const mockLoadSettings = vi.fn().mockResolvedValue(undefined);
-const mockSaveSettings = vi.fn().mockResolvedValue(undefined);
-const mockLoadBadgeSettings = vi.fn().mockResolvedValue(undefined);
-const mockSaveAppSettings = vi.fn().mockResolvedValue(undefined);
-const mockSetProjectOverride = vi.fn().mockResolvedValue(undefined);
-const mockClearProjectOverride = vi.fn().mockResolvedValue(undefined);
+const mockLoadSettings = vi.fn();
+const mockSaveSettings = vi.fn();
+const mockLoadBadgeSettings = vi.fn();
+const mockSaveAppSettings = vi.fn();
+const mockSetProjectOverride = vi.fn();
+const mockClearProjectOverride = vi.fn();
 
 function resetStores(opts: { projectOverrides?: Record<string, any> } = {}) {
   useNotificationStore.setState({
@@ -47,6 +47,12 @@ function resetStores(opts: { projectOverrides?: Record<string, any> } = {}) {
 describe('NotificationSettingsView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLoadSettings.mockResolvedValue(undefined);
+    mockSaveSettings.mockResolvedValue(undefined);
+    mockLoadBadgeSettings.mockResolvedValue(undefined);
+    mockSaveAppSettings.mockResolvedValue(undefined);
+    mockSetProjectOverride.mockResolvedValue(undefined);
+    mockClearProjectOverride.mockResolvedValue(undefined);
   });
 
   it('renders loading state when settings are null', () => {

--- a/src/renderer/features/settings/ProjectSettings.test.tsx
+++ b/src/renderer/features/settings/ProjectSettings.test.tsx
@@ -33,8 +33,8 @@ const baseProject: Project = {
 
 const mockUpdateProject = vi.fn();
 const mockRemoveProject = vi.fn();
-const mockPickProjectImage = vi.fn().mockResolvedValue(null);
-const mockSaveCroppedProjectIcon = vi.fn().mockResolvedValue(undefined);
+const mockPickProjectImage = vi.fn();
+const mockSaveCroppedProjectIcon = vi.fn();
 const mockToggleSettings = vi.fn();
 
 function resetStores(projectOverrides: Partial<Project> = {}) {
@@ -56,6 +56,8 @@ function resetStores(projectOverrides: Partial<Project> = {}) {
 describe('ProjectSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPickProjectImage.mockResolvedValue(null);
+    mockSaveCroppedProjectIcon.mockResolvedValue(undefined);
     window.clubhouse.project.resetProject = vi.fn().mockResolvedValue(undefined);
   });
 

--- a/src/renderer/stores/soundStore.test.ts
+++ b/src/renderer/stores/soundStore.test.ts
@@ -27,7 +27,7 @@ Object.defineProperty(globalThis, 'window', {
 });
 
 // Mock Audio - each instance must have its own pause/play so module-level references work
-const mockPlay = vi.fn().mockResolvedValue(undefined);
+const mockPlay = vi.fn();
 const mockPause = vi.fn();
 
 class MockAudio {
@@ -60,6 +60,7 @@ const DEFAULT_SETTINGS: SoundSettings = {
 describe('soundStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPlay.mockResolvedValue(undefined);
     useSoundStore.setState({ settings: null, packs: [], soundCache: {} });
   });
 

--- a/src/renderer/utils/safe-markdown-links.test.ts
+++ b/src/renderer/utils/safe-markdown-links.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useSafeMarkdownLinks } from './safe-markdown-links';
 
-const mockOpenExternalUrl = vi.fn().mockResolvedValue(undefined);
+const mockOpenExternalUrl = vi.fn();
 
 Object.defineProperty(globalThis, 'window', {
   value: {
@@ -36,6 +36,7 @@ function makeClickEvent(anchorAttrs?: { href?: string } | null) {
 describe('useSafeMarkdownLinks', () => {
   beforeEach(() => {
     mockOpenExternalUrl.mockClear();
+    mockOpenExternalUrl.mockResolvedValue(undefined);
   });
 
   it('returns a stable callback', () => {


### PR DESCRIPTION
## Summary
- Fix flaky test behavior caused by `mockReset: true` interacting with module-level mock setup
- Move all `mockResolvedValue`/`mockReturnValue` calls from module scope into `beforeEach` blocks across 7 test files
- Closes #655

## Changes
With `mockReset: true` in `vitest.config.ts`, all mock implementations are reset between tests. When return values are set at module level (outside `beforeEach`), they only apply to the first test in each suite — subsequent tests get bare `vi.fn()` mocks with no return value configured.

**Files fixed:**
- `src/renderer/stores/soundStore.test.ts` — `mockPlay.mockResolvedValue(undefined)`
- `src/renderer/features/agents/SleepingAgent.test.tsx` — `mockSpawnDurableAgent.mockResolvedValue(undefined)`
- `src/renderer/features/settings/ProjectSettings.test.tsx` — `mockPickProjectImage`, `mockSaveCroppedProjectIcon`
- `src/renderer/features/settings/NotificationSettingsView.test.tsx` — 6 mock functions (`mockLoadSettings`, `mockSaveSettings`, `mockLoadBadgeSettings`, `mockSaveAppSettings`, `mockSetProjectOverride`, `mockClearProjectOverride`)
- `src/renderer/utils/safe-markdown-links.test.ts` — `mockOpenExternalUrl`
- `src/renderer/features/popout/PopoutHubView.test.tsx` — `mockLoadDurableAgents`, `mockLoadProjects`
- `src/renderer/features/popout/PopoutHubPane.test.tsx` — `mockKillAgent`

## Test Plan
- [x] All 220 test files pass (5679 tests)
- [x] TypeScript type check passes
- [x] No new lint errors introduced (pre-existing lint error in PluginListSettings.tsx is unrelated)
- [x] Tests pass both individually and in suite (the exact scenario that was failing)

## Manual Validation
No manual validation needed — this is a test-only change with no runtime impact.