### PR TITLE
fix: prevent right-click double-paste when clipboardCompat is enabled

### DIFF
--- a/src/renderer/features/terminal/clipboard.test.ts
+++ b/src/renderer/features/terminal/clipboard.test.ts
@@ -261,6 +261,28 @@ describe('clipboard — right-click context menu', () => {
     expect(writeToPty).toHaveBeenCalledWith('right-click paste');
   });
 
+  it('stops propagation to prevent xterm double-paste (issue #760)', async () => {
+    const term = createMockTerminal({ hasSelection: false });
+    const container = createContainer();
+    attachClipboardHandlers(term as any, container, writeToPty);
+
+    // Simulate a child element (like xterm's internal element) that would
+    // also handle the contextmenu event and trigger a second paste.
+    const child = document.createElement('div');
+    container.appendChild(child);
+    const childHandler = vi.fn();
+    child.addEventListener('contextmenu', childHandler);
+
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    child.dispatchEvent(event);
+
+    await flush();
+    // Our capture-phase handler should have stopped propagation,
+    // preventing the child's own bubble-phase handler from firing.
+    expect(childHandler).not.toHaveBeenCalled();
+    expect(writeToPty).toHaveBeenCalledTimes(1);
+  });
+
   it('copies selection on right-click when text is selected', async () => {
     const term = createMockTerminal({ hasSelection: true, selection: 'right-click copy' });
     const container = createContainer();

--- a/src/renderer/features/terminal/clipboard.ts
+++ b/src/renderer/features/terminal/clipboard.ts
@@ -111,8 +111,13 @@ export function attachClipboardHandlers(
   });
 
   // --- Right-click context menu ---
+  // Use the capture phase so this fires before xterm.js's own contextmenu
+  // handler (which focuses its hidden textarea and can trigger a second
+  // native paste event on Windows/Electron).  stopPropagation prevents
+  // the event from reaching xterm's handler, avoiding the double-paste.
   const onContextMenu = (e: MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     if (term.hasSelection()) {
       writeClipboard(term.getSelection());
       term.clearSelection();
@@ -120,9 +125,9 @@ export function attachClipboardHandlers(
       pasteIntoTerminal(term, writeToPty);
     }
   };
-  container.addEventListener('contextmenu', onContextMenu);
+  container.addEventListener('contextmenu', onContextMenu, true);
 
   return () => {
-    container.removeEventListener('contextmenu', onContextMenu);
+    container.removeEventListener('contextmenu', onContextMenu, true);
   };
 }


### PR DESCRIPTION
## Summary

Fixes #760 — right-click paste was duplicating text when `clipboardCompat` is enabled (Windows default).

## Root Cause

The custom `contextmenu` handler in `clipboard.ts` calls `pasteIntoTerminal()`, but xterm.js has its own `contextmenu` handler that focuses a hidden textarea, triggering a second native paste event on Windows/Electron.

## Fix

- Register the `contextmenu` listener in the **capture phase** so it fires before xterm's handler
- Call `e.stopPropagation()` to prevent the event from reaching xterm's handler

Two lines changed in `clipboard.ts`, plus a new regression test.

## Testing

- Verified locally on Windows with clipboardCompat toggle **on** — single paste on right-click
- All 19 clipboard tests pass (including new issue #760 test)
- Typecheck passes
