### PR TITLE
test: add killAgent error resilience and cleanup tests (#645)

### DIFF
--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -1400,5 +1400,89 @@ describe('agent-system', () => {
       // Clean up
       delete (mockProvider as any).createStructuredAdapter;
     });
+
+    it('does not reject when headless kill throws', async () => {
+      mockIsHeadless.mockReturnValue(true);
+      mockHeadlessKill.mockImplementation(() => { throw new Error('kill failed'); });
+
+      await expect(killAgent('ext-headless', '/project')).resolves.toBeUndefined();
+    });
+
+    it('does not reject when structured cancelSession rejects', async () => {
+      mockIsStructuredSession.mockReturnValue(true);
+      mockCancelSession.mockRejectedValue(new Error('cancel failed'));
+
+      await expect(killAgent('ext-structured', '/project')).resolves.toBeUndefined();
+    });
+
+    it('untrackAgent is called even when headless kill throws', async () => {
+      mockGetSpawnMode.mockReturnValue('headless');
+      mockProvider.buildHeadlessCommand = vi.fn(() =>
+        Promise.resolve({
+          binary: '/usr/bin/claude',
+          args: ['--headless'],
+          env: {},
+          outputKind: 'stream-json' as const,
+        }),
+      );
+
+      await spawnAgent({
+        agentId: 'test-headless',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'quick',
+        mission: 'test',
+      });
+
+      expect(getAgentProjectPath('test-headless')).toBe('/project');
+
+      mockHeadlessKill.mockImplementation(() => { throw new Error('kill failed'); });
+      await killAgent('test-headless', '/project');
+
+      // Agent should still be untracked despite kill failure
+      expect(getAgentProjectPath('test-headless')).toBeUndefined();
+      expect(getAgentOrchestrator('test-headless')).toBeUndefined();
+
+      // Clean up
+      delete (mockProvider as any).buildHeadlessCommand;
+    });
+
+    it('untrackAgent is called even when structured cancelSession rejects', async () => {
+      mockGetSpawnMode.mockReturnValue('structured');
+      const mockAdapter = { start: vi.fn(), sendMessage: vi.fn(), respondToPermission: vi.fn(), cancel: vi.fn(), dispose: vi.fn() };
+      mockProvider.createStructuredAdapter = vi.fn(() => mockAdapter);
+
+      await spawnAgent({
+        agentId: 'test-structured',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'quick',
+        mission: 'test',
+      });
+
+      expect(getAgentProjectPath('test-structured')).toBe('/project');
+
+      mockCancelSession.mockRejectedValue(new Error('cancel failed'));
+      await killAgent('test-structured', '/project');
+
+      // Agent should still be untracked despite cancel failure
+      expect(getAgentProjectPath('test-structured')).toBeUndefined();
+      expect(getAgentOrchestrator('test-structured')).toBeUndefined();
+
+      // Clean up
+      delete (mockProvider as any).createStructuredAdapter;
+    });
+
+    it('structured branch takes priority over headless when both match', async () => {
+      mockIsStructuredSession.mockReturnValue(true);
+      mockIsHeadless.mockReturnValue(true);
+
+      await killAgent('dual-agent', '/project');
+
+      // Structured branch checked first — only cancelSession called
+      expect(mockCancelSession).toHaveBeenCalledWith('dual-agent');
+      expect(mockHeadlessKill).not.toHaveBeenCalled();
+      expect(mockPtyGracefulKill).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add 5 new test cases for `killAgent` covering error resilience and resource cleanup in the structured and headless branches
- Closes #645: killAgent was missing tests verifying proper cleanup when structured/headless termination fails

## Changes
- **Error resilience tests**: Verify `killAgent` doesn't reject when `headlessManager.kill()` throws or `structuredManager.cancelSession()` rejects
- **Cleanup-on-failure tests**: Verify the agent registry is cleaned up (`untrackAgent`) even when the kill/cancel operation fails — preventing resource leaks
- **Priority test**: Verify structured branch takes priority over headless when both managers claim the agent

## Test Plan
- [x] `does not reject when headless kill throws` — headless kill error caught by try-catch
- [x] `does not reject when structured cancelSession rejects` — async cancel error caught
- [x] `untrackAgent is called even when headless kill throws` — registry cleaned up despite kill failure
- [x] `untrackAgent is called even when structured cancelSession rejects` — registry cleaned up despite cancel failure
- [x] `structured branch takes priority over headless when both match` — correct routing order

## Manual Validation
All 6172 tests pass. No build or lint regressions.