### PR TITLE
feat: make Close Project discoverable (#763)

### DIFF
--- a/src/renderer/features/command-palette/command-actions.test.ts
+++ b/src/renderer/features/command-palette/command-actions.test.ts
@@ -9,6 +9,7 @@ const mockToggleExplorerCollapse = vi.fn();
 const mockToggleAccessoryCollapse = vi.fn();
 const mockSetExplorerTab = vi.fn();
 const mockPickAndAddProject = vi.fn();
+const mockRemoveProject = vi.fn();
 const mockSetActiveAgent = vi.fn();
 const mockOpenQuickAgentDialog = vi.fn();
 
@@ -21,7 +22,7 @@ vi.mock('../../stores/uiStore', () => ({
 }));
 
 vi.mock('../../stores/projectStore', () => ({
-  useProjectStore: { getState: () => ({ setActiveProject: mockSetActiveProject, pickAndAddProject: mockPickAndAddProject, activeProjectId: 'proj-1', projects: [{ id: 'proj-1', name: 'A' }, { id: 'proj-2', name: 'B' }] }) },
+  useProjectStore: { getState: () => ({ setActiveProject: mockSetActiveProject, pickAndAddProject: mockPickAndAddProject, removeProject: mockRemoveProject, activeProjectId: 'proj-1', projects: [{ id: 'proj-1', name: 'A' }, { id: 'proj-2', name: 'B' }] }) },
 }));
 
 vi.mock('../../stores/panelStore', () => ({
@@ -60,6 +61,7 @@ describe('command-actions', () => {
     expect(ids).toContain('toggle-accessory');
     expect(ids).toContain('new-quick-agent');
     expect(ids).toContain('add-project');
+    expect(ids).toContain('close-project');
     expect(ids).toContain('switch-agent-1');
     expect(ids).toContain('switch-agent-9');
     expect(ids).toContain('switch-project-1');
@@ -129,6 +131,11 @@ describe('command-actions', () => {
   it('switch-agent-2 sets active agent to second durable agent', () => {
     findAction('switch-agent-2')?.execute();
     expect(mockSetActiveAgent).toHaveBeenCalledWith('a2', 'proj-1');
+  });
+
+  it('close-project calls removeProject with activeProjectId', () => {
+    findAction('close-project')?.execute();
+    expect(mockRemoveProject).toHaveBeenCalledWith('proj-1');
   });
 
   it('new-quick-agent is marked global so it fires from text inputs', () => {

--- a/src/renderer/features/command-palette/command-actions.ts
+++ b/src/renderer/features/command-palette/command-actions.ts
@@ -49,6 +49,15 @@ export function getCommandActions(): CommandAction[] {
       id: 'add-project',
       execute: () => useProjectStore.getState().pickAndAddProject(),
     },
+    {
+      id: 'close-project',
+      execute: () => {
+        const { activeProjectId, removeProject } = useProjectStore.getState();
+        if (activeProjectId) {
+          removeProject(activeProjectId);
+        }
+      },
+    },
   ];
 
   // switch-agent-1..9

--- a/src/renderer/features/command-palette/use-command-source.ts
+++ b/src/renderer/features/command-palette/use-command-source.ts
@@ -32,6 +32,7 @@ const HUB_TAB = 'plugin:hub';
 export function useCommandSource(): CommandItem[] {
   const projects = useProjectStore((s) => s.projects);
   const setActiveProject = useProjectStore((s) => s.setActiveProject);
+  const removeProject = useProjectStore((s) => s.removeProject);
   const agents = useAgentStore((s) => s.agents);
   const setActiveAgent = useAgentStore((s) => s.setActiveAgent);
   const setExplorerTab = useUIStore((s) => s.setExplorerTab);
@@ -320,6 +321,17 @@ export function useCommandSource(): CommandItem[] {
       },
     });
 
+    if (activeProjectId) {
+      items.push({
+        id: 'action:close-project',
+        label: 'Close Project',
+        category: 'Actions',
+        shortcut: getShortcut(shortcuts, 'close-project'),
+        keywords: ['remove', 'delete', 'close', 'project'],
+        execute: () => removeProject(activeProjectId),
+      });
+    }
+
     // Annex actions
     items.push({
       id: 'action:toggle-annex',
@@ -385,7 +397,7 @@ export function useCommandSource(): CommandItem[] {
     annexSettings, annexStatus,
     projectHubs, projectActiveHubId, appHubs, appActiveHubId,
     otherProjectHubs,
-    setActiveProject, setActiveAgent, setExplorerTab, toggleSettings,
+    setActiveProject, removeProject, setActiveAgent, setExplorerTab, toggleSettings,
     setSettingsSubPage, setSettingsContext, toggleHelp, openAbout,
     toggleExplorerCollapse, toggleAccessoryCollapse,
   ]);

--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useProjectStore } from '../stores/projectStore';
 import { useUIStore } from '../stores/uiStore';
@@ -119,5 +119,57 @@ describe('ProjectRail badge clipping', () => {
     // Badge wrapper uses -top-1 -right-1 to position outside icon bounds
     expect(badgeWrapper.className).toContain('-top-1');
     expect(badgeWrapper.className).toContain('-right-1');
+  });
+});
+
+describe('ProjectRail context menu', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(_cb: () => void) {}
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+    resetStores();
+  });
+
+  it('shows context menu on right-click of a project icon', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+      activeProjectId: 'p1',
+    });
+
+    render(<ProjectRail />);
+    const projectButton = screen.getByTestId('project-p1');
+    fireEvent.contextMenu(projectButton.parentElement!);
+
+    expect(screen.getByTestId('project-context-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('ctx-project-settings')).toBeInTheDocument();
+    expect(screen.getByTestId('ctx-close-project')).toBeInTheDocument();
+  });
+
+  it('closes project when Close Project is clicked', () => {
+    const removeProject = vi.fn();
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+      activeProjectId: 'p1',
+      removeProject,
+    });
+
+    render(<ProjectRail />);
+    const projectButton = screen.getByTestId('project-p1');
+    fireEvent.contextMenu(projectButton.parentElement!);
+    fireEvent.click(screen.getByTestId('ctx-close-project'));
+
+    expect(removeProject).toHaveBeenCalledWith('p1');
+  });
+
+  it('does not show context menu initially', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' })],
+      activeProjectId: 'p1',
+    });
+
+    render(<ProjectRail />);
+    expect(screen.queryByTestId('project-context-menu')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -9,6 +9,72 @@ import { Project } from '../../shared/types';
 import { PluginRegistryEntry } from '../../shared/plugin-types';
 import { AGENT_COLORS } from '../../shared/name-generator';
 
+function ProjectContextMenu({ position, onClose, onSettings, onCloseProject }: {
+  position: { x: number; y: number };
+  onClose: () => void;
+  onSettings: () => void;
+  onCloseProject: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  const style = useMemo(() => {
+    const menuWidth = 180;
+    const menuHeight = 2 * 32 + 8;
+    const x = Math.min(position.x, window.innerWidth - menuWidth - 8);
+    const y = Math.min(position.y, window.innerHeight - menuHeight - 8);
+    return { left: x, top: y };
+  }, [position]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-50 min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
+      style={style}
+      data-testid="project-context-menu"
+    >
+      <button
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer"
+        onClick={(e) => { e.stopPropagation(); onSettings(); onClose(); }}
+        data-testid="ctx-project-settings"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+        <span>Project Settings</span>
+      </button>
+      <button
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-red-400 hover:bg-surface-1 hover:text-red-300 transition-colors cursor-pointer"
+        onClick={(e) => { e.stopPropagation(); onCloseProject(); onClose(); }}
+        data-testid="ctx-close-project"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+        <span>Close Project</span>
+      </button>
+    </div>
+  );
+}
+
 function getColorHex(colorId?: string): string {
   if (!colorId) return '#6366f1'; // indigo default
   return AGENT_COLORS.find((c) => c.id === colorId)?.hex || '#6366f1';
@@ -155,8 +221,10 @@ function PluginRailButton({ entry, isActive, onClick, expanded }: {
 }
 
 export function ProjectRail() {
-  const { projects, activeProjectId, setActiveProject, pickAndAddProject, reorderProjects } =
+  const { projects, activeProjectId, setActiveProject, pickAndAddProject, reorderProjects, removeProject } =
     useProjectStore();
+  const setSettingsContext = useUIStore((s) => s.setSettingsContext);
+  const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
   const toggleSettings = useUIStore((s) => s.toggleSettings);
   const toggleHelp = useUIStore((s) => s.toggleHelp);
   const explorerTab = useUIStore((s) => s.explorerTab);
@@ -259,6 +327,8 @@ export function ProjectRail() {
     }
     action();
   }, [inSettings, inHelp, isAppPlugin, previousExplorerTab, setExplorerTab]);
+
+  const [contextMenu, setContextMenu] = useState<{ projectId: string; x: number; y: number } | null>(null);
 
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
@@ -377,6 +447,10 @@ export function ProjectRail() {
               onDragEnd={handleDragEnd}
               onDragOver={(e) => handleDragOver(e, i)}
               onDrop={(e) => handleDrop(e, i)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setContextMenu({ projectId: p.id, x: e.clientX, y: e.clientY });
+              }}
               className="relative flex-shrink-0"
             >
               {dragOverIndex === i && dragIndex !== null && dragIndex !== i && (
@@ -473,6 +547,19 @@ export function ProjectRail() {
           <span className={`text-xs font-medium truncate pr-3 whitespace-nowrap text-ctp-text transition-opacity duration-200 ${expanded ? 'opacity-100' : 'opacity-0'}`}>Settings</span>
         </button>
       </div>
+      {contextMenu && (
+        <ProjectContextMenu
+          position={{ x: contextMenu.x, y: contextMenu.y }}
+          onClose={() => setContextMenu(null)}
+          onSettings={() => {
+            setActiveProject(contextMenu.projectId);
+            toggleSettings();
+            setSettingsContext('project');
+            setSettingsSubPage('project');
+          }}
+          onCloseProject={() => removeProject(contextMenu.projectId)}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/stores/keyboardShortcutsStore.test.ts
+++ b/src/renderer/stores/keyboardShortcutsStore.test.ts
@@ -75,6 +75,8 @@ describe('keyboardShortcutsStore', () => {
     expect(shortcuts['new-quick-agent'].defaultBinding).toBe('Meta+Shift+N');
     expect(shortcuts['add-project']).toBeDefined();
     expect(shortcuts['add-project'].defaultBinding).toBe('Meta+Shift+O');
+    expect(shortcuts['close-project']).toBeDefined();
+    expect(shortcuts['close-project'].defaultBinding).toBe('Meta+Shift+W');
   });
 
   it('sets a custom binding', () => {

--- a/src/renderer/stores/keyboardShortcutsStore.ts
+++ b/src/renderer/stores/keyboardShortcutsStore.ts
@@ -94,6 +94,7 @@ const DEFAULT_SHORTCUTS: Omit<ShortcutDefinition, 'currentBinding'>[] = [
 
   // Projects
   { id: 'add-project', label: 'Add Project', category: 'Projects', defaultBinding: 'Meta+Shift+O' },
+  { id: 'close-project', label: 'Close Project', category: 'Projects', defaultBinding: 'Meta+Shift+W' },
   ...Array.from({ length: 9 }, (_, i) => ({
     id: `switch-project-${i + 1}`,
     label: `Switch to Project ${i + 1}`,


### PR DESCRIPTION
## Summary
- Close Project was buried in Settings > Project Settings > Danger Zone — users couldn't find it
- Added three discoverable entry points: command palette, keyboard shortcut, and right-click context menu on project icons

## Changes
- **Command palette**: Added "Close Project" action (visible only when a project is active) with keywords "remove", "delete", "close"
- **Keyboard shortcut**: Added `Meta+Shift+W` (`Cmd+Shift+W` on macOS) as the default binding for closing the active project, customizable via the keyboard shortcuts settings
- **Context menu**: Right-clicking a project icon in the sidebar rail now shows a context menu with "Project Settings" and "Close Project" options
- Added `close-project` to both `keyboardShortcutsStore` (default shortcuts) and `command-actions` (action handler)

## Test Plan
- [x] `close-project` shortcut is defined with default binding `Meta+Shift+W`
- [x] `close-project` command action calls `removeProject` with the active project ID
- [x] Command palette includes `close-project` in the actions list
- [x] Right-click on a project icon shows context menu with "Project Settings" and "Close Project"
- [x] Clicking "Close Project" in context menu calls `removeProject` with the correct project ID
- [x] Context menu is not visible by default (only on right-click)
- [x] All 6342 existing tests continue to pass
- [x] TypeScript compiles cleanly
- [x] Linter passes

## Manual Validation
1. Open the app with at least one project added
2. Press `Cmd+K` to open the command palette, type "close" — should see "Close Project" action
3. Right-click a project icon in the left sidebar — should see context menu with "Project Settings" and "Close Project"
4. Press `Cmd+Shift+W` — should close the active project
5. Verify the shortcut appears in Settings > Keyboard Shortcuts under the "Projects" category

Fixes #763