### PR TITLE
perf: lazy-copy feedItems and Maps in processEvent (#630)

### DIFF
--- a/src/renderer/features/agents/structured/StructuredAgentView.tsx
+++ b/src/renderer/features/agents/structured/StructuredAgentView.tsx
@@ -47,7 +47,7 @@ type FeedItem =
   | { kind: 'plan'; plan: PlanUpdate }
   | { kind: 'error'; error: ErrorEvent };
 
-interface ViewState {
+export interface ViewState {
   feedItems: FeedItem[];
   /** Tool ID → index in feedItems, for fast updates */
   toolIndexMap: Map<string, number>;
@@ -60,7 +60,7 @@ interface ViewState {
   endReason?: string;
 }
 
-const initialState: ViewState = {
+export const initialState: ViewState = {
   feedItems: [],
   toolIndexMap: new Map(),
   commandIndexMap: new Map(),
@@ -240,22 +240,32 @@ function EndIcon({ reason }: { reason: string }) {
 
 // ── Event processing (pure function) ──────────────────────────────────
 
-function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
-  const feedItems = [...prev.feedItems];
-  const toolIndexMap = new Map(prev.toolIndexMap);
-  const commandIndexMap = new Map(prev.commandIndexMap);
+export function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
+  // Lazy-copy: only clone a data structure when this event actually mutates it.
+  // This avoids copying up to 500 feedItems + two Maps on every event.
+  let feedItems = prev.feedItems;
+  let toolIndexMap = prev.toolIndexMap;
+  let commandIndexMap = prev.commandIndexMap;
   let pendingPermissions = prev.pendingPermissions;
   let plan = prev.plan;
   let usage = prev.usage;
   let isComplete = prev.isComplete;
   let endReason = prev.endReason;
 
+  let feedCloned = false;
+  function cloneFeed() {
+    if (!feedCloned) {
+      feedItems = [...feedItems];
+      feedCloned = true;
+    }
+  }
+
   switch (event.type) {
     case 'text_delta': {
       const data = event.data as TextDelta;
       const last = feedItems[feedItems.length - 1];
+      cloneFeed();
       if (last && last.kind === 'text' && last.isStreaming) {
-        // Append to existing streaming text block
         feedItems[feedItems.length - 1] = { ...last, text: last.text + data.text };
       } else {
         feedItems.push({ kind: 'text', text: data.text, isStreaming: true });
@@ -266,6 +276,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
     case 'text_done': {
       const data = event.data as TextDone;
       const last = feedItems[feedItems.length - 1];
+      cloneFeed();
       if (last && last.kind === 'text') {
         feedItems[feedItems.length - 1] = { kind: 'text', text: data.text, isStreaming: false };
       } else {
@@ -276,8 +287,10 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
 
     case 'tool_start': {
       const data = event.data as ToolStart;
+      cloneFeed();
       const idx = feedItems.length;
       feedItems.push({ kind: 'tool', tool: data, output: '', status: 'running' });
+      toolIndexMap = new Map(prev.toolIndexMap);
       toolIndexMap.set(data.id, idx);
       break;
     }
@@ -286,6 +299,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
       const data = event.data as ToolOutput;
       const idx = toolIndexMap.get(data.id);
       if (idx != null && feedItems[idx]?.kind === 'tool') {
+        cloneFeed();
         const item = feedItems[idx] as Extract<FeedItem, { kind: 'tool' }>;
         feedItems[idx] = { ...item, output: item.output + data.output };
       }
@@ -296,6 +310,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
       const data = event.data as ToolEnd;
       const idx = toolIndexMap.get(data.id);
       if (idx != null && feedItems[idx]?.kind === 'tool') {
+        cloneFeed();
         const item = feedItems[idx] as Extract<FeedItem, { kind: 'tool' }>;
         feedItems[idx] = {
           ...item,
@@ -308,18 +323,21 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
 
     case 'file_diff': {
       const data = event.data as FileDiff;
+      cloneFeed();
       feedItems.push({ kind: 'diff', diff: data });
       break;
     }
 
     case 'command_output': {
       const data = event.data as CommandOutput;
+      cloneFeed();
       const existingIdx = commandIndexMap.get(data.id);
       if (existingIdx != null) {
         feedItems[existingIdx] = { kind: 'command', command: data };
       } else {
         const idx = feedItems.length;
         feedItems.push({ kind: 'command', command: data });
+        commandIndexMap = new Map(prev.commandIndexMap);
         commandIndexMap.set(data.id, idx);
       }
       break;
@@ -327,6 +345,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
 
     case 'permission_request': {
       const data = event.data as PermissionRequest;
+      cloneFeed();
       pendingPermissions = new Map(pendingPermissions);
       pendingPermissions.set(data.id, data);
       feedItems.push({ kind: 'permission', request: data });
@@ -342,6 +361,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
     case 'thinking': {
       const data = event.data as Thinking;
       const last = feedItems[feedItems.length - 1];
+      cloneFeed();
       if (last && last.kind === 'thinking' && last.isStreaming) {
         feedItems[feedItems.length - 1] = {
           kind: 'thinking',
@@ -356,6 +376,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
 
     case 'error': {
       const data = event.data as ErrorEvent;
+      cloneFeed();
       feedItems.push({ kind: 'error', error: data });
       break;
     }
@@ -363,7 +384,6 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
     case 'usage': {
       const data = event.data as UsageEvent;
       if (usage) {
-        // Accumulate across turns
         usage = {
           inputTokens: usage.inputTokens + data.inputTokens,
           outputTokens: usage.outputTokens + data.outputTokens,
@@ -382,6 +402,7 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
       isComplete = true;
       endReason = data.reason;
       if (data.summary) {
+        cloneFeed();
         feedItems.push({ kind: 'text', text: data.summary, isStreaming: false });
       }
       break;
@@ -389,7 +410,23 @@ function processEvent(prev: ViewState, event: StructuredEvent): ViewState {
   }
 
   // Cap feed items
-  const capped = feedItems.length > MAX_EVENTS ? feedItems.slice(feedItems.length - MAX_EVENTS) : feedItems;
+  if (feedItems.length > MAX_EVENTS) {
+    feedItems = feedItems.slice(feedItems.length - MAX_EVENTS);
+  }
 
-  return { feedItems: capped, toolIndexMap, commandIndexMap, pendingPermissions, plan, usage, isComplete, endReason };
+  // Skip state update if nothing changed
+  if (
+    feedItems === prev.feedItems &&
+    toolIndexMap === prev.toolIndexMap &&
+    commandIndexMap === prev.commandIndexMap &&
+    pendingPermissions === prev.pendingPermissions &&
+    plan === prev.plan &&
+    usage === prev.usage &&
+    isComplete === prev.isComplete &&
+    endReason === prev.endReason
+  ) {
+    return prev;
+  }
+
+  return { feedItems, toolIndexMap, commandIndexMap, pendingPermissions, plan, usage, isComplete, endReason };
 }

--- a/src/renderer/features/agents/structured/processEvent.test.ts
+++ b/src/renderer/features/agents/structured/processEvent.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from 'vitest';
+import { processEvent, initialState, MAX_EVENTS } from './StructuredAgentView';
+import type { ViewState } from './StructuredAgentView';
+import type { StructuredEvent } from '../../../../shared/structured-events';
+
+/**
+ * Unit tests for processEvent lazy-copy optimization (Issue #630).
+ *
+ * These tests verify that processEvent only clones data structures
+ * that are actually mutated by each event type, rather than eagerly
+ * copying feedItems + both Maps on every event.
+ */
+
+function makeState(overrides: Partial<ViewState> = {}): ViewState {
+  return { ...initialState, ...overrides };
+}
+
+function ts(): number {
+  return Date.now();
+}
+
+describe('processEvent – lazy copy optimization', () => {
+  // ── Reference stability: events that don't touch feedItems ──────────
+
+  describe('plan_update does not copy feedItems or maps', () => {
+    it('preserves feedItems, toolIndexMap, and commandIndexMap references', () => {
+      const feedItems = [{ kind: 'text' as const, text: 'hi', isStreaming: false }];
+      const toolIndexMap = new Map([['t1', 0]]);
+      const commandIndexMap = new Map([['c1', 0]]);
+      const prev = makeState({ feedItems, toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'plan_update',
+        timestamp: ts(),
+        data: { steps: [{ description: 'step 1', status: 'pending' }] },
+      } as StructuredEvent);
+
+      expect(next.feedItems).toBe(feedItems);
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+      expect(next.plan).toEqual({ steps: [{ description: 'step 1', status: 'pending' }] });
+    });
+  });
+
+  describe('usage does not copy feedItems or maps', () => {
+    it('preserves feedItems, toolIndexMap, and commandIndexMap references', () => {
+      const feedItems = [{ kind: 'text' as const, text: 'hi', isStreaming: false }];
+      const toolIndexMap = new Map([['t1', 0]]);
+      const commandIndexMap = new Map([['c1', 0]]);
+      const prev = makeState({ feedItems, toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'usage',
+        timestamp: ts(),
+        data: { inputTokens: 100, outputTokens: 50, costUsd: 0.001 },
+      } as StructuredEvent);
+
+      expect(next.feedItems).toBe(feedItems);
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+    });
+  });
+
+  // ── Reference stability: events that only touch feedItems ───────────
+
+  describe('text_delta does not copy maps', () => {
+    it('preserves toolIndexMap and commandIndexMap references', () => {
+      const toolIndexMap = new Map([['t1', 0]]);
+      const commandIndexMap = new Map([['c1', 1]]);
+      const prev = makeState({ toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'text_delta',
+        timestamp: ts(),
+        data: { text: 'hello' },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+      expect(next.feedItems).not.toBe(prev.feedItems); // feed IS cloned
+      expect(next.feedItems).toHaveLength(1);
+    });
+  });
+
+  describe('text_done does not copy maps', () => {
+    it('preserves map references', () => {
+      const toolIndexMap = new Map<string, number>();
+      const commandIndexMap = new Map<string, number>();
+      const prev = makeState({ toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'text_done',
+        timestamp: ts(),
+        data: { text: 'done' },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+    });
+  });
+
+  describe('tool_output does not copy maps', () => {
+    it('preserves toolIndexMap and commandIndexMap when updating existing tool', () => {
+      const toolIndexMap = new Map([['t1', 0]]);
+      const commandIndexMap = new Map<string, number>();
+      const feedItems = [
+        { kind: 'tool' as const, tool: { id: 't1', name: 'Read', displayVerb: 'Reading', input: {} }, output: '', status: 'running' as const },
+      ];
+      const prev = makeState({ feedItems, toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'tool_output',
+        timestamp: ts(),
+        data: { id: 't1', output: 'file contents', isPartial: false },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+      expect(next.feedItems).not.toBe(feedItems); // feed IS cloned
+    });
+  });
+
+  describe('tool_end does not copy maps', () => {
+    it('preserves map references', () => {
+      const toolIndexMap = new Map([['t1', 0]]);
+      const commandIndexMap = new Map<string, number>();
+      const feedItems = [
+        { kind: 'tool' as const, tool: { id: 't1', name: 'Read', displayVerb: 'Reading', input: {} }, output: 'data', status: 'running' as const },
+      ];
+      const prev = makeState({ feedItems, toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'tool_end',
+        timestamp: ts(),
+        data: { id: 't1', name: 'Read', result: 'ok', durationMs: 50, status: 'success' },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+      expect(next.feedItems).not.toBe(feedItems);
+    });
+  });
+
+  describe('error does not copy maps', () => {
+    it('preserves map references', () => {
+      const toolIndexMap = new Map<string, number>();
+      const commandIndexMap = new Map<string, number>();
+      const prev = makeState({ toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'error',
+        timestamp: ts(),
+        data: { code: 'ERR', message: 'oops' },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+    });
+  });
+
+  describe('thinking does not copy maps', () => {
+    it('preserves map references', () => {
+      const toolIndexMap = new Map<string, number>();
+      const commandIndexMap = new Map<string, number>();
+      const prev = makeState({ toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'thinking',
+        timestamp: ts(),
+        data: { text: 'hmm', isPartial: false },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).toBe(toolIndexMap);
+      expect(next.commandIndexMap).toBe(commandIndexMap);
+    });
+  });
+
+  // ── Events that DO need to copy specific maps ──────────────────────
+
+  describe('tool_start copies only toolIndexMap', () => {
+    it('clones toolIndexMap but preserves commandIndexMap', () => {
+      const toolIndexMap = new Map<string, number>();
+      const commandIndexMap = new Map<string, number>();
+      const prev = makeState({ toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'tool_start',
+        timestamp: ts(),
+        data: { id: 't1', name: 'Read', displayVerb: 'Reading', input: {} },
+      } as StructuredEvent);
+
+      expect(next.toolIndexMap).not.toBe(toolIndexMap); // cloned
+      expect(next.commandIndexMap).toBe(commandIndexMap); // preserved
+      expect(next.toolIndexMap.get('t1')).toBe(0);
+    });
+  });
+
+  describe('command_output (new command) copies only commandIndexMap', () => {
+    it('clones commandIndexMap but preserves toolIndexMap', () => {
+      const toolIndexMap = new Map<string, number>();
+      const commandIndexMap = new Map<string, number>();
+      const prev = makeState({ toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'command_output',
+        timestamp: ts(),
+        data: { id: 'cmd1', command: 'npm test', status: 'running', output: 'ok' },
+      } as StructuredEvent);
+
+      expect(next.commandIndexMap).not.toBe(commandIndexMap); // cloned
+      expect(next.toolIndexMap).toBe(toolIndexMap); // preserved
+      expect(next.commandIndexMap.get('cmd1')).toBe(0);
+    });
+  });
+
+  describe('command_output (existing command) preserves both maps', () => {
+    it('does not clone commandIndexMap for in-place update', () => {
+      const commandIndexMap = new Map([['cmd1', 0]]);
+      const toolIndexMap = new Map<string, number>();
+      const feedItems = [
+        { kind: 'command' as const, command: { id: 'cmd1', command: 'npm test', status: 'running', output: 'line 1' } },
+      ];
+      const prev = makeState({ feedItems, toolIndexMap, commandIndexMap });
+
+      const next = processEvent(prev, {
+        type: 'command_output',
+        timestamp: ts(),
+        data: { id: 'cmd1', command: 'npm test', status: 'completed', output: 'line 1\nline 2', exitCode: 0 },
+      } as StructuredEvent);
+
+      expect(next.commandIndexMap).toBe(commandIndexMap); // preserved
+      expect(next.toolIndexMap).toBe(toolIndexMap); // preserved
+    });
+  });
+
+  // ── No-op returns prev identity ────────────────────────────────────
+
+  describe('tool_output for unknown tool returns prev', () => {
+    it('returns same state reference when tool ID is not found', () => {
+      const prev = makeState({
+        feedItems: [{ kind: 'text' as const, text: 'hi', isStreaming: false }],
+        toolIndexMap: new Map(),
+      });
+
+      const next = processEvent(prev, {
+        type: 'tool_output',
+        timestamp: ts(),
+        data: { id: 'nonexistent', output: 'data', isPartial: false },
+      } as StructuredEvent);
+
+      expect(next).toBe(prev); // exact same object, no re-render
+    });
+  });
+
+  describe('tool_end for unknown tool returns prev', () => {
+    it('returns same state reference when tool ID is not found', () => {
+      const prev = makeState({
+        feedItems: [{ kind: 'text' as const, text: 'hi', isStreaming: false }],
+        toolIndexMap: new Map(),
+      });
+
+      const next = processEvent(prev, {
+        type: 'tool_end',
+        timestamp: ts(),
+        data: { id: 'nonexistent', name: 'Read', result: 'ok', durationMs: 10, status: 'success' },
+      } as StructuredEvent);
+
+      expect(next).toBe(prev);
+    });
+  });
+
+  describe('end without summary does not copy feedItems', () => {
+    it('preserves feedItems reference when no summary', () => {
+      const feedItems = [{ kind: 'text' as const, text: 'hi', isStreaming: false }];
+      const prev = makeState({ feedItems });
+
+      const next = processEvent(prev, {
+        type: 'end',
+        timestamp: ts(),
+        data: { reason: 'complete' },
+      } as StructuredEvent);
+
+      expect(next.feedItems).toBe(feedItems);
+      expect(next.isComplete).toBe(true);
+    });
+  });
+
+  // ── Functional correctness ─────────────────────────────────────────
+
+  describe('consecutive text_deltas merge into one item', () => {
+    it('appends text to the last streaming item', () => {
+      let state = makeState();
+      state = processEvent(state, {
+        type: 'text_delta', timestamp: ts(), data: { text: 'a' },
+      } as StructuredEvent);
+      state = processEvent(state, {
+        type: 'text_delta', timestamp: ts(), data: { text: 'b' },
+      } as StructuredEvent);
+      state = processEvent(state, {
+        type: 'text_delta', timestamp: ts(), data: { text: 'c' },
+      } as StructuredEvent);
+
+      expect(state.feedItems).toHaveLength(1);
+      expect(state.feedItems[0]).toEqual({ kind: 'text', text: 'abc', isStreaming: true });
+    });
+  });
+
+  describe('usage accumulates across events', () => {
+    it('sums inputTokens and outputTokens', () => {
+      let state = makeState();
+      state = processEvent(state, {
+        type: 'usage', timestamp: ts(),
+        data: { inputTokens: 1000, outputTokens: 500, costUsd: 0.003 },
+      } as StructuredEvent);
+      state = processEvent(state, {
+        type: 'usage', timestamp: ts(),
+        data: { inputTokens: 500, outputTokens: 200, costUsd: 0.001 },
+      } as StructuredEvent);
+
+      expect(state.usage).toEqual({
+        inputTokens: 1500,
+        outputTokens: 700,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        costUsd: 0.004,
+      });
+    });
+  });
+
+  describe('feed cap at MAX_EVENTS', () => {
+    it('trims older items when feed exceeds MAX_EVENTS', () => {
+      let state = makeState();
+      for (let i = 0; i < MAX_EVENTS + 10; i++) {
+        state = processEvent(state, {
+          type: 'error', timestamp: ts(),
+          data: { code: 'E', message: `error-${i}` },
+        } as StructuredEvent);
+      }
+
+      expect(state.feedItems).toHaveLength(MAX_EVENTS);
+      // First item should be error-10 (oldest 10 were trimmed)
+      const first = state.feedItems[0];
+      expect(first.kind).toBe('error');
+      if (first.kind === 'error') {
+        expect(first.error.message).toBe('error-10');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Eliminates eager copying of up to 500 feedItems + two Maps on every structured event in `StructuredAgentView`
- Each data structure is now only cloned when the specific event type actually mutates it
- Returns previous state identity when nothing changed, preventing unnecessary React re-renders

## Changes
- **`StructuredAgentView.tsx`**: Refactored `processEvent` to use lazy cloning via a `cloneFeed()` helper that defers the array spread until the first mutation
  - `text_delta`/`text_done`/`tool_output`/`tool_end`/`error`/`thinking`/`file_diff`: clone feedItems only (not maps)
  - `plan_update`/`usage`: clone neither feedItems nor maps
  - `tool_start`: clone feedItems + toolIndexMap only (not commandIndexMap)
  - `command_output` (new command): clone feedItems + commandIndexMap only (not toolIndexMap)
  - `command_output` (existing): clone feedItems only (map already has the index)
  - `end` without summary: don't clone feedItems
  - No-op events (unknown tool ID in `tool_output`/`tool_end`): return `prev` identity — zero allocations
- Added identity equality check at the end to skip state updates when nothing changed
- Exported `processEvent`, `ViewState`, and `initialState` for direct unit testing

## Test Plan
- [x] New `processEvent.test.ts` with 16 test cases verifying:
  - [x] `plan_update` preserves feedItems, toolIndexMap, commandIndexMap references
  - [x] `usage` preserves feedItems, toolIndexMap, commandIndexMap references
  - [x] `text_delta` clones feedItems but preserves both map references
  - [x] `text_done` preserves map references
  - [x] `tool_output` preserves map references (only clones feedItems)
  - [x] `tool_end` preserves map references
  - [x] `error`/`thinking` preserve map references
  - [x] `tool_start` clones toolIndexMap but preserves commandIndexMap
  - [x] `command_output` (new) clones commandIndexMap but preserves toolIndexMap
  - [x] `command_output` (existing) preserves both maps
  - [x] `tool_output` for unknown ID returns `prev` identity (zero alloc)
  - [x] `tool_end` for unknown ID returns `prev` identity
  - [x] `end` without summary preserves feedItems reference
  - [x] Consecutive `text_delta` merges correctly
  - [x] Usage accumulation works correctly
  - [x] Feed cap at MAX_EVENTS still works
- [x] All 258 existing test files (6424 tests) pass
- [x] TypeScript type check passes
- [x] ESLint passes

## Manual Validation
Stream a long agent session and observe reduced GC pauses in DevTools Performance tab, especially during rapid `text_delta` bursts.

Closes #630