### PR TITLE
Fix IPC handler argument validation drift

### DIFF
--- a/src/main/ipc/file-handlers.test.ts
+++ b/src/main/ipc/file-handlers.test.ts
@@ -153,6 +153,12 @@ describe('file-handlers', () => {
     expect(result).toEqual({ size: 100, isFile: true });
   });
 
+  it('rejects invalid path arguments before delegating', async () => {
+    const handler = handlers.get(IPC.FILE.READ)!;
+    expect(() => handler({}, null)).toThrow('arg1 must be a string');
+    expect(fileService.readFile).not.toHaveBeenCalled();
+  });
+
   it('READ throws descriptive error and logs when readFile fails', async () => {
     const err = Object.assign(new Error('no such file or directory'), { code: 'ENOENT' });
     vi.mocked(fileService.readFile).mockRejectedValueOnce(err);

--- a/src/main/ipc/file-handlers.ts
+++ b/src/main/ipc/file-handlers.ts
@@ -5,9 +5,21 @@ import * as searchService from '../services/search-service';
 import { startWatch, stopWatch } from '../services/file-watch-service';
 import { appLog } from '../services/log-service';
 import type { FileSearchOptions } from '../../shared/types';
+import { booleanArg, numberArg, objectArg, stringArg, withValidatedArgs } from './validation';
 
 export function registerFileHandlers(): void {
-  ipcMain.handle(IPC.FILE.READ_TREE, async (event, dirPath: string, options?: { includeHidden?: boolean; depth?: number }) => {
+  ipcMain.handle(IPC.FILE.READ_TREE, withValidatedArgs(
+    [
+      stringArg(),
+      objectArg<{ includeHidden?: boolean; depth?: number }>({
+        optional: true,
+        validate: (value, argName) => {
+          if (value.includeHidden !== undefined) booleanArg()(value.includeHidden, `${argName}.includeHidden`);
+          if (value.depth !== undefined) numberArg({ integer: true, min: 0 })(value.depth, `${argName}.depth`);
+        },
+      }),
+    ],
+    async (event, dirPath: string, options?: { includeHidden?: boolean; depth?: number }) => {
     const controller = new AbortController();
     const abort = () => controller.abort();
     event.sender.once('destroyed', abort);
@@ -16,9 +28,10 @@ export function registerFileHandlers(): void {
     } finally {
       event.sender.off('destroyed', abort);
     }
-  });
+    },
+  ));
 
-  ipcMain.handle(IPC.FILE.READ, async (_event, filePath: string) => {
+  ipcMain.handle(IPC.FILE.READ, withValidatedArgs([stringArg()], async (_event, filePath: string) => {
     try {
       return await fileService.readFile(filePath);
     } catch (err) {
@@ -29,49 +42,53 @@ export function registerFileHandlers(): void {
       });
       throw new Error(`Failed to read file "${filePath}": ${code} - ${message}`);
     }
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.WRITE, async (_event, filePath: string, content: string) => {
+  ipcMain.handle(IPC.FILE.WRITE, withValidatedArgs([stringArg(), stringArg({ minLength: 0 })], async (_event, filePath: string, content: string) => {
     await fileService.writeFile(filePath, content);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.READ_BINARY, async (_event, filePath: string) => {
+  ipcMain.handle(IPC.FILE.READ_BINARY, withValidatedArgs([stringArg()], async (_event, filePath: string) => {
     return fileService.readBinary(filePath);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.SHOW_IN_FOLDER, (_event, filePath: string) => {
+  ipcMain.handle(IPC.FILE.SHOW_IN_FOLDER, withValidatedArgs([stringArg()], (_event, filePath: string) => {
     shell.showItemInFolder(filePath);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.MKDIR, async (_event, dirPath: string) => {
+  ipcMain.handle(IPC.FILE.MKDIR, withValidatedArgs([stringArg()], async (_event, dirPath: string) => {
     await fileService.mkdir(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.DELETE, async (_event, filePath: string) => {
+  ipcMain.handle(IPC.FILE.DELETE, withValidatedArgs([stringArg()], async (_event, filePath: string) => {
     await fileService.deleteFile(filePath);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.RENAME, async (_event, oldPath: string, newPath: string) => {
+  ipcMain.handle(IPC.FILE.RENAME, withValidatedArgs([stringArg(), stringArg()], async (_event, oldPath: string, newPath: string) => {
     await fileService.rename(oldPath, newPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.COPY, async (_event, src: string, dest: string) => {
+  ipcMain.handle(IPC.FILE.COPY, withValidatedArgs([stringArg(), stringArg()], async (_event, src: string, dest: string) => {
     await fileService.copy(src, dest);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.STAT, async (_event, filePath: string) => {
+  ipcMain.handle(IPC.FILE.STAT, withValidatedArgs([stringArg()], async (_event, filePath: string) => {
     return fileService.stat(filePath);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.WATCH_START, (event, watchId: string, glob: string) => {
+  ipcMain.handle(IPC.FILE.WATCH_START, withValidatedArgs([stringArg(), stringArg()], (event, watchId: string, glob: string) => {
     startWatch(watchId, glob, event.sender);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.WATCH_STOP, (_event, watchId: string) => {
+  ipcMain.handle(IPC.FILE.WATCH_STOP, withValidatedArgs([stringArg()], (_event, watchId: string) => {
     stopWatch(watchId);
-  });
+  }));
 
-  ipcMain.handle(IPC.FILE.SEARCH, async (_event, rootPath: string, query: string, options?: FileSearchOptions) => {
+  ipcMain.handle(IPC.FILE.SEARCH, withValidatedArgs([
+    stringArg(),
+    stringArg({ minLength: 0 }),
+    objectArg<FileSearchOptions>({ optional: true }),
+  ], async (_event, rootPath: string, query: string, options?: FileSearchOptions) => {
     return searchService.searchFiles(rootPath, query, options);
-  });
+  }));
 }

--- a/src/main/ipc/git-handlers.test.ts
+++ b/src/main/ipc/git-handlers.test.ts
@@ -135,4 +135,10 @@ describe('git-handlers', () => {
     await handler({}, '/project');
     expect(gitService.stashPop).toHaveBeenCalledWith('/project');
   });
+
+  it('rejects invalid file arguments before delegating', async () => {
+    const handler = handlers.get(IPC.GIT.STAGE)!;
+    expect(() => handler({}, '/project', 42)).toThrow('arg2 must be a string');
+    expect(gitService.stage).not.toHaveBeenCalled();
+  });
 });

--- a/src/main/ipc/git-handlers.ts
+++ b/src/main/ipc/git-handlers.ts
@@ -1,61 +1,62 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import * as gitService from '../services/git-service';
+import { booleanArg, stringArg, withValidatedArgs } from './validation';
 
 export function registerGitHandlers(): void {
-  ipcMain.handle(IPC.GIT.INFO, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.INFO, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.getGitInfo(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.CHECKOUT, (_event, dirPath: string, branch: string) => {
+  ipcMain.handle(IPC.GIT.CHECKOUT, withValidatedArgs([stringArg(), stringArg()], (_event, dirPath: string, branch: string) => {
     return gitService.checkout(dirPath, branch);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.STAGE, (_event, dirPath: string, filePath: string) => {
+  ipcMain.handle(IPC.GIT.STAGE, withValidatedArgs([stringArg(), stringArg()], (_event, dirPath: string, filePath: string) => {
     return gitService.stage(dirPath, filePath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.UNSTAGE, (_event, dirPath: string, filePath: string) => {
+  ipcMain.handle(IPC.GIT.UNSTAGE, withValidatedArgs([stringArg(), stringArg()], (_event, dirPath: string, filePath: string) => {
     return gitService.unstage(dirPath, filePath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.STAGE_ALL, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.STAGE_ALL, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.stageAll(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.UNSTAGE_ALL, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.UNSTAGE_ALL, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.unstageAll(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.DISCARD, (_event, dirPath: string, filePath: string, isUntracked: boolean) => {
+  ipcMain.handle(IPC.GIT.DISCARD, withValidatedArgs([stringArg(), stringArg(), booleanArg()], (_event, dirPath: string, filePath: string, isUntracked: boolean) => {
     return gitService.discardFile(dirPath, filePath, isUntracked);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.COMMIT, (_event, dirPath: string, message: string) => {
+  ipcMain.handle(IPC.GIT.COMMIT, withValidatedArgs([stringArg(), stringArg({ minLength: 0 })], (_event, dirPath: string, message: string) => {
     return gitService.commit(dirPath, message);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.PUSH, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.PUSH, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.push(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.PULL, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.PULL, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.pull(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.DIFF, (_event, dirPath: string, filePath: string, staged: boolean) => {
+  ipcMain.handle(IPC.GIT.DIFF, withValidatedArgs([stringArg(), stringArg(), booleanArg()], (_event, dirPath: string, filePath: string, staged: boolean) => {
     return gitService.getFileDiff(dirPath, filePath, staged);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.CREATE_BRANCH, (_event, dirPath: string, branchName: string) => {
+  ipcMain.handle(IPC.GIT.CREATE_BRANCH, withValidatedArgs([stringArg(), stringArg()], (_event, dirPath: string, branchName: string) => {
     return gitService.createBranch(dirPath, branchName);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.STASH, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.STASH, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.stash(dirPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.GIT.STASH_POP, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.GIT.STASH_POP, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return gitService.stashPop(dirPath);
-  });
+  }));
 }

--- a/src/main/ipc/plugin-handlers.test.ts
+++ b/src/main/ipc/plugin-handlers.test.ts
@@ -239,4 +239,10 @@ describe('plugin-handlers', () => {
     expect(pluginDiscovery.listOrphanedPluginIds).toHaveBeenCalledWith('/project/path', ['plugin-a']);
     expect(result).toEqual([]);
   });
+
+  it('rejects invalid mkdir arguments before delegating', async () => {
+    const handler = handlers.get(IPC.PLUGIN.MKDIR)!;
+    expect(() => handler({}, 'p1', 'project', 123, '/project')).toThrow('arg3 must be a string');
+    expect(pluginStorage.mkdirPlugin).not.toHaveBeenCalled();
+  });
 });

--- a/src/main/ipc/plugin-handlers.ts
+++ b/src/main/ipc/plugin-handlers.ts
@@ -1,11 +1,29 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
-import { PluginManifest } from '../../shared/plugin-types';
+import type {
+  PluginFileRequest,
+  PluginManifest,
+  PluginStorageDeleteRequest,
+  PluginStorageListRequest,
+  PluginStorageReadRequest,
+  PluginStorageWriteRequest,
+} from '../../shared/plugin-types';
 import * as pluginStorage from '../services/plugin-storage';
 import * as pluginDiscovery from '../services/plugin-discovery';
 import * as gitignoreManager from '../services/gitignore-manager';
 import * as safeMode from '../services/safe-mode';
 import * as pluginManifestRegistry from '../services/plugin-manifest-registry';
+import { arrayArg, objectArg, optional, stringArg, withValidatedArgs } from './validation';
+
+type PluginScope = 'project' | 'project-local' | 'global';
+
+function pluginScopeArg(value: unknown, argName: string): PluginScope {
+  const scope = stringArg()(value, argName);
+  if (scope !== 'project' && scope !== 'project-local' && scope !== 'global') {
+    throw new Error(`${argName} must be one of: project, project-local, global`);
+  }
+  return scope;
+}
 
 export function registerPluginHandlers(): void {
   // ── Discovery ────────────────────────────────────────────────────────
@@ -14,92 +32,155 @@ export function registerPluginHandlers(): void {
   });
 
   // ── KV Storage ───────────────────────────────────────────────────────
-  ipcMain.handle(IPC.PLUGIN.STORAGE_READ, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.STORAGE_READ, withValidatedArgs([objectArg<PluginStorageReadRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.key, `${argName}.key`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     return pluginStorage.readKey(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.STORAGE_WRITE, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.STORAGE_WRITE, withValidatedArgs([objectArg<PluginStorageWriteRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.key, `${argName}.key`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     await pluginStorage.writeKey(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.STORAGE_DELETE, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.STORAGE_DELETE, withValidatedArgs([objectArg<PluginStorageDeleteRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.key, `${argName}.key`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     await pluginStorage.deleteKey(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.STORAGE_LIST, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.STORAGE_LIST, withValidatedArgs([objectArg<PluginStorageListRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     return pluginStorage.listKeys(req);
-  });
+  }));
 
   // ── File Storage ─────────────────────────────────────────────────────
-  ipcMain.handle(IPC.PLUGIN.FILE_READ, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.FILE_READ, withValidatedArgs([objectArg<PluginFileRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.relativePath, `${argName}.relativePath`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     return pluginStorage.readPluginFile(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.FILE_WRITE, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.FILE_WRITE, withValidatedArgs([objectArg<PluginFileRequest & { content: string }>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.relativePath, `${argName}.relativePath`);
+      stringArg({ minLength: 0 })(req.content, `${argName}.content`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     await pluginStorage.writePluginFile(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.FILE_DELETE, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.FILE_DELETE, withValidatedArgs([objectArg<PluginFileRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.relativePath, `${argName}.relativePath`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     await pluginStorage.deletePluginFile(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.FILE_EXISTS, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.FILE_EXISTS, withValidatedArgs([objectArg<PluginFileRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.relativePath, `${argName}.relativePath`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     return pluginStorage.pluginFileExists(req);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.FILE_LIST_DIR, async (_event, req) => {
+  ipcMain.handle(IPC.PLUGIN.FILE_LIST_DIR, withValidatedArgs([objectArg<PluginFileRequest>({
+    validate: (req, argName) => {
+      stringArg()(req.pluginId, `${argName}.pluginId`);
+      pluginScopeArg(req.scope, `${argName}.scope`);
+      stringArg()(req.relativePath, `${argName}.relativePath`);
+      optional(stringArg())(req.projectPath, `${argName}.projectPath`);
+    },
+  })], async (_event, req) => {
     return pluginStorage.listPluginDir(req);
-  });
+  }));
 
   // ── Gitignore ────────────────────────────────────────────────────────
-  ipcMain.handle(IPC.PLUGIN.GITIGNORE_ADD, (_event, projectPath: string, pluginId: string, patterns: string[]) => {
+  ipcMain.handle(IPC.PLUGIN.GITIGNORE_ADD, withValidatedArgs([stringArg(), stringArg(), arrayArg(stringArg())], (_event, projectPath: string, pluginId: string, patterns: string[]) => {
     gitignoreManager.addEntries(projectPath, pluginId, patterns);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.GITIGNORE_REMOVE, (_event, projectPath: string, pluginId: string) => {
+  ipcMain.handle(IPC.PLUGIN.GITIGNORE_REMOVE, withValidatedArgs([stringArg(), stringArg()], (_event, projectPath: string, pluginId: string) => {
     gitignoreManager.removeEntries(projectPath, pluginId);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.GITIGNORE_CHECK, (_event, projectPath: string, pattern: string) => {
+  ipcMain.handle(IPC.PLUGIN.GITIGNORE_CHECK, withValidatedArgs([stringArg(), stringArg()], (_event, projectPath: string, pattern: string) => {
     return gitignoreManager.isIgnored(projectPath, pattern);
-  });
+  }));
 
   // ── Safe Mode / Startup Marker ───────────────────────────────────────
   ipcMain.handle(IPC.PLUGIN.STARTUP_MARKER_READ, () => {
     return safeMode.readMarker();
   });
 
-  ipcMain.handle(IPC.PLUGIN.STARTUP_MARKER_WRITE, (_event, enabledPlugins: string[]) => {
+  ipcMain.handle(IPC.PLUGIN.STARTUP_MARKER_WRITE, withValidatedArgs([arrayArg(stringArg())], (_event, enabledPlugins: string[]) => {
     safeMode.writeMarker(enabledPlugins);
-  });
+  }));
 
   ipcMain.handle(IPC.PLUGIN.STARTUP_MARKER_CLEAR, () => {
     safeMode.clearMarker();
   });
 
   // ── Misc ─────────────────────────────────────────────────────────────
-  ipcMain.handle(IPC.PLUGIN.MKDIR, async (_event, pluginId: string, scope: string, relativePath: string, projectPath?: string) => {
+  ipcMain.handle(IPC.PLUGIN.MKDIR, withValidatedArgs([stringArg(), stringArg(), stringArg(), stringArg({ optional: true })], async (_event, pluginId: string, scope: string, relativePath: string, projectPath?: string) => {
     await pluginStorage.mkdirPlugin(pluginId, scope as 'project' | 'global', relativePath, projectPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.UNINSTALL, async (_event, pluginId: string) => {
+  ipcMain.handle(IPC.PLUGIN.UNINSTALL, withValidatedArgs([stringArg()], async (_event, pluginId: string) => {
     await pluginDiscovery.uninstallPlugin(pluginId);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.LIST_PROJECT_INJECTIONS, (_event, pluginId: string, projectPath: string) => {
+  ipcMain.handle(IPC.PLUGIN.LIST_PROJECT_INJECTIONS, withValidatedArgs([stringArg(), stringArg()], (_event, pluginId: string, projectPath: string) => {
     return pluginDiscovery.listProjectPluginInjections(pluginId, projectPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.CLEANUP_PROJECT_INJECTIONS, async (_event, pluginId: string, projectPath: string) => {
+  ipcMain.handle(IPC.PLUGIN.CLEANUP_PROJECT_INJECTIONS, withValidatedArgs([stringArg(), stringArg()], async (_event, pluginId: string, projectPath: string) => {
     await pluginDiscovery.cleanupProjectPluginInjections(pluginId, projectPath);
-  });
+  }));
 
-  ipcMain.handle(IPC.PLUGIN.LIST_ORPHANED_PLUGIN_IDS, (_event, projectPath: string, knownPluginIds: string[]) => {
+  ipcMain.handle(IPC.PLUGIN.LIST_ORPHANED_PLUGIN_IDS, withValidatedArgs([stringArg(), arrayArg(stringArg())], (_event, projectPath: string, knownPluginIds: string[]) => {
     return pluginDiscovery.listOrphanedPluginIds(projectPath, knownPluginIds);
-  });
+  }));
 
   // ── Manifest Registry ─────────────────────────────────────────────────
-  ipcMain.handle(IPC.PLUGIN.REGISTER_MANIFEST, (_event, pluginId: string, manifest: PluginManifest) => {
+  ipcMain.handle(IPC.PLUGIN.REGISTER_MANIFEST, withValidatedArgs([stringArg(), objectArg<PluginManifest>()], (_event, pluginId: string, manifest: PluginManifest) => {
     pluginManifestRegistry.registerManifest(pluginId, manifest);
-  });
+  }));
 }

--- a/src/main/ipc/process-handlers.test.ts
+++ b/src/main/ipc/process-handlers.test.ts
@@ -186,6 +186,17 @@ describe('process-handlers', () => {
     });
   });
 
+  it('rejects invalid argument types before policy checks run', async () => {
+    const handler = handlers.get(IPC.PROCESS.EXEC)!;
+    expect(() => handler({}, {
+      pluginId: 'p1',
+      command: 'ls',
+      args: ['-la'],
+      projectPath: 42,
+    })).toThrow('arg1.projectPath must be a string');
+    expect(getAllowedCommands).not.toHaveBeenCalled();
+  });
+
   // ── Execution behavior ─────────────────────────────────────────────
 
   it('executes valid commands via execFile', async () => {

--- a/src/main/ipc/process-handlers.ts
+++ b/src/main/ipc/process-handlers.ts
@@ -3,6 +3,7 @@ import { execFile } from 'child_process';
 import { IPC } from '../../shared/ipc-channels';
 import { getShellEnvironment } from '../util/shell';
 import { getAllowedCommands } from '../services/plugin-manifest-registry';
+import { arrayArg, numberArg, objectArg, stringArg, withValidatedArgs } from './validation';
 
 interface ProcessExecRequest {
   pluginId: string;
@@ -17,7 +18,20 @@ const MAX_TIMEOUT = 60000;
 const DEFAULT_TIMEOUT = 15000;
 
 export function registerProcessHandlers(): void {
-  ipcMain.handle(IPC.PROCESS.EXEC, (_event, req: ProcessExecRequest) => {
+  ipcMain.handle(IPC.PROCESS.EXEC, withValidatedArgs([objectArg<ProcessExecRequest>({
+    validate: (req, argName) => {
+      stringArg({ optional: true, minLength: 0 })(req.pluginId, `${argName}.pluginId`);
+      stringArg({ optional: true, minLength: 0 })(req.command, `${argName}.command`);
+      arrayArg(stringArg())(req.args, `${argName}.args`);
+      stringArg({ optional: true })(req.projectPath, `${argName}.projectPath`);
+      objectArg<{ timeout?: number }>({
+        optional: true,
+        validate: (options, optionsArgName) => {
+          if (options.timeout !== undefined) numberArg({ integer: true, min: 0 })(options.timeout, `${optionsArgName}.timeout`);
+        },
+      })(req.options, `${argName}.options`);
+    },
+  })], (_event, req: ProcessExecRequest) => {
     const { pluginId, command, args, projectPath, options } = req;
 
     // Reject requests without a pluginId
@@ -76,5 +90,5 @@ export function registerProcessHandlers(): void {
         },
       );
     });
-  });
+  }));
 }

--- a/src/main/ipc/project-handlers.test.ts
+++ b/src/main/ipc/project-handlers.test.ts
@@ -137,6 +137,12 @@ describe('project-handlers', () => {
     expect(result).toEqual({ id: 'proj_1', name: 'test', path: '/tmp/readonly-project' });
   });
 
+  it('rejects invalid project paths before delegating', async () => {
+    const handler = handlers.get(IPC.PROJECT.ADD)!;
+    expect(() => handler({}, { bad: true })).toThrow('arg1 must be a string');
+    expect(projectStore.add).not.toHaveBeenCalled();
+  });
+
   // --- REMOVE ---
 
   it('REMOVE delegates to projectStore.remove', async () => {

--- a/src/main/ipc/project-handlers.ts
+++ b/src/main/ipc/project-handlers.ts
@@ -6,13 +6,14 @@ import { IPC } from '../../shared/ipc-channels';
 import * as projectStore from '../services/project-store';
 import { ensureGitignore } from '../services/agent-config';
 import { appLog } from '../services/log-service';
+import { arrayArg, objectArg, stringArg, withValidatedArgs } from './validation';
 
 export function registerProjectHandlers(): void {
   ipcMain.handle(IPC.PROJECT.LIST, () => {
     return projectStore.list();
   });
 
-  ipcMain.handle(IPC.PROJECT.ADD, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.PROJECT.ADD, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     const project = projectStore.add(dirPath);
     try {
       ensureGitignore(dirPath);
@@ -20,11 +21,11 @@ export function registerProjectHandlers(): void {
       // Non-fatal
     }
     return project;
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.REMOVE, (_event, id: string) => {
+  ipcMain.handle(IPC.PROJECT.REMOVE, withValidatedArgs([stringArg()], (_event, id: string) => {
     projectStore.remove(id);
-  });
+  }));
 
   ipcMain.handle(IPC.PROJECT.PICK_DIR, async () => {
     const win = BrowserWindow.getFocusedWindow();
@@ -37,24 +38,24 @@ export function registerProjectHandlers(): void {
     return result.filePaths[0];
   });
 
-  ipcMain.handle(IPC.PROJECT.CHECK_GIT, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.PROJECT.CHECK_GIT, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     return fs.existsSync(path.join(dirPath, '.git'));
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.GIT_INIT, (_event, dirPath: string) => {
+  ipcMain.handle(IPC.PROJECT.GIT_INIT, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
     try {
       execSync('git init', { cwd: dirPath, encoding: 'utf-8' });
       return true;
     } catch {
       return false;
     }
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.UPDATE, (_event, id: string, updates: Record<string, unknown>) => {
+  ipcMain.handle(IPC.PROJECT.UPDATE, withValidatedArgs([stringArg(), objectArg<Record<string, unknown>>()], (_event, id: string, updates: Record<string, unknown>) => {
     return projectStore.update(id, updates as any);
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.PICK_ICON, async (_event, projectId: string) => {
+  ipcMain.handle(IPC.PROJECT.PICK_ICON, withValidatedArgs([stringArg()], async (_event, projectId: string) => {
     const win = BrowserWindow.getFocusedWindow();
     if (!win) return null;
     const result = await dialog.showOpenDialog(win, {
@@ -64,15 +65,15 @@ export function registerProjectHandlers(): void {
     });
     if (result.canceled || result.filePaths.length === 0) return null;
     return projectStore.setIcon(projectId, result.filePaths[0]);
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.REORDER, (_event, orderedIds: string[]) => {
+  ipcMain.handle(IPC.PROJECT.REORDER, withValidatedArgs([arrayArg(stringArg())], (_event, orderedIds: string[]) => {
     return projectStore.reorder(orderedIds);
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.READ_ICON, (_event, filename: string) => {
+  ipcMain.handle(IPC.PROJECT.READ_ICON, withValidatedArgs([stringArg()], (_event, filename: string) => {
     return projectStore.readIconData(filename);
-  });
+  }));
 
   ipcMain.handle(IPC.PROJECT.PICK_IMAGE, async () => {
     const win = BrowserWindow.getFocusedWindow();
@@ -94,11 +95,11 @@ export function registerProjectHandlers(): void {
     return `data:${mime};base64,${data.toString('base64')}`;
   });
 
-  ipcMain.handle(IPC.PROJECT.SAVE_CROPPED_ICON, (_event, projectId: string, dataUrl: string) => {
+  ipcMain.handle(IPC.PROJECT.SAVE_CROPPED_ICON, withValidatedArgs([stringArg(), stringArg()], (_event, projectId: string, dataUrl: string) => {
     return projectStore.saveCroppedIcon(projectId, dataUrl);
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.LIST_CLUBHOUSE_FILES, (_event, projectPath: string): string[] => {
+  ipcMain.handle(IPC.PROJECT.LIST_CLUBHOUSE_FILES, withValidatedArgs([stringArg()], (_event, projectPath: string): string[] => {
     const clubhouseDir = path.join(projectPath, '.clubhouse');
     if (!fs.existsSync(clubhouseDir)) return [];
     try {
@@ -120,9 +121,9 @@ export function registerProjectHandlers(): void {
     } catch {
       return [];
     }
-  });
+  }));
 
-  ipcMain.handle(IPC.PROJECT.RESET_PROJECT, (_event, projectPath: string): boolean => {
+  ipcMain.handle(IPC.PROJECT.RESET_PROJECT, withValidatedArgs([stringArg()], (_event, projectPath: string): boolean => {
     const clubhouseDir = path.join(projectPath, '.clubhouse');
     if (!fs.existsSync(clubhouseDir)) return true;
     try {
@@ -137,5 +138,5 @@ export function registerProjectHandlers(): void {
       });
       return false;
     }
-  });
+  }));
 }

--- a/src/main/ipc/pty-handlers.test.ts
+++ b/src/main/ipc/pty-handlers.test.ts
@@ -75,4 +75,10 @@ describe('pty-handlers', () => {
     expect(ptyManager.getBuffer).toHaveBeenCalledWith('agent-1');
     expect(result).toBe('terminal output');
   });
+
+  it('rejects invalid spawn arguments before delegating', async () => {
+    const handler = handleHandlers.get(IPC.PTY.SPAWN_SHELL)!;
+    expect(() => handler({}, 'agent-1', null)).toThrow('arg2 must be a string');
+    expect(ptyManager.spawnShell).not.toHaveBeenCalled();
+  });
 });

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -1,25 +1,26 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import * as ptyManager from '../services/pty-manager';
+import { numberArg, stringArg, withValidatedArgs } from './validation';
 
 export function registerPtyHandlers(): void {
-  ipcMain.handle(IPC.PTY.SPAWN_SHELL, (_event, id: string, projectPath: string) => {
+  ipcMain.handle(IPC.PTY.SPAWN_SHELL, withValidatedArgs([stringArg(), stringArg()], (_event, id: string, projectPath: string) => {
     ptyManager.spawnShell(id, projectPath);
-  });
+  }));
 
-  ipcMain.on(IPC.PTY.WRITE, (_event, agentId: string, data: string) => {
+  ipcMain.on(IPC.PTY.WRITE, withValidatedArgs([stringArg(), stringArg({ minLength: 0 })], (_event, agentId: string, data: string) => {
     ptyManager.write(agentId, data);
-  });
+  }));
 
-  ipcMain.on(IPC.PTY.RESIZE, (_event, agentId: string, cols: number, rows: number) => {
+  ipcMain.on(IPC.PTY.RESIZE, withValidatedArgs([stringArg(), numberArg({ integer: true, min: 1 }), numberArg({ integer: true, min: 1 })], (_event, agentId: string, cols: number, rows: number) => {
     ptyManager.resize(agentId, cols, rows);
-  });
+  }));
 
-  ipcMain.handle(IPC.PTY.KILL, (_event, agentId: string) => {
+  ipcMain.handle(IPC.PTY.KILL, withValidatedArgs([stringArg()], (_event, agentId: string) => {
     ptyManager.gracefulKill(agentId);
-  });
+  }));
 
-  ipcMain.handle(IPC.PTY.GET_BUFFER, (_event, agentId: string) => {
+  ipcMain.handle(IPC.PTY.GET_BUFFER, withValidatedArgs([stringArg()], (_event, agentId: string) => {
     return ptyManager.getBuffer(agentId);
-  });
+  }));
 }

--- a/src/main/ipc/validation.ts
+++ b/src/main/ipc/validation.ts
@@ -1,0 +1,119 @@
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+
+type IpcEvent = IpcMainEvent | IpcMainInvokeEvent;
+type IpcHandler<Args extends unknown[], Result> = (event: IpcEvent, ...args: Args) => Result;
+
+export type ArgValidator<T> = (value: unknown, argName: string) => T;
+
+function fail(argName: string, message: string): never {
+  throw new Error(`${argName} ${message}`);
+}
+
+function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+export function stringArg(options: { minLength?: number; optional: true }): ArgValidator<string | undefined>;
+export function stringArg(options?: { minLength?: number; optional?: false }): ArgValidator<string>;
+export function stringArg(options: { minLength?: number; optional?: boolean } = {}): ArgValidator<string | undefined> {
+  const { minLength = 1, optional = false } = options;
+
+  return (value, argName) => {
+    if (optional && value === undefined) return undefined;
+    if (typeof value !== 'string') {
+      fail(argName, `must be a string, received ${describeType(value)}`);
+    }
+    if (value.length < minLength) {
+      fail(argName, `must be at least ${minLength} character${minLength === 1 ? '' : 's'}`);
+    }
+    return value;
+  };
+}
+
+export function booleanArg(): ArgValidator<boolean> {
+  return (value, argName) => {
+    if (typeof value !== 'boolean') {
+      fail(argName, `must be a boolean, received ${describeType(value)}`);
+    }
+    return value;
+  };
+}
+
+export function numberArg(options: { integer?: boolean; min?: number; optional: true }): ArgValidator<number | undefined>;
+export function numberArg(options?: { integer?: boolean; min?: number; optional?: false }): ArgValidator<number>;
+export function numberArg(options: { integer?: boolean; min?: number; optional?: boolean } = {}): ArgValidator<number | undefined> {
+  const { integer = false, min, optional = false } = options;
+
+  return (value, argName) => {
+    if (optional && value === undefined) return undefined;
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      fail(argName, `must be a number, received ${describeType(value)}`);
+    }
+    if (integer && !Number.isInteger(value)) {
+      fail(argName, 'must be an integer');
+    }
+    if (min !== undefined && value < min) {
+      fail(argName, `must be greater than or equal to ${min}`);
+    }
+    return value;
+  };
+}
+
+export function arrayArg<T>(itemValidator: ArgValidator<T>, options: { optional: true }): ArgValidator<T[] | undefined>;
+export function arrayArg<T>(itemValidator: ArgValidator<T>, options?: { optional?: false }): ArgValidator<T[]>;
+export function arrayArg<T>(itemValidator: ArgValidator<T>, options: { optional?: boolean } = {}): ArgValidator<T[] | undefined> {
+  const { optional = false } = options;
+
+  return (value, argName) => {
+    if (optional && value === undefined) return undefined;
+    if (!Array.isArray(value)) {
+      fail(argName, `must be an array, received ${describeType(value)}`);
+    }
+    return value.map((item, index) => itemValidator(item, `${argName}[${index}]`));
+  };
+}
+
+export function objectArg<T extends object>(options: {
+  optional: true;
+  validate?: (value: T, argName: string) => void;
+}): ArgValidator<T | undefined>;
+export function objectArg<T extends object>(options?: {
+  optional?: false;
+  validate?: (value: T, argName: string) => void;
+}): ArgValidator<T>;
+export function objectArg<T extends object>(options: {
+  optional?: boolean;
+  validate?: (value: T, argName: string) => void;
+} = {}): ArgValidator<T | undefined> {
+  const { optional = false, validate } = options;
+
+  return (value, argName) => {
+    if (optional && value === undefined) return undefined;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      fail(argName, `must be an object, received ${describeType(value)}`);
+    }
+    const typedValue = value as T;
+    validate?.(typedValue, argName);
+    return typedValue;
+  };
+}
+
+export function optional<T>(validator: ArgValidator<T>): ArgValidator<T | undefined> {
+  return (value, argName) => (value === undefined ? undefined : validator(value, argName));
+}
+
+function validateArgs<Args extends unknown[]>(args: unknown[], validators: { [K in keyof Args]: ArgValidator<Args[K]> }): Args {
+  return validators.map((validator, index) => validator(args[index], `arg${index + 1}`)) as Args;
+}
+
+export function withValidatedArgs<Args extends unknown[], Result>(
+  validators: { [K in keyof Args]: ArgValidator<Args[K]> },
+  handler: IpcHandler<Args, Result>,
+): IpcHandler<Args, Result> {
+  return (event, ...rawArgs) => {
+    const args = validateArgs(rawArgs, validators);
+    return handler(event, ...args);
+  };
+}

--- a/src/picomatch.d.ts
+++ b/src/picomatch.d.ts
@@ -1,0 +1,10 @@
+declare module 'picomatch' {
+  interface PicomatchOptions {
+    dot?: boolean;
+    nocase?: boolean;
+  }
+
+  type Matcher = (input: string) => boolean;
+
+  export default function picomatch(pattern: string | readonly string[], options?: PicomatchOptions): Matcher;
+}

--- a/test/issue-578-ipc-validation-plan.md
+++ b/test/issue-578-ipc-validation-plan.md
@@ -1,0 +1,27 @@
+# Issue 578 Test Plan
+
+## Goal
+Ensure IPC handlers validate user-controlled and path-like arguments before delegating to main-process services.
+
+## Acceptance Criteria
+- IPC handlers use a shared validation wrapper instead of ad hoc inline checks.
+- Invalid argument types are rejected before any service call executes.
+- Existing valid payloads continue to delegate unchanged.
+- Regression tests cover representative handler families with path-like inputs.
+
+## Test Cases
+1. `file-handlers`
+   - Accept valid file paths and delegate to file services.
+   - Reject non-string file path arguments for read/write/search style handlers.
+2. `git-handlers`
+   - Accept valid repository and file paths.
+   - Reject invalid path arguments before invoking git services.
+3. `project-handlers`
+   - Accept valid project paths and identifiers.
+   - Reject invalid project path arguments for add/check/reset flows.
+4. `plugin-handlers`
+   - Accept valid plugin/project path inputs.
+   - Reject invalid mkdir/gitignore/orphaned-project arguments before service calls.
+5. `pty-handlers`
+   - Accept valid shell spawn parameters.
+   - Reject invalid `projectPath` payloads before PTY creation.


### PR DESCRIPTION
## Summary
- add a shared IPC argument validation wrapper for `ipcMain.handle`/`ipcMain.on`
- apply the wrapper to file, git, project, plugin, process, and PTY handlers with path-like or user-controlled inputs
- add regression tests for rejected invalid payloads and record the issue test plan in-tree

## Changes
- introduced `src/main/ipc/validation.ts` with reusable validators and middleware-style handler wrapping
- replaced ad hoc delegation in the affected IPC handlers with centralized argument checks before service calls
- preserved existing `process:exec` policy behavior while moving structural request validation into the shared layer
- added `src/picomatch.d.ts` so `npm run typecheck` can pass in this worktree

## Test Plan
- [x] `npm test -- src/main/ipc/file-handlers.test.ts src/main/ipc/git-handlers.test.ts src/main/ipc/project-handlers.test.ts src/main/ipc/plugin-handlers.test.ts src/main/ipc/process-handlers.test.ts src/main/ipc/pty-handlers.test.ts`
- [x] `npm run typecheck`
- [ ] `npm run build` (blocked: no `build` script exists in `package.json`)
- [ ] `npm test` (blocked by existing repo failures outside this patch, including `src/main/services/hook-server.test.ts`, `src/main/services/search-service.test.ts`, and sandboxed `annex-server` listen errors)
- [ ] `npm run lint` (blocked by existing repo failures in `src/main/services/hook-server.test.ts` and `src/renderer/features/settings/PluginListSettings.tsx`)

## Manual Validation
- invalid IPC payloads now throw before delegating to main-process services in the covered handler families
- valid payloads still delegate to the same service entry points as before