### PR TITLE
perf: convert ripgrep discovery from sync to async (#612)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import * as annexServer from './services/annex-server';
 import { flushAllPending as flushPendingBroadcasts } from './util/ipc-broadcast';
 import { flushAllAgentConfigs } from './services/agent-config';
 import { preWarmShellEnvironment } from './util/shell';
+import { initializeRipgrep } from './services/search-service';
 
 // Set the app name early so the dock, menu bar, and notifications all say "Clubhouse"
 // instead of "Electron" during development.
@@ -115,6 +116,10 @@ app.on('ready', () => {
   // Pre-warm the shell environment cache in background so the first agent
   // wake doesn't pay the 500ms–2s login shell penalty.
   preWarmShellEnvironment();
+
+  // Pre-resolve ripgrep binary path in background so the first search
+  // doesn't block the main process with a synchronous `which` call.
+  initializeRipgrep();
 
   registerAllHandlers();
   buildMenu();

--- a/src/main/services/search-service.test.ts
+++ b/src/main/services/search-service.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { searchFiles } from './search-service';
+import { searchFiles, initializeRipgrep, _resetForTesting } from './search-service';
 
 describe('search-service', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
+    _resetForTesting();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'search-test-'));
 
     // Create test files
@@ -180,5 +181,24 @@ describe('search-service', () => {
     const result = await searchFiles(tmpDir, 'match_token');
     expect(result.totalMatches).toBeLessThanOrEqual(1000);
     expect(result.truncated).toBe(true);
+  });
+
+  it('initializeRipgrep pre-warms the cache so searchFiles does not block', async () => {
+    // Call initializeRipgrep and wait for it to complete by searching
+    initializeRipgrep();
+
+    // Calling initializeRipgrep again should be a no-op (idempotent)
+    initializeRipgrep();
+
+    // searchFiles should work normally after pre-warming
+    const result = await searchFiles(tmpDir, 'hello');
+    expect(result.totalMatches).toBeGreaterThan(0);
+  });
+
+  it('searchFiles works without explicit initializeRipgrep (lazy init)', async () => {
+    // Without calling initializeRipgrep, searchFiles should still work
+    // via lazy initialization in getRipgrepPath
+    const result = await searchFiles(tmpDir, 'hello');
+    expect(result.totalMatches).toBeGreaterThan(0);
   });
 });

--- a/src/main/services/search-service.ts
+++ b/src/main/services/search-service.ts
@@ -1,4 +1,5 @@
-import { execFile, execFileSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import * as path from 'path';
 const picomatch = require('picomatch') as (
   patterns: string[],
@@ -6,14 +7,16 @@ const picomatch = require('picomatch') as (
 ) => (input: string) => boolean;
 import type { FileSearchOptions, FileSearchResult, FileSearchFileResult, FileSearchMatch } from '../../shared/types';
 
+const execFileAsync = promisify(execFile);
+
 const DEFAULT_MAX_RESULTS = 1_000;
 const DEFAULT_CONTEXT_LINES = 0;
 const MAX_LINE_CONTENT_LENGTH = 500;
 
 /**
- * Try to locate the ripgrep binary. Returns the path or null if not found.
+ * Try to locate the ripgrep binary asynchronously. Returns the path or null if not found.
  */
-function findRipgrep(): string | null {
+async function findRipgrep(): Promise<string | null> {
   const candidates = [
     '/usr/local/bin/rg',
     '/opt/homebrew/bin/rg',
@@ -22,10 +25,11 @@ function findRipgrep(): string | null {
 
   // Also try resolving 'rg' via `which`
   try {
-    const resolved = execFileSync('which', ['rg'], {
+    const { stdout } = await execFileAsync('which', ['rg'], {
       timeout: 3000,
       encoding: 'utf-8',
-    }).trim();
+    });
+    const resolved = stdout.trim();
     if (resolved && !candidates.includes(resolved)) {
       candidates.unshift(resolved);
     }
@@ -35,10 +39,7 @@ function findRipgrep(): string | null {
 
   for (const candidate of candidates) {
     try {
-      execFileSync(candidate, ['--version'], {
-        timeout: 3000,
-        stdio: 'ignore',
-      });
+      await execFileAsync(candidate, ['--version'], { timeout: 3000 });
       return candidate;
     } catch {
       // not found, try next
@@ -48,12 +49,33 @@ function findRipgrep(): string | null {
 }
 
 let _rgPath: string | null | undefined;
+let _rgPathPromise: Promise<string | null> | null = null;
 
-function getRipgrepPath(): string | null {
-  if (_rgPath === undefined) {
-    _rgPath = findRipgrep();
+/**
+ * Kick off async ripgrep discovery. Call during app initialization so the
+ * binary path is resolved before the first search request arrives.
+ */
+export function initializeRipgrep(): void {
+  if (!_rgPathPromise) {
+    _rgPathPromise = findRipgrep().then(p => {
+      _rgPath = p;
+      return p;
+    });
   }
-  return _rgPath;
+}
+
+async function getRipgrepPath(): Promise<string | null> {
+  if (_rgPath !== undefined) return _rgPath;
+  if (!_rgPathPromise) {
+    initializeRipgrep();
+  }
+  return _rgPathPromise!;
+}
+
+/** Reset module state between tests. */
+export function _resetForTesting(): void {
+  _rgPath = undefined;
+  _rgPathPromise = null;
 }
 
 /**
@@ -68,7 +90,7 @@ export async function searchFiles(
     return { results: [], totalMatches: 0, truncated: false };
   }
 
-  const rgPath = getRipgrepPath();
+  const rgPath = await getRipgrepPath();
   if (rgPath) {
     return searchWithRipgrep(rgPath, rootPath, query, options);
   }


### PR DESCRIPTION
## Summary
- Convert `findRipgrep` from synchronous `execFileSync` to async `execFile` (promisified), eliminating main-process blocking on first search
- Add `initializeRipgrep()` export called during `app.on('ready')` to pre-resolve the binary path before any search request
- Maintain lazy-init fallback so `searchFiles` still works if called before initialization completes

## Changes
- **src/main/services/search-service.ts**: Replace `execFileSync` calls in `findRipgrep` with promisified `execFile`. Add `_rgPathPromise` for deduplication. Export `initializeRipgrep()` and `_resetForTesting()`.
- **src/main/index.ts**: Import and call `initializeRipgrep()` in `app.on('ready')` alongside existing pre-warm calls.
- **src/main/services/search-service.test.ts**: Add `_resetForTesting()` in `beforeEach` to isolate tests. Add two new tests for eager and lazy initialization paths.

## Test Plan
- [x] All 15 search-service tests pass (13 existing + 2 new)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Manual: verify first search in app doesn't cause a visible pause

## Manual Validation
1. Launch the app and open a project
2. Trigger a file search immediately — it should respond without the ~3s blocking delay previously caused by synchronous `which` resolution

Closes #612