### PR TITLE
Fix agent lifecycle registry cleanup

### DIFF
--- a/notes/issue-566-test-plan.md
+++ b/notes/issue-566-test-plan.md
@@ -1,0 +1,13 @@
+Issue #566 / M-15 Test Plan
+
+Acceptance criteria
+- Agent metadata is tracked through a single registry in `agent-system`.
+- Agent metadata is removed on both explicit kill and natural exit paths.
+- Headless and structured liveness checks defer to their managers instead of duplicate module-level sets.
+
+Test cases
+- PTY spawn stores project path, resolved orchestrator, and nonce in the registry.
+- PTY exit callback restores config and removes tracked metadata.
+- Headless exit callback restores config and removes tracked metadata.
+- Structured exit callback removes tracked metadata.
+- Kill path still uses the tracked orchestrator when choosing the provider exit command.

--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -156,6 +156,18 @@ import * as fs from 'fs';
 describe('agent-system', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHeadlessSpawn.mockImplementation((agentId: string) => {
+      mockIsHeadless.mockImplementation((trackedAgentId: string) => trackedAgentId === agentId);
+    });
+    mockHeadlessKill.mockImplementation((agentId: string) => {
+      mockIsHeadless.mockImplementation((trackedAgentId: string) => trackedAgentId !== agentId);
+    });
+    mockStartStructured.mockImplementation(async (agentId: string) => {
+      mockIsStructuredSession.mockImplementation((trackedAgentId: string) => trackedAgentId === agentId);
+    });
+    mockCancelSession.mockImplementation(async (agentId: string) => {
+      mockIsStructuredSession.mockImplementation((trackedAgentId: string) => trackedAgentId !== agentId);
+    });
   });
 
   afterEach(() => {
@@ -164,6 +176,8 @@ describe('agent-system', () => {
     untrackAgent('agent-1');
     untrackAgent('test-headless');
     untrackAgent('test-structured');
+    mockIsHeadless.mockReturnValue(false);
+    mockIsStructuredSession.mockReturnValue(false);
   });
 
   describe('resolveOrchestrator', () => {

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -17,35 +17,50 @@ import * as structuredManager from './structured-manager';
 
 const DEFAULT_ORCHESTRATOR: OrchestratorId = 'claude-code';
 
-/** Track agentId → projectPath for hook event routing */
-const agentProjectMap = new Map<string, string>();
-/** Track agentId → orchestratorId override */
-const agentOrchestratorMap = new Map<string, OrchestratorId>();
-/** Track agentId → hook nonce for authenticating hook events */
-const agentNonceMap = new Map<string, string>();
-/** Track which agents are running in headless mode */
-const headlessAgentSet = new Set<string>();
-/** Track which agents are running in structured mode */
-const structuredAgentSet = new Set<string>();
+interface AgentRegistration {
+  projectPath: string;
+  orchestrator: OrchestratorId;
+  nonce?: string;
+}
+
+class AgentRegistry {
+  private readonly registrations = new Map<string, AgentRegistration>();
+
+  register(agentId: string, registration: AgentRegistration): void {
+    this.registrations.set(agentId, registration);
+  }
+
+  get(agentId: string): AgentRegistration | undefined {
+    return this.registrations.get(agentId);
+  }
+
+  setNonce(agentId: string, nonce: string): void {
+    const registration = this.registrations.get(agentId);
+    if (!registration) return;
+    registration.nonce = nonce;
+  }
+
+  untrack(agentId: string): void {
+    this.registrations.delete(agentId);
+  }
+}
+
+const agentRegistry = new AgentRegistry();
 
 export function getAgentProjectPath(agentId: string): string | undefined {
-  return agentProjectMap.get(agentId);
+  return agentRegistry.get(agentId)?.projectPath;
 }
 
 export function getAgentOrchestrator(agentId: string): OrchestratorId | undefined {
-  return agentOrchestratorMap.get(agentId);
+  return agentRegistry.get(agentId)?.orchestrator;
 }
 
 export function getAgentNonce(agentId: string): string | undefined {
-  return agentNonceMap.get(agentId);
+  return agentRegistry.get(agentId)?.nonce;
 }
 
 export function untrackAgent(agentId: string): void {
-  agentProjectMap.delete(agentId);
-  agentOrchestratorMap.delete(agentId);
-  agentNonceMap.delete(agentId);
-  headlessAgentSet.delete(agentId);
-  structuredAgentSet.delete(agentId);
+  agentRegistry.untrack(agentId);
 }
 
 /** Read the project-level orchestrator setting from .clubhouse/settings.json */
@@ -103,11 +118,11 @@ export interface SpawnAgentParams {
 }
 
 export function isHeadlessAgent(agentId: string): boolean {
-  return headlessAgentSet.has(agentId) || headlessManager.isHeadless(agentId);
+  return headlessManager.isHeadless(agentId);
 }
 
 export function isStructuredAgent(agentId: string): boolean {
-  return structuredAgentSet.has(agentId) || structuredManager.isStructuredSession(agentId);
+  return structuredManager.isStructuredSession(agentId);
 }
 
 export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
@@ -134,8 +149,10 @@ export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
     throw new Error(msg);
   }
 
-  agentProjectMap.set(params.agentId, params.projectPath);
-  agentOrchestratorMap.set(params.agentId, provider.id as OrchestratorId);
+  agentRegistry.register(params.agentId, {
+    projectPath: params.projectPath,
+    orchestrator: provider.id as OrchestratorId,
+  });
 
   try {
     // Clubhouse Mode: materialize project defaults into worktree before spawn
@@ -159,25 +176,19 @@ export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
     const spawnMode = headlessSettings.getSpawnMode(params.projectPath);
     if (spawnMode === 'structured' && params.kind === 'quick' && provider.createStructuredAdapter) {
       const adapter = provider.createStructuredAdapter();
-      structuredAgentSet.add(params.agentId);
-      try {
-        await structuredManager.startStructuredSession(params.agentId, adapter, {
-          mission: params.mission || '',
-          systemPrompt: params.systemPrompt,
-          model: params.model,
-          cwd: params.cwd,
-          env: profileEnv,
-          allowedTools,
-          freeAgentMode: params.freeAgentMode,
-          commandPrefix,
-        }, (exitAgentId) => {
-          untrackAgent(exitAgentId);
-        });
-        return;
-      } catch (err) {
-        structuredAgentSet.delete(params.agentId);
-        throw err;
-      }
+      await structuredManager.startStructuredSession(params.agentId, adapter, {
+        mission: params.mission || '',
+        systemPrompt: params.systemPrompt,
+        model: params.model,
+        cwd: params.cwd,
+        env: profileEnv,
+        allowedTools,
+        freeAgentMode: params.freeAgentMode,
+        commandPrefix,
+      }, (exitAgentId) => {
+        untrackAgent(exitAgentId);
+      });
+      return;
     }
 
     // Try headless path for quick agents when enabled
@@ -194,27 +205,21 @@ export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
       });
 
       if (headlessResult) {
-        headlessAgentSet.add(params.agentId);
         const spawnEnv = { ...headlessResult.env, ...profileEnv, CLUBHOUSE_AGENT_ID: params.agentId };
-        try {
-          headlessManager.spawnHeadless(
-            params.agentId,
-            params.cwd,
-            headlessResult.binary,
-            headlessResult.args,
-            spawnEnv,
-            headlessResult.outputKind || 'stream-json',
-            (exitAgentId) => {
-              configPipeline.restoreForAgent(exitAgentId);
-              untrackAgent(exitAgentId);
-            },
-            commandPrefix,
-          );
-          return;
-        } catch (err) {
-          headlessAgentSet.delete(params.agentId);
-          throw err;
-        }
+        headlessManager.spawnHeadless(
+          params.agentId,
+          params.cwd,
+          headlessResult.binary,
+          headlessResult.args,
+          spawnEnv,
+          headlessResult.outputKind || 'stream-json',
+          (exitAgentId) => {
+            configPipeline.restoreForAgent(exitAgentId);
+            untrackAgent(exitAgentId);
+          },
+          commandPrefix,
+        );
+        return;
       }
     }
 
@@ -234,7 +239,7 @@ async function spawnPtyAgent(
   commandPrefix?: string,
 ): Promise<void> {
   const nonce = randomUUID();
-  agentNonceMap.set(params.agentId, nonce);
+  agentRegistry.setNonce(params.agentId, nonce);
 
   // Snapshot hooks config before writing so we can restore on exit
   const hookConfigPath = configPipeline.getHooksConfigPath(provider, params.cwd);
@@ -314,17 +319,17 @@ async function spawnPtyAgent(
 export async function killAgent(agentId: string, projectPath: string, orchestrator?: OrchestratorId): Promise<void> {
   appLog('core:agent', 'info', 'Killing agent', { meta: { agentId } });
   try {
-    if (structuredAgentSet.has(agentId) || structuredManager.isStructuredSession(agentId)) {
+    if (structuredManager.isStructuredSession(agentId)) {
       untrackAgent(agentId);
       await structuredManager.cancelSession(agentId);
       return;
     }
-    if (headlessAgentSet.has(agentId) || headlessManager.isHeadless(agentId)) {
+    if (headlessManager.isHeadless(agentId)) {
       untrackAgent(agentId);
       headlessManager.kill(agentId);
       return;
     }
-    const tracked = agentOrchestratorMap.get(agentId);
+    const tracked = agentRegistry.get(agentId)?.orchestrator;
     const provider = resolveOrchestrator(projectPath, tracked || orchestrator);
     const exitCmd = provider.getExitCommand();
     ptyManager.gracefulKill(agentId, exitCmd);

--- a/src/main/services/headless-integration.test.ts
+++ b/src/main/services/headless-integration.test.ts
@@ -97,6 +97,12 @@ import {
 describe('Headless integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHeadlessSpawn.mockImplementation((agentId: string) => {
+      mockHeadlessIsHeadless.mockImplementation((trackedAgentId: string) => trackedAgentId === agentId);
+    });
+    mockHeadlessKill.mockImplementation((agentId: string) => {
+      mockHeadlessIsHeadless.mockImplementation((trackedAgentId: string) => trackedAgentId !== agentId);
+    });
     mockGetSettings.mockReturnValue({ enabled: false });
     mockGetSpawnMode.mockReturnValue('interactive');
     mockBuildHeadlessCommand.mockResolvedValue({
@@ -108,6 +114,7 @@ describe('Headless integration', () => {
 
   afterEach(() => {
     untrackAgent('test-agent');
+    mockHeadlessIsHeadless.mockReturnValue(false);
   });
 
   describe('headless spawn routing', () => {


### PR DESCRIPTION
## Summary
- replace module-level agent tracking maps and sets with a single agent registry in `agent-system`
- remove duplicated headless and structured liveness state so runtime status comes from the managers
- keep cleanup on natural exit and explicit kill paths, with regression coverage for PTY and headless flows

## Test Plan
- [x] `npx vitest run src/main/services/agent-system.test.ts src/main/services/headless-integration.test.ts`
- [x] `npx eslint src/main/services/agent-system.ts src/main/services/agent-system.test.ts src/main/services/headless-integration.test.ts`
- [ ] `npm test` blocked by existing repo failures:
  - `src/main/services/search-service.test.ts`
  - `src/renderer/stores/commandPaletteStore.test.ts`
  - `src/renderer/stores/onboardingStore.test.ts`
  - `src/renderer/stores/uiStore.test.ts`
  - sandbox-related `EPERM` listener failures in `src/main/services/annex-server.test.ts`
- [ ] `npm run lint` blocked by pre-existing repo errors:
  - `src/main/services/hook-server.test.ts:342`
  - `src/renderer/features/settings/PluginListSettings.tsx:198`
- [ ] `npm run build` blocked because `package.json` has no `build` script

## Manual Validation
- not run
