### PR TITLE
Fix PTY buffer joins on repeated reads

### DIFF
--- a/src/main/services/pty-manager.test.ts
+++ b/src/main/services/pty-manager.test.ts
@@ -118,6 +118,28 @@ describe('pty-manager', () => {
       expect(getBuffer('agent_concat')).toBe('hello world');
     });
 
+    it('reuses the joined buffer until new data arrives', () => {
+      spawnAndActivate('agent_cache');
+      const onDataCb = mockProcess.onData.mock.calls[0][0];
+      onDataCb('hello ');
+      onDataCb('world');
+
+      const joinSpy = vi.spyOn(Array.prototype, 'join');
+      try {
+        expect(getBuffer('agent_cache')).toBe('hello world');
+        expect(getBuffer('agent_cache')).toBe('hello world');
+        expect(joinSpy).toHaveBeenCalledTimes(1);
+
+        onDataCb('!');
+
+        expect(getBuffer('agent_cache')).toBe('hello world!');
+        expect(getBuffer('agent_cache')).toBe('hello world!');
+        expect(joinSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        joinSpy.mockRestore();
+      }
+    });
+
     it('evicts oldest chunks when >512KB', () => {
       spawnAndActivate('agent_evict');
       const onDataCb = mockProcess.onData.mock.calls[0][0];
@@ -130,6 +152,23 @@ describe('pty-manager', () => {
       const buf = getBuffer('agent_evict');
       expect(buf.length).toBeLessThanOrEqual(600 * 1024); // some tolerance
       expect(buf.length).toBeGreaterThan(0);
+    });
+
+    it('drops evicted chunks from a previously cached buffer', () => {
+      spawnAndActivate('agent_cached_evict');
+      const onDataCb = mockProcess.onData.mock.calls[0][0];
+      const chunkSize = 128 * 1024;
+      const chunks = ['a', 'b', 'c', 'd', 'e'].map((char) => char.repeat(chunkSize));
+
+      for (const chunk of chunks.slice(0, 4)) {
+        onDataCb(chunk);
+      }
+
+      expect(getBuffer('agent_cached_evict')).toBe(chunks.slice(0, 4).join(''));
+
+      onDataCb(chunks[4]);
+
+      expect(getBuffer('agent_cached_evict')).toBe(chunks.slice(1).join(''));
     });
 
     it('keeps last chunk even if it alone exceeds limit', () => {

--- a/src/main/services/pty-manager.ts
+++ b/src/main/services/pty-manager.ts
@@ -16,6 +16,8 @@ interface ManagedSession {
   outputChunks: string[];
   outputHead: number;
   outputSize: number;
+  bufferCache: string;
+  bufferCacheDirty: boolean;
   pendingCommand?: string;
   eofTimer?: ReturnType<typeof setTimeout>;
   termTimer?: ReturnType<typeof setTimeout>;
@@ -145,9 +147,25 @@ export function stopStaleSweep(): void {
 /** Compact threshold: reclaim array memory once the dead-head region grows large. */
 const COMPACT_THRESHOLD = 1000;
 
+function createSession(process: pty.IPty, agentId: string, pendingCommand?: string): ManagedSession {
+  return {
+    process,
+    agentId,
+    lastActivity: Date.now(),
+    killing: false,
+    outputChunks: [],
+    outputHead: 0,
+    outputSize: 0,
+    bufferCache: '',
+    bufferCacheDirty: false,
+    pendingCommand,
+  };
+}
+
 function appendToBuffer(session: ManagedSession, data: string): void {
   session.outputChunks.push(data);
   session.outputSize += data.length;
+  session.bufferCacheDirty = true;
   // Evict oldest chunks using a head pointer — O(1) per eviction step.
   while (session.outputSize > MAX_BUFFER_SIZE && session.outputHead < session.outputChunks.length - 1) {
     session.outputSize -= session.outputChunks[session.outputHead]!.length;
@@ -160,9 +178,18 @@ function appendToBuffer(session: ManagedSession, data: string): void {
   }
 }
 
+function getSessionBuffer(session: ManagedSession): string {
+  if (session.bufferCacheDirty) {
+    session.bufferCache = session.outputChunks.slice(session.outputHead).join('');
+    session.bufferCacheDirty = false;
+  }
+
+  return session.bufferCache;
+}
+
 export function getBuffer(agentId: string): string {
   const session = sessions.get(agentId);
-  return session ? session.outputChunks.slice(session.outputHead).join('') : '';
+  return session ? getSessionBuffer(session) : '';
 }
 
 /** Check whether an agent has an active PTY session. */
@@ -238,16 +265,7 @@ export function spawn(agentId: string, cwd: string, binary: string, args: string
     throw err;
   }
 
-  const session: ManagedSession = {
-    process: proc,
-    agentId,
-    lastActivity: Date.now(),
-    killing: false,
-    outputChunks: [],
-    outputHead: 0,
-    outputSize: 0,
-    pendingCommand,
-  };
+  const session = createSession(proc, agentId, pendingCommand);
   sessions.set(agentId, session);
 
   proc.onData((data: string) => {
@@ -270,7 +288,7 @@ export function spawn(agentId: string, cwd: string, binary: string, args: string
     const current = sessions.get(agentId);
     if (!current || current.process !== proc) return;
 
-    const fullBuffer = current.outputChunks.slice(current.outputHead).join('');
+    const fullBuffer = getSessionBuffer(current);
     const ptyBuffer = fullBuffer.slice(-500);
     appLog('core:pty', exitCode !== 0 && !current.killing ? 'error' : 'info', `PTY exited`, {
       meta: { agentId, exitCode, binary, lastOutput: ptyBuffer },
@@ -313,15 +331,7 @@ export function spawnShell(id: string, projectPath: string): void {
     throw err;
   }
 
-  const session: ManagedSession = {
-    process: proc,
-    agentId: id,
-    lastActivity: Date.now(),
-    killing: false,
-    outputChunks: [],
-    outputHead: 0,
-    outputSize: 0,
-  };
+  const session = createSession(proc, id);
   sessions.set(id, session);
 
   proc.onData((data: string) => {


### PR DESCRIPTION
## Summary
- cache each PTY session's joined buffer so repeated `getBuffer()` reads do not rejoin all chunks
- reuse the cached buffer for exit handling while preserving existing trim and compaction behavior
- add regression tests covering cache reuse and buffer eviction after a cached read

## Changes
- added per-session buffer cache state in `src/main/services/pty-manager.ts`
- centralized session creation and buffer access helpers so spawn paths share the same buffering logic
- invalidated the cached string whenever new PTY data arrives, then recomputed it lazily on the next read
- updated the PTY manager test suite with cases that prove repeated reads only join once per unchanged buffer and still drop trimmed chunks correctly

## Test Plan
- [x] `npx vitest run --project main src/main/services/pty-manager.test.ts`
- [x] `npm run make`
- [x] `npm test`
- [x] `npm run lint`

## Manual Validation
- No additional manual validation was required beyond the automated checks above.

Closes #614
