### PR TITLE
feat(files): add hover states to file picker and context menus

### DIFF
--- a/src/renderer/plugins/builtin/files/FileTree.test.tsx
+++ b/src/renderer/plugins/builtin/files/FileTree.test.tsx
@@ -1230,4 +1230,64 @@ describe('FileTree — accessibility', () => {
       expect(srcNode.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
     });
   });
+
+  // ── Hover state tests ──────────────────────────────────────────────
+
+  it('tree items have hover class when not selected', async () => {
+    const api = createFilesAPI();
+    const { container } = render(<FileTree api={api} />);
+    await screen.findByText('README.md');
+
+    const readmeNode = container.querySelector('[data-path="/project/README.md"]') as HTMLElement;
+    expect(readmeNode.className).toContain('hover:bg-ctp-surface0');
+    expect(readmeNode.className).toContain('rounded-sm');
+    expect(readmeNode.className).toContain('transition-colors');
+  });
+
+  it('selected tree items retain a hover state', async () => {
+    const api = createFilesAPI();
+    const { container } = render(<FileTree api={api} />);
+
+    const readme = await screen.findByText('README.md');
+    fireEvent.click(readme);
+
+    await waitFor(() => {
+      const readmeNode = container.querySelector('[data-path="/project/README.md"]') as HTMLElement;
+      expect(readmeNode.className).toContain('bg-ctp-surface1');
+      expect(readmeNode.className).toContain('hover:bg-ctp-surface2/50');
+    });
+  });
+
+  it('context menu items have rounded hover styling', async () => {
+    const api = createFilesAPI();
+    render(<FileTree api={api} />);
+
+    const readme = await screen.findByText('README.md');
+    fireEvent.contextMenu(readme);
+
+    await waitFor(() => {
+      expect(screen.getByText('Rename')).toBeInTheDocument();
+    });
+
+    const renameButton = screen.getByText('Rename');
+    expect(renameButton.className).toContain('hover:bg-ctp-surface1');
+    expect(renameButton.className).toContain('rounded-sm');
+    expect(renameButton.className).toContain('transition-colors');
+  });
+
+  it('context menu delete item has themed hover', async () => {
+    const api = createFilesAPI();
+    render(<FileTree api={api} />);
+
+    const readme = await screen.findByText('README.md');
+    fireEvent.contextMenu(readme);
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByText('Delete');
+    expect(deleteButton.className).toContain('text-ctp-error');
+    expect(deleteButton.className).toContain('hover:bg-ctp-error/10');
+  });
 });

--- a/src/renderer/plugins/builtin/files/FileTree.ts
+++ b/src/renderer/plugins/builtin/files/FileTree.ts
@@ -194,7 +194,11 @@ const TreeNode = React.memo(function TreeNodeInner({ node, depth, expanded, onTo
   const relPath = getRelativePath(node.path, projectPath);
   const gitStatus = gitMap.get(relPath);
 
-  const bgClass = isSelected ? 'bg-ctp-surface1' : isFocused ? 'bg-ctp-surface1/60 ring-1 ring-inset ring-ctp-blue' : 'hover:bg-ctp-surface0';
+  const bgClass = isSelected
+    ? 'bg-ctp-surface1 hover:bg-ctp-surface2/50'
+    : isFocused
+      ? 'bg-ctp-surface1/60 ring-1 ring-inset ring-ctp-blue hover:bg-ctp-surface1/80'
+      : 'hover:bg-ctp-surface0';
 
   const handleClick = () => {
     if (node.isDirectory) {
@@ -221,7 +225,7 @@ const TreeNode = React.memo(function TreeNodeInner({ node, depth, expanded, onTo
   const elements: React.ReactNode[] = [
     React.createElement('div', {
       key: node.path,
-      className: `flex items-center gap-1 px-2 py-0.5 cursor-pointer select-none text-xs ${bgClass} transition-colors`,
+      className: `flex items-center gap-1 px-2 py-0.5 cursor-pointer select-none text-xs rounded-sm ${bgClass} transition-colors`,
       style: { paddingLeft: `${8 + depth * 12}px` },
       onClick: handleClick,
       onDoubleClick: handleDoubleClick,
@@ -333,7 +337,12 @@ function ContextMenu({ x, y, node: _node, onClose, onAction }: ContextMenuProps)
     ...items.map((item) =>
       React.createElement('button', {
         key: item.action,
-        className: `w-full text-left px-3 py-1 text-xs text-ctp-text hover:bg-ctp-surface0 transition-colors ${item.action === 'delete' ? 'text-ctp-error' : ''}`,
+        className: `w-full text-left px-2 py-1 mx-1 rounded-sm text-xs transition-colors ${
+          item.action === 'delete'
+            ? 'text-ctp-error hover:bg-ctp-error/10'
+            : 'text-ctp-text hover:bg-ctp-surface1 hover:text-ctp-text'
+        }`,
+        style: { width: 'calc(100% - 8px)' },
         onClick: () => { onAction(item.action); onClose(); },
       }, item.label),
     ),

--- a/src/renderer/plugins/builtin/files/SearchPanel.ts
+++ b/src/renderer/plugins/builtin/files/SearchPanel.ts
@@ -104,7 +104,7 @@ function FileResultGroup({ result, onMatchClick }: {
   return React.createElement('div', { className: 'mb-0.5' },
     // File header
     React.createElement('div', {
-      className: 'flex items-center gap-1 px-2 py-0.5 cursor-pointer hover:bg-ctp-surface0 transition-colors',
+      className: 'flex items-center gap-1 px-2 py-0.5 cursor-pointer rounded-sm hover:bg-ctp-surface0 transition-colors',
       onClick: () => setCollapsed(!collapsed),
     },
       collapsed ? ChevronRight : ChevronDown,
@@ -123,7 +123,7 @@ function FileResultGroup({ result, onMatchClick }: {
       ...result.matches.slice(0, 100).map((match, i) =>
         React.createElement('div', {
           key: `${match.line}-${match.column}-${i}`,
-          className: 'flex items-start gap-1 px-2 py-px cursor-pointer hover:bg-ctp-surface0 transition-colors text-[11px]',
+          className: 'flex items-start gap-1 px-2 py-px cursor-pointer rounded-sm hover:bg-ctp-surface0 transition-colors text-[11px]',
           onClick: () => onMatchClick(result.filePath, match.line),
         },
           React.createElement('span', {

--- a/src/renderer/plugins/builtin/files/TabBar.ts
+++ b/src/renderer/plugins/builtin/files/TabBar.ts
@@ -107,7 +107,8 @@ function TabContextMenu({ x, y, tab, onClose, onAction }: TabContextMenuProps) {
       }
       return React.createElement('button', {
         key: item.action,
-        className: 'w-full text-left px-3 py-1 text-xs text-ctp-text hover:bg-ctp-surface0 transition-colors',
+        className: 'w-full text-left px-2 py-1 mx-1 rounded-sm text-xs text-ctp-text hover:bg-ctp-surface1 hover:text-ctp-text transition-colors',
+        style: { width: 'calc(100% - 8px)' },
         onClick: () => { onAction(item.action); onClose(); },
       }, item.label);
     }),


### PR DESCRIPTION
## Summary
- Adds visible hover states to file tree items, context menus, and search results in the files plugin
- Selected/focused tree items now retain hover feedback instead of losing it entirely
- Context menu items use rounded inset styling with stronger contrast for a modern IDE feel

## Changes
- **FileTree.ts — TreeNode**: Selected items get `hover:bg-ctp-surface2/50`, focused items get `hover:bg-ctp-surface1/80`, all items get `rounded-sm`
- **FileTree.ts — ContextMenu**: Items upgraded from `hover:bg-ctp-surface0` to `hover:bg-ctp-surface1` with `rounded-sm mx-1` inset styling; delete action uses themed `hover:bg-ctp-error/10`
- **TabBar.ts — TabContextMenu**: Same rounded inset hover treatment as FileTree context menu
- **SearchPanel.ts**: Added `rounded-sm` to file result headers and match items for consistency
- **FileTree.test.tsx**: 4 new tests verifying hover classes on default items, selected items, context menu items, and delete action theming

## Test Plan
- [x] Tree items show `hover:bg-ctp-surface0` with `rounded-sm` when not selected
- [x] Selected tree items retain hover via `hover:bg-ctp-surface2/50`
- [x] Context menu items have `hover:bg-ctp-surface1` and `rounded-sm` styling
- [x] Delete context menu item uses `hover:bg-ctp-error/10` for themed hover
- [x] All 6411 existing tests pass
- [x] Typecheck clean, lint clean

## Manual Validation
1. Open the files plugin sidebar and hover over tree items — should see subtle background highlight
2. Click a file to select it, then hover — should see a slightly different hover shade
3. Right-click a file to open context menu — hover over items to see rounded highlight
4. Verify the Delete item shows a red-tinted hover background
5. Right-click a tab in the tab bar — context menu items should have the same rounded hover style

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)