### PR TITLE
Fix structured agent message markdown XSS

### DIFF
--- a/src/renderer/features/agents/structured/MessageStream.test.tsx
+++ b/src/renderer/features/agents/structured/MessageStream.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MessageStream } from './MessageStream';
+
+describe('MessageStream', () => {
+  it('renders trusted markdown formatting for structured output', () => {
+    render(<MessageStream text="**bold** and [docs](https://example.com)" isStreaming={false} />);
+
+    expect(screen.getByText('bold').tagName).toBe('STRONG');
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('sanitizes quote-based href breakout payloads', () => {
+    render(
+      <MessageStream
+        text={'[click](https://example.com" onclick="alert(1))'}
+        isStreaming={false}
+      />,
+    );
+
+    const link = document.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).not.toHaveAttribute('onclick');
+    expect(link.outerHTML).not.toContain('alert(1)');
+  });
+
+  it('strips unsafe link protocols from structured output', () => {
+    render(<MessageStream text={'[click](javascript:alert(1))'} isStreaming={false} />);
+
+    const link = document.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link).not.toHaveAttribute('href');
+  });
+});

--- a/src/renderer/features/agents/structured/MessageStream.tsx
+++ b/src/renderer/features/agents/structured/MessageStream.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { renderMarkdownSafe } from '../../../utils/safe-markdown';
 
 interface Props {
   text: string;
@@ -10,7 +11,7 @@ interface Props {
  * Accumulates deltas in the parent; this component just renders the buffer.
  */
 export function MessageStream({ text, isStreaming }: Props) {
-  const rendered = useMemo(() => renderMarkdown(text), [text]);
+  const rendered = useMemo(() => renderMarkdownSafe(text), [text]);
 
   if (!text) return null;
 
@@ -25,40 +26,4 @@ export function MessageStream({ text, isStreaming }: Props) {
       )}
     </div>
   );
-}
-
-/** Lightweight markdown: code blocks, inline code, bold, italic, links, lists. */
-function renderMarkdown(text: string): string {
-  // Escape HTML entities first
-  let html = text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-
-  // Fenced code blocks: ```lang\n...\n```
-  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) =>
-    `<pre class="bg-ctp-mantle rounded p-2 my-1 text-xs overflow-x-auto"><code>${code.trim()}</code></pre>`
-  );
-
-  // Inline code: `...`
-  html = html.replace(/`([^`]+)`/g,
-    '<code class="bg-ctp-mantle px-1 rounded text-xs">$1</code>');
-
-  // Bold: **...**
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-
-  // Italic: *...*
-  html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
-
-  // Links: [text](url)
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a class="text-indigo-400 hover:underline" href="$2" target="_blank" rel="noopener">$1</a>');
-
-  // Unordered list items: - item
-  html = html.replace(/^- (.+)$/gm, '<li class="ml-4 list-disc">$1</li>');
-
-  // Ordered list items: 1. item
-  html = html.replace(/^\d+\. (.+)$/gm, '<li class="ml-4 list-decimal">$1</li>');
-
-  return html;
 }


### PR DESCRIPTION
## Summary
- replace the bespoke MessageStream markdown-to-HTML renderer with the shared sanitized markdown utility
- cover structured agent output with regression tests for normal markdown, href quote breakout payloads, and unsafe URL schemes
- remove the vulnerable manual href interpolation path from structured message rendering

## Changes
- `MessageStream` now renders agent text through `renderMarkdownSafe`, which uses `marked` plus `DOMPurify`
- deleted the manual `renderMarkdown()` helper that built anchor tags with unescaped attribute content
- added `MessageStream.test.tsx` to assert the structured renderer blocks attribute injection and strips unsafe protocols

## Test Plan
- [x] `npm test -- --project renderer src/renderer/features/agents/structured/MessageStream.test.tsx src/renderer/features/agents/structured/StructuredAgentView.test.tsx src/renderer/utils/safe-markdown.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` outside sandbox

## Validation Notes
- `npm run build` could not be run because this repo has no `build` script in `package.json`
- full `npm test` passes for this change area but still has one unrelated pre-existing failure in `src/main/services/search-service.test.ts` (`finds matches across multiple files` expects `node_modules` to be excluded)
