### PR TITLE
test: improve auto-update-service.ts coverage (#641)

### DIFF
--- a/src/main/services/auto-update-check.test.ts
+++ b/src/main/services/auto-update-check.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'stream';
+import type { UpdateManifest } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Hoisted variables for use in vi.mock factories
+// ---------------------------------------------------------------------------
+
+const { httpsGetSpy, mockSettings } = vi.hoisted(() => ({
+  httpsGetSpy: vi.fn(),
+  mockSettings: {
+    autoUpdate: true,
+    previewChannel: false,
+    lastCheck: null as string | null,
+    dismissedVersion: null as string | null,
+    lastSeenVersion: '0.25.0' as string | null,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+  flush: vi.fn(),
+}));
+
+vi.mock('./settings-store', () => ({
+  createSettingsStore: () => ({
+    get: () => ({ ...mockSettings }),
+    save: vi.fn(),
+    update: vi.fn(),
+  }),
+}));
+
+vi.mock('https', () => ({ get: httpsGetSpy }));
+vi.mock('http', () => ({ get: vi.fn() }));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    unlink: vi.fn((_p: string, cb: () => void) => cb()),
+    createWriteStream: actual.createWriteStream,
+    createReadStream: actual.createReadStream,
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => { throw new Error('ENOENT'); }),
+  unlink: vi.fn(async () => {}),
+  rm: vi.fn(async () => {}),
+  readdir: vi.fn(async () => []),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import { checkForUpdates } from './auto-update-service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeManifest(version: string, overrides?: Partial<UpdateManifest>): UpdateManifest {
+  const key = `${process.platform}-${process.arch}`;
+  return {
+    version,
+    releaseDate: '2026-01-01',
+    releaseNotes: 'Test notes',
+    releaseMessage: 'Test Message',
+    artifacts: {
+      [key]: {
+        url: 'https://example.com/Clubhouse-1.0.0.zip',
+        sha256: 'abc123',
+        size: 1000,
+      },
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Mock https.get to call the callback synchronously (so data/end listeners
+ * get attached) then emit data + end on the next tick.
+ */
+function mockHttpsGet(statusCode: number, body: string) {
+  httpsGetSpy.mockImplementation((_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+    const res = new EventEmitter() as EventEmitter & {
+      statusCode: number;
+      headers: Record<string, string>;
+      resume: () => void;
+      pipe: (dest: unknown) => unknown;
+    };
+    res.statusCode = statusCode;
+    res.headers = {};
+    res.resume = vi.fn();
+    res.pipe = vi.fn((dest) => dest);
+
+    // Call callback synchronously so fetchJSON attaches data/end listeners
+    cb(res);
+
+    // Emit data + end on next tick (listeners are already attached)
+    process.nextTick(() => {
+      res.emit('data', Buffer.from(body));
+      res.emit('end');
+    });
+
+    const req = new EventEmitter();
+    return req;
+  });
+}
+
+function mockHttpsGetError(errorMessage: string) {
+  httpsGetSpy.mockImplementation((_url: string, _opts: unknown, _cb: unknown) => {
+    const req = new EventEmitter();
+    process.nextTick(() => req.emit('error', new Error(errorMessage)));
+    return req;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests — paths that DON'T involve downloading (resolve before download)
+// ---------------------------------------------------------------------------
+
+describe('checkForUpdates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettings.autoUpdate = true;
+    mockSettings.previewChannel = false;
+    mockSettings.lastCheck = null;
+    mockSettings.dismissedVersion = null;
+    mockSettings.lastSeenVersion = '0.25.0';
+  });
+
+  it('skips check when autoUpdate is false and not manual', async () => {
+    mockSettings.autoUpdate = false;
+    const result = await checkForUpdates(false);
+    expect(httpsGetSpy).not.toHaveBeenCalled();
+    expect(result.state).toBe('idle');
+  });
+
+  it('proceeds with fetch when autoUpdate is false but check is manual', async () => {
+    mockSettings.autoUpdate = false;
+    // Use a version that's NOT newer so we don't enter download flow
+    const manifest = makeManifest('0.0.0');
+    mockHttpsGet(200, JSON.stringify(manifest));
+
+    const result = await checkForUpdates(true);
+    expect(httpsGetSpy).toHaveBeenCalled();
+    expect(result.state).toBe('idle');
+  });
+
+  it('returns idle when current version is up to date', async () => {
+    const manifest = makeManifest('0.0.0');
+    mockHttpsGet(200, JSON.stringify(manifest));
+
+    const result = await checkForUpdates(true);
+    expect(result.state).toBe('idle');
+  });
+
+  it('skips dismissed version on non-manual check', async () => {
+    const manifest = makeManifest('1.0.0');
+    mockSettings.dismissedVersion = '1.0.0';
+    mockHttpsGet(200, JSON.stringify(manifest));
+
+    const result = await checkForUpdates(false);
+    expect(result.state).toBe('idle');
+  });
+
+  it('returns idle when no artifact for current platform', async () => {
+    const manifest = makeManifest('1.0.0', {
+      artifacts: { 'fake-platform-fake-arch': { url: 'x', sha256: 'y' } },
+    });
+    mockHttpsGet(200, JSON.stringify(manifest));
+
+    const result = await checkForUpdates(true);
+    expect(result.state).toBe('idle');
+  });
+
+  it('sets error state on non-retryable HTTP error', async () => {
+    mockHttpsGet(500, 'Internal Server Error');
+    const result = await checkForUpdates(true);
+    expect(result.state).toBe('error');
+    expect(result.error).toContain('HTTP 500');
+  });
+
+  it('sets error state on invalid JSON response', async () => {
+    mockHttpsGet(200, 'not valid json');
+    const result = await checkForUpdates(true);
+    expect(result.state).toBe('error');
+  });
+
+  it('fetches both manifests when preview channel is enabled', async () => {
+    mockSettings.previewChannel = true;
+    // Both manifests report an old version → idle, no download
+    const manifest = makeManifest('0.0.0');
+    mockHttpsGet(200, JSON.stringify(manifest));
+
+    const result = await checkForUpdates(true);
+    // At least 2 calls: stable + preview
+    expect(httpsGetSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(result.state).toBe('idle');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests with fake timers for retry delays
+// ---------------------------------------------------------------------------
+
+describe('checkForUpdates (retry paths)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockSettings.autoUpdate = true;
+    mockSettings.previewChannel = false;
+    mockSettings.lastCheck = null;
+    mockSettings.dismissedVersion = null;
+    mockSettings.lastSeenVersion = '0.25.0';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sets error state on transient network failure after retries', async () => {
+    mockHttpsGetError('connect ECONNREFUSED 127.0.0.1:443');
+
+    const promise = checkForUpdates(true);
+    // 3 retries: 5s, 10s, 20s
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const result = await promise;
+    expect(result.state).toBe('error');
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+
+  it('handles request timeout with retries', async () => {
+    httpsGetSpy.mockImplementation((_url: string, _opts: unknown, _cb: unknown) => {
+      const req = new EventEmitter();
+      process.nextTick(() => req.emit('timeout'));
+      req.destroy = vi.fn(() => {
+        process.nextTick(() => req.emit('error', new Error('Request timed out')));
+        return req as ReturnType<typeof req.destroy>;
+      });
+      return req;
+    });
+
+    const promise = checkForUpdates(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const result = await promise;
+    expect(result.state).toBe('error');
+    expect(result.error).toContain('timed out');
+  });
+});

--- a/src/main/services/auto-update-history.test.ts
+++ b/src/main/services/auto-update-history.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { filterVersionHistory, composeVersionHistoryMarkdown } from './auto-update-service';
+import type { VersionHistoryEntry } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// filterVersionHistory
+// ---------------------------------------------------------------------------
+
+describe('filterVersionHistory', () => {
+  const today = new Date().toISOString();
+  const twoMonthsAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  const sixMonthsAgo = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000).toISOString();
+
+  function entry(version: string, releaseDate: string): VersionHistoryEntry {
+    return { version, releaseDate, releaseMessage: `v${version}`, releaseNotes: `Notes for ${version}` };
+  }
+
+  it('filters out versions newer than currentVersion', () => {
+    const entries = [entry('0.30.0', today), entry('0.31.0', today), entry('0.32.0', today)];
+    const result = filterVersionHistory(entries, '0.31.0');
+    expect(result.map((e) => e.version)).toEqual(['0.31.0', '0.30.0']);
+  });
+
+  it('filters out entries older than 3 months', () => {
+    const entries = [entry('0.28.0', sixMonthsAgo), entry('0.30.0', twoMonthsAgo)];
+    const result = filterVersionHistory(entries, '0.30.0');
+    expect(result.map((e) => e.version)).toEqual(['0.30.0']);
+  });
+
+  it('caps at 5 entries', () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      entry(`0.${20 + i}.0`, today),
+    );
+    const result = filterVersionHistory(entries, '0.29.0');
+    expect(result.length).toBe(5);
+  });
+
+  it('returns entries sorted newest-first', () => {
+    const entries = [entry('0.28.0', today), entry('0.30.0', today), entry('0.29.0', today)];
+    const result = filterVersionHistory(entries, '0.30.0');
+    expect(result.map((e) => e.version)).toEqual(['0.30.0', '0.29.0', '0.28.0']);
+  });
+
+  it('returns empty array when no entries match', () => {
+    const entries = [entry('0.32.0', today)];
+    const result = filterVersionHistory(entries, '0.31.0');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterVersionHistory([], '1.0.0')).toEqual([]);
+  });
+
+  it('includes the current version itself', () => {
+    const entries = [entry('0.31.0', today)];
+    const result = filterVersionHistory(entries, '0.31.0');
+    expect(result.map((e) => e.version)).toEqual(['0.31.0']);
+  });
+
+  it('handles prerelease versions correctly', () => {
+    const entries = [entry('0.34.0-beta.1', today), entry('0.34.0', today)];
+    const result = filterVersionHistory(entries, '0.34.0');
+    // 0.34.0 stable is not newer than itself, and beta is not newer than stable
+    expect(result.map((e) => e.version)).toEqual(['0.34.0', '0.34.0-beta.1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeVersionHistoryMarkdown
+// ---------------------------------------------------------------------------
+
+describe('composeVersionHistoryMarkdown', () => {
+  function entry(version: string, message: string, notes: string): VersionHistoryEntry {
+    return { version, releaseDate: new Date().toISOString(), releaseMessage: message, releaseNotes: notes };
+  }
+
+  it('composes a single entry with H1 header and notes', () => {
+    const md = composeVersionHistoryMarkdown([entry('0.30.0', 'Big Release', 'Bug fixes')]);
+    expect(md).toBe('# Big Release\n\nBug fixes');
+  });
+
+  it('separates multiple entries with horizontal rules', () => {
+    const entries = [
+      entry('0.31.0', 'v0.31.0', 'New stuff'),
+      entry('0.30.0', 'v0.30.0', 'Old stuff'),
+    ];
+    const md = composeVersionHistoryMarkdown(entries);
+    expect(md).toBe('# v0.31.0\n\nNew stuff\n\n----\n\n# v0.30.0\n\nOld stuff');
+  });
+
+  it('uses version as fallback when releaseMessage is empty', () => {
+    const entries = [{ version: '0.30.0', releaseDate: '', releaseMessage: '', releaseNotes: 'notes' }];
+    const md = composeVersionHistoryMarkdown(entries);
+    expect(md).toBe('# v0.30.0\n\nnotes');
+  });
+
+  it('handles entries with empty releaseNotes', () => {
+    const entries = [{ version: '0.30.0', releaseDate: '', releaseMessage: 'Title', releaseNotes: '' }];
+    const md = composeVersionHistoryMarkdown(entries);
+    expect(md).toBe('# Title\n\n');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(composeVersionHistoryMarkdown([])).toBe('');
+  });
+});

--- a/src/main/services/auto-update-lifecycle.test.ts
+++ b/src/main/services/auto-update-lifecycle.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'stream';
+
+// ---------------------------------------------------------------------------
+// Hoisted variables for use in vi.mock factories
+// ---------------------------------------------------------------------------
+
+const { mockSettings, mockSave } = vi.hoisted(() => ({
+  mockSettings: {
+    autoUpdate: true,
+    previewChannel: false,
+    lastCheck: null as string | null,
+    dismissedVersion: null as string | null,
+    lastSeenVersion: null as string | null,
+  },
+  mockSave: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+  flush: vi.fn(),
+}));
+
+vi.mock('./settings-store', () => ({
+  createSettingsStore: () => ({
+    get: () => ({ ...mockSettings }),
+    save: mockSave,
+    update: vi.fn(),
+  }),
+}));
+
+vi.mock('https', () => ({
+  get: vi.fn((_url: string, _opts: unknown, _cb: unknown) => {
+    return new EventEmitter();
+  }),
+}));
+
+vi.mock('http', () => ({ get: vi.fn() }));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    createReadStream: actual.createReadStream,
+    createWriteStream: actual.createWriteStream,
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => { throw new Error('ENOENT'); }),
+  unlink: vi.fn(async () => {}),
+  rm: vi.fn(async () => {}),
+  readdir: vi.fn(async () => []),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import { startPeriodicChecks, stopPeriodicChecks } from './auto-update-service';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('startPeriodicChecks / stopPeriodicChecks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockSettings.autoUpdate = true;
+    mockSettings.previewChannel = false;
+    mockSettings.lastCheck = null;
+    mockSettings.dismissedVersion = 'old-dismissed';
+    mockSettings.lastSeenVersion = null;
+  });
+
+  afterEach(() => {
+    stopPeriodicChecks();
+    vi.useRealTimers();
+  });
+
+  it('seeds lastSeenVersion on first launch', () => {
+    mockSettings.lastSeenVersion = null;
+    startPeriodicChecks();
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({ lastSeenVersion: expect.any(String) }),
+    );
+  });
+
+  it('clears dismissedVersion on startup', () => {
+    mockSettings.dismissedVersion = '0.30.0';
+    startPeriodicChecks();
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({ dismissedVersion: null }),
+    );
+  });
+
+  it('returns early without scheduling when autoUpdate is false', () => {
+    mockSettings.autoUpdate = false;
+    // Should not throw and should return early
+    startPeriodicChecks();
+    // stopPeriodicChecks is safe even when no timer was created
+    expect(() => stopPeriodicChecks()).not.toThrow();
+  });
+
+  it('stopPeriodicChecks is safe to call multiple times', () => {
+    startPeriodicChecks();
+    stopPeriodicChecks();
+    expect(() => stopPeriodicChecks()).not.toThrow();
+  });
+
+  it('calling startPeriodicChecks twice does not create duplicate timers', () => {
+    startPeriodicChecks();
+    startPeriodicChecks(); // second call should be a no-op
+    stopPeriodicChecks();
+  });
+});

--- a/src/main/services/auto-update-persistence.test.ts
+++ b/src/main/services/auto-update-persistence.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+  flush: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    createReadStream: actual.createReadStream,
+    createWriteStream: actual.createWriteStream,
+  };
+});
+
+import * as fs from 'fs';
+import {
+  writeApplyAttempt,
+  readApplyAttempt,
+  clearApplyAttempt,
+  getPendingReleaseNotes,
+  clearPendingReleaseNotes,
+  dismissUpdate,
+  getStatus,
+} from './auto-update-service';
+
+// ---------------------------------------------------------------------------
+// Apply attempt persistence
+// ---------------------------------------------------------------------------
+
+describe('apply attempt persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('writeApplyAttempt', () => {
+    it('writes attempt as JSON to the correct path', () => {
+      const attempt = { version: '0.30.0', artifactUrl: 'https://example.com/a.zip', attemptedAt: '2026-01-01T00:00:00Z' };
+      writeApplyAttempt(attempt);
+      // Find the call that wrote to the apply-attempt file
+      const calls = vi.mocked(fs.writeFileSync).mock.calls;
+      const call = calls.find((c) => String(c[0]).includes('update-apply-attempt.json'));
+      expect(call).toBeDefined();
+      expect(call![1]).toBe(JSON.stringify(attempt));
+    });
+
+    it('does not throw on write failure', () => {
+      vi.mocked(fs.writeFileSync).mockImplementation(() => { throw new Error('EPERM'); });
+      expect(() => writeApplyAttempt({
+        version: '0.30.0', artifactUrl: null, attemptedAt: '2026-01-01T00:00:00Z',
+      })).not.toThrow();
+    });
+  });
+
+  describe('readApplyAttempt', () => {
+    it('returns null when file does not exist', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      expect(readApplyAttempt()).toBeNull();
+    });
+
+    it('returns parsed attempt when file exists', () => {
+      const attempt = { version: '0.30.0', artifactUrl: 'https://example.com/a.zip', attemptedAt: '2026-01-01T00:00:00Z' };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(attempt));
+      expect(readApplyAttempt()).toEqual(attempt);
+    });
+
+    it('returns null on invalid JSON', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('not json');
+      expect(readApplyAttempt()).toBeNull();
+    });
+  });
+
+  describe('clearApplyAttempt', () => {
+    it('unlinks the attempt file', () => {
+      clearApplyAttempt();
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining('update-apply-attempt.json'),
+      );
+    });
+
+    it('does not throw when file does not exist', () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      expect(() => clearApplyAttempt()).not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending release notes persistence
+// ---------------------------------------------------------------------------
+
+describe('pending release notes persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPendingReleaseNotes', () => {
+    it('returns null when file does not exist', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      expect(getPendingReleaseNotes()).toBeNull();
+    });
+
+    it('returns parsed notes when file exists', () => {
+      const notes = { version: '0.30.0', releaseNotes: '## Bug fixes\n- Fixed a bug' };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(notes));
+      expect(getPendingReleaseNotes()).toEqual(notes);
+    });
+
+    it('returns null on invalid JSON', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('{bad');
+      expect(getPendingReleaseNotes()).toBeNull();
+    });
+  });
+
+  describe('clearPendingReleaseNotes', () => {
+    it('unlinks the notes file', () => {
+      clearPendingReleaseNotes();
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining('pending-release-notes.json'),
+      );
+    });
+
+    it('does not throw when file does not exist', () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      expect(() => clearPendingReleaseNotes()).not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStatus / dismissUpdate
+// ---------------------------------------------------------------------------
+
+describe('getStatus', () => {
+  it('returns a copy of the current status', () => {
+    const s1 = getStatus();
+    const s2 = getStatus();
+    expect(s1).toEqual(s2);
+    expect(s1).not.toBe(s2); // must be a copy
+  });
+
+  it('has the expected default shape', () => {
+    const s = getStatus();
+    expect(s).toMatchObject({
+      state: expect.any(String),
+      downloadProgress: expect.any(Number),
+      applyAttempted: expect.any(Boolean),
+    });
+  });
+});
+
+describe('dismissUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is a function', () => {
+    expect(typeof dismissUpdate).toBe('function');
+  });
+
+  it('resets status to idle after dismiss', () => {
+    // dismissUpdate resets state to idle regardless
+    dismissUpdate();
+    const s = getStatus();
+    expect(s.state).toBe('idle');
+    expect(s.availableVersion).toBeNull();
+    expect(s.releaseNotes).toBeNull();
+    expect(s.downloadProgress).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 44 new tests across 4 test files to address critically low coverage in `auto-update-service.ts` (was 20.3% statements, 7.9% branches)
- Covers previously untested code paths: version history filtering, persistence layers, checkForUpdates flow, retry/timeout handling, and lifecycle management
- Closes #641

## Changes
- **`auto-update-history.test.ts`** (13 tests): `filterVersionHistory` (filtering by version/date, sorting, cap at 5, prerelease handling) and `composeVersionHistoryMarkdown` (single/multi entry, fallbacks, empty input)
- **`auto-update-persistence.test.ts`** (16 tests): `writeApplyAttempt`/`readApplyAttempt`/`clearApplyAttempt`, `getPendingReleaseNotes`/`clearPendingReleaseNotes`, `getStatus` (returns copy), `dismissUpdate` (resets state)
- **`auto-update-check.test.ts`** (10 tests): `checkForUpdates` — autoUpdate guard, manual override, up-to-date version, dismissed version skip, missing platform artifact, HTTP 500 error, invalid JSON, preview channel dual fetch, transient error retries with exponential backoff, request timeout retries
- **`auto-update-lifecycle.test.ts`** (5 tests): `startPeriodicChecks` (seeds lastSeenVersion, clears dismissedVersion, autoUpdate guard) and `stopPeriodicChecks` (idempotent, no duplicate timers)

## Test Plan
- [x] All 44 new tests pass
- [x] All 89 auto-update tests pass (44 new + 45 existing)
- [x] Full test suite passes (5756 tests, 3 pre-existing failures unrelated to this PR)
- [x] Type check passes (1 pre-existing picomatch error unrelated to this PR)
- [x] Lint passes (2 pre-existing errors unrelated to this PR)

## Manual Validation
No manual validation needed — this is a test-only change with no production code modifications.