### PR TITLE
Throttle PTY onData recordActivity to reduce excessive re-renders

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -190,3 +190,95 @@ describe('AgentList completed selector stability', () => {
     expect(screen.getByText('Completed (0)')).toBeInTheDocument();
   });
 });
+
+describe('AgentList onData throttle', () => {
+  let onDataCallback: (agentId: string) => void;
+  let recordActivitySpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    resetStores();
+
+    recordActivitySpy = vi.fn();
+    useAgentStore.setState({ recordActivity: recordActivitySpy });
+
+    // Capture the onData callback when the component registers it
+    window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: (agentId: string) => void) => {
+      onDataCallback = cb;
+      return () => {};
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires recordActivity immediately on first onData call', () => {
+    render(<AgentList />);
+    act(() => { onDataCallback('agent-1'); });
+    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+    expect(recordActivitySpy).toHaveBeenCalledWith('agent-1');
+  });
+
+  it('throttles rapid onData calls to at most one per 150ms', () => {
+    render(<AgentList />);
+
+    // First call goes through immediately
+    act(() => { onDataCallback('agent-1'); });
+    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+
+    // Rapid subsequent calls within the throttle window should not fire immediately
+    act(() => {
+      onDataCallback('agent-1');
+      onDataCallback('agent-1');
+      onDataCallback('agent-1');
+    });
+    // Only 1 call so far (the initial one) + 1 trailing timer scheduled
+    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+
+    // After the throttle interval, the trailing call fires
+    act(() => { vi.advanceTimersByTime(150); });
+    expect(recordActivitySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('throttles independently per agent', () => {
+    render(<AgentList />);
+
+    // Both agents fire immediately on first call
+    act(() => { onDataCallback('agent-1'); });
+    act(() => { onDataCallback('agent-2'); });
+    expect(recordActivitySpy).toHaveBeenCalledTimes(2);
+    expect(recordActivitySpy).toHaveBeenCalledWith('agent-1');
+    expect(recordActivitySpy).toHaveBeenCalledWith('agent-2');
+
+    // Rapid calls for agent-1 only — agent-2 is not affected
+    act(() => {
+      onDataCallback('agent-1');
+      onDataCallback('agent-1');
+    });
+    // Still 2 from above — agent-1's rapid calls are throttled
+    expect(recordActivitySpy).toHaveBeenCalledTimes(2);
+
+    // agent-2 can still fire after its own throttle window passes
+    act(() => { vi.advanceTimersByTime(150); });
+    // Now agent-1's trailing call fires
+    expect(recordActivitySpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('cleans up pending timers on unmount', () => {
+    const { unmount } = render(<AgentList />);
+
+    // Fire initial + schedule a trailing call
+    act(() => { onDataCallback('agent-1'); });
+    act(() => { onDataCallback('agent-1'); });
+    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+
+    // Unmount before the trailing timer fires
+    unmount();
+
+    // Advance timers — the trailing call should NOT fire
+    act(() => { vi.advanceTimersByTime(300); });
+    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -80,12 +80,34 @@ export function AgentList() {
     }
   }, [activeProject, loadDurableAgents]);
 
-  // Track activity from pty data
+  // Track activity from pty data (throttled per agent to avoid excessive store updates)
+  const lastActivityRef = useRef<Record<string, number>>({});
   useEffect(() => {
+    const THROTTLE_MS = 150;
+    const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
     const unsub = window.clubhouse.pty.onData((agentId: string) => {
-      recordActivity(agentId);
+      const now = Date.now();
+      const last = lastActivityRef.current[agentId] ?? 0;
+      if (now - last >= THROTTLE_MS) {
+        lastActivityRef.current[agentId] = now;
+        recordActivity(agentId);
+      } else if (!pendingTimers.has(agentId)) {
+        // Schedule a trailing call so we don't miss the last burst of activity
+        const delay = THROTTLE_MS - (now - last);
+        pendingTimers.set(agentId, setTimeout(() => {
+          lastActivityRef.current[agentId] = Date.now();
+          recordActivity(agentId);
+          pendingTimers.delete(agentId);
+        }, delay));
+      }
     });
-    return unsub;
+
+    return () => {
+      unsub();
+      for (const timer of pendingTimers.values()) clearTimeout(timer);
+      pendingTimers.clear();
+    };
   }, [recordActivity]);
 
   // Tick for activity status refresh


### PR DESCRIPTION
## Summary
- Throttle `recordActivity` calls from PTY `onData` to fire at most once per 150ms per agent
- Fixes excessive Zustand store updates and re-renders during high-output agent operations
- Closes #650

## Changes
- **`src/renderer/features/agents/AgentList.tsx`**: Replace direct `recordActivity(agentId)` call in `onData` listener with a leading+trailing throttle (150ms per agent). Uses a `useRef` map to track last-fire timestamps and a `Map` for pending trailing timers. Timers are cleaned up on effect teardown.
- **`src/renderer/features/agents/AgentList.test.tsx`**: Added 4 new test cases covering throttle behavior:
  - Immediate fire on first `onData` call
  - Suppression of rapid calls within the 150ms window (with trailing fire)
  - Independent throttling per agent ID
  - Cleanup of pending timers on unmount

## Test Plan
- [x] First `onData` event fires `recordActivity` immediately (no delay for responsiveness)
- [x] Rapid successive `onData` events within 150ms are coalesced into at most one trailing call
- [x] Different agent IDs are throttled independently
- [x] Pending trailing timers are cleared when component unmounts
- [x] All 11 AgentList tests pass
- [x] Full test suite passes (3 pre-existing failures unrelated to this change)

## Manual Validation
1. Start an agent with high output (e.g., a build or large file operation)
2. Observe that the activity indicator still responds promptly
3. Verify no perceptible UI jank during high-throughput PTY output