### PR TITLE
test: add file-watch lifecycle/cleanup tests (#654)

### DIFF
--- a/src/main/services/file-watch-service.test.ts
+++ b/src/main/services/file-watch-service.test.ts
@@ -620,8 +620,9 @@ describe('file-watch lifecycle and cleanup', () => {
       startWatch('w1', path.join(tmpDir, '**', '*.ts'), sender as any);
       startWatch('w2', path.join(tmpDir, '**', '*.js'), sender as any);
 
-      // Make w1's watcher.close throw
+      // Save real close so we can release the native handle after the test
       const entry1 = _activeWatches.get('w1')!;
+      const realClose1 = entry1.watcher.close.bind(entry1.watcher);
       vi.spyOn(entry1.watcher, 'close').mockImplementation(() => {
         throw new Error('already closed');
       });
@@ -631,6 +632,9 @@ describe('file-watch lifecycle and cleanup', () => {
 
       expect(closeSpy2).toHaveBeenCalledOnce();
       expect(getActiveWatchCount()).toBe(0);
+
+      // Close the leaked native handle to avoid keeping the process alive on Windows
+      realClose1();
     });
 
     it('still removes from map when watcher.close() throws', () => {
@@ -638,6 +642,7 @@ describe('file-watch lifecycle and cleanup', () => {
       startWatch('w1', path.join(tmpDir, '**', '*.ts'), sender as any);
 
       const entry = _activeWatches.get('w1')!;
+      const realClose = entry.watcher.close.bind(entry.watcher);
       vi.spyOn(entry.watcher, 'close').mockImplementation(() => {
         throw new Error('already closed');
       });
@@ -646,6 +651,9 @@ describe('file-watch lifecycle and cleanup', () => {
 
       expect(_activeWatches.has('w1')).toBe(false);
       expect(getActiveWatchCount()).toBe(0);
+
+      // Close the leaked native handle to avoid keeping the process alive on Windows
+      realClose();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds 28 dedicated unit tests for file-watch-service lifecycle and cleanup behavior
- Verifies resource cleanup (FSWatcher close, debounce timer clearing, listener removal) across all teardown paths
- Closes #654

## Changes
- **Window close cleanup tests**: Verify `cleanupWatchesForWindow` closes FSWatchers, clears debounce timers, removes destroyed listeners, handles multiple watches per window, and isolates watches from other windows
- **Sender destruction cleanup tests**: Verify destroyed event triggers full resource cleanup, no events leak after destruction, pending debounce is handled gracefully, and only the affected watch is cleaned up
- **Application shutdown tests**: Verify `stopAllWatches` closes all FSWatchers, removes all destroyed listeners, clears all pending debounce timers, empties the activeWatches map, and is safe to call multiple times
- **Error resilience tests**: Verify cleanup continues when `watcher.close()` throws, and the watch is still removed from the map

## Test Plan
- [x] All 28 new lifecycle/cleanup tests pass
- [x] All 48 total file-watch-service tests pass
- [x] No regressions in existing test suite (3 pre-existing renderer store failures unrelated)
- [x] Lint clean for changed files (2 pre-existing errors in unrelated files)
- [x] Typecheck has 1 pre-existing error in file-watch-service.ts (missing picomatch types) — not introduced by this PR

## Manual Validation
No manual validation needed — this is a test-only change with no production code modifications.