### PR TITLE
test: add comprehensive unit tests for project-handlers.ts (#648)

### DIFF
--- a/src/main/ipc/project-handlers.test.ts
+++ b/src/main/ipc/project-handlers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as path from 'path';
 import { execSync } from 'child_process';
 
 vi.mock('electron', () => {
@@ -194,7 +195,7 @@ describe('project-handlers', () => {
     const handler = handlers.get(IPC.PROJECT.CHECK_GIT)!;
     const result = await handler({}, '/tmp/my-project');
 
-    expect(fs.existsSync).toHaveBeenCalledWith('/tmp/my-project/.git');
+    expect(fs.existsSync).toHaveBeenCalledWith(path.join('/tmp/my-project', '.git'));
     expect(result).toBe(true);
   });
 
@@ -204,7 +205,7 @@ describe('project-handlers', () => {
     const handler = handlers.get(IPC.PROJECT.CHECK_GIT)!;
     const result = await handler({}, '/tmp/no-git-project');
 
-    expect(fs.existsSync).toHaveBeenCalledWith('/tmp/no-git-project/.git');
+    expect(fs.existsSync).toHaveBeenCalledWith(path.join('/tmp/no-git-project', '.git'));
     expect(result).toBe(false);
   });
 
@@ -472,7 +473,7 @@ describe('project-handlers', () => {
     const handler = handlers.get(IPC.PROJECT.LIST_CLUBHOUSE_FILES)!;
     const result = await handler({}, '/tmp/project');
 
-    expect(fs.existsSync).toHaveBeenCalledWith('/tmp/project/.clubhouse');
+    expect(fs.existsSync).toHaveBeenCalledWith(path.join('/tmp/project', '.clubhouse'));
     expect(result).toEqual([]);
   });
 
@@ -519,7 +520,7 @@ describe('project-handlers', () => {
     const handler = handlers.get(IPC.PROJECT.RESET_PROJECT)!;
     const result = await handler({}, '/tmp/project');
 
-    expect(fs.existsSync).toHaveBeenCalledWith('/tmp/project/.clubhouse');
+    expect(fs.existsSync).toHaveBeenCalledWith(path.join('/tmp/project', '.clubhouse'));
     expect(result).toBe(true);
   });
 
@@ -535,7 +536,7 @@ describe('project-handlers', () => {
       'Resetting project .clubhouse directory',
       { meta: { projectPath: '/tmp/project' } },
     );
-    expect(fs.rmSync).toHaveBeenCalledWith('/tmp/project/.clubhouse', {
+    expect(fs.rmSync).toHaveBeenCalledWith(path.join('/tmp/project', '.clubhouse'), {
       recursive: true,
       force: true,
     });


### PR DESCRIPTION
## Summary
- Expand test coverage for `src/main/ipc/project-handlers.ts` from 26.2% statements / 20% branches to **100% / 100%**
- Add 33 new test cases covering all 14 IPC handlers (up from 4 tests covering only PICK_DIR)
- Closes #648

## Changes
- **Registration test**: Verifies all 14 expected IPC handlers are registered
- **Delegation tests**: LIST, REMOVE, UPDATE, REORDER, READ_ICON, SAVE_CROPPED_ICON — verify correct args passed to project-store and return values forwarded
- **ADD handler**: Tests delegation to `projectStore.add`, `ensureGitignore` call, and graceful handling when `ensureGitignore` throws
- **Dialog handlers** (PICK_DIR, PICK_ICON, PICK_IMAGE): Tests for no focused window → null, dialog canceled → null, successful selection → correct return
- **PICK_IMAGE MIME mapping**: Tests all 6 supported formats (png, jpg, gif, webp, svg, jpeg) plus fallback to `image/png` for unknown extensions
- **CHECK_GIT**: Tests both `.git` existing and not existing
- **GIT_INIT**: Tests successful `execSync` and error case
- **LIST_CLUBHOUSE_FILES**: Tests missing `.clubhouse` dir, recursive directory walk with files and subdirectories, and `readdirSync` permission error
- **RESET_PROJECT**: Tests missing dir (no-op), successful `rmSync`, `rmSync` failure with Error, and non-Error thrown values — verifies `appLog` calls for both warn and error cases

## Test Plan
- [x] All 37 tests pass (`npx vitest run src/main/ipc/project-handlers.test.ts`)
- [x] Coverage report shows 100% statements, branches, functions, and lines
- [x] No lint warnings or errors in the test file
- [x] Full test suite passes (pre-existing failures in unrelated files only)

## Manual Validation
No manual validation needed — this is a test-only change with no production code modifications.