### PR TITLE
refactor: extract shared optimisticUpdate utility for store rollback (#588)

### DIFF
--- a/src/renderer/stores/clubhouseModeStore.ts
+++ b/src/renderer/stores/clubhouseModeStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { SourceControlProvider } from '../../shared/types';
+import { optimisticUpdate } from './optimistic-update';
 
 interface ClubhouseModeState {
   enabled: boolean;
@@ -32,16 +33,14 @@ export const useClubhouseModeStore = create<ClubhouseModeState>((set, get) => ({
   },
 
   setEnabled: async (enabled, projectPath?) => {
-    const { enabled: prev, projectOverrides, sourceControlProvider } = get();
-    set({ enabled });
-    try {
-      await window.clubhouse.app.saveClubhouseModeSettings(
+    const { projectOverrides, sourceControlProvider } = get();
+    await optimisticUpdate(set, get,
+      { enabled },
+      () => window.clubhouse.app.saveClubhouseModeSettings(
         { enabled, projectOverrides, sourceControlProvider },
         projectPath,
-      );
-    } catch {
-      set({ enabled: prev });
-    }
+      ),
+    );
   },
 
   isEnabledForProject: (projectPath?) => {
@@ -53,42 +52,35 @@ export const useClubhouseModeStore = create<ClubhouseModeState>((set, get) => ({
   },
 
   setProjectOverride: async (projectPath, enabled) => {
-    const { enabled: currentEnabled, projectOverrides: prevOverrides, sourceControlProvider } = get();
-    const newOverrides = { ...prevOverrides, [projectPath]: enabled };
-    set({ projectOverrides: newOverrides });
-    try {
-      await window.clubhouse.app.saveClubhouseModeSettings(
+    const { enabled: currentEnabled, sourceControlProvider } = get();
+    const newOverrides = { ...get().projectOverrides, [projectPath]: enabled };
+    await optimisticUpdate(set, get,
+      { projectOverrides: newOverrides },
+      () => window.clubhouse.app.saveClubhouseModeSettings(
         { enabled: currentEnabled, projectOverrides: newOverrides, sourceControlProvider },
         projectPath,
-      );
-    } catch {
-      set({ projectOverrides: prevOverrides });
-    }
+      ),
+    );
   },
 
   clearProjectOverride: async (projectPath) => {
-    const { enabled, projectOverrides: prevOverrides, sourceControlProvider } = get();
-    const { [projectPath]: _, ...rest } = prevOverrides;
-    set({ projectOverrides: rest });
-    try {
-      await window.clubhouse.app.saveClubhouseModeSettings(
+    const { enabled, projectOverrides, sourceControlProvider } = get();
+    const { [projectPath]: _, ...rest } = projectOverrides;
+    await optimisticUpdate(set, get,
+      { projectOverrides: rest },
+      () => window.clubhouse.app.saveClubhouseModeSettings(
         { enabled, projectOverrides: rest, sourceControlProvider },
-        projectPath,
-      );
-    } catch {
-      set({ projectOverrides: prevOverrides });
-    }
+      ),
+    );
   },
 
   setSourceControlProvider: async (provider) => {
-    const { sourceControlProvider: prev, enabled, projectOverrides } = get();
-    set({ sourceControlProvider: provider });
-    try {
-      await window.clubhouse.app.saveClubhouseModeSettings(
+    const { enabled, projectOverrides } = get();
+    await optimisticUpdate(set, get,
+      { sourceControlProvider: provider },
+      () => window.clubhouse.app.saveClubhouseModeSettings(
         { enabled, projectOverrides, sourceControlProvider: provider },
-      );
-    } catch {
-      set({ sourceControlProvider: prev });
-    }
+      ),
+    );
   },
 }));

--- a/src/renderer/stores/headlessStore.ts
+++ b/src/renderer/stores/headlessStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { optimisticUpdate } from './optimistic-update';
 
 export type SpawnMode = 'headless' | 'interactive' | 'structured';
 
@@ -31,16 +32,14 @@ export const useHeadlessStore = create<HeadlessState>((set, get) => ({
   },
 
   setDefaultMode: async (mode) => {
-    const { defaultMode: prevDefaultMode, projectOverrides: currentOverrides } = get();
-    set({ defaultMode: mode });
-    try {
-      await window.clubhouse.app.saveHeadlessSettings({
+    const { projectOverrides } = get();
+    await optimisticUpdate(set, get,
+      { defaultMode: mode },
+      () => window.clubhouse.app.saveHeadlessSettings({
         defaultMode: mode,
-        projectOverrides: currentOverrides,
-      });
-    } catch {
-      set({ defaultMode: prevDefaultMode });
-    }
+        projectOverrides,
+      }),
+    );
   },
 
   getProjectMode: (projectPath?) => {
@@ -52,30 +51,26 @@ export const useHeadlessStore = create<HeadlessState>((set, get) => ({
   },
 
   setProjectMode: async (projectPath, mode) => {
-    const { projectOverrides: prevOverrides, defaultMode: currentDefault } = get();
-    const newOverrides = { ...prevOverrides, [projectPath]: mode };
-    set({ projectOverrides: newOverrides });
-    try {
-      await window.clubhouse.app.saveHeadlessSettings({
-        defaultMode: currentDefault,
+    const { defaultMode } = get();
+    const newOverrides = { ...get().projectOverrides, [projectPath]: mode };
+    await optimisticUpdate(set, get,
+      { projectOverrides: newOverrides },
+      () => window.clubhouse.app.saveHeadlessSettings({
+        defaultMode,
         projectOverrides: newOverrides,
-      });
-    } catch {
-      set({ projectOverrides: prevOverrides });
-    }
+      }),
+    );
   },
 
   clearProjectMode: async (projectPath) => {
-    const { projectOverrides: prevOverrides, defaultMode: currentDefault } = get();
-    const { [projectPath]: _, ...rest } = prevOverrides;
-    set({ projectOverrides: rest });
-    try {
-      await window.clubhouse.app.saveHeadlessSettings({
-        defaultMode: currentDefault,
+    const { defaultMode, projectOverrides } = get();
+    const { [projectPath]: _, ...rest } = projectOverrides;
+    await optimisticUpdate(set, get,
+      { projectOverrides: rest },
+      () => window.clubhouse.app.saveHeadlessSettings({
+        defaultMode,
         projectOverrides: rest,
-      });
-    } catch {
-      set({ projectOverrides: prevOverrides });
-    }
+      }),
+    );
   },
 }));

--- a/src/renderer/stores/optimistic-update.test.ts
+++ b/src/renderer/stores/optimistic-update.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { optimisticUpdate } from './optimistic-update';
+
+interface TestState {
+  count: number;
+  name: string;
+  items: string[];
+}
+
+function createMockStore(initial: TestState) {
+  let state = { ...initial };
+  const set = vi.fn((partial: Partial<TestState>) => {
+    state = { ...state, ...partial };
+  });
+  const get = () => state;
+  return { set, get };
+}
+
+describe('optimisticUpdate', () => {
+  it('applies the update optimistically', async () => {
+    const { set, get } = createMockStore({ count: 0, name: 'a', items: [] });
+    const ipcCall = vi.fn().mockResolvedValue(undefined);
+
+    await optimisticUpdate(set, get, { count: 1 }, ipcCall);
+
+    expect(get().count).toBe(1);
+    expect(set).toHaveBeenCalledWith({ count: 1 });
+  });
+
+  it('calls the IPC function after applying update', async () => {
+    const { set, get } = createMockStore({ count: 0, name: 'a', items: [] });
+    const callOrder: string[] = [];
+
+    const ipcCall = vi.fn().mockImplementation(async () => {
+      callOrder.push('ipc');
+    });
+    set.mockImplementation((partial: Partial<TestState>) => {
+      callOrder.push('set');
+      Object.assign(get(), partial);
+    });
+
+    await optimisticUpdate(set, get, { count: 1 }, ipcCall);
+
+    expect(callOrder).toEqual(['set', 'ipc']);
+  });
+
+  it('reverts on IPC failure', async () => {
+    const { set, get } = createMockStore({ count: 5, name: 'a', items: [] });
+    const ipcCall = vi.fn().mockRejectedValue(new Error('IPC failed'));
+
+    await optimisticUpdate(set, get, { count: 10 }, ipcCall);
+
+    // Should have reverted to 5
+    expect(get().count).toBe(5);
+    // Two set calls: optimistic update + revert
+    expect(set).toHaveBeenCalledTimes(2);
+    expect(set).toHaveBeenNthCalledWith(1, { count: 10 });
+    expect(set).toHaveBeenNthCalledWith(2, { count: 5 });
+  });
+
+  it('does not revert on IPC success', async () => {
+    const { set, get } = createMockStore({ count: 0, name: 'a', items: [] });
+    const ipcCall = vi.fn().mockResolvedValue(undefined);
+
+    await optimisticUpdate(set, get, { count: 42 }, ipcCall);
+
+    expect(get().count).toBe(42);
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('only snapshots and reverts the fields being updated', async () => {
+    const { set, get } = createMockStore({ count: 0, name: 'original', items: ['a'] });
+    const ipcCall = vi.fn().mockRejectedValue(new Error('fail'));
+
+    await optimisticUpdate(set, get, { count: 99 }, ipcCall);
+
+    // count should revert
+    expect(get().count).toBe(0);
+    // name and items should be unchanged
+    expect(get().name).toBe('original');
+    expect(get().items).toEqual(['a']);
+    // Revert call should only include the snapshotted field
+    expect(set).toHaveBeenNthCalledWith(2, { count: 0 });
+  });
+
+  it('handles multi-field updates and rollbacks', async () => {
+    const { set, get } = createMockStore({ count: 1, name: 'old', items: ['x'] });
+    const ipcCall = vi.fn().mockRejectedValue(new Error('fail'));
+
+    await optimisticUpdate(set, get, { count: 2, name: 'new' }, ipcCall);
+
+    expect(get().count).toBe(1);
+    expect(get().name).toBe('old');
+    expect(set).toHaveBeenNthCalledWith(2, { count: 1, name: 'old' });
+  });
+
+  it('snapshots state before the optimistic set', async () => {
+    const { set: originalSet, get } = createMockStore({ count: 0, name: 'a', items: [] });
+
+    // Track what state was when ipcCall runs
+    let stateAtIpcCall: TestState | undefined;
+    const ipcCall = vi.fn().mockImplementation(async () => {
+      stateAtIpcCall = { ...get() };
+    });
+
+    await optimisticUpdate(originalSet, get, { count: 7 }, ipcCall);
+
+    // At IPC call time, optimistic update should already be applied
+    expect(stateAtIpcCall?.count).toBe(7);
+  });
+
+  it('works with reference-type values (objects/arrays)', async () => {
+    const origItems = ['a', 'b'];
+    const { set, get } = createMockStore({ count: 0, name: 'a', items: origItems });
+    const ipcCall = vi.fn().mockRejectedValue(new Error('fail'));
+
+    await optimisticUpdate(set, get, { items: ['x', 'y', 'z'] }, ipcCall);
+
+    // Should revert to the original array reference
+    expect(get().items).toBe(origItems);
+  });
+});

--- a/src/renderer/stores/optimistic-update.ts
+++ b/src/renderer/stores/optimistic-update.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared optimistic-update-with-rollback utility for Zustand stores.
+ *
+ * Pattern: snapshot the fields being updated, apply the update optimistically,
+ * run the async IPC call, and revert on failure.
+ *
+ * Callers should capture any additional pre-update state (for the IPC payload)
+ * before calling this function.
+ */
+export async function optimisticUpdate<State>(
+  set: (partial: Partial<State>) => void,
+  get: () => State,
+  update: Partial<State>,
+  ipcCall: () => Promise<unknown>,
+): Promise<void> {
+  const current = get();
+  const snapshot: Partial<State> = {};
+  for (const key of Object.keys(update) as (keyof State)[]) {
+    snapshot[key] = current[key];
+  }
+
+  set(update);
+
+  try {
+    await ipcCall();
+  } catch {
+    set(snapshot);
+  }
+}

--- a/src/renderer/stores/orchestratorStore.ts
+++ b/src/renderer/stores/orchestratorStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { ProviderCapabilities, OrchestratorInfo } from '../../shared/types';
+import { optimisticUpdate } from './optimistic-update';
 
 interface OrchestratorState {
   enabled: string[];
@@ -41,13 +42,10 @@ export const useOrchestratorStore = create<OrchestratorState>((set, get) => ({
       // Don't allow disabling all orchestrators
       if (next.length === 0) return;
     }
-    set({ enabled: next });
-    try {
-      await window.clubhouse.app.saveOrchestratorSettings({ enabled: next });
-    } catch {
-      // Revert on error
-      set({ enabled: current });
-    }
+    await optimisticUpdate(set, get,
+      { enabled: next },
+      () => window.clubhouse.app.saveOrchestratorSettings({ enabled: next }),
+    );
   },
 
   checkAllAvailability: async () => {


### PR DESCRIPTION
## Summary
- Extract a shared `optimisticUpdate(set, get, update, ipcCall)` utility that handles the save-state/optimistic-update/IPC-call/revert-on-error pattern
- Deduplicate 8 independent implementations of this pattern across `headlessStore`, `clubhouseModeStore`, and `orchestratorStore`
- Add comprehensive tests for the new utility

Fixes #588

## Changes
- **`src/renderer/stores/optimistic-update.ts`** — New utility function that snapshots the fields being updated, applies the optimistic update, awaits the IPC call, and reverts on failure
- **`src/renderer/stores/headlessStore.ts`** — Refactored `setDefaultMode`, `setProjectMode`, `clearProjectMode` to use `optimisticUpdate`
- **`src/renderer/stores/clubhouseModeStore.ts`** — Refactored `setEnabled`, `setProjectOverride`, `clearProjectOverride`, `setSourceControlProvider` to use `optimisticUpdate`
- **`src/renderer/stores/orchestratorStore.ts`** — Refactored `setEnabled` to use `optimisticUpdate`
- **`src/renderer/stores/optimistic-update.test.ts`** — 8 tests covering success, failure/rollback, multi-field updates, field isolation, reference types, and call ordering

## Test Plan
- [x] All 8 new `optimistic-update.test.ts` tests pass
- [x] All 39 existing `headlessStore.test.ts` tests pass (including race condition prevention)
- [x] All 11 existing `clubhouseModeStore.test.ts` tests pass (including race condition prevention)
- [x] All 18 existing `orchestratorStore.test.ts` tests pass
- [x] TypeScript compiles without new errors
- [x] Lint passes on changed files

## Manual Validation
- Toggle headless mode settings and verify optimistic updates + rollback behavior
- Toggle clubhouse mode, project overrides, and source control provider settings
- Enable/disable orchestrators in settings