### PR TITLE
fix: harden git-service against argument injection (S-4)

### DIFF
--- a/src/main/services/git-service.test.ts
+++ b/src/main/services/git-service.test.ts
@@ -771,6 +771,99 @@ describe('getFileDiff — edge cases', () => {
   });
 });
 
+describe('security — input validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('branch name validation', () => {
+    it('rejects branch names starting with -', async () => {
+      await expect(checkout(DIR, '--track')).rejects.toThrow("must not start with '-'");
+      await expect(createBranch(DIR, '-evil')).rejects.toThrow("must not start with '-'");
+    });
+
+    it('rejects branch names with null bytes', async () => {
+      await expect(checkout(DIR, 'main\0evil')).rejects.toThrow('null bytes');
+      await expect(createBranch(DIR, 'branch\0name')).rejects.toThrow('null bytes');
+    });
+
+    it('allows valid branch names with slashes and dots', async () => {
+      mockGitExec(() => 'Switched\n');
+      const result = await checkout(DIR, 'feature/my-branch.v2');
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('file path validation', () => {
+    it('rejects absolute paths', async () => {
+      await expect(stage(DIR, '/etc/passwd')).rejects.toThrow('must be relative');
+      await expect(unstage(DIR, '/etc/passwd')).rejects.toThrow('must be relative');
+      await expect(getFileDiff(DIR, '/etc/passwd', false)).rejects.toThrow('must be relative');
+      await expect(discardFile(DIR, '/etc/passwd', false)).rejects.toThrow('must be relative');
+    });
+
+    it('rejects paths with .. traversal', async () => {
+      await expect(stage(DIR, '../../etc/passwd')).rejects.toThrow('traverse above');
+      await expect(unstage(DIR, '../secret')).rejects.toThrow('traverse above');
+      await expect(getFileDiff(DIR, '../../etc/shadow', true)).rejects.toThrow('traverse above');
+      await expect(discardFile(DIR, '../../../tmp/evil', true)).rejects.toThrow('traverse above');
+    });
+
+    it('rejects paths with null bytes', async () => {
+      await expect(stage(DIR, 'file\0.ts')).rejects.toThrow('null bytes');
+      await expect(getFileDiff(DIR, 'src/\0evil', false)).rejects.toThrow('null bytes');
+    });
+
+    it('allows valid relative paths including nested dirs', async () => {
+      mockGitExec(() => '');
+      const result = await stage(DIR, 'src/components/Header.tsx');
+      expect(result.ok).toBe(true);
+    });
+
+    it('allows paths with internal .. that resolve within repo', async () => {
+      mockGitExec(() => '');
+      const result = await stage(DIR, 'src/../lib/util.ts');
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('shell metacharacter safety', () => {
+    it('commit message with backticks is passed as-is (no shell interpretation)', async () => {
+      mockGitExec(() => 'committed\n');
+      await commit(DIR, 'Fix `bug` in code');
+      const call = vi.mocked(execFile).mock.calls[0];
+      const args = call[1] as string[];
+      expect(args).toEqual(['commit', '-m', 'Fix `bug` in code']);
+    });
+
+    it('commit message with $() is passed as-is', async () => {
+      mockGitExec(() => 'committed\n');
+      await commit(DIR, 'Update $(whoami) reference');
+      const call = vi.mocked(execFile).mock.calls[0];
+      const args = call[1] as string[];
+      expect(args).toEqual(['commit', '-m', 'Update $(whoami) reference']);
+    });
+
+    it('branch name with shell metacharacters is passed as a single arg', async () => {
+      mockGitExec(() => 'Switched\n');
+      await checkout(DIR, 'feature/test;echo-pwned');
+      const call = vi.mocked(execFile).mock.calls[0];
+      expect(call[0]).toBe('git');
+      expect(call[1]).toEqual(['checkout', 'feature/test;echo-pwned']);
+    });
+  });
+
+  describe('execFile usage (no shell interpretation)', () => {
+    it('uses execFile not execSync — args are always arrays', async () => {
+      mockGitExec(() => '');
+      await stage(DIR, 'file.ts');
+      const call = vi.mocked(execFile).mock.calls[0];
+      expect(call[0]).toBe('git');
+      expect(Array.isArray(call[1])).toBe(true);
+    });
+  });
+});
+
 describe('getGitInfo — command failure resilience', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -7,6 +7,30 @@ import { appLog } from './log-service';
 // Conflict status codes from git porcelain format
 const CONFLICT_CODES = new Set(['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']);
 
+/** Reject branch names that could be misinterpreted as git flags or contain dangerous chars. */
+function validateBranchName(name: string): void {
+  if (name.startsWith('-')) {
+    throw new Error(`Invalid branch name: must not start with '-'`);
+  }
+  if (name.includes('\0')) {
+    throw new Error('Invalid branch name: must not contain null bytes');
+  }
+}
+
+/** Reject file paths with traversal sequences or null bytes. */
+function validateFilePath(filePath: string): void {
+  if (path.isAbsolute(filePath)) {
+    throw new Error('Invalid file path: must be relative');
+  }
+  const normalized = path.normalize(filePath);
+  if (normalized.startsWith('..')) {
+    throw new Error('Invalid file path: must not traverse above repository root');
+  }
+  if (filePath.includes('\0')) {
+    throw new Error('Invalid file path: must not contain null bytes');
+  }
+}
+
 function gitExec(args: string[], cwd: string, timeout = 10000): Promise<string> {
   return new Promise((resolve, reject) => {
     nodeExecFile('git', args, { cwd, encoding: 'utf-8', timeout }, (error, stdout, stderr) => {
@@ -123,14 +147,17 @@ export async function getGitInfo(dirPath: string): Promise<GitInfo> {
 }
 
 export async function checkout(dirPath: string, branchName: string): Promise<GitOpResult> {
+  validateBranchName(branchName);
   return runResult(['checkout', branchName], dirPath);
 }
 
 export async function stage(dirPath: string, filePath: string): Promise<GitOpResult> {
+  validateFilePath(filePath);
   return runResult(['add', '--', filePath], dirPath);
 }
 
 export async function unstage(dirPath: string, filePath: string): Promise<GitOpResult> {
+  validateFilePath(filePath);
   return runResult(['reset', 'HEAD', '--', filePath], dirPath);
 }
 
@@ -151,6 +178,8 @@ export async function getFileDiff(
   filePath: string,
   staged: boolean
 ): Promise<{ original: string; modified: string }> {
+  validateFilePath(filePath);
+
   // Get the HEAD version (empty for new/untracked files)
   let original = '';
   try {
@@ -196,6 +225,7 @@ export async function unstageAll(dirPath: string): Promise<GitOpResult> {
 }
 
 export async function discardFile(dirPath: string, filePath: string, isUntracked: boolean): Promise<GitOpResult> {
+  validateFilePath(filePath);
   if (isUntracked) {
     // Remove untracked file from disk
     try {
@@ -209,6 +239,7 @@ export async function discardFile(dirPath: string, filePath: string, isUntracked
 }
 
 export async function createBranch(dirPath: string, branchName: string): Promise<GitOpResult> {
+  validateBranchName(branchName);
   return runResult(['checkout', '-b', branchName], dirPath);
 }
 


### PR DESCRIPTION
## Summary
- Add defense-in-depth input validation to `git-service.ts` to block git argument injection and path traversal
- The core shell injection fix (`execSync` → `execFile`) was already applied in #738; this PR adds the validation layer on top
- Add comprehensive security-focused tests covering injection vectors

## Changes
- **`validateBranchName()`** — rejects branch names starting with `-` (prevents git flag confusion) and containing null bytes
- **`validateFilePath()`** — rejects absolute paths, `..` traversal above repo root, and null bytes
- Applied validation to: `checkout`, `createBranch`, `stage`, `unstage`, `getFileDiff`, `discardFile`
- `commit` and `push`/`pull` don't need validation: commit messages are safe as `-m` value args, and push/pull derive remote/branch from git output (not user input)

## Test Plan
- [x] Branch names starting with `-` are rejected by checkout and createBranch
- [x] Branch names with null bytes are rejected
- [x] Valid branch names with slashes and dots pass through
- [x] Absolute file paths are rejected by stage, unstage, getFileDiff, discardFile
- [x] `..` traversal paths are rejected
- [x] Null bytes in file paths are rejected
- [x] Internal `..` that resolves within repo (e.g. `src/../lib/util.ts`) is allowed
- [x] Shell metacharacters in commit messages (backticks, `$(...)`) are passed as-is with no shell interpretation
- [x] execFile is confirmed to receive array args (not string interpolation)
- [x] All 6187 existing tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes

## Manual Validation
No manual validation needed — all security properties are verified by unit tests.