### PR TITLE
Fix #599 settings-store blocking disk access

### DIFF
--- a/src/main/ipc/annex-handlers.ts
+++ b/src/main/ipc/annex-handlers.ts
@@ -16,9 +16,9 @@ export function registerAnnexHandlers(): void {
     return annexSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.ANNEX.SAVE_SETTINGS, (_event, settings: AnnexSettings) => {
+  ipcMain.handle(IPC.ANNEX.SAVE_SETTINGS, async (_event, settings: AnnexSettings) => {
     const previous = annexSettings.getSettings();
-    annexSettings.saveSettings(settings);
+    await annexSettings.saveSettings(settings);
 
     // Start or stop server based on enabled state
     if (settings.enabled && !previous.enabled) {

--- a/src/main/ipc/app-handlers.ts
+++ b/src/main/ipc/app-handlers.ts
@@ -45,8 +45,8 @@ export function registerAppHandlers(): void {
     return notificationService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_NOTIFICATION_SETTINGS, (_event, settings: NotificationSettings) => {
-    notificationService.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_NOTIFICATION_SETTINGS, async (_event, settings: NotificationSettings) => {
+    await notificationService.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.APP.SEND_NOTIFICATION, (_event, title: string, body: string, silent: boolean, agentId?: string, projectId?: string) => {
@@ -61,8 +61,8 @@ export function registerAppHandlers(): void {
     return themeService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_THEME, (_event, settings: { themeId: string }) => {
-    themeService.saveSettings(settings as any);
+  ipcMain.handle(IPC.APP.SAVE_THEME, async (_event, settings: { themeId: string }) => {
+    await themeService.saveSettings(settings as any);
     annexServer.broadcastThemeChanged();
   });
 
@@ -83,24 +83,24 @@ export function registerAppHandlers(): void {
     return orchestratorSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_ORCHESTRATOR_SETTINGS, (_event, settings: orchestratorSettings.OrchestratorSettings) => {
-    orchestratorSettings.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_ORCHESTRATOR_SETTINGS, async (_event, settings: orchestratorSettings.OrchestratorSettings) => {
+    await orchestratorSettings.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.APP.GET_HEADLESS_SETTINGS, () => {
     return headlessSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_HEADLESS_SETTINGS, (_event, settings: headlessSettings.HeadlessSettings) => {
-    headlessSettings.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_HEADLESS_SETTINGS, async (_event, settings: headlessSettings.HeadlessSettings) => {
+    await headlessSettings.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.APP.GET_BADGE_SETTINGS, () => {
     return badgeSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_BADGE_SETTINGS, (_event, settings: BadgeSettings) => {
-    badgeSettings.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_BADGE_SETTINGS, async (_event, settings: BadgeSettings) => {
+    await badgeSettings.saveSettings(settings);
   });
 
   // Clipboard settings are now managed via createManagedSettings() in settings-handlers.ts.
@@ -109,8 +109,8 @@ export function registerAppHandlers(): void {
     return clipboardSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_CLIPBOARD_SETTINGS, (_event, settings: ClipboardSettings) => {
-    clipboardSettings.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_CLIPBOARD_SETTINGS, async (_event, settings: ClipboardSettings) => {
+    await clipboardSettings.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.APP.SET_DOCK_BADGE, (_event, count: number) => {
@@ -126,10 +126,10 @@ export function registerAppHandlers(): void {
     return autoUpdateService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_UPDATE_SETTINGS, (_event, settings: UpdateSettings) => {
-    autoUpdateService.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_UPDATE_SETTINGS, async (_event, settings: UpdateSettings) => {
+    await autoUpdateService.saveSettings(settings);
     if (settings.autoUpdate) {
-      autoUpdateService.startPeriodicChecks();
+      await autoUpdateService.startPeriodicChecks();
     } else {
       autoUpdateService.stopPeriodicChecks();
     }
@@ -168,8 +168,8 @@ export function registerAppHandlers(): void {
     return logSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.LOG.SAVE_LOG_SETTINGS, (_event, settings: LoggingSettings) => {
-    logSettings.saveSettings(settings);
+  ipcMain.handle(IPC.LOG.SAVE_LOG_SETTINGS, async (_event, settings: LoggingSettings) => {
+    await logSettings.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.LOG.GET_LOG_NAMESPACES, () => {
@@ -185,8 +185,8 @@ export function registerAppHandlers(): void {
     return soundService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_SOUND_SETTINGS, (_event, settings: SoundSettings) => {
-    soundService.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_SOUND_SETTINGS, async (_event, settings: SoundSettings) => {
+    await soundService.saveSettings(settings);
   });
 
   ipcMain.handle(IPC.APP.LIST_SOUND_PACKS, () => {
@@ -210,8 +210,8 @@ export function registerAppHandlers(): void {
     return sessionSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_SESSION_SETTINGS, (_event, settings: sessionSettings.SessionSettings) => {
-    sessionSettings.saveSettings(settings);
+  ipcMain.handle(IPC.APP.SAVE_SESSION_SETTINGS, async (_event, settings: sessionSettings.SessionSettings) => {
+    await sessionSettings.saveSettings(settings);
   });
 
   // --- Clubhouse Mode ---
@@ -224,7 +224,7 @@ export function registerAppHandlers(): void {
       ? clubhouseModeSettings.isClubhouseModeEnabled(projectPath)
       : clubhouseModeSettings.getSettings().enabled;
 
-    clubhouseModeSettings.saveSettings(settings);
+    await clubhouseModeSettings.saveSettings(settings);
 
     const nowEnabled = projectPath
       ? clubhouseModeSettings.isClubhouseModeEnabled(projectPath)

--- a/src/main/ipc/profile-handlers.ts
+++ b/src/main/ipc/profile-handlers.ts
@@ -9,12 +9,12 @@ export function registerProfileHandlers(): void {
     return profileSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.PROFILE.SAVE_PROFILE, (_event, profile: OrchestratorProfile) => {
-    profileSettings.saveProfile(profile);
+  ipcMain.handle(IPC.PROFILE.SAVE_PROFILE, async (_event, profile: OrchestratorProfile) => {
+    await profileSettings.saveProfile(profile);
   });
 
-  ipcMain.handle(IPC.PROFILE.DELETE_PROFILE, (_event, profileId: string) => {
-    profileSettings.deleteProfile(profileId);
+  ipcMain.handle(IPC.PROFILE.DELETE_PROFILE, async (_event, profileId: string) => {
+    await profileSettings.deleteProfile(profileId);
   });
 
   ipcMain.handle(IPC.PROFILE.GET_PROFILE_ENV_KEYS, (_event, orchestratorId: string) => {

--- a/src/main/ipc/settings-handlers.test.ts
+++ b/src/main/ipc/settings-handlers.test.ts
@@ -19,10 +19,13 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from '../services/settings-store';
 import { clipboardSettings, CLIPBOARD_SETTINGS, registerSettingsHandlers } from './settings-handlers';
 
 // IPC handlers are deferred — call register to bind them
@@ -32,6 +35,8 @@ beforeAll(() => {
 
 describe('settings-handlers', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
     vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
   });
 
@@ -80,10 +85,10 @@ describe('settings-handlers', () => {
       expect(handler({} as any)).toEqual({ clipboardCompat: true });
     });
 
-    it('save handler persists settings', () => {
+    it('save handler persists settings', async () => {
       const handler = registeredHandlers.get('settings:clipboard:save')!;
-      handler({} as any, { clipboardCompat: true });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      await handler({} as any, { clipboardCompat: true });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         path.join('/tmp/test-app', 'clipboard-settings.json'),
         JSON.stringify({ clipboardCompat: true }, null, 2),
         'utf-8',

--- a/src/main/services/annex-settings.test.ts
+++ b/src/main/services/annex-settings.test.ts
@@ -9,26 +9,30 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings } from './annex-settings';
 
 describe('annex-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns defaults when no file exists', () => {
+    it('returns defaults when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       expect(result.enabled).toBe(false);
       expect(result.deviceName).toBe(`Clubhouse on ${os.hostname()}`);
     });
 
-    it('returns saved settings from file', () => {
+    it('returns saved settings from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ enabled: true, deviceName: 'My Device' }),
       );
@@ -37,7 +41,7 @@ describe('annex-settings', () => {
       expect(result.deviceName).toBe('My Device');
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       const result = getSettings();
@@ -45,14 +49,14 @@ describe('annex-settings', () => {
       expect(result.deviceName).toBe(`Clubhouse on ${os.hostname()}`);
     });
 
-    it('merges partial settings with defaults', () => {
+    it('merges partial settings with defaults', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       const result = getSettings();
       expect(result.enabled).toBe(true);
       expect(result.deviceName).toBe(`Clubhouse on ${os.hostname()}`);
     });
 
-    it('preserves custom device name when only enabled changes', () => {
+    it('preserves custom device name when only enabled changes', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ deviceName: 'Custom Name' }),
       );
@@ -61,7 +65,7 @@ describe('annex-settings', () => {
       expect(result.deviceName).toBe('Custom Name');
     });
 
-    it('reads from the correct file path', () => {
+    it('reads from the correct file path', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
@@ -72,29 +76,29 @@ describe('annex-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes settings as JSON', () => {
-      saveSettings({ enabled: true, deviceName: 'Test Device' });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+    it('writes settings as JSON', async () => {
+      await saveSettings({ enabled: true, deviceName: 'Test Device' });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         expect.stringContaining('annex-settings.json'),
         expect.any(String),
         'utf-8',
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(true);
       expect(written.deviceName).toBe('Test Device');
     });
 
-    it('round-trips: saved settings can be read back', () => {
+    it('round-trips: saved settings can be read back', async () => {
       const settings = { enabled: true, deviceName: 'Round Trip Device' };
-      saveSettings(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      await saveSettings(settings);
+      const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       vi.mocked(fs.readFileSync).mockReturnValue(written);
       expect(getSettings()).toEqual(settings);
     });
 
-    it('can disable annex', () => {
-      saveSettings({ enabled: false, deviceName: 'My Device' });
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+    it('can disable annex', async () => {
+      await saveSettings({ enabled: false, deviceName: 'My Device' });
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(false);
     });
   });

--- a/src/main/services/auto-update-lifecycle.test.ts
+++ b/src/main/services/auto-update-lifecycle.test.ts
@@ -88,39 +88,54 @@ describe('startPeriodicChecks / stopPeriodicChecks', () => {
     vi.useRealTimers();
   });
 
-  it('seeds lastSeenVersion on first launch', () => {
+  it('seeds lastSeenVersion on first launch', async () => {
     mockSettings.lastSeenVersion = null;
-    startPeriodicChecks();
+    await startPeriodicChecks();
     expect(mockSave).toHaveBeenCalledWith(
       expect.objectContaining({ lastSeenVersion: expect.any(String) }),
     );
   });
 
-  it('clears dismissedVersion on startup', () => {
+  it('clears dismissedVersion on startup', async () => {
     mockSettings.dismissedVersion = '0.30.0';
-    startPeriodicChecks();
+    await startPeriodicChecks();
     expect(mockSave).toHaveBeenCalledWith(
       expect.objectContaining({ dismissedVersion: null }),
     );
   });
 
-  it('returns early without scheduling when autoUpdate is false', () => {
+  it('preserves lastSeenVersion when clearing dismissedVersion in the same startup pass', async () => {
+    mockSettings.lastSeenVersion = null;
+    mockSettings.dismissedVersion = '0.30.0';
+
+    await startPeriodicChecks();
+
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(mockSave.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        lastSeenVersion: expect.any(String),
+        dismissedVersion: null,
+      }),
+    );
+  });
+
+  it('returns early without scheduling when autoUpdate is false', async () => {
     mockSettings.autoUpdate = false;
     // Should not throw and should return early
-    startPeriodicChecks();
+    await startPeriodicChecks();
     // stopPeriodicChecks is safe even when no timer was created
     expect(() => stopPeriodicChecks()).not.toThrow();
   });
 
-  it('stopPeriodicChecks is safe to call multiple times', () => {
-    startPeriodicChecks();
+  it('stopPeriodicChecks is safe to call multiple times', async () => {
+    await startPeriodicChecks();
     stopPeriodicChecks();
     expect(() => stopPeriodicChecks()).not.toThrow();
   });
 
-  it('calling startPeriodicChecks twice does not create duplicate timers', () => {
-    startPeriodicChecks();
-    startPeriodicChecks(); // second call should be a no-op
+  it('calling startPeriodicChecks twice does not create duplicate timers', async () => {
+    await startPeriodicChecks();
+    await startPeriodicChecks(); // second call should be a no-op
     stopPeriodicChecks();
   });
 });

--- a/src/main/services/auto-update-persistence.test.ts
+++ b/src/main/services/auto-update-persistence.test.ts
@@ -163,9 +163,9 @@ describe('dismissUpdate', () => {
     expect(typeof dismissUpdate).toBe('function');
   });
 
-  it('resets status to idle after dismiss', () => {
+  it('resets status to idle after dismiss', async () => {
     // dismissUpdate resets state to idle regardless
-    dismissUpdate();
+    await dismissUpdate();
     const s = getStatus();
     expect(s.state).toBe('idle');
     expect(s.availableVersion).toBeNull();

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -448,7 +448,7 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
         meta: { currentVersion, latestVersion: manifest.version },
       });
       setState('idle');
-      saveSettings({ ...settings, lastCheck: new Date().toISOString() });
+      await saveSettings({ ...settings, lastCheck: new Date().toISOString() });
       return status;
     }
 
@@ -458,7 +458,7 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
         meta: { version: manifest.version },
       });
       setState('idle');
-      saveSettings({ ...settings, lastCheck: new Date().toISOString() });
+      await saveSettings({ ...settings, lastCheck: new Date().toISOString() });
       return status;
     }
 
@@ -476,7 +476,7 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
       meta: { currentVersion, newVersion: manifest.version },
     });
 
-    saveSettings({ ...settings, lastCheck: new Date().toISOString(), dismissedVersion: null });
+    await saveSettings({ ...settings, lastCheck: new Date().toISOString(), dismissedVersion: null });
 
     // On Windows, use Squirrel native update — skip our own download.
     // Update.exe will download the nupkg when we apply.
@@ -865,10 +865,10 @@ export function applyUpdateOnQuit(): void {
 // Dismiss
 // ---------------------------------------------------------------------------
 
-export function dismissUpdate(): void {
+export async function dismissUpdate(): Promise<void> {
   if (status.availableVersion) {
     const settings = getSettings();
-    saveSettings({ ...settings, dismissedVersion: status.availableVersion });
+    await saveSettings({ ...settings, dismissedVersion: status.availableVersion });
   }
   setState('idle', {
     availableVersion: null,
@@ -1074,20 +1074,22 @@ export function getStatus(): UpdateStatus {
   return { ...status };
 }
 
-export function startPeriodicChecks(): void {
+export async function startPeriodicChecks(): Promise<void> {
   if (checkTimer) return;
 
-  const settings = getSettings();
+  let settings = getSettings();
 
   // Seed lastSeenVersion on first launch to prevent What's New on fresh install
   if (settings.lastSeenVersion === null) {
-    saveSettings({ ...settings, lastSeenVersion: app.getVersion() });
+    settings = { ...settings, lastSeenVersion: app.getVersion() };
+    await saveSettings(settings);
   }
 
   // Clear dismissedVersion on startup so the banner always shows if an update
   // is already downloaded. The dismiss is session-scoped (renderer-side timer).
   if (settings.dismissedVersion) {
-    saveSettings({ ...settings, dismissedVersion: null });
+    settings = { ...settings, dismissedVersion: null };
+    await saveSettings(settings);
   }
 
   // Detect previous apply attempt that failed silently (app restarted but

--- a/src/main/services/badge-settings.test.ts
+++ b/src/main/services/badge-settings.test.ts
@@ -8,19 +8,23 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings } from './badge-settings';
 
 describe('badge-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns defaults when no file exists', () => {
+    it('returns defaults when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       expect(result).toEqual({
@@ -30,7 +34,7 @@ describe('badge-settings', () => {
       });
     });
 
-    it('returns saved settings from file', () => {
+    it('returns saved settings from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ enabled: false, pluginBadges: false, projectRailBadges: false }),
       );
@@ -40,7 +44,7 @@ describe('badge-settings', () => {
       expect(result.projectRailBadges).toBe(false);
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       const result = getSettings();
@@ -49,7 +53,7 @@ describe('badge-settings', () => {
       expect(result.projectRailBadges).toBe(true);
     });
 
-    it('merges partial settings with defaults', () => {
+    it('merges partial settings with defaults', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: false }));
       const result = getSettings();
       expect(result.enabled).toBe(false);
@@ -57,7 +61,7 @@ describe('badge-settings', () => {
       expect(result.projectRailBadges).toBe(true);
     });
 
-    it('preserves projectOverrides when present', () => {
+    it('preserves projectOverrides when present', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         pluginBadges: true,
@@ -70,13 +74,13 @@ describe('badge-settings', () => {
       expect(result.projectOverrides).toEqual({ '/my/project': { enabled: false } });
     });
 
-    it('does not include projectOverrides by default', () => {
+    it('does not include projectOverrides by default', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       expect(result.projectOverrides).toBeUndefined();
     });
 
-    it('reads from the correct file path', () => {
+    it('reads from the correct file path', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
@@ -87,42 +91,42 @@ describe('badge-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes settings as JSON', () => {
-      saveSettings({ enabled: false, pluginBadges: true, projectRailBadges: false });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+    it('writes settings as JSON', async () => {
+      await saveSettings({ enabled: false, pluginBadges: true, projectRailBadges: false });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         expect.stringContaining('badge-settings.json'),
         expect.any(String),
         'utf-8',
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(false);
       expect(written.pluginBadges).toBe(true);
       expect(written.projectRailBadges).toBe(false);
     });
 
-    it('round-trips: saved settings can be read back', () => {
+    it('round-trips: saved settings can be read back', async () => {
       const settings = { enabled: false, pluginBadges: false, projectRailBadges: true };
-      saveSettings(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      await saveSettings(settings);
+      const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       vi.mocked(fs.readFileSync).mockReturnValue(written);
       expect(getSettings()).toEqual(settings);
     });
 
-    it('can save settings with projectOverrides', () => {
+    it('can save settings with projectOverrides', async () => {
       const settings = {
         enabled: true,
         pluginBadges: true,
         projectRailBadges: true,
         projectOverrides: { '/project': { enabled: false, pluginBadges: false } },
       };
-      saveSettings(settings);
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      await saveSettings(settings);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides).toEqual({ '/project': { enabled: false, pluginBadges: false } });
     });
 
-    it('can toggle individual badge types independently', () => {
-      saveSettings({ enabled: true, pluginBadges: false, projectRailBadges: true });
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+    it('can toggle individual badge types independently', async () => {
+      await saveSettings({ enabled: true, pluginBadges: false, projectRailBadges: true });
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.pluginBadges).toBe(false);
       expect(written.projectRailBadges).toBe(true);
     });

--- a/src/main/services/clipboard-settings.test.ts
+++ b/src/main/services/clipboard-settings.test.ts
@@ -8,19 +8,23 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings } from './clipboard-settings';
 
 describe('clipboard-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns defaults when no file exists', () => {
+    it('returns defaults when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       // Default depends on platform: true on win32, false otherwise
@@ -28,7 +32,7 @@ describe('clipboard-settings', () => {
       expect(result).toEqual({ clipboardCompat: expectedDefault });
     });
 
-    it('returns saved settings from file', () => {
+    it('returns saved settings from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ clipboardCompat: true }),
       );
@@ -36,7 +40,7 @@ describe('clipboard-settings', () => {
       expect(result.clipboardCompat).toBe(true);
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       const result = getSettings();
@@ -44,19 +48,19 @@ describe('clipboard-settings', () => {
       expect(result.clipboardCompat).toBe(expectedDefault);
     });
 
-    it('can override default to true', () => {
+    it('can override default to true', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ clipboardCompat: true }));
       const result = getSettings();
       expect(result.clipboardCompat).toBe(true);
     });
 
-    it('can override default to false', () => {
+    it('can override default to false', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ clipboardCompat: false }));
       const result = getSettings();
       expect(result.clipboardCompat).toBe(false);
     });
 
-    it('reads from the correct file path', () => {
+    it('reads from the correct file path', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
@@ -67,28 +71,28 @@ describe('clipboard-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes settings as JSON', () => {
-      saveSettings({ clipboardCompat: true });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+    it('writes settings as JSON', async () => {
+      await saveSettings({ clipboardCompat: true });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         expect.stringContaining('clipboard-settings.json'),
         expect.any(String),
         'utf-8',
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.clipboardCompat).toBe(true);
     });
 
-    it('round-trips: saved settings can be read back', () => {
+    it('round-trips: saved settings can be read back', async () => {
       const settings = { clipboardCompat: true };
-      saveSettings(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      await saveSettings(settings);
+      const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       vi.mocked(fs.readFileSync).mockReturnValue(written);
       expect(getSettings()).toEqual(settings);
     });
 
-    it('can save disabled clipboard compat', () => {
-      saveSettings({ clipboardCompat: false });
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+    it('can save disabled clipboard compat', async () => {
+      await saveSettings({ clipboardCompat: false });
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.clipboardCompat).toBe(false);
     });
   });

--- a/src/main/services/clubhouse-mode-settings.test.ts
+++ b/src/main/services/clubhouse-mode-settings.test.ts
@@ -7,29 +7,33 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { isClubhouseModeEnabled, setProjectOverride, clearProjectOverride, getSettings, saveSettings } from './clubhouse-mode-settings';
 
 describe('clubhouse-mode-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('isClubhouseModeEnabled', () => {
-    it('returns false when global disabled and no project override (default)', () => {
+    it('returns false when global disabled and no project override (default)', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       expect(isClubhouseModeEnabled('/some/project')).toBe(false);
     });
 
-    it('returns true when global enabled and no project override', () => {
+    it('returns true when global enabled and no project override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       expect(isClubhouseModeEnabled('/some/project')).toBe(true);
     });
 
-    it('returns project override when present, regardless of global', () => {
+    it('returns project override when present, regardless of global', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: { '/my/project': true },
@@ -37,7 +41,7 @@ describe('clubhouse-mode-settings', () => {
       expect(isClubhouseModeEnabled('/my/project')).toBe(true);
     });
 
-    it('project override false overrides global enabled', () => {
+    it('project override false overrides global enabled', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/my/project': false },
@@ -45,7 +49,7 @@ describe('clubhouse-mode-settings', () => {
       expect(isClubhouseModeEnabled('/my/project')).toBe(false);
     });
 
-    it('falls back to global when project has no override', () => {
+    it('falls back to global when project has no override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/other/project': false },
@@ -53,13 +57,13 @@ describe('clubhouse-mode-settings', () => {
       expect(isClubhouseModeEnabled('/my/project')).toBe(true);
     });
 
-    it('handles undefined projectPath by using global default', () => {
+    it('handles undefined projectPath by using global default', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       expect(isClubhouseModeEnabled()).toBe(true);
       expect(isClubhouseModeEnabled(undefined)).toBe(true);
     });
 
-    it('handles multiple project overrides independently', () => {
+    it('handles multiple project overrides independently', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: {
@@ -76,16 +80,16 @@ describe('clubhouse-mode-settings', () => {
   });
 
   describe('setProjectOverride', () => {
-    it('saves project override while preserving existing settings', () => {
+    it('saves project override while preserving existing settings', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/existing': false },
       }));
 
-      setProjectOverride('/new-project', true);
+      await setProjectOverride('/new-project', true);
 
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(true);
       expect(written.projectOverrides).toEqual({
         '/existing': false,
@@ -93,52 +97,52 @@ describe('clubhouse-mode-settings', () => {
       });
     });
 
-    it('creates projectOverrides when none exist', () => {
+    it('creates projectOverrides when none exist', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: false }));
 
-      setProjectOverride('/project', true);
+      await setProjectOverride('/project', true);
 
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides).toEqual({ '/project': true });
     });
   });
 
   describe('clearProjectOverride', () => {
-    it('removes a single project override', () => {
+    it('removes a single project override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/project-a': true, '/project-b': false },
       }));
 
-      clearProjectOverride('/project-a');
+      await clearProjectOverride('/project-a');
 
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides).toEqual({ '/project-b': false });
     });
 
-    it('sets projectOverrides to undefined when last override removed', () => {
+    it('sets projectOverrides to undefined when last override removed', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/only-project': true },
       }));
 
-      clearProjectOverride('/only-project');
+      await clearProjectOverride('/only-project');
 
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides).toBeUndefined();
     });
 
-    it('no-ops when no projectOverrides exist', () => {
+    it('no-ops when no projectOverrides exist', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
 
-      clearProjectOverride('/project');
+      await clearProjectOverride('/project');
 
-      expect(fs.writeFileSync).not.toHaveBeenCalled();
+      expect(fs.promises.writeFile).not.toHaveBeenCalled();
     });
   });
 
   describe('getSettings defaults', () => {
-    it('returns disabled by default when file does not exist', () => {
+    it('returns disabled by default when file does not exist', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const settings = getSettings();
       expect(settings.enabled).toBe(false);
@@ -146,15 +150,15 @@ describe('clubhouse-mode-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes settings as JSON', () => {
-      saveSettings({ enabled: true, projectOverrides: { '/p': true } });
+    it('writes settings as JSON', async () => {
+      await saveSettings({ enabled: true, projectOverrides: { '/p': true } });
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('clubhouse-mode-settings.json'),
         expect.any(String),
         'utf-8',
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(true);
     });
   });

--- a/src/main/services/clubhouse-mode-settings.ts
+++ b/src/main/services/clubhouse-mode-settings.ts
@@ -16,15 +16,15 @@ export function isClubhouseModeEnabled(projectPath?: string): boolean {
   return settings.enabled;
 }
 
-export function setProjectOverride(projectPath: string, enabled: boolean): void {
+export async function setProjectOverride(projectPath: string, enabled: boolean): Promise<void> {
   const settings = getSettings();
   const overrides = { ...settings.projectOverrides, [projectPath]: enabled };
-  saveSettings({ ...settings, projectOverrides: overrides });
+  await saveSettings({ ...settings, projectOverrides: overrides });
 }
 
-export function clearProjectOverride(projectPath: string): void {
+export async function clearProjectOverride(projectPath: string): Promise<void> {
   const settings = getSettings();
   if (!settings.projectOverrides) return;
   const { [projectPath]: _, ...rest } = settings.projectOverrides;
-  saveSettings({ ...settings, projectOverrides: Object.keys(rest).length > 0 ? rest : undefined });
+  await saveSettings({ ...settings, projectOverrides: Object.keys(rest).length > 0 ? rest : undefined });
 }

--- a/src/main/services/headless-settings.test.ts
+++ b/src/main/services/headless-settings.test.ts
@@ -7,32 +7,36 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSpawnMode, setProjectSpawnMode, getSettings, saveSettings } from './headless-settings';
 
 describe('headless-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   // ============================================================
   // getSpawnMode
   // ============================================================
   describe('getSpawnMode', () => {
-    it('returns interactive when global disabled and no project override', () => {
+    it('returns interactive when global disabled and no project override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: false }));
       expect(getSpawnMode('/some/project')).toBe('interactive');
     });
 
-    it('returns headless when global enabled and no project override', () => {
+    it('returns headless when global enabled and no project override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       expect(getSpawnMode('/some/project')).toBe('headless');
     });
 
-    it('returns project override when present, regardless of global', () => {
+    it('returns project override when present, regardless of global', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: { '/my/project': 'headless' },
@@ -40,7 +44,7 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/my/project')).toBe('headless');
     });
 
-    it('project override interactive overrides global enabled', () => {
+    it('project override interactive overrides global enabled', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/my/project': 'interactive' },
@@ -48,7 +52,7 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/my/project')).toBe('interactive');
     });
 
-    it('falls back to global when project has no override', () => {
+    it('falls back to global when project has no override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/other/project': 'interactive' },
@@ -56,18 +60,18 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/my/project')).toBe('headless');
     });
 
-    it('handles undefined projectPath by using global default', () => {
+    it('handles undefined projectPath by using global default', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       expect(getSpawnMode()).toBe('headless');
       expect(getSpawnMode(undefined)).toBe('headless');
     });
 
-    it('handles old-format settings (no projectOverrides) gracefully', () => {
+    it('handles old-format settings (no projectOverrides) gracefully', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       expect(getSpawnMode('/any/project')).toBe('headless');
     });
 
-    it('handles empty projectOverrides object', () => {
+    it('handles empty projectOverrides object', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: {},
@@ -75,12 +79,12 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/project')).toBe('interactive');
     });
 
-    it('returns headless when settings file does not exist (default)', () => {
+    it('returns headless when settings file does not exist (default)', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       expect(getSpawnMode('/project')).toBe('headless');
     });
 
-    it('handles multiple project overrides independently', () => {
+    it('handles multiple project overrides independently', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: {
@@ -95,12 +99,12 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/project-d')).toBe('interactive'); // no override → global (enabled: false)
     });
 
-    it('returns defaultMode when set', () => {
+    it('returns defaultMode when set', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ defaultMode: 'structured' }));
       expect(getSpawnMode('/project')).toBe('structured');
     });
 
-    it('defaultMode takes precedence over legacy enabled', () => {
+    it('defaultMode takes precedence over legacy enabled', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         defaultMode: 'structured',
@@ -108,7 +112,7 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/project')).toBe('structured');
     });
 
-    it('project override structured overrides global headless', () => {
+    it('project override structured overrides global headless', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         defaultMode: 'headless',
         projectOverrides: { '/my/project': 'structured' },
@@ -116,7 +120,7 @@ describe('headless-settings', () => {
       expect(getSpawnMode('/my/project')).toBe('structured');
     });
 
-    it('handles mixed modes across projects', () => {
+    it('handles mixed modes across projects', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         defaultMode: 'interactive',
         projectOverrides: {
@@ -134,16 +138,16 @@ describe('headless-settings', () => {
   // setProjectSpawnMode
   // ============================================================
   describe('setProjectSpawnMode', () => {
-    it('saves project override while preserving existing settings', () => {
+    it('saves project override while preserving existing settings', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: true,
         projectOverrides: { '/existing': 'interactive' },
       }));
 
-      setProjectSpawnMode('/new-project', 'headless');
+      await setProjectSpawnMode('/new-project', 'headless');
 
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(true);
       expect(written.projectOverrides).toEqual({
         '/existing': 'interactive',
@@ -151,24 +155,24 @@ describe('headless-settings', () => {
       });
     });
 
-    it('overwrites existing override for same project', () => {
+    it('overwrites existing override for same project', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: { '/project': 'headless' },
       }));
 
-      setProjectSpawnMode('/project', 'interactive');
+      await setProjectSpawnMode('/project', 'interactive');
 
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides['/project']).toBe('interactive');
     });
 
-    it('creates projectOverrides when old-format settings had none', () => {
+    it('creates projectOverrides when old-format settings had none', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
 
-      setProjectSpawnMode('/project', 'interactive');
+      await setProjectSpawnMode('/project', 'interactive');
 
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides).toEqual({ '/project': 'interactive' });
     });
   });
@@ -177,14 +181,14 @@ describe('headless-settings', () => {
   // getSettings backward compat
   // ============================================================
   describe('getSettings backward compat', () => {
-    it('loads old format with only enabled field', () => {
+    it('loads old format with only enabled field', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: true }));
       const settings = getSettings();
       expect(settings.enabled).toBe(true);
       expect(settings.projectOverrides).toBeUndefined();
     });
 
-    it('loads new format with projectOverrides', () => {
+    it('loads new format with projectOverrides', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         enabled: false,
         projectOverrides: { '/p': 'headless' },
@@ -194,13 +198,13 @@ describe('headless-settings', () => {
       expect(settings.projectOverrides).toEqual({ '/p': 'headless' });
     });
 
-    it('returns defaults when file does not exist', () => {
+    it('returns defaults when file does not exist', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const settings = getSettings();
       expect(settings.enabled).toBe(true);
     });
 
-    it('returns defaults when file contains invalid JSON', () => {
+    it('returns defaults when file contains invalid JSON', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue('not json');
       const settings = getSettings();
@@ -212,15 +216,15 @@ describe('headless-settings', () => {
   // saveSettings
   // ============================================================
   describe('saveSettings', () => {
-    it('writes settings as JSON to correct path', () => {
-      saveSettings({ enabled: true, projectOverrides: { '/p': 'headless' } });
+    it('writes settings as JSON to correct path', async () => {
+      await saveSettings({ enabled: true, projectOverrides: { '/p': 'headless' } });
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('headless-settings.json'),
         expect.any(String),
         'utf-8'
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toBe(true);
       expect(written.projectOverrides).toEqual({ '/p': 'headless' });
     });

--- a/src/main/services/headless-settings.ts
+++ b/src/main/services/headless-settings.ts
@@ -31,8 +31,8 @@ export function getSpawnMode(projectPath?: string): SpawnMode {
   return resolveDefaultMode(settings);
 }
 
-export function setProjectSpawnMode(projectPath: string, mode: SpawnMode): void {
+export async function setProjectSpawnMode(projectPath: string, mode: SpawnMode): Promise<void> {
   const settings = getSettings();
   const overrides = { ...settings.projectOverrides, [projectPath]: mode };
-  saveSettings({ ...settings, projectOverrides: overrides });
+  await saveSettings({ ...settings, projectOverrides: overrides });
 }

--- a/src/main/services/log-settings.test.ts
+++ b/src/main/services/log-settings.test.ts
@@ -5,11 +5,14 @@ import * as path from 'path';
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
   mkdirSync: vi.fn(),
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings } from './log-settings';
 
 const SETTINGS_PATH = path.join(os.tmpdir(), 'clubhouse-test-userData', 'logging-settings.json');
@@ -17,10 +20,11 @@ const SETTINGS_PATH = path.join(os.tmpdir(), 'clubhouse-test-userData', 'logging
 describe('log-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns defaults when no file exists', () => {
+    it('returns defaults when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => {
         throw new Error('ENOENT');
       });
@@ -28,7 +32,7 @@ describe('log-settings', () => {
       expect(result).toEqual({ enabled: true, namespaces: {}, retention: 'medium', minLogLevel: 'info' });
     });
 
-    it('returns saved settings from file', () => {
+    it('returns saved settings from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ enabled: false, namespaces: { 'app:test': false } }),
       );
@@ -37,13 +41,13 @@ describe('log-settings', () => {
       expect(result.namespaces['app:test']).toBe(false);
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       const result = getSettings();
       expect(result).toEqual({ enabled: true, namespaces: {}, retention: 'medium', minLogLevel: 'info' });
     });
 
-    it('merges partial settings with defaults', () => {
+    it('merges partial settings with defaults', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: false }));
       const result = getSettings();
       expect(result.enabled).toBe(false);
@@ -54,11 +58,11 @@ describe('log-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes JSON to the settings path', () => {
+    it('writes JSON to the settings path', async () => {
       const settings = { enabled: false, namespaces: { 'app:ipc': false } };
-      saveSettings(settings);
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledTimes(1);
-      const [path, data] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string, string];
+      await saveSettings(settings);
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledTimes(1);
+      const [path, data] = vi.mocked(fs.promises.writeFile).mock.calls[0] as [string, string, string];
       expect(path).toBe(SETTINGS_PATH);
       const parsed = JSON.parse(data);
       expect(parsed.enabled).toBe(false);

--- a/src/main/services/managed-settings.test.ts
+++ b/src/main/services/managed-settings.test.ts
@@ -12,11 +12,14 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import { ipcMain } from 'electron';
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { createManagedSettings } from './managed-settings';
 import type { SettingsDefinition } from '../../shared/settings-definitions';
 
@@ -34,6 +37,7 @@ const TEST_DEF: SettingsDefinition<TestSettings> = {
 describe('managed-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
     // Reset readFileSync to throw ENOENT (file not found)
     vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
   });
@@ -94,7 +98,7 @@ describe('managed-settings', () => {
       expect(getHandler({} as any)).toEqual(TEST_DEF.defaults);
     });
 
-    it('save handler persists settings', () => {
+    it('save handler persists settings', async () => {
       const managed = createManagedSettings(TEST_DEF);
       managed.register();
 
@@ -103,9 +107,9 @@ describe('managed-settings', () => {
       )![1];
 
       const newSettings: TestSettings = { enabled: true, name: 'updated' };
-      saveHandler({} as any, newSettings);
+      await saveHandler({} as any, newSettings);
 
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         path.join('/tmp/test-app', 'test-settings.json'),
         JSON.stringify(newSettings, null, 2),
         'utf-8',
@@ -122,11 +126,11 @@ describe('managed-settings', () => {
       );
     });
 
-    it('saveSettings persists to the correct file', () => {
+    it('saveSettings persists to the correct file', async () => {
       const managed = createManagedSettings(TEST_DEF);
-      managed.saveSettings({ enabled: true, name: 'direct' });
+      await managed.saveSettings({ enabled: true, name: 'direct' });
 
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         path.join('/tmp/test-app', 'test-settings.json'),
         expect.any(String),
         'utf-8',
@@ -135,7 +139,7 @@ describe('managed-settings', () => {
   });
 
   describe('onSave callback', () => {
-    it('calls onSave after saving via IPC handler', () => {
+    it('calls onSave after saving via IPC handler', async () => {
       const onSave = vi.fn();
       const managed = createManagedSettings(TEST_DEF, { onSave });
       managed.register();
@@ -145,12 +149,12 @@ describe('managed-settings', () => {
       )![1];
 
       const newSettings: TestSettings = { enabled: true, name: 'callback' };
-      saveHandler({} as any, newSettings);
+      await saveHandler({} as any, newSettings);
 
       expect(onSave).toHaveBeenCalledWith(newSettings);
     });
 
-    it('passes extra args to onSave', () => {
+    it('passes extra args to onSave', async () => {
       const onSave = vi.fn();
       const managed = createManagedSettings(TEST_DEF, { onSave });
       managed.register();
@@ -160,16 +164,16 @@ describe('managed-settings', () => {
       )![1];
 
       const newSettings: TestSettings = { enabled: true, name: 'extra' };
-      saveHandler({} as any, newSettings, '/some/path');
+      await saveHandler({} as any, newSettings, '/some/path');
 
       expect(onSave).toHaveBeenCalledWith(newSettings, '/some/path');
     });
 
-    it('does not call onSave when saving directly via saveSettings', () => {
+    it('does not call onSave when saving directly via saveSettings', async () => {
       const onSave = vi.fn();
       const managed = createManagedSettings(TEST_DEF, { onSave });
 
-      managed.saveSettings({ enabled: true, name: 'direct' });
+      await managed.saveSettings({ enabled: true, name: 'direct' });
 
       // onSave is only triggered via IPC, not direct calls
       expect(onSave).not.toHaveBeenCalled();
@@ -221,11 +225,11 @@ describe('managed-settings', () => {
       expect(typeof managed.store.update).toBe('function');
     });
 
-    it('store.update works for read-modify-write', () => {
+    it('store.update works for read-modify-write', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: false, name: 'original' }));
 
       const managed = createManagedSettings(TEST_DEF);
-      const result = managed.store.update((current) => ({ ...current, enabled: true }));
+      const result = await managed.store.update((current) => ({ ...current, enabled: true }));
 
       expect(result.enabled).toBe(true);
       expect(result.name).toBe('original');

--- a/src/main/services/managed-settings.ts
+++ b/src/main/services/managed-settings.ts
@@ -17,12 +17,12 @@
  *
  *   // Use
  *   clipboardSettings.getSettings();
- *   clipboardSettings.saveSettings(v);
+ *   await clipboardSettings.saveSettings(v);
  *
  * For settings with side effects on save:
  *   const updateSettings = createManagedSettings(UPDATE_SETTINGS, {
  *     onSave: (settings) => {
- *       if (settings.autoUpdate) startPeriodicChecks();
+ *       if (settings.autoUpdate) void startPeriodicChecks();
  *     },
  *   });
  */
@@ -34,7 +34,7 @@ export interface ManagedSettings<T> {
   /** Read current settings from disk (with defaults fallback). */
   getSettings(): T;
   /** Persist settings to disk. */
-  saveSettings(settings: T): void;
+  saveSettings(settings: T): Promise<void>;
   /** The underlying SettingsStore (for advanced use: update, etc.). */
   store: SettingsStore<T>;
   /** Register IPC handlers. Call once during handler bootstrap. */
@@ -86,8 +86,8 @@ export function createManagedSettings<T>(
 
       ipcMain.handle(channels.get, () => store.get());
 
-      ipcMain.handle(channels.save, (_event: Electron.IpcMainInvokeEvent, settings: T, ...extraArgs: unknown[]) => {
-        store.save(settings);
+      ipcMain.handle(channels.save, async (_event: Electron.IpcMainInvokeEvent, settings: T, ...extraArgs: unknown[]) => {
+        await store.save(settings);
         options?.onSave?.(settings, ...extraArgs);
       });
     },

--- a/src/main/services/orchestrator-settings.test.ts
+++ b/src/main/services/orchestrator-settings.test.ts
@@ -8,25 +8,29 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings } from './orchestrator-settings';
 
 describe('orchestrator-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns defaults when no file exists', () => {
+    it('returns defaults when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       expect(result).toEqual({ enabled: ['claude-code'] });
     });
 
-    it('returns saved settings from file', () => {
+    it('returns saved settings from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ enabled: ['claude-code', 'copilot'] }),
       );
@@ -34,26 +38,26 @@ describe('orchestrator-settings', () => {
       expect(result.enabled).toEqual(['claude-code', 'copilot']);
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       const result = getSettings();
       expect(result).toEqual({ enabled: ['claude-code'] });
     });
 
-    it('merges partial settings with defaults', () => {
+    it('merges partial settings with defaults', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: [] }));
       const result = getSettings();
       expect(result.enabled).toEqual([]);
     });
 
-    it('handles empty enabled array', () => {
+    it('handles empty enabled array', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enabled: [] }));
       const result = getSettings();
       expect(result.enabled).toEqual([]);
     });
 
-    it('reads from the correct file path', () => {
+    it('reads from the correct file path', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
@@ -64,28 +68,28 @@ describe('orchestrator-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes settings as JSON', () => {
-      saveSettings({ enabled: ['claude-code', 'copilot'] });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+    it('writes settings as JSON', async () => {
+      await saveSettings({ enabled: ['claude-code', 'copilot'] });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         expect.stringContaining('orchestrator-settings.json'),
         expect.any(String),
         'utf-8',
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toEqual(['claude-code', 'copilot']);
     });
 
-    it('round-trips: saved settings can be read back', () => {
+    it('round-trips: saved settings can be read back', async () => {
       const settings = { enabled: ['provider-a', 'provider-b'] };
-      saveSettings(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      await saveSettings(settings);
+      const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       vi.mocked(fs.readFileSync).mockReturnValue(written);
       expect(getSettings()).toEqual(settings);
     });
 
-    it('can save empty enabled list', () => {
-      saveSettings({ enabled: [] });
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+    it('can save empty enabled list', async () => {
+      await saveSettings({ enabled: [] });
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.enabled).toEqual([]);
     });
   });

--- a/src/main/services/profile-settings.ts
+++ b/src/main/services/profile-settings.ts
@@ -13,8 +13,8 @@ export function getSettings(): ProfilesSettings {
   return store.get();
 }
 
-export function saveSettings(settings: ProfilesSettings): void {
-  store.save(settings);
+export function saveSettings(settings: ProfilesSettings): Promise<void> {
+  return store.save(settings);
 }
 
 export function getProfiles(): OrchestratorProfile[] {
@@ -25,7 +25,7 @@ export function getProfile(profileId: string): OrchestratorProfile | undefined {
   return store.get().profiles.find((p) => p.id === profileId);
 }
 
-export function saveProfile(profile: OrchestratorProfile): void {
+export function saveProfile(profile: OrchestratorProfile): Promise<void> {
   const settings = store.get();
   const idx = settings.profiles.findIndex((p) => p.id === profile.id);
   if (idx >= 0) {
@@ -33,13 +33,13 @@ export function saveProfile(profile: OrchestratorProfile): void {
   } else {
     settings.profiles.push(profile);
   }
-  store.save(settings);
+  return store.save(settings);
 }
 
-export function deleteProfile(profileId: string): void {
+export function deleteProfile(profileId: string): Promise<void> {
   const settings = store.get();
   settings.profiles = settings.profiles.filter((p) => p.id !== profileId);
-  store.save(settings);
+  return store.save(settings);
 }
 
 /** Expand ~ in env var values to the user's home directory */

--- a/src/main/services/session-settings.test.ts
+++ b/src/main/services/session-settings.test.ts
@@ -8,25 +8,29 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings, shouldPromptForName } from './session-settings';
 
 describe('session-settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns defaults when no file exists', () => {
+    it('returns defaults when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       expect(result).toEqual({ promptForName: false });
     });
 
-    it('returns saved settings from file', () => {
+    it('returns saved settings from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ promptForName: true }),
       );
@@ -34,14 +38,14 @@ describe('session-settings', () => {
       expect(result.promptForName).toBe(true);
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       const result = getSettings();
       expect(result.promptForName).toBe(false);
     });
 
-    it('merges partial settings with defaults', () => {
+    it('merges partial settings with defaults', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         projectOverrides: { '/project': true },
       }));
@@ -50,13 +54,13 @@ describe('session-settings', () => {
       expect(result.projectOverrides).toEqual({ '/project': true });
     });
 
-    it('does not include projectOverrides by default', () => {
+    it('does not include projectOverrides by default', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const result = getSettings();
       expect(result.projectOverrides).toBeUndefined();
     });
 
-    it('reads from the correct file path', () => {
+    it('reads from the correct file path', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       getSettings();
       expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith(
@@ -67,57 +71,57 @@ describe('session-settings', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes settings as JSON', () => {
-      saveSettings({ promptForName: true });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+    it('writes settings as JSON', async () => {
+      await saveSettings({ promptForName: true });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         expect.stringContaining('session-settings.json'),
         expect.any(String),
         'utf-8',
       );
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.promptForName).toBe(true);
     });
 
-    it('round-trips: saved settings can be read back', () => {
+    it('round-trips: saved settings can be read back', async () => {
       const settings = { promptForName: true };
-      saveSettings(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      await saveSettings(settings);
+      const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       vi.mocked(fs.readFileSync).mockReturnValue(written);
       expect(getSettings()).toEqual(settings);
     });
 
-    it('can save settings with projectOverrides', () => {
+    it('can save settings with projectOverrides', async () => {
       const settings = {
         promptForName: false,
         projectOverrides: { '/project': true },
       };
-      saveSettings(settings);
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      await saveSettings(settings);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.projectOverrides).toEqual({ '/project': true });
     });
   });
 
   describe('shouldPromptForName', () => {
-    it('returns default (false) when no file exists and no project path', () => {
+    it('returns default (false) when no file exists and no project path', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       expect(shouldPromptForName()).toBe(false);
     });
 
-    it('returns global setting when no project path given', () => {
+    it('returns global setting when no project path given', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ promptForName: true }),
       );
       expect(shouldPromptForName()).toBe(true);
     });
 
-    it('returns global setting when project path has no override', () => {
+    it('returns global setting when project path has no override', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ promptForName: true }),
       );
       expect(shouldPromptForName('/some/unknown/project')).toBe(true);
     });
 
-    it('returns project override when it exists (true overrides false default)', () => {
+    it('returns project override when it exists (true overrides false default)', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({
           promptForName: false,
@@ -127,7 +131,7 @@ describe('session-settings', () => {
       expect(shouldPromptForName('/my/project')).toBe(true);
     });
 
-    it('returns project override when it exists (false overrides true default)', () => {
+    it('returns project override when it exists (false overrides true default)', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({
           promptForName: true,
@@ -137,21 +141,21 @@ describe('session-settings', () => {
       expect(shouldPromptForName('/my/project')).toBe(false);
     });
 
-    it('returns global setting when projectOverrides is undefined', () => {
+    it('returns global setting when projectOverrides is undefined', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ promptForName: true }),
       );
       expect(shouldPromptForName('/any/project')).toBe(true);
     });
 
-    it('returns global setting when projectOverrides is empty', () => {
+    it('returns global setting when projectOverrides is empty', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ promptForName: true, projectOverrides: {} }),
       );
       expect(shouldPromptForName('/any/project')).toBe(true);
     });
 
-    it('matches exact project path only', () => {
+    it('matches exact project path only', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({
           promptForName: false,
@@ -166,7 +170,7 @@ describe('session-settings', () => {
       expect(shouldPromptForName('/my')).toBe(false);
     });
 
-    it('handles undefined project path with overrides present', () => {
+    it('handles undefined project path with overrides present', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({
           promptForName: true,
@@ -176,7 +180,7 @@ describe('session-settings', () => {
       expect(shouldPromptForName(undefined)).toBe(true);
     });
 
-    it('handles empty string project path (falsy) by returning global setting', () => {
+    it('handles empty string project path (falsy) by returning global setting', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({
           promptForName: true,
@@ -187,7 +191,7 @@ describe('session-settings', () => {
       expect(shouldPromptForName('')).toBe(true);
     });
 
-    it('differentiates between multiple project overrides', () => {
+    it('differentiates between multiple project overrides', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({
           promptForName: false,

--- a/src/main/services/settings-store.test.ts
+++ b/src/main/services/settings-store.test.ts
@@ -8,11 +8,13 @@ vi.mock('electron', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
 }));
 
 import * as fs from 'fs';
-import { createSettingsStore } from './settings-store';
+import { createSettingsStore, resetAllSettingsStoresForTests } from './settings-store';
 
 interface TestSettings {
   name: string;
@@ -29,20 +31,23 @@ const DEFAULTS: TestSettings = {
 describe('settings-store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('createSettingsStore', () => {
-    it('returns an object with get and save methods', () => {
+    it('returns an object with get, save, and update methods', () => {
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
       expect(store).toHaveProperty('get');
       expect(store).toHaveProperty('save');
+      expect(store).toHaveProperty('update');
       expect(typeof store.get).toBe('function');
       expect(typeof store.save).toBe('function');
+      expect(typeof store.update).toBe('function');
     });
   });
 
   describe('get', () => {
-    it('returns defaults when file does not exist (readFileSync throws)', () => {
+    it('returns defaults when file does not exist', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
       expect(store.get()).toEqual(DEFAULTS);
@@ -55,6 +60,7 @@ describe('settings-store', () => {
       const b = store.get();
       expect(a).toEqual(b);
       expect(a).not.toBe(b);
+      expect(a.nested).not.toBe(b.nested);
     });
 
     it('parses stored JSON and returns settings', () => {
@@ -118,6 +124,16 @@ describe('settings-store', () => {
       expect(result.name).toBe('default');
     });
 
+    it('reads from disk once after the cache is warm', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ name: 'cached', count: 7 }));
+      const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
+
+      expect(store.get()).toEqual({ name: 'cached', count: 7, nested: { flag: false } });
+      expect(store.get()).toEqual({ name: 'cached', count: 7, nested: { flag: false } });
+
+      expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledTimes(1);
+    });
+
     it('reads from the correct file path under userData', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const store = createSettingsStore<TestSettings>('my-settings.json', DEFAULTS);
@@ -130,107 +146,139 @@ describe('settings-store', () => {
   });
 
   describe('save', () => {
-    it('writes JSON to the correct file path', () => {
+    it('writes JSON to the correct file path asynchronously', async () => {
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
       const settings: TestSettings = { name: 'saved', count: 10, nested: { flag: true } };
-      store.save(settings);
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+
+      await store.save(settings);
+
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
         path.join('/tmp/test-app', 'test.json'),
         expect.any(String),
         'utf-8',
       );
     });
 
-    it('writes pretty-printed JSON', () => {
+    it('writes pretty-printed JSON', async () => {
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
       const settings: TestSettings = { name: 'pretty', count: 1, nested: { flag: false } };
-      store.save(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+
+      await store.save(settings);
+
+      const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       expect(written).toBe(JSON.stringify(settings, null, 2));
     });
 
-    it('round-trips: saved settings can be read back', () => {
+    it('updates the cache immediately before async persistence completes', async () => {
+      let resolveWrite: (() => void) | undefined;
+      vi.mocked(fs.promises.writeFile).mockImplementation(
+        () => new Promise<void>((resolve) => { resolveWrite = resolve; }),
+      );
+
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
-      const settings: TestSettings = { name: 'round-trip', count: 77, nested: { flag: true } };
-      store.save(settings);
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
-      vi.mocked(fs.readFileSync).mockReturnValue(written);
+      const settings: TestSettings = { name: 'cached-save', count: 11, nested: { flag: true } };
+
+      const savePromise = store.save(settings);
+
       expect(store.get()).toEqual(settings);
+      expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledTimes(1);
+      });
+      resolveWrite?.();
+      await savePromise;
     });
 
-    it('can overwrite previously saved settings', () => {
+    it('round-trips from the in-memory cache after save', async () => {
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
-      store.save({ name: 'first', count: 1, nested: { flag: false } });
-      store.save({ name: 'second', count: 2, nested: { flag: true } });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledTimes(2);
-      const lastWritten = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[1][1] as string);
-      expect(lastWritten.name).toBe('second');
+      const settings: TestSettings = { name: 'round-trip', count: 77, nested: { flag: true } };
+
+      await store.save(settings);
+
+      expect(store.get()).toEqual(settings);
+      expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+    });
+
+    it('queues writes in call order', async () => {
+      const writeOrder: string[] = [];
+      vi.mocked(fs.promises.writeFile).mockImplementation(async (_filePath, data) => {
+        writeOrder.push(JSON.parse(String(data)).name);
+      });
+
+      const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
+
+      await Promise.all([
+        store.save({ name: 'first', count: 1, nested: { flag: false } }),
+        store.save({ name: 'second', count: 2, nested: { flag: true } }),
+      ]);
+
+      expect(writeOrder).toEqual(['first', 'second']);
+      expect(store.get().name).toBe('second');
     });
   });
 
   describe('multiple stores', () => {
-    it('different filenames produce independent stores', () => {
+    it('different filenames produce independent stores', async () => {
       const storeA = createSettingsStore<TestSettings>('store-a.json', DEFAULTS);
       const storeB = createSettingsStore<TestSettings>('store-b.json', { ...DEFAULTS, name: 'b-default' });
 
-      storeA.save({ name: 'a-value', count: 1, nested: { flag: false } });
-      storeB.save({ name: 'b-value', count: 2, nested: { flag: true } });
+      await storeA.save({ name: 'a-value', count: 1, nested: { flag: false } });
+      await storeB.save({ name: 'b-value', count: 2, nested: { flag: true } });
 
-      const [callA, callB] = vi.mocked(fs.writeFileSync).mock.calls;
+      const [callA, callB] = vi.mocked(fs.promises.writeFile).mock.calls;
       expect(callA[0]).toContain('store-a.json');
       expect(callB[0]).toContain('store-b.json');
     });
   });
 
   describe('update', () => {
-    it('reads current value, applies fn, and saves the result', () => {
+    it('reads current value, applies fn, and saves the result', async () => {
       const saved: TestSettings = { name: 'original', count: 5, nested: { flag: false } };
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(saved));
 
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
-      const result = store.update((current) => ({ ...current, count: current.count + 1 }));
+      const result = await store.update((current) => ({ ...current, count: current.count + 1 }));
 
       expect(result.count).toBe(6);
       expect(result.name).toBe('original');
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledTimes(1);
-      const written = JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string);
       expect(written.count).toBe(6);
     });
 
-    it('returns the updated settings object', () => {
+    it('returns the updated settings object', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(DEFAULTS));
 
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
-      const result = store.update((current) => ({ ...current, name: 'updated' }));
+      const result = await store.update((current) => ({ ...current, name: 'updated' }));
 
       expect(result.name).toBe('updated');
     });
 
-    it('uses defaults when file does not exist', () => {
+    it('uses defaults when file does not exist', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
 
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
-      const result = store.update((current) => ({ ...current, count: current.count + 10 }));
+      const result = await store.update((current) => ({ ...current, count: current.count + 10 }));
 
       expect(result.count).toBe(10);
       expect(result.name).toBe('default');
     });
 
-    it('sequential updates each see the result of the previous update', () => {
-      // Simulate a scenario where the file content changes between calls
-      let fileContent = JSON.stringify({ name: 'v1', count: 1, nested: { flag: false } });
-      vi.mocked(fs.readFileSync).mockImplementation(() => fileContent);
-      vi.mocked(fs.writeFileSync).mockImplementation((_p: any, data: any) => { fileContent = String(data); });
+    it('sequential updates each see the result of the previous update', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ name: 'v1', count: 1, nested: { flag: false } }));
 
       const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
 
-      // First update increments count
-      store.update((current) => ({ ...current, count: current.count + 1 }));
-      // Second update increments count again — should see the first update's result
-      store.update((current) => ({ ...current, count: current.count + 1 }));
+      await store.update((current) => ({ ...current, count: current.count + 1 }));
+      await store.update((current) => ({ ...current, count: current.count + 1 }));
 
-      const final = JSON.parse(fileContent);
-      expect(final.count).toBe(3); // 1 + 1 + 1, not 1 + 1 (lost update)
+      expect(store.get().count).toBe(3);
+      const writes = vi.mocked(fs.promises.writeFile).mock.calls.map(
+        (call) => JSON.parse(call[1] as string).count,
+      );
+      expect(writes).toEqual([2, 3]);
     });
   });
 });

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -1,12 +1,33 @@
 import { app } from 'electron';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 
 export interface SettingsStore<T> {
   get(): T;
-  save(settings: T): void;
+  save(settings: T): Promise<void>;
   /** Sequential read-modify-write: reads the current value, applies `fn`, saves, and returns the updated value. */
-  update(fn: (current: T) => T): T;
+  update(fn: (current: T) => T): Promise<T>;
+}
+
+const settingsStoreResetters = new Set<() => void>();
+
+function cloneSettings<T>(settings: T): T {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(settings);
+  }
+  return JSON.parse(JSON.stringify(settings)) as T;
+}
+
+/**
+ * Resets all in-memory settings caches.
+ *
+ * This is only intended for unit tests that exercise module-level singleton
+ * stores across multiple test cases.
+ */
+export function resetAllSettingsStoresForTests(): void {
+  for (const reset of settingsStoreResetters) {
+    reset();
+  }
 }
 
 export function createSettingsStore<T>(
@@ -15,30 +36,72 @@ export function createSettingsStore<T>(
   migrate?: (raw: Record<string, unknown>) => T,
 ): SettingsStore<T> {
   const filePath = path.join(app.getPath('userData'), filename);
+  let cachedSettings: T | null = null;
+  let cacheLoaded = false;
+  let pendingWrite: Promise<void> = Promise.resolve();
+
+  function parseSettings(raw: string): T {
+    const merged = {
+      ...cloneSettings(defaults),
+      ...JSON.parse(raw),
+    } as Record<string, unknown>;
+    const parsed = migrate ? migrate(merged) : (merged as T);
+    return cloneSettings(parsed);
+  }
+
+  function loadSettings(): T {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      cachedSettings = parseSettings(raw);
+      cacheLoaded = true;
+      return cloneSettings(cachedSettings);
+    } catch (err) {
+      if (fs.existsSync(filePath)) {
+        console.warn(
+          `[settings-store] Failed to parse ${filename}, using defaults:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+      cachedSettings = cloneSettings(defaults);
+      cacheLoaded = true;
+      return cloneSettings(cachedSettings);
+    }
+  }
+
+  function queueWrite(settings: T): Promise<void> {
+    const snapshot = cloneSettings(settings);
+    const serialized = JSON.stringify(snapshot, null, 2);
+    const writeTask = pendingWrite
+      .catch((_err): void => {})
+      .then(() => fs.promises.writeFile(filePath, serialized, 'utf-8'));
+    pendingWrite = writeTask;
+    return writeTask;
+  }
+
   const store: SettingsStore<T> = {
     get() {
-      try {
-        const raw = fs.readFileSync(filePath, 'utf-8');
-        const parsed = { ...defaults, ...JSON.parse(raw) };
-        return migrate ? migrate(parsed) : parsed;
-      } catch (err) {
-        // Use console.warn here — cannot use appLog because log-settings itself
-        // depends on this store, and calling appLog would create infinite recursion.
-        if (fs.existsSync(filePath)) {
-          console.warn(`[settings-store] Failed to parse ${filename}, using defaults:`, err instanceof Error ? err.message : err);
-        }
-        return { ...defaults };
+      if (!cacheLoaded || cachedSettings === null) {
+        return loadSettings();
       }
+      return cloneSettings(cachedSettings);
     },
     save(settings: T) {
-      fs.writeFileSync(filePath, JSON.stringify(settings, null, 2), 'utf-8');
+      cachedSettings = cloneSettings(settings);
+      cacheLoaded = true;
+      return queueWrite(cachedSettings);
     },
-    update(fn: (current: T) => T): T {
+    update(fn: (current: T) => T): Promise<T> {
       const current = store.get();
       const updated = fn(current);
-      store.save(updated);
-      return updated;
+      return store.save(updated).then(() => cloneSettings(updated));
     },
   };
+
+  settingsStoreResetters.add(() => {
+    cachedSettings = null;
+    cacheLoaded = false;
+    pendingWrite = Promise.resolve();
+  });
+
   return store;
 }

--- a/src/main/services/sound-service.test.ts
+++ b/src/main/services/sound-service.test.ts
@@ -16,7 +16,16 @@ vi.mock('electron', () => ({
   },
 }));
 
-vi.mock('fs');
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+  rmSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
+}));
 
 import {
   getSettings,
@@ -30,17 +39,19 @@ import {
   resolveSlotPack,
   resolveActivePack,
 } from './sound-service';
+import { resetAllSettingsStoresForTests } from './settings-store';
 
 describe('sound-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
 
     // Default: readFileSync throws (file not found)
     vi.mocked(fs.readFileSync).mockImplementation(() => {
       throw new Error('ENOENT');
     });
     vi.mocked(fs.existsSync).mockReturnValue(false);
-    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
   });
 
   describe('getSettings / saveSettings', () => {
@@ -59,11 +70,11 @@ describe('sound-service', () => {
       expect(settings.eventSettings.notification.enabled).toBe(true);
     });
 
-    it('saves settings to file', () => {
+    it('saves settings to file', async () => {
       const settings = getSettings();
       settings.slotAssignments = { 'agent-done': { packId: 'my-pack' } };
-      saveSettings(settings);
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
+      await saveSettings(settings);
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('sound-settings.json'),
         expect.stringContaining('"my-pack"'),
         'utf-8',
@@ -256,7 +267,7 @@ describe('sound-service', () => {
   });
 
   describe('deleteSoundPack', () => {
-    it('deletes a user sound pack and cleans slot assignments', () => {
+    it('deletes a user sound pack and cleans slot assignments', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.rmSync).mockImplementation(() => {});
       vi.mocked(fs.readFileSync).mockImplementation((p) => {
@@ -273,24 +284,24 @@ describe('sound-service', () => {
         throw new Error('ENOENT');
       });
 
-      const result = deleteSoundPack('my-pack');
+      const result = await deleteSoundPack('my-pack');
       expect(result).toBe(true);
       expect(fs.rmSync).toHaveBeenCalled();
       // Should save cleaned settings
-      expect(fs.writeFileSync).toHaveBeenCalled();
-      const savedJson = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(fs.promises.writeFile).toHaveBeenCalled();
+      const savedJson = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
       const savedSettings = JSON.parse(savedJson);
       expect(savedSettings.slotAssignments['agent-done']).toBeUndefined();
       expect(savedSettings.slotAssignments.error?.packId).toBe('other-pack');
     });
 
-    it('refuses to delete plugin packs', () => {
-      expect(deleteSoundPack('plugin:test')).toBe(false);
+    it('refuses to delete plugin packs', async () => {
+      await expect(deleteSoundPack('plugin:test')).resolves.toBe(false);
     });
 
-    it('returns false for non-existent packs', () => {
+    it('returns false for non-existent packs', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      expect(deleteSoundPack('nonexistent')).toBe(false);
+      await expect(deleteSoundPack('nonexistent')).resolves.toBe(false);
     });
   });
 

--- a/src/main/services/sound-service.ts
+++ b/src/main/services/sound-service.ts
@@ -262,7 +262,7 @@ export async function importSoundPack(): Promise<SoundPackInfo | null> {
   };
 }
 
-export function deleteSoundPack(packId: string): boolean {
+export async function deleteSoundPack(packId: string): Promise<boolean> {
   // Don't allow deleting plugin packs through this method
   if (packId.startsWith('plugin:')) return false;
 
@@ -300,7 +300,7 @@ export function deleteSoundPack(packId: string): boolean {
   }
 
   if (changed) {
-    saveSettings({ ...settings, slotAssignments: slots, projectOverrides: overrides });
+    await saveSettings({ ...settings, slotAssignments: slots, projectOverrides: overrides });
   }
 
   return true;

--- a/src/main/services/theme-service.test.ts
+++ b/src/main/services/theme-service.test.ts
@@ -5,11 +5,14 @@ import * as path from 'path';
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
+  promises: {
+    writeFile: vi.fn(async () => {}),
+  },
   mkdirSync: vi.fn(),
 }));
 
 import * as fs from 'fs';
+import { resetAllSettingsStoresForTests } from './settings-store';
 import { getSettings, saveSettings } from './theme-service';
 
 const SETTINGS_PATH = path.join(os.tmpdir(), 'clubhouse-test-userData', 'theme-settings.json');
@@ -17,10 +20,11 @@ const SETTINGS_PATH = path.join(os.tmpdir(), 'clubhouse-test-userData', 'theme-s
 describe('theme-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllSettingsStoresForTests();
   });
 
   describe('getSettings', () => {
-    it('returns default catppuccin-mocha when no file exists', () => {
+    it('returns default catppuccin-mocha when no file exists', async () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => {
         throw new Error('ENOENT');
       });
@@ -28,7 +32,7 @@ describe('theme-service', () => {
       expect(result).toEqual({ themeId: 'catppuccin-mocha' });
     });
 
-    it('returns saved themeId from file', () => {
+    it('returns saved themeId from file', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ themeId: 'dracula' })
       );
@@ -36,13 +40,13 @@ describe('theme-service', () => {
       expect(result.themeId).toBe('dracula');
     });
 
-    it('returns defaults on corrupt JSON', () => {
+    it('returns defaults on corrupt JSON', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue('{{invalid');
       const result = getSettings();
       expect(result).toEqual({ themeId: 'catppuccin-mocha' });
     });
 
-    it('merges partial settings with defaults', () => {
+    it('merges partial settings with defaults', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({}));
       const result = getSettings();
       expect(result.themeId).toBe('catppuccin-mocha');
@@ -50,16 +54,16 @@ describe('theme-service', () => {
   });
 
   describe('saveSettings', () => {
-    it('writes JSON to the settings path', () => {
-      saveSettings({ themeId: 'nord' });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledTimes(1);
-      const [path, data] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string, string];
+    it('writes JSON to the settings path', async () => {
+      await saveSettings({ themeId: 'nord' });
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledTimes(1);
+      const [path, data] = vi.mocked(fs.promises.writeFile).mock.calls[0] as [string, string, string];
       expect(path).toBe(SETTINGS_PATH);
       const parsed = JSON.parse(data);
       expect(parsed.themeId).toBe('nord');
     });
 
-    it('persists each theme ID correctly', () => {
+    it('persists each theme ID correctly', async () => {
       const themeIds = [
         'catppuccin-mocha',
         'catppuccin-latte',
@@ -73,8 +77,8 @@ describe('theme-service', () => {
 
       for (const id of themeIds) {
         vi.clearAllMocks();
-        saveSettings({ themeId: id });
-        const [, data] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string, string];
+        await saveSettings({ themeId: id });
+        const [, data] = vi.mocked(fs.promises.writeFile).mock.calls[0] as [string, string, string];
         expect(JSON.parse(data).themeId).toBe(id);
       }
     });


### PR DESCRIPTION
## Summary
- cache settings-store reads in memory so repeated `get()` calls stop hitting disk after the first load
- move settings persistence from synchronous `writeFileSync` calls to queued async writes and update callers to await saves
- add regression coverage for cached reads, async persistence ordering, IPC-managed settings, and the auto-update startup save sequence

## Changes
- rewrote `src/main/services/settings-store.ts` to warm and serve an in-memory cache, queue `fs.promises.writeFile` operations, and expose async `save()` / `update()` methods
- updated managed settings and affected main-process callers and IPC handlers to await async settings saves so persistence errors still surface correctly
- added `resetAllSettingsStoresForTests()` and updated singleton-based tests to reset store cache state between cases
- extended tests for settings-store behavior and fixed dependent test suites to mock async file writes
- patched `startPeriodicChecks()` in `auto-update-service.ts` so seeding `lastSeenVersion` and clearing `dismissedVersion` in the same startup pass no longer overwrite each other

## Test Plan
- [x] `npx vitest run --project main src/main/services/auto-update-lifecycle.test.ts`
- [x] `npx vitest run --project main src/main/ipc/settings-handlers.test.ts src/main/services/auto-update-lifecycle.test.ts`
- [x] `npm run make`
- [x] `npm test`
- [x] `npm run lint`

## Manual Validation
- No extra manual validation required beyond the automated coverage above.

Closes #599.
