### PR TITLE
fix: enforce path-segment boundary in plugin storage traversal guard

### DIFF
--- a/src/main/services/plugin-storage.test.ts
+++ b/src/main/services/plugin-storage.test.ts
@@ -227,6 +227,35 @@ describe('plugin-storage', () => {
     });
   });
 
+  // ── Path segment boundary enforcement ─────────────────────────────────
+
+  describe('assertSafePath segment boundary', () => {
+    it('rejects prefix collision via sibling directory name', async () => {
+      // A pluginId like "my-plugin-evil" should not be able to read from
+      // "my-plugin" storage via a relative path that resolves to a prefix match
+      // e.g. base = ".../my-plugin/kv", target resolves to ".../my-plugin-evil/kv/secret"
+      // The old startsWith check would allow ".../my-plugin-evil".startsWith(".../my-plugin")
+      await expect(
+        readPluginFile({ pluginId: 'p', scope: 'global', relativePath: '../p-evil/secret.txt' }),
+      ).rejects.toThrow('Path traversal');
+    });
+
+    it('rejects key that escapes via prefix collision', async () => {
+      // key "../my-plugin-evil/data" resolves outside the kv dir via prefix trick
+      await expect(
+        readKey({ pluginId: 'p', scope: 'global', key: '../p-evil/data' }),
+      ).rejects.toThrow('Path traversal');
+    });
+
+    it('allows path that exactly equals base (e.g. relativePath ".")', async () => {
+      vi.mocked(fsp.readdir).mockResolvedValue([
+        { name: 'file.txt', isDirectory: () => false },
+      ] as any);
+      const entries = await listPluginDir({ pluginId: 'p', scope: 'global', relativePath: '.' });
+      expect(entries).toEqual([{ name: 'file.txt', isDirectory: false }]);
+    });
+  });
+
   // ── project-local scope ──────────────────────────────────────────────
 
   describe('project-local scope', () => {

--- a/src/main/services/plugin-storage.ts
+++ b/src/main/services/plugin-storage.ts
@@ -56,7 +56,7 @@ async function ensureDir(dirPath: string): Promise<void> {
 function assertSafePath(base: string, target: string): void {
   const resolvedBase = path.resolve(base);
   const resolved = path.resolve(base, target);
-  if (!resolved.startsWith(resolvedBase)) {
+  if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + path.sep)) {
     appLog('core:plugin-storage', 'error', 'Path traversal attempt blocked', {
       meta: { base, target, resolved },
     });


### PR DESCRIPTION
## Summary
- Fix bypassable path traversal guard in `plugin-storage.ts` where `startsWith` didn't enforce a path-segment boundary (S-6)
- `/base-evil` would pass `startsWith('/base')`, allowing reads/writes/deletes to escape the plugin storage sandbox via directory name prefix collision

## Changes
- **`src/main/services/plugin-storage.ts`**: Changed `assertSafePath` to require `resolved === resolvedBase || resolved.startsWith(resolvedBase + path.sep)` instead of bare `resolved.startsWith(resolvedBase)`
- **`src/main/services/plugin-storage.test.ts`**: Added 3 test cases covering prefix collision via sibling directory names, key-based prefix escape, and exact base path equality (relativePath `.`)

## Test Plan
- [x] Existing path traversal tests (`../../etc/passwd`, `../../../evil`, `../bad`, `../../escape`) still pass
- [x] New test: `readPluginFile` with `relativePath: '../p-evil/secret.txt'` rejects (prefix collision)
- [x] New test: `readKey` with `key: '../p-evil/data'` rejects (prefix collision via key)
- [x] New test: `listPluginDir` with `relativePath: '.'` succeeds (exact base match still allowed)
- [x] Full suite: 249 test files, 6178 tests passing
- [x] Typecheck and lint clean

## Manual Validation
No manual validation needed — this is a pure logic fix with comprehensive unit test coverage.