### PR TITLE
Fix headless stderr memory growth

### DIFF
--- a/src/main/services/headless-manager.test.ts
+++ b/src/main/services/headless-manager.test.ts
@@ -98,6 +98,7 @@ import {
   getTranscriptInfo,
   readTranscriptPage,
   setMaxTranscriptBytes,
+  setMaxStderrBytes,
   startStaleSweep,
   stopStaleSweep,
 } from './headless-manager';
@@ -123,6 +124,7 @@ describe('headless-manager', () => {
     }
     // Reset transcript cap to default
     setMaxTranscriptBytes(10 * 1024 * 1024);
+    setMaxStderrBytes(64 * 1024);
     stopStaleSweep();
     vi.useRealTimers();
   });
@@ -944,6 +946,62 @@ describe('headless-manager', () => {
       expect(lines.length).toBeLessThan(6);
       expect(lines.length).toBeGreaterThan(0);
       expect(transcript).toContain('trigger');
+    });
+  });
+
+  describe('stderr memory cap', () => {
+    it('retains recent stderr output when the buffer exceeds the cap', () => {
+      setMaxStderrBytes(70);
+      spawnHeadless('test-agent', '/project', '/usr/local/bin/claude', ['-p', 'test']);
+
+      mockProcess.stderr!.emit('data', Buffer.from(`first-${'x'.repeat(30)}`));
+      mockProcess.stderr!.emit('data', Buffer.from(`second-${'y'.repeat(30)}`));
+      mockProcess.stderr!.emit('data', Buffer.from(`third-${'z'.repeat(30)}`));
+
+      mockProcess.emit('close', 1);
+
+      expect(appLog).toHaveBeenCalledWith(
+        'core:headless',
+        'info',
+        'Process exited',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            agentId: 'test-agent',
+            stderr: expect.stringContaining('third-'),
+          }),
+        }),
+      );
+
+      expect(appLog).not.toHaveBeenCalledWith(
+        'core:headless',
+        'info',
+        'Process exited',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            stderr: expect.stringContaining('first-'),
+          }),
+        }),
+      );
+    });
+
+    it('setMaxStderrBytes changes the retention cap', () => {
+      setMaxStderrBytes(20);
+      spawnHeadless('test-agent', '/project', '/usr/local/bin/claude', ['-p', 'test']);
+
+      mockProcess.stderr!.emit('data', Buffer.from('alpha-alpha-alpha'));
+      mockProcess.stderr!.emit('data', Buffer.from('beta'));
+      mockProcess.emit('close', 1);
+
+      expect(appLog).toHaveBeenCalledWith(
+        'core:headless',
+        'info',
+        'Process exited',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            stderr: 'beta',
+          }),
+        }),
+      );
     });
   });
 

--- a/src/main/services/headless-manager.ts
+++ b/src/main/services/headless-manager.ts
@@ -27,9 +27,17 @@ function winQuoteHeadlessArg(arg: string): string {
 /** Maximum in-memory transcript size in bytes before old events are evicted to reclaim memory. */
 let maxTranscriptBytes = 10 * 1024 * 1024; // 10 MB
 
+/** Maximum in-memory stderr buffer in bytes before old chunks are evicted. */
+let maxStderrBytes = 64 * 1024; // 64 KB
+
 /** Change the in-memory transcript cap. Primarily for testing. */
 export function setMaxTranscriptBytes(bytes: number): void {
   maxTranscriptBytes = bytes;
+}
+
+/** Change the in-memory stderr cap. Primarily for testing. */
+export function setMaxStderrBytes(bytes: number): void {
+  maxStderrBytes = bytes;
 }
 
 interface HeadlessSession {
@@ -131,6 +139,36 @@ function evictOldEvents(session: HeadlessSession): void {
   }
 }
 
+/**
+ * Evict oldest stderr chunks from the in-memory buffer to stay under the cap.
+ * stderr is only retained for exit diagnostics, so keeping a recent window is sufficient.
+ */
+function evictOldStderrChunks(
+  stderrChunks: string[],
+  stderrChunkSizes: number[],
+  stderrBytes: number,
+): number {
+  const target = Math.floor(maxStderrBytes * 0.75);
+  let removeBytes = 0;
+  let removeCount = 0;
+
+  while (
+    removeCount < stderrChunkSizes.length &&
+    (stderrBytes - removeBytes) > target
+  ) {
+    removeBytes += stderrChunkSizes[removeCount];
+    removeCount++;
+  }
+
+  if (removeCount > 0) {
+    stderrChunks.splice(0, removeCount);
+    stderrChunkSizes.splice(0, removeCount);
+    return stderrBytes - removeBytes;
+  }
+
+  return stderrBytes;
+}
+
 export function isHeadless(agentId: string): boolean {
   return sessions.has(agentId);
 }
@@ -206,6 +244,8 @@ export function spawnHeadless(
   const transcriptEventSizes: number[] = [];
   let stdoutBytes = 0;
   const stderrChunks: string[] = [];
+  const stderrChunkSizes: number[] = [];
+  let stderrBytes = 0;
 
   const session: HeadlessSession = {
     process: proc,
@@ -288,7 +328,17 @@ export function spawnHeadless(
 
   proc.stderr?.on('data', (chunk: Buffer) => {
     const msg = chunk.toString().trim();
+    if (!msg) return;
+
+    const msgBytes = Buffer.byteLength(msg, 'utf-8');
     stderrChunks.push(msg);
+    stderrChunkSizes.push(msgBytes);
+    stderrBytes += msgBytes;
+
+    if (stderrBytes > maxStderrBytes) {
+      stderrBytes = evictOldStderrChunks(stderrChunks, stderrChunkSizes, stderrBytes);
+    }
+
     appLog('core:headless', 'warn', `stderr`, { meta: { agentId, message: msg } });
 
     // Forward stderr to renderer + annex so headless view can show errors


### PR DESCRIPTION
## Summary
- bound in-memory stderr retention for headless sessions with a rolling byte cap
- keep only the newest stderr chunks for exit diagnostics while preserving per-chunk notifications
- add regression coverage for stderr eviction and the configurable cap

Fixes #613

## Changes
- added `maxStderrBytes` and `setMaxStderrBytes()` in `headless-manager.ts`
- implemented eviction of oldest stderr chunks once the in-memory stderr buffer exceeds the configured cap
- ignored empty stderr chunks after trimming so whitespace-only writes do not consume retained buffer space
- added tests covering eviction behavior and cap overrides in `headless-manager.test.ts`

## Test Plan
- [x] `npm test -- --run src/main/services/headless-manager.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm run build` (blocked: repository currently has no `build` script)
- [ ] `npm test` (repo-wide suite currently fails in unrelated existing tests: `hook-server.test.ts`, `annex-server.test.ts`, `search-service.test.ts`, `file-handlers.test.ts`; several failures are sandbox-dependent `listen EPERM` / `rg` command issues)

## Manual Validation
- not run; covered by automated tests above