### PR TITLE
fix(perf): stabilize isThinking callback with ref pattern

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -9,10 +9,15 @@ import { AgentList } from './AgentList';
 import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 
 // Mock child components
+const isThinkingCaptures: boolean[] = [];
+
 vi.mock('./AgentListItem', () => ({
-  AgentListItem: (props: any) => (
-    <div data-testid={`agent-item-${props.agent.id}`}>{props.agent.name}</div>
-  ),
+  AgentListItem: (props: any) => {
+    isThinkingCaptures.push(props.isThinking);
+    return (
+      <div data-testid={`agent-item-${props.agent.id}`} data-thinking={props.isThinking}>{props.agent.name}</div>
+    );
+  },
 }));
 
 vi.mock('./AddAgentDialog', () => ({
@@ -346,5 +351,56 @@ describe('AgentList activity tick optimization', () => {
     expect(tickIntervals).toHaveLength(0);
 
     setIntervalSpy.mockRestore();
+  });
+});
+
+describe('AgentList isThinking callback stability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    isThinkingCaptures.length = 0;
+    window.clubhouse.pty.onData = vi.fn().mockReturnValue(() => {});
+  });
+
+  it('reflects thinking state when agentActivity has recent timestamp', () => {
+    useAgentStore.setState({
+      agentActivity: { 'agent-1': Date.now() },
+    });
+
+    render(<AgentList />);
+    // The agent should be rendered as "thinking" since activity is recent
+    const lastCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
+    expect(lastCapture).toBe(true);
+  });
+
+  it('updates thinking state when agentActivity changes from empty to active', () => {
+    useAgentStore.setState({ agentActivity: {} });
+    render(<AgentList />);
+
+    // Initially not thinking
+    const initialCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
+    expect(initialCapture).toBe(false);
+
+    // Simulate activity update via store change
+    act(() => {
+      useAgentStore.setState({
+        agentActivity: { 'agent-1': Date.now() },
+      });
+    });
+
+    // After agentActivity updates, the ref-based callback should read the new value
+    const updatedCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
+    expect(updatedCapture).toBe(true);
+  });
+
+  it('shows not-thinking when activity timestamp is stale', () => {
+    // Activity from 10 seconds ago — well past the 3s threshold
+    useAgentStore.setState({
+      agentActivity: { 'agent-1': Date.now() - 10000 },
+    });
+
+    render(<AgentList />);
+    const lastCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
+    expect(lastCapture).toBe(false);
   });
 });

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -211,11 +211,14 @@ export function AgentList() {
     }
   };
 
+  const agentActivityRef = useRef(agentActivity);
+  agentActivityRef.current = agentActivity;
+
   const isThinking = useCallback((id: string) => {
-    const last = agentActivity[id];
+    const last = agentActivityRef.current[id];
     if (!last) return false;
     return Date.now() - last < 3000;
-  }, [agentActivity]);
+  }, []);
 
   // Drag-to-reorder handlers for durable agents
   const handleDragStart = useCallback((e: React.DragEvent, index: number) => {


### PR DESCRIPTION
## Summary
- Fix `isThinking` callback in `AgentList` being recreated on every PTY data event due to `[agentActivity]` dependency
- Use a ref to hold `agentActivity` so the callback has an empty dependency array and remains stable

Closes #627

## Changes
- **`AgentList.tsx`**: Added `agentActivityRef` that tracks the latest `agentActivity` value. The `isThinking` callback now reads from the ref instead of closing over the state directly, allowing `useCallback` to use `[]` dependencies and maintain a stable identity.
- **`AgentList.test.tsx`**: Added 3 new tests verifying:
  - Thinking state is reflected when agentActivity has a recent timestamp
  - Thinking state updates correctly when agentActivity changes from empty to active (proving the ref reads latest data)
  - Not-thinking is shown when the activity timestamp is stale (>3s old)

## Test Plan
- [x] New tests verify isThinking produces correct boolean values for recent, empty, and stale activity
- [x] All 258 test files pass (6449 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes

## Manual Validation
- Open the agent list with active agents
- Verify the "thinking" indicator still appears when agents are processing PTY data
- Verify the indicator disappears after ~3 seconds of inactivity