### PR TITLE
perf: replace aggressive transcript polling with hook-driven syncs

### DIFF
--- a/src/renderer/features/agents/HeadlessAgentView.test.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.test.tsx
@@ -224,8 +224,9 @@ describe('HeadlessAgentView', () => {
     expect(screen.getByText('Read')).toBeInTheDocument();
     expect(screen.getByText('Inspect file')).toBeInTheDocument();
 
+    // Advance past the 5s fallback poll interval to trigger the next sync
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(5000);
     });
     await flushAsyncWork();
 
@@ -240,7 +241,7 @@ describe('HeadlessAgentView', () => {
     expect(screen.getByText('Inspect file')).toBeInTheDocument();
   });
 
-  it('suppresses polling when hooks are actively firing', async () => {
+  it('suppresses fallback polling when hooks are actively firing', async () => {
     let hookCallback: (agentId: string, event: Record<string, unknown>) => void = () => {};
     window.clubhouse.agent.onHookEvent = vi.fn((cb) => {
       hookCallback = cb;
@@ -257,7 +258,7 @@ describe('HeadlessAgentView', () => {
     await flushAsyncWork();
     const callsAfterMount = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
 
-    // Fire hook events to mark hooks as active
+    // Fire hook event to mark hooks as active
     act(() => {
       hookCallback(headlessAgent.id, {
         kind: 'pre_tool',
@@ -268,22 +269,35 @@ describe('HeadlessAgentView', () => {
     await flushAsyncWork();
     const callsAfterHook = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
 
-    // Advance past multiple poll intervals (500ms each) while hooks are "active"
-    // The poller should skip these cycles since hooks fired recently
+    // Fire another hook at t=3s to keep hooks "active"
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    act(() => {
+      hookCallback(headlessAgent.id, {
+        kind: 'post_tool',
+        toolName: 'Read',
+        timestamp: Date.now(),
+      });
+    });
+    await flushAsyncWork();
+    const callsAfterSecondHook = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+
+    // Advance to t=7.5s — the fallback poll at t=5s should have been suppressed
+    // because the second hook at t=3s keeps lastHookTimestamp within the 5s threshold
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4500);
     });
     await flushAsyncWork();
     const callsAfterPolling = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
 
-    // Hook-triggered sync should have added calls, but the poller intervals
-    // should NOT have added any additional calls
-    expect(callsAfterPolling).toBe(callsAfterHook);
-    // Verify hook did trigger at least one sync beyond the initial mount
+    // Only hook-triggered syncs should have occurred, no fallback polls
+    expect(callsAfterPolling).toBe(callsAfterSecondHook);
+    // Verify hooks triggered syncs beyond the initial mount
     expect(callsAfterHook).toBeGreaterThan(callsAfterMount);
   });
 
-  it('resumes polling when hooks stop firing', async () => {
+  it('resumes fallback polling when hooks stop firing', async () => {
     let hookCallback: (agentId: string, event: Record<string, unknown>) => void = () => {};
     window.clubhouse.agent.onHookEvent = vi.fn((cb) => {
       hookCallback = cb;
@@ -308,15 +322,46 @@ describe('HeadlessAgentView', () => {
     await flushAsyncWork();
     const callsAfterHook = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
 
-    // Advance past the hook active threshold (5s) so hooks are no longer "active"
+    // Advance past both the hook active threshold and fallback poll interval
+    // so polling resumes (hook at t=0 is stale by t=10s, and the t=10s poll fires)
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(6000);
+      await vi.advanceTimersByTimeAsync(10_000);
     });
     await flushAsyncWork();
     const callsAfterThreshold = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
 
-    // Polling should have resumed and made additional calls
+    // Fallback polling should have resumed and made additional calls
     expect(callsAfterThreshold).toBeGreaterThan(callsAfterHook);
+  });
+
+  it('does not aggressively poll during startup — only initial sync and fallback', async () => {
+    window.clubhouse.agent.readTranscriptPage = vi.fn().mockResolvedValue({
+      events: [],
+      totalEvents: 0,
+    });
+
+    render(<HeadlessAgentView agent={headlessAgent} />);
+    await flushAsyncWork();
+
+    // Initial mount sync
+    const callsAfterMount = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+    expect(callsAfterMount).toBe(1);
+
+    // Advance 4.9s — no fallback poll should have fired yet (interval is 5s)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4900);
+    });
+    await flushAsyncWork();
+    const callsBefore5s = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+    expect(callsBefore5s).toBe(1);
+
+    // Advance past the 5s fallback interval — exactly one fallback poll should fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    await flushAsyncWork();
+    const callsAfter5s = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
+    expect(callsAfter5s).toBe(2);
   });
 
   it('freezes the timer when the agent is no longer running', () => {

--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -252,6 +252,9 @@ function AnimatedTreehouse() {
 /** How recently a hook must have fired for us to consider hooks "active" and skip polling. */
 const HOOK_ACTIVE_THRESHOLD_MS = 5_000;
 
+/** Fallback poll interval — only used when hooks are not actively firing. */
+const FALLBACK_POLL_INTERVAL_MS = 5_000;
+
 export function HeadlessAgentView({ agent }: Props) {
   const [feedItems, setFeedItems] = useState<FeedItem[]>([]);
   const [elapsed, setElapsed] = useState(0);
@@ -288,12 +291,10 @@ export function HeadlessAgentView({ agent }: Props) {
     });
   }, []);
 
-  // Poll transcript pages incrementally so the transcript remains the canonical
-  // source for tool/text/result activity without rebuilding the whole feed.
+  // Sync transcript incrementally — hook events trigger immediate syncs while a
+  // low-frequency fallback poll (5 s) catches anything hooks miss.
   useEffect(() => {
     let cancelled = false;
-    let pollCount = 0;
-    let interval: ReturnType<typeof setInterval>;
 
     prevCountRef.current = 0;
     transcriptOffsetRef.current = 0;
@@ -370,27 +371,21 @@ export function HeadlessAgentView({ agent }: Props) {
       },
     );
 
+    // Initial sync on mount
     void syncTranscript();
-    const fastInterval = setInterval(() => {
-      pollCount++;
-      // Skip poll when hooks are actively firing — they already trigger syncs
+
+    // Low-frequency fallback poll — only fires when hooks haven't been active
+    // and the agent is still running.  Hook-triggered syncs handle the common
+    // case so this only matters for startup or providers without hook support.
+    const fallbackInterval = setInterval(() => {
       if (Date.now() - lastHookTimestampRef.current < HOOK_ACTIVE_THRESHOLD_MS) return;
       void syncTranscript();
-      if (pollCount >= 10) {
-        clearInterval(fastInterval);
-        interval = setInterval(() => {
-          // Skip poll when hooks are actively firing
-          if (Date.now() - lastHookTimestampRef.current < HOOK_ACTIVE_THRESHOLD_MS) return;
-          void syncTranscript();
-        }, 2000);
-      }
-    }, 500);
+    }, FALLBACK_POLL_INTERVAL_MS);
 
     return () => {
       cancelled = true;
       removeListener();
-      clearInterval(fastInterval);
-      if (interval) clearInterval(interval);
+      clearInterval(fallbackInterval);
     };
   }, [agent.id, appendNotificationItem]);
 


### PR DESCRIPTION
## Summary
- Eliminates the aggressive 500ms startup polling phase and 2s ongoing polling in `HeadlessAgentView`
- Replaces with a single 5s fallback poll that only fires when hook events are not active
- Hook-triggered syncs remain the primary update path, providing responsive UI without wasted CPU

Closes #636

## Changes
- **Removed fast polling phase**: Previously polled every 500ms for the first 5 seconds (10 polls), then switched to 2s intervals indefinitely. Now uses only a single 5s fallback `setInterval`.
- **Added `FALLBACK_POLL_INTERVAL_MS` constant** (5s): Replaces the hardcoded 500ms/2s two-phase approach. The fallback poll is suppressed when hook events are actively firing (within the existing 5s `HOOK_ACTIVE_THRESHOLD_MS` window).
- **Simplified cleanup**: Only one interval to clear instead of managing fast→slow interval transition.
- **Updated tests**: Adjusted timing in polling tests to match the new 5s fallback interval. Added a new test (`does not aggressively poll during startup`) that verifies only 1 IPC call (the initial sync) occurs in the first 5 seconds.

## Test Plan
- [x] `does not aggressively poll during startup` — verifies only 1 readTranscriptPage call in first 4.9s, then exactly 2 after 5.1s
- [x] `suppresses fallback polling when hooks are actively firing` — hooks fired at t=0 and t=3s suppress the t=5s fallback poll
- [x] `resumes fallback polling when hooks stop firing` — after hooks go stale, fallback poll resumes
- [x] `polls transcript pages incrementally` — offset-based pagination still works via 5s fallback
- [x] `uses transcript pages as the canonical source` — hook events trigger transcript sync, not direct feed items
- [x] All 6439 existing tests pass, typecheck clean, lint clean

## Manual Validation
1. Launch a headless agent and observe the Live Activity feed updates in real-time
2. Verify tool use events appear promptly (driven by hook events, not polling)
3. Confirm no visible latency regression compared to the old 500ms polling
4. Monitor IPC traffic — should see significantly fewer `readTranscriptPage` calls during active agent execution