### PR TITLE
fix: suppress redundant polling when hooks are active (#646)

### DIFF
--- a/src/renderer/features/agents/HeadlessAgentView.test.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.test.tsx
@@ -240,6 +240,85 @@ describe('HeadlessAgentView', () => {
     expect(screen.getByText('Inspect file')).toBeInTheDocument();
   });
 
+  it('suppresses polling when hooks are actively firing', async () => {
+    let hookCallback: (agentId: string, event: Record<string, unknown>) => void = () => {};
+    window.clubhouse.agent.onHookEvent = vi.fn((cb) => {
+      hookCallback = cb;
+      return vi.fn();
+    });
+    window.clubhouse.agent.readTranscriptPage = vi.fn().mockResolvedValue({
+      events: [],
+      totalEvents: 0,
+    });
+
+    render(<HeadlessAgentView agent={headlessAgent} />);
+
+    // Initial mount triggers one sync
+    await flushAsyncWork();
+    const callsAfterMount = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+
+    // Fire hook events to mark hooks as active
+    act(() => {
+      hookCallback(headlessAgent.id, {
+        kind: 'pre_tool',
+        toolName: 'Read',
+        timestamp: Date.now(),
+      });
+    });
+    await flushAsyncWork();
+    const callsAfterHook = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+
+    // Advance past multiple poll intervals (500ms each) while hooks are "active"
+    // The poller should skip these cycles since hooks fired recently
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await flushAsyncWork();
+    const callsAfterPolling = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+
+    // Hook-triggered sync should have added calls, but the poller intervals
+    // should NOT have added any additional calls
+    expect(callsAfterPolling).toBe(callsAfterHook);
+    // Verify hook did trigger at least one sync beyond the initial mount
+    expect(callsAfterHook).toBeGreaterThan(callsAfterMount);
+  });
+
+  it('resumes polling when hooks stop firing', async () => {
+    let hookCallback: (agentId: string, event: Record<string, unknown>) => void = () => {};
+    window.clubhouse.agent.onHookEvent = vi.fn((cb) => {
+      hookCallback = cb;
+      return vi.fn();
+    });
+    window.clubhouse.agent.readTranscriptPage = vi.fn().mockResolvedValue({
+      events: [],
+      totalEvents: 0,
+    });
+
+    render(<HeadlessAgentView agent={headlessAgent} />);
+    await flushAsyncWork();
+
+    // Fire a hook event to suppress polling
+    act(() => {
+      hookCallback(headlessAgent.id, {
+        kind: 'pre_tool',
+        toolName: 'Read',
+        timestamp: Date.now(),
+      });
+    });
+    await flushAsyncWork();
+    const callsAfterHook = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+
+    // Advance past the hook active threshold (5s) so hooks are no longer "active"
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    await flushAsyncWork();
+    const callsAfterThreshold = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+
+    // Polling should have resumed and made additional calls
+    expect(callsAfterThreshold).toBeGreaterThan(callsAfterHook);
+  });
+
   it('freezes the timer when the agent is no longer running', () => {
     const now = Date.now();
     resetStore(now - 60_000);

--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -249,6 +249,9 @@ function AnimatedTreehouse() {
   );
 }
 
+/** How recently a hook must have fired for us to consider hooks "active" and skip polling. */
+const HOOK_ACTIVE_THRESHOLD_MS = 5_000;
+
 export function HeadlessAgentView({ agent }: Props) {
   const [feedItems, setFeedItems] = useState<FeedItem[]>([]);
   const [elapsed, setElapsed] = useState(0);
@@ -262,6 +265,7 @@ export function HeadlessAgentView({ agent }: Props) {
   const notificationCountsRef = useRef<Map<string, number>>(new Map());
   const syncingTranscriptRef = useRef(false);
   const syncRequestedRef = useRef(false);
+  const lastHookTimestampRef = useRef(0);
   const killAgent = useAgentStore((s) => s.killAgent);
   const spawnedAt = useAgentStore((s) => s.agentSpawnedAt[agent.id]);
 
@@ -300,6 +304,7 @@ export function HeadlessAgentView({ agent }: Props) {
     notificationCountsRef.current = new Map();
     syncingTranscriptRef.current = false;
     syncRequestedRef.current = false;
+    lastHookTimestampRef.current = 0;
     setFeedItems([]);
 
     async function syncTranscript(): Promise<void> {
@@ -352,6 +357,7 @@ export function HeadlessAgentView({ agent }: Props) {
     const removeListener = window.clubhouse.agent.onHookEvent(
       (agentId: string, event: AgentHookEvent) => {
         if (agentId !== agent.id) return;
+        lastHookTimestampRef.current = Date.now();
 
         if (event.kind === 'notification' && event.message) {
           appendNotificationItem(event.message, event.timestamp || Date.now());
@@ -367,10 +373,16 @@ export function HeadlessAgentView({ agent }: Props) {
     void syncTranscript();
     const fastInterval = setInterval(() => {
       pollCount++;
+      // Skip poll when hooks are actively firing — they already trigger syncs
+      if (Date.now() - lastHookTimestampRef.current < HOOK_ACTIVE_THRESHOLD_MS) return;
       void syncTranscript();
       if (pollCount >= 10) {
         clearInterval(fastInterval);
-        interval = setInterval(() => { void syncTranscript(); }, 2000);
+        interval = setInterval(() => {
+          // Skip poll when hooks are actively firing
+          if (Date.now() - lastHookTimestampRef.current < HOOK_ACTIVE_THRESHOLD_MS) return;
+          void syncTranscript();
+        }, 2000);
       }
     }, 500);
 


### PR DESCRIPTION
## Summary
- Fixes #646 — dual data sources (hooks + polling) causing redundant transcript syncs
- When hook events are actively firing, the periodic poller skips its cycles since hooks already trigger `syncTranscript()` on each relevant event
- Polling automatically resumes as a fallback when hooks stop firing (after 5s threshold)

## Changes
- Added `lastHookTimestampRef` to track when the most recent hook event was received
- Added `HOOK_ACTIVE_THRESHOLD_MS` (5s) constant defining the "hooks active" window
- Poller intervals check `lastHookTimestampRef` and skip when hooks fired recently
- Reset `lastHookTimestampRef` on agent change alongside other refs

## Test Plan
- [x] New test: poller is suppressed while hooks are actively firing
- [x] New test: polling resumes after hooks stop firing (past 5s threshold)
- [x] All 247 existing test files pass (6169 tests)
- [x] Lint clean

## Manual Validation
1. Start a headless agent — hook events should drive the live feed with no visual jumps
2. Verify the transcript poller does not fire redundant syncs while hooks are active (can observe via devtools network/console)
3. If hooks stop (e.g., provider doesn't support them), polling should resume after ~5s