### PR TITLE
perf: use running counters for getTranscriptInfo (fixes #639)

### DIFF
--- a/src/main/services/headless-manager.test.ts
+++ b/src/main/services/headless-manager.test.ts
@@ -1046,7 +1046,7 @@ describe('headless-manager', () => {
       expect(info!.fileSizeBytes).toBe(diskData.length);
     });
 
-    it('falls back to disk when session has evicted events', async () => {
+    it('uses running counters when session has evicted events (no disk I/O)', async () => {
       setMaxTranscriptBytes(200);
       spawnHeadless('test-agent', '/project', '/usr/local/bin/claude', ['-p', 'test']);
 
@@ -1056,13 +1056,14 @@ describe('headless-manager', () => {
         mockProcess.stdout!.emit('data', Buffer.from(JSON.stringify(event) + '\n'));
       }
 
-      const diskData = '{"type":"result"}\n{"type":"result"}\n{"type":"result"}\n{"type":"result"}\n{"type":"result"}\n';
-      mockFsPromises.stat.mockResolvedValue({ size: diskData.length });
-      mockCreateReadStream.mockReturnValue(Readable.from([diskData]));
-
+      // Should NOT read from disk — running counters are used instead
       const info = await getTranscriptInfo('test-agent');
       expect(info).not.toBeNull();
       expect(info!.totalEvents).toBe(5);
+      expect(info!.fileSizeBytes).toBeGreaterThan(0);
+      // Verify no disk reads were attempted
+      expect(mockFsPromises.stat).not.toHaveBeenCalled();
+      expect(mockCreateReadStream).not.toHaveBeenCalled();
     });
   });
 

--- a/src/main/services/headless-manager.ts
+++ b/src/main/services/headless-manager.ts
@@ -52,6 +52,10 @@ interface HeadlessSession {
   transcriptBytes: number;
   /** True once events have been evicted from the in-memory transcript. */
   transcriptEvicted: boolean;
+  /** Total events ever written (including evicted). Used for O(1) metadata lookups. */
+  totalTranscriptEvents: number;
+  /** Total bytes written to the transcript file on disk. */
+  totalTranscriptBytesWritten: number;
   transcriptPath: string;
   startedAt: number;
   textBuffer?: string;
@@ -256,6 +260,8 @@ export function spawnHeadless(
     transcriptEventSizes,
     transcriptBytes: 0,
     transcriptEvicted: false,
+    totalTranscriptEvents: 0,
+    totalTranscriptBytesWritten: 0,
     transcriptPath,
     startedAt: Date.now(),
   };
@@ -274,6 +280,9 @@ export function spawnHeadless(
       transcript.push(event);
       transcriptEventSizes.push(eventBytes);
       session.transcriptBytes += eventBytes;
+      session.totalTranscriptEvents++;
+      // Disk write is serialized + newline
+      session.totalTranscriptBytesWritten += eventBytes + 1;
 
       // Log first event for diagnostics
       if (transcript.length === 1) {
@@ -374,6 +383,8 @@ export function spawnHeadless(
       transcript.push(resultEvent);
       transcriptEventSizes.push(eventBytes);
       session.transcriptBytes += eventBytes;
+      session.totalTranscriptEvents++;
+      session.totalTranscriptBytesWritten += eventBytes + 1;
       logStream.write(serialized + '\n');
 
       const stopEvent = {
@@ -490,21 +501,22 @@ export interface TranscriptPage {
 
 /**
  * Return metadata about a transcript without loading event data.
- * Streams the file line-by-line to count events without buffering the entire
- * file contents in memory.
+ * For active sessions, returns O(1) running counters maintained as events
+ * are appended — no file I/O required even when old events have been evicted.
+ * For completed sessions (no in-memory session), falls back to disk.
  */
 export async function getTranscriptInfo(agentId: string): Promise<TranscriptInfo | null> {
-  // Check in-memory session first
+  // Active session — use running counters (O(1), no file I/O)
   const session = sessions.get(agentId);
-  if (session && !session.transcriptEvicted) {
+  if (session) {
     return {
-      totalEvents: session.transcript.length,
-      fileSizeBytes: session.transcriptBytes,
+      totalEvents: session.totalTranscriptEvents,
+      fileSizeBytes: session.totalTranscriptBytesWritten,
     };
   }
 
-  // Stream from disk (evicted session or completed session)
-  const transcriptPath = session?.transcriptPath ?? path.join(LOGS_DIR, `${agentId}.jsonl`);
+  // Completed session — stream from disk
+  const transcriptPath = path.join(LOGS_DIR, `${agentId}.jsonl`);
   try {
     const stat = await fsPromises.stat(transcriptPath);
     const stream = fs.createReadStream(transcriptPath, { encoding: 'utf-8' });


### PR DESCRIPTION
## Summary
- **Fixes #639** — `getTranscriptInfo` no longer reads the entire transcript file from disk just to count lines
- Added `totalTranscriptEvents` and `totalTranscriptBytesWritten` running counters to `HeadlessSession`, incremented O(1) as events are appended
- Active sessions (including those with evicted in-memory events) now return metadata instantly with zero file I/O

## Changes
- **`src/main/services/headless-manager.ts`**:
  - Added `totalTranscriptEvents` and `totalTranscriptBytesWritten` fields to `HeadlessSession` interface
  - Increment both counters in the parser `line` handler and text-mode close handler
  - Simplified `getTranscriptInfo` to use running counters for any active session (removed the `transcriptEvicted` branch that fell back to disk streaming)
  - Disk fallback retained only for completed sessions with no in-memory session
- **`src/main/services/headless-manager.test.ts`**:
  - Updated evicted-session test to verify no disk I/O occurs (asserts `stat` and `createReadStream` are not called)

## Test Plan
- [x] Existing test: returns in-memory info for active session (non-evicted)
- [x] Existing test: returns disk info for completed session
- [x] Updated test: uses running counters when session has evicted events — verifies no disk I/O
- [x] Existing test: returns null for unknown agent with no transcript on disk
- [x] All 6438 tests pass, typecheck clean, lint clean

## Manual Validation
- Spawn a headless agent with a large transcript (enough to trigger eviction)
- Call `getTranscriptInfo` — should return instantly without disk reads
- Kill the agent, then call `getTranscriptInfo` — should fall back to disk streaming