### PR TITLE
Fix AgentList filtered array allocations

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { useQuickAgentStore } from '../../stores/quickAgentStore';
 import { useUIStore } from '../../stores/uiStore';
-import { AgentList } from './AgentList';
+import { AgentList, useProjectAgentBuckets } from './AgentList';
 import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 
 // Mock child components
@@ -188,6 +188,88 @@ describe('AgentList completed selector stability', () => {
     // Should render without errors even with no completed agents data
     expect(screen.getByTestId('agent-list')).toBeInTheDocument();
     expect(screen.getByText('Completed (0)')).toBeInTheDocument();
+  });
+});
+
+describe('useProjectAgentBuckets', () => {
+  const durableAgent: Agent = {
+    ...defaultAgent,
+    id: 'durable-1',
+    name: 'durable-agent',
+  };
+
+  const quickAgent: Agent = {
+    ...defaultAgent,
+    id: 'quick-1',
+    name: 'quick-agent',
+    kind: 'quick',
+    mission: 'Investigate issue',
+  };
+
+  const childQuickAgent: Agent = {
+    ...quickAgent,
+    id: 'quick-2',
+    name: 'child-quick-agent',
+    parentAgentId: durableAgent.id,
+  };
+
+  const otherProjectAgent: Agent = {
+    ...defaultAgent,
+    id: 'durable-2',
+    projectId: 'proj-2',
+    name: 'other-project-agent',
+  };
+
+  it('returns stable filtered arrays across unrelated rerenders', () => {
+    const agents = {
+      [durableAgent.id]: durableAgent,
+      [quickAgent.id]: quickAgent,
+      [childQuickAgent.id]: childQuickAgent,
+      [otherProjectAgent.id]: otherProjectAgent,
+    };
+    const { result, rerender } = renderHook(
+      ({ currentAgents, currentProjectId }) => useProjectAgentBuckets(currentAgents, currentProjectId),
+      {
+        initialProps: {
+          currentAgents: agents,
+          currentProjectId: 'proj-1' as string | null,
+        },
+      }
+    );
+
+    const initialBuckets = result.current;
+    rerender({ currentAgents: agents, currentProjectId: 'proj-1' });
+
+    expect(result.current.projectAgents).toBe(initialBuckets.projectAgents);
+    expect(result.current.durableAgents).toBe(initialBuckets.durableAgents);
+    expect(result.current.quickAgents).toBe(initialBuckets.quickAgents);
+    expect(result.current.orphanQuickAgents).toBe(initialBuckets.orphanQuickAgents);
+  });
+
+  it('recomputes filtered arrays when the active project changes', () => {
+    const agents = {
+      [durableAgent.id]: durableAgent,
+      [quickAgent.id]: quickAgent,
+      [otherProjectAgent.id]: otherProjectAgent,
+    };
+    const { result, rerender } = renderHook(
+      ({ currentAgents, currentProjectId }) => useProjectAgentBuckets(currentAgents, currentProjectId),
+      {
+        initialProps: {
+          currentAgents: agents,
+          currentProjectId: 'proj-1' as string | null,
+        },
+      }
+    );
+
+    const initialBuckets = result.current;
+    rerender({ currentAgents: agents, currentProjectId: 'proj-2' });
+
+    expect(result.current.projectAgents).not.toBe(initialBuckets.projectAgents);
+    expect(result.current.projectAgents).toEqual([otherProjectAgent]);
+    expect(result.current.durableAgents).toEqual([otherProjectAgent]);
+    expect(result.current.quickAgents).toEqual([]);
+    expect(result.current.orphanQuickAgents).toEqual([]);
   });
 });
 

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -10,9 +10,45 @@ import { QuickAgentGhostCompact } from './QuickAgentGhost';
 import { useModelOptions } from '../../hooks/useModelOptions';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { useEffectiveOrchestrators } from '../../hooks/useEffectiveOrchestrators';
-import type { CompletedQuickAgent } from '../../../shared/types';
+import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 
 const EMPTY_COMPLETED: CompletedQuickAgent[] = [];
+const EMPTY_AGENTS: Agent[] = [];
+
+type ProjectAgentBuckets = {
+  projectAgents: Agent[];
+  durableAgents: Agent[];
+  quickAgents: Agent[];
+  orphanQuickAgents: Agent[];
+};
+
+export function useProjectAgentBuckets(
+  agents: Record<string, Agent>,
+  activeProjectId: string | null
+): ProjectAgentBuckets {
+  return useMemo(() => {
+    if (!activeProjectId) {
+      return {
+        projectAgents: EMPTY_AGENTS,
+        durableAgents: EMPTY_AGENTS,
+        quickAgents: EMPTY_AGENTS,
+        orphanQuickAgents: EMPTY_AGENTS,
+      };
+    }
+
+    const projectAgents = Object.values(agents).filter((agent) => agent.projectId === activeProjectId);
+    const durableAgents = projectAgents.filter((agent) => agent.kind === 'durable');
+    const quickAgents = projectAgents.filter((agent) => agent.kind === 'quick');
+    const orphanQuickAgents = quickAgents.filter((agent) => !agent.parentAgentId);
+
+    return {
+      projectAgents,
+      durableAgents,
+      quickAgents,
+      orphanQuickAgents,
+    };
+  }, [agents, activeProjectId]);
+}
 
 export function AgentList() {
   const agents = useAgentStore((s) => s.agents);
@@ -129,13 +165,10 @@ export function AgentList() {
     return () => clearInterval(interval);
   }, [hasRecentActivity]);
 
-  const projectAgents = Object.values(agents).filter(
-    (a) => a.projectId === activeProjectId
+  const { durableAgents, quickAgents, orphanQuickAgents } = useProjectAgentBuckets(
+    agents,
+    activeProjectId
   );
-
-  const durableAgents = projectAgents.filter((a) => a.kind === 'durable');
-  const quickAgents = projectAgents.filter((a) => a.kind === 'quick');
-  const orphanQuickAgents = quickAgents.filter((a) => !a.parentAgentId);
   const orphanCompleted = useMemo(
     () => completedAgents.filter((r) => !r.parentAgentId),
     [completedAgents]


### PR DESCRIPTION
## Summary
- memoize the active project agent buckets in `AgentList` so filtering only runs when `agents` or `activeProjectId` change
- reuse shared empty arrays when there is no active project to avoid unnecessary allocations
- add hook-level regression coverage for referential stability and recomputation on dependency changes

## Test Plan
- [x] `npm run typecheck`
- [x] `npm test -- src/renderer/features/agents/AgentList.test.tsx`
- [x] `npm run lint`
- [ ] `npm test` (repo-wide suite is not clean in this environment; it hit unrelated failing suites and sandbox `listen EPERM 0.0.0.0` errors in `annex-server` tests)

## Manual Validation
- not run
