### PR TITLE
perf: load durable agent icons in parallel with Promise.all

### DIFF
--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -17,6 +17,7 @@ vi.stubGlobal('window', {
       deleteForce: vi.fn().mockResolvedValue({ ok: true, message: '' }),
       deleteUnregister: vi.fn().mockResolvedValue({ ok: true, message: '' }),
       reorderDurable: vi.fn().mockResolvedValue(undefined),
+      readIcon: vi.fn().mockResolvedValue(null),
       getDurableConfig: vi.fn().mockResolvedValue(null),
       spawnAgent: vi.fn().mockResolvedValue(undefined),
       killAgent: vi.fn().mockResolvedValue(undefined),
@@ -67,6 +68,7 @@ describe('agentStore', () => {
       agentSpawnedAt: {},
       agentDetailedStatus: {},
       projectActiveAgent: {},
+      agentIcons: {},
     });
   });
 
@@ -881,6 +883,30 @@ describe('agentStore', () => {
 
       await getState().loadDurableAgents('proj_1', '/project');
       expect(getState().agents['durable_nomodel'].model).toBeUndefined();
+    });
+
+    it('loads icons in parallel via Promise.all', async () => {
+      const mockAgent = window.clubhouse.agent as any;
+      mockAgent.listDurable.mockResolvedValue([
+        { id: 'icon_a', name: 'agent-a', color: 'indigo', icon: 'icon_a.png', createdAt: '2024-01-01' },
+        { id: 'icon_b', name: 'agent-b', color: 'emerald', icon: 'icon_b.png', createdAt: '2024-01-01' },
+        { id: 'no_icon', name: 'agent-c', color: 'amber', createdAt: '2024-01-01' },
+      ]);
+      mockAgent.readIcon.mockImplementation((iconPath: string) => {
+        if (iconPath === 'icon_a.png') return Promise.resolve('data:image/png;base64,aaaa');
+        if (iconPath === 'icon_b.png') return Promise.resolve('data:image/png;base64,bbbb');
+        return Promise.resolve(null);
+      });
+
+      await getState().loadDurableAgents('proj_1', '/project');
+
+      // Both icons should be loaded
+      expect(getState().agentIcons['icon_a']).toBe('data:image/png;base64,aaaa');
+      expect(getState().agentIcons['icon_b']).toBe('data:image/png;base64,bbbb');
+      // Agent without icon should not have an entry
+      expect(getState().agentIcons['no_icon']).toBeUndefined();
+      // readIcon should have been called exactly twice (not for no_icon)
+      expect(mockAgent.readIcon).toHaveBeenCalledTimes(2);
     });
 
     it('updates projectId when same agent is loaded under a different project', async () => {

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -376,12 +376,12 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
     set({ agents });
 
-    // Load icons for agents that have them
-    for (const config of configs) {
-      if (config.icon && agents[config.id]) {
-        get().loadAgentIcon(agents[config.id]);
-      }
-    }
+    // Load icons for agents that have them (in parallel)
+    await Promise.all(
+      configs
+        .filter((config) => config.icon && agents[config.id])
+        .map((config) => get().loadAgentIcon(agents[config.id])),
+    );
   },
 
   renameAgent: async (id, newName, projectPath) => {


### PR DESCRIPTION
## Summary
- Replace sequential `for` loop icon loading with `Promise.all` in `loadDurableAgents` to load all agent icons concurrently
- Fixes #647 — eliminates unnecessary latency proportional to agent count

## Changes
- `src/renderer/stores/agentStore.ts`: Changed icon loading loop from sequential fire-and-forget calls to `await Promise.all(...)` with filter+map
- `src/renderer/stores/agentStore.test.ts`: Added test verifying parallel icon loading, added `readIcon` mock and `agentIcons` state reset

## Test Plan
- [x] New test: `loads icons in parallel via Promise.all` — verifies icons for multiple agents are loaded, agents without icons are skipped, and `readIcon` is called exactly the right number of times
- [x] All 76 agentStore tests pass
- [x] Full test suite passes (3 pre-existing failures unrelated to this change)
- [x] TypeScript typecheck passes (1 pre-existing picomatch type error unrelated)

## Manual Validation
1. Add multiple durable agents with custom icons
2. Restart the app and observe that the agent list loads icons without noticeable sequential delay