### PR TITLE
Fix git info IPC handler blocking

### DIFF
--- a/src/main/ipc/git-handlers.test.ts
+++ b/src/main/ipc/git-handlers.test.ts
@@ -57,6 +57,23 @@ describe('git-handlers', () => {
     expect(result).toEqual({ branch: 'main' });
   });
 
+  it('INFO defers gitService.getGitInfo to an async boundary', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = handlers.get(IPC.GIT.INFO)!;
+      const resultPromise = handler({}, '/project');
+
+      expect(gitService.getGitInfo).not.toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+
+      expect(gitService.getGitInfo).toHaveBeenCalledWith('/project');
+      await expect(resultPromise).resolves.toEqual({ branch: 'main' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('CHECKOUT delegates to gitService.checkout', async () => {
     const handler = handlers.get(IPC.GIT.CHECKOUT)!;
     await handler({}, '/project', 'feature');

--- a/src/main/ipc/git-handlers.ts
+++ b/src/main/ipc/git-handlers.ts
@@ -3,9 +3,19 @@ import { IPC } from '../../shared/ipc-channels';
 import * as gitService from '../services/git-service';
 import { booleanArg, stringArg, withValidatedArgs } from './validation';
 
+function deferInvocation<Result>(operation: () => Promise<Result> | Result): Promise<Result> {
+  return new Promise((resolve, reject) => {
+    setImmediate(() => {
+      void Promise.resolve()
+        .then(operation)
+        .then(resolve, reject);
+    });
+  });
+}
+
 export function registerGitHandlers(): void {
-  ipcMain.handle(IPC.GIT.INFO, withValidatedArgs([stringArg()], (_event, dirPath: string) => {
-    return gitService.getGitInfo(dirPath);
+  ipcMain.handle(IPC.GIT.INFO, withValidatedArgs([stringArg()], async (_event, dirPath: string) => {
+    return deferInvocation(() => gitService.getGitInfo(dirPath));
   }));
 
   ipcMain.handle(IPC.GIT.CHECKOUT, withValidatedArgs([stringArg(), stringArg()], (_event, dirPath: string, branch: string) => {


### PR DESCRIPTION
## Summary
- defer `IPC.GIT.INFO` work behind an explicit async boundary in the main process
- add a regression test proving the handler does not invoke `gitService.getGitInfo` synchronously
- keep validation behavior unchanged for all git IPC routes
- Fixes #596 

## Changes
- added a small `deferInvocation` helper in `src/main/ipc/git-handlers.ts`
- updated the `IPC.GIT.INFO` registration to invoke `gitService.getGitInfo` through that helper
- added an IPC test using fake timers to verify the async boundary

## Test Plan
- [x] `npm test -- --run src/main/ipc/git-handlers.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm run build` (script is missing from `package.json` in this repo)
- [ ] `npm test` (repo has unrelated existing failures, including `hook-server.test.ts`, `annex-server.test.ts` sandbox `listen EPERM` errors, `file-handlers.test.ts`, and `search-service.test.ts`)

## Manual Validation
- Not run. Change is covered by the targeted IPC regression test.