### PR TITLE
Batch hook events into single IPC message per flush

### DIFF
--- a/src/main/util/ipc-broadcast-policies.test.ts
+++ b/src/main/util/ipc-broadcast-policies.test.ts
@@ -57,7 +57,7 @@ describe('registerDefaultBroadcastPolicies', () => {
     expect(win.webContents.send).toHaveBeenCalledWith('pty:data', 'agent-1', 'hello world');
   });
 
-  it('throttles agent:hook-event with queue (preserves all events)', () => {
+  it('throttles agent:hook-event with merge (batches events into array)', () => {
     const win = createMockWindow();
     mockGetAllWindows.mockReturnValue([win]);
 
@@ -71,9 +71,24 @@ describe('registerDefaultBroadcastPolicies', () => {
 
     vi.advanceTimersByTime(50);
 
-    expect(win.webContents.send).toHaveBeenCalledTimes(2);
-    expect(win.webContents.send).toHaveBeenNthCalledWith(1, 'agent:hook-event', 'agent-1', ev1);
-    expect(win.webContents.send).toHaveBeenNthCalledWith(2, 'agent:hook-event', 'agent-1', ev2);
+    // Single IPC message with batched array instead of 2 separate calls
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+    expect(win.webContents.send).toHaveBeenCalledWith('agent:hook-event', 'agent-1', [ev1, ev2]);
+  });
+
+  it('sends a single hook event unwrapped when only one arrives in the window', () => {
+    const win = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+
+    const ev1 = { kind: 'pre_tool', toolName: 'Read', timestamp: 1 };
+
+    broadcastToAllWindows('agent:hook-event', 'agent-1', ev1);
+
+    vi.advanceTimersByTime(50);
+
+    // Single event is sent as-is (no array wrapping) for backwards compatibility
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+    expect(win.webContents.send).toHaveBeenCalledWith('agent:hook-event', 'agent-1', ev1);
   });
 
   it('does not throttle unregistered channels', () => {

--- a/src/main/util/ipc-broadcast-policies.ts
+++ b/src/main/util/ipc-broadcast-policies.ts
@@ -8,8 +8,9 @@ import { setChannelPolicy } from './ipc-broadcast';
 const PTY_DATA_INTERVAL_MS = 16;
 
 /**
- * Hook events are semantically distinct and cannot be merged, but can be
- * queued and flushed in bursts to reduce IPC round-trips.
+ * Hook events are semantically distinct and cannot be merged into one, but
+ * can be batched into an array and sent as a single IPC message per flush
+ * to avoid N-events × M-windows multiplicative IPC overhead.
  */
 const HOOK_EVENT_INTERVAL_MS = 50;
 
@@ -30,11 +31,17 @@ export function registerDefaultBroadcastPolicies(): void {
     ],
   });
 
-  // Hook events: queue per agent and flush in bursts
+  // Hook events: batch per agent into an array and flush as a single IPC message
   // Call shape: broadcastToAllWindows(IPC.AGENT.HOOK_EVENT, agentId, hookEvent)
+  // Flush shape: sendToAllWindows(IPC.AGENT.HOOK_EVENT, agentId, hookEvent | hookEvent[])
   setChannelPolicy(IPC.AGENT.HOOK_EVENT, {
     intervalMs: HOOK_EVENT_INTERVAL_MS,
-    merge: false,
+    merge: true,
     keyFn: (agentId) => String(agentId),
+    mergeFn: (existing, incoming) => {
+      const batch = Array.isArray(existing[1]) ? existing[1] : [existing[1]];
+      batch.push(incoming[1]);
+      return [existing[0], batch];
+    },
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -147,8 +147,17 @@ const api = {
       toolVerb?: string;
       timestamp: number;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, agentId: string, hookEvent: AgentHookEvent) =>
-        callback(agentId, hookEvent);
+      // Hook events may arrive as a single event or as a batched array
+      // (the broadcast policy merges events within a 50ms window).
+      const listener = (_event: Electron.IpcRendererEvent, agentId: string, hookEventOrBatch: AgentHookEvent | AgentHookEvent[]) => {
+        if (Array.isArray(hookEventOrBatch)) {
+          for (const ev of hookEventOrBatch) {
+            callback(agentId, ev);
+          }
+        } else {
+          callback(agentId, hookEventOrBatch);
+        }
+      };
       ipcRenderer.on(IPC.AGENT.HOOK_EVENT, listener);
       return () => { ipcRenderer.removeListener(IPC.AGENT.HOOK_EVENT, listener); };
     },


### PR DESCRIPTION
## Summary
- Hook events previously used queue mode (`merge: false`), causing each accumulated event to be sent as a separate IPC call on flush — 20 events × N windows = 20N IPC messages
- Switched to merge mode with a `mergeFn` that collects events into an array, so all accumulated events within the 50ms window are sent as a single IPC message per window
- The preload layer transparently unpacks batched arrays, so all renderer consumers are unaffected

Fixes #649

## Changes
- **`src/main/util/ipc-broadcast-policies.ts`**: Changed hook event policy from `merge: false` (queue mode) to `merge: true` with a custom `mergeFn` that accumulates events into an array. Single events remain unwrapped for backwards compatibility; multiple events are batched as `[event1, event2, ...]`.
- **`src/preload/index.ts`**: Updated `onHookEvent` listener to handle both single events and batched arrays, dispatching each event individually to the callback.
- **`src/main/util/ipc-broadcast-policies.test.ts`**: Updated test to verify batched output (1 IPC call with array) instead of individual calls. Added test for single-event case remaining unwrapped.

## Test Plan
- [x] `ipc-broadcast-policies.test.ts` — verifies multiple hook events are batched into a single IPC message with array payload
- [x] `ipc-broadcast-policies.test.ts` — verifies a single hook event is sent unwrapped (backwards compatible)
- [x] `ipc-broadcast.test.ts` — all 21 existing broadcast tests continue to pass (queue mode still works for other consumers)
- [x] TypeScript type checking passes (pre-existing picomatch error only)
- [x] Lint passes on all changed files

## Manual Validation
1. Open the app with multiple windows (main + popout)
2. Run an agent that triggers rapid hook events (e.g. multiple tool calls in succession)
3. Verify hook events still appear correctly in all windows
4. Confirm in DevTools Network/Performance that IPC messages are reduced during bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)