### PR TITLE
Fix quick-agent store cleanup leak

### DIFF
--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -64,11 +64,16 @@ describe('agentStore', () => {
       activeAgentId: null,
       agentSettingsOpenFor: null,
       deleteDialogAgent: null,
+      configChangesDialogAgent: null,
+      configChangesProjectPath: null,
       agentActivity: {},
       agentSpawnedAt: {},
+      agentTerminalAt: {},
       agentDetailedStatus: {},
+      cancelledAgentIds: {},
       projectActiveAgent: {},
       agentIcons: {},
+      sessionNamePromptFor: null,
     });
   });
 
@@ -214,6 +219,17 @@ describe('agentStore', () => {
       expect(getState().agents['q_early'].status).toBe('sleeping');
     });
 
+    it('records terminal time for quick agents when they stop', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      seedAgent({ id: 'q_done', kind: 'quick', status: 'running' });
+      getState().updateAgentStatus('q_done', 'sleeping');
+
+      expect(getState().agentTerminalAt['q_done']).toBe(now);
+    });
+
     it('clears detailedStatus when agent stops', () => {
       seedAgent({ id: 'a_stop', status: 'running' });
       useAgentStore.setState((s) => ({
@@ -246,6 +262,18 @@ describe('agentStore', () => {
       // Should also process the hook event
       expect(getState().agentDetailedStatus['a_wake']).toBeDefined();
       expect(getState().agentDetailedStatus['a_wake'].state).toBe('working');
+    });
+
+    it('clears quick-agent terminal time when a sleeping agent wakes', () => {
+      seedAgent({ id: 'q_wake', kind: 'quick', status: 'sleeping' });
+      useAgentStore.setState((s) => ({
+        agentTerminalAt: { ...s.agentTerminalAt, q_wake: 123 },
+      }));
+
+      getState().handleHookEvent('q_wake', { kind: 'post_tool', timestamp: 100 });
+
+      expect(getState().agents['q_wake'].status).toBe('running');
+      expect(getState().agentTerminalAt['q_wake']).toBeUndefined();
     });
 
     it('transitions error agent to running on hook event', () => {
@@ -384,6 +412,67 @@ describe('agentStore', () => {
       getState().clearStaleStatuses();
       expect(getState().agentDetailedStatus['a_perm_stale']).toBeDefined();
     });
+
+    it('prunes completed quick agents older than the retention window', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      seedAgent({ id: 'q_old', kind: 'quick', status: 'sleeping' });
+      seedAgent({ id: 'q_recent', kind: 'quick', status: 'sleeping' });
+      useAgentStore.setState((s) => ({
+        agentTerminalAt: {
+          ...s.agentTerminalAt,
+          q_old: now - 61_000,
+          q_recent: now - 5_000,
+        },
+      }));
+
+      getState().clearStaleStatuses();
+
+      expect(getState().agents['q_old']).toBeUndefined();
+      expect(getState().agents['q_recent']).toBeDefined();
+    });
+
+    it('retains only the newest completed quick agents when the cap is exceeded', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      for (let index = 0; index < 22; index += 1) {
+        seedAgent({ id: `q_${index}`, kind: 'quick', status: 'sleeping' });
+      }
+      useAgentStore.setState((s) => ({
+        agentTerminalAt: Object.fromEntries(
+          Array.from({ length: 22 }, (_, index) => [`q_${index}`, now - index * 1_000]),
+        ),
+        agentSpawnedAt: s.agentSpawnedAt,
+      }));
+
+      getState().clearStaleStatuses();
+
+      expect(Object.keys(getState().agents)).toHaveLength(20);
+      expect(getState().agents.q_0).toBeDefined();
+      expect(getState().agents.q_19).toBeDefined();
+      expect(getState().agents.q_20).toBeUndefined();
+      expect(getState().agents.q_21).toBeUndefined();
+    });
+
+    it('does not prune a protected completed quick agent', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      seedAgent({ id: 'q_active', kind: 'quick', status: 'sleeping' });
+      useAgentStore.setState((s) => ({
+        activeAgentId: 'q_active',
+        agentTerminalAt: { ...s.agentTerminalAt, q_active: now - 61_000 },
+      }));
+
+      getState().clearStaleStatuses();
+
+      expect(getState().agents['q_active']).toBeDefined();
+    });
   });
 
   describe('toolVerb (tested via handleHookEvent)', () => {
@@ -489,6 +578,47 @@ describe('agentStore', () => {
       useAgentStore.setState({ activeAgentId: 'a_keep_active' });
       getState().removeAgent('a_other');
       expect(getState().activeAgentId).toBe('a_keep_active');
+    });
+
+    it('clears per-agent metadata when an agent is removed', () => {
+      seedAgent({ id: 'a_cleanup', projectId: 'proj_1' });
+      useAgentStore.setState({
+        activeAgentId: 'a_cleanup',
+        agentSettingsOpenFor: 'a_cleanup',
+        deleteDialogAgent: 'a_cleanup',
+        configChangesDialogAgent: 'a_cleanup',
+        configChangesProjectPath: '/project',
+        sessionNamePromptFor: 'a_cleanup',
+        agentActivity: { a_cleanup: 10, keep: 20 },
+        agentSpawnedAt: { a_cleanup: 11, keep: 21 },
+        agentTerminalAt: { a_cleanup: 12, keep: 22 },
+        agentDetailedStatus: {
+          a_cleanup: { state: 'idle', message: 'Idle', timestamp: 1 },
+          keep: { state: 'working', message: 'Reading', timestamp: 2 },
+        },
+        cancelledAgentIds: { a_cleanup: true, keep: true },
+        agentIcons: { a_cleanup: 'icon-cleanup', keep: 'icon-keep' },
+        projectActiveAgent: { proj_1: 'a_cleanup', proj_2: 'keep' },
+      });
+
+      getState().removeAgent('a_cleanup');
+
+      expect(getState().agentActivity['a_cleanup']).toBeUndefined();
+      expect(getState().agentSpawnedAt['a_cleanup']).toBeUndefined();
+      expect(getState().agentTerminalAt['a_cleanup']).toBeUndefined();
+      expect(getState().agentDetailedStatus['a_cleanup']).toBeUndefined();
+      expect(getState().cancelledAgentIds['a_cleanup']).toBeUndefined();
+      expect(getState().agentIcons['a_cleanup']).toBeUndefined();
+      expect(getState().activeAgentId).toBeNull();
+      expect(getState().agentSettingsOpenFor).toBeNull();
+      expect(getState().deleteDialogAgent).toBeNull();
+      expect(getState().configChangesDialogAgent).toBeNull();
+      expect(getState().configChangesProjectPath).toBeNull();
+      expect(getState().sessionNamePromptFor).toBeNull();
+      expect(getState().projectActiveAgent.proj_1).toBeUndefined();
+      expect(getState().projectActiveAgent.proj_2).toBe('keep');
+      expect(getState().agentActivity.keep).toBe(20);
+      expect(getState().agentIcons.keep).toBe('icon-keep');
     });
   });
 

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -8,6 +8,9 @@ import { useProjectStore } from './projectStore';
 
 /** Detailed statuses older than this are considered stale and cleared */
 const STALE_THRESHOLD_MS = 30_000;
+/** Keep a small backstop of completed quick agents in-memory before pruning */
+const COMPLETED_QUICK_AGENT_RETENTION_MS = 60_000;
+const MAX_COMPLETED_QUICK_AGENTS = 20;
 
 export type DeleteMode = 'commit-push' | 'cleanup-branch' | 'save-patch' | 'force' | 'unregister';
 
@@ -20,6 +23,7 @@ interface AgentState {
   configChangesProjectPath: string | null;
   agentActivity: Record<string, number>; // agentId -> last data timestamp
   agentSpawnedAt: Record<string, number>; // agentId -> spawn timestamp
+  agentTerminalAt: Record<string, number>; // agentId -> terminal timestamp
   agentDetailedStatus: Record<string, AgentDetailedStatus>;
   /** Track agents that were user-cancelled (not naturally completed) */
   cancelledAgentIds: Record<string, true>;
@@ -61,6 +65,99 @@ interface AgentState {
   setSessionNamePrompt: (agentId: string | null) => void;
 }
 
+function omitRecordKeys<T>(record: Record<string, T>, ids: Set<string>): Record<string, T> {
+  if (ids.size === 0) return record;
+
+  let changed = false;
+  const next: Record<string, T> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (ids.has(key)) {
+      changed = true;
+      continue;
+    }
+    next[key] = value;
+  }
+  return changed ? next : record;
+}
+
+function omitRecordKey<T>(record: Record<string, T>, id: string): Record<string, T> {
+  if (!(id in record)) return record;
+  const { [id]: _removed, ...rest } = record;
+  return rest;
+}
+
+function protectedAgentIds(state: Pick<AgentState,
+  'activeAgentId' |
+  'agentSettingsOpenFor' |
+  'deleteDialogAgent' |
+  'configChangesDialogAgent' |
+  'sessionNamePromptFor'
+>): Set<string> {
+  const ids = [
+    state.activeAgentId,
+    state.agentSettingsOpenFor,
+    state.deleteDialogAgent,
+    state.configChangesDialogAgent,
+    state.sessionNamePromptFor,
+  ].filter((id): id is string => Boolean(id));
+
+  return new Set(ids);
+}
+
+function removeAgentsFromState(state: AgentState, idsToRemove: Iterable<string>): Partial<AgentState> | AgentState {
+  const ids = new Set(idsToRemove);
+  if (ids.size === 0) return state;
+
+  const agents = omitRecordKeys(state.agents, ids);
+  const agentActivity = omitRecordKeys(state.agentActivity, ids);
+  const agentSpawnedAt = omitRecordKeys(state.agentSpawnedAt, ids);
+  const agentTerminalAt = omitRecordKeys(state.agentTerminalAt, ids);
+  const agentDetailedStatus = omitRecordKeys(state.agentDetailedStatus, ids);
+  const cancelledAgentIds = omitRecordKeys(state.cancelledAgentIds, ids);
+  const agentIcons = omitRecordKeys(state.agentIcons, ids);
+
+  let projectActiveAgent = state.projectActiveAgent;
+  for (const agentId of Object.values(state.projectActiveAgent)) {
+    if (agentId && ids.has(agentId)) {
+      projectActiveAgent = Object.fromEntries(
+        Object.entries(state.projectActiveAgent).filter(([, currentId]) => !currentId || !ids.has(currentId)),
+      );
+      break;
+    }
+  }
+
+  const activeAgentId = state.activeAgentId && ids.has(state.activeAgentId) ? null : state.activeAgentId;
+  const agentSettingsOpenFor = state.agentSettingsOpenFor && ids.has(state.agentSettingsOpenFor)
+    ? null
+    : state.agentSettingsOpenFor;
+  const deleteDialogAgent = state.deleteDialogAgent && ids.has(state.deleteDialogAgent)
+    ? null
+    : state.deleteDialogAgent;
+  const clearConfigDialog = state.configChangesDialogAgent && ids.has(state.configChangesDialogAgent);
+  const configChangesDialogAgent = clearConfigDialog ? null : state.configChangesDialogAgent;
+  const configChangesProjectPath = clearConfigDialog ? null : state.configChangesProjectPath;
+  const sessionNamePromptFor = state.sessionNamePromptFor && ids.has(state.sessionNamePromptFor)
+    ? null
+    : state.sessionNamePromptFor;
+
+  return {
+    agents,
+    activeAgentId,
+    agentSettingsOpenFor,
+    deleteDialogAgent,
+    configChangesDialogAgent,
+    configChangesProjectPath,
+    agentActivity,
+    agentSpawnedAt,
+    agentTerminalAt,
+    agentDetailedStatus,
+    cancelledAgentIds,
+    projectActiveAgent,
+    agentIcons,
+    sessionNamePromptFor,
+  };
+}
+
 export const useAgentStore = create<AgentState>((set, get) => ({
   agents: {},
   activeAgentId: null,
@@ -70,6 +167,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   configChangesProjectPath: null,
   agentActivity: {},
   agentSpawnedAt: {},
+  agentTerminalAt: {},
   agentDetailedStatus: {},
   cancelledAgentIds: {},
   projectActiveAgent: {},
@@ -478,27 +576,20 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     const newStatus: AgentStatus = 'sleeping';
     set((s) => {
       const { [id]: _, ...restStatus } = s.agentDetailedStatus;
+      const agentTerminalAt = agent.kind === 'quick' && !(id in s.agentTerminalAt)
+        ? { ...s.agentTerminalAt, [id]: Date.now() }
+        : s.agentTerminalAt;
+
       return {
         agents: { ...s.agents, [id]: { ...s.agents[id], status: newStatus } },
         agentDetailedStatus: restStatus,
+        agentTerminalAt,
       };
     });
   },
 
   removeAgent: (id) => {
-    set((s) => {
-      const { [id]: _, ...rest } = s.agents;
-      const { [id]: _ds, ...restStatus } = s.agentDetailedStatus;
-      const activeAgentId = s.activeAgentId === id ? null : s.activeAgentId;
-      // Clear projectActiveAgent entry if this agent was the active one for its project
-      const removedAgent = s.agents[id];
-      let projectActiveAgent = s.projectActiveAgent;
-      if (removedAgent && s.projectActiveAgent[removedAgent.projectId] === id) {
-        const { [removedAgent.projectId]: _pa, ...restPA } = s.projectActiveAgent;
-        projectActiveAgent = restPA;
-      }
-      return { agents: rest, activeAgentId, agentDetailedStatus: restStatus, projectActiveAgent };
-    });
+    set((s) => removeAgentsFromState(s, [id]));
   },
 
   deleteDurableAgent: async (id, projectPath) => {
@@ -546,6 +637,15 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
       // Clear detailed status when agent stops
       const { [id]: _, ...restStatus } = s.agentDetailedStatus;
+      let agentTerminalAt = s.agentTerminalAt;
+
+      if (finalStatus === 'running' || agent.kind !== 'quick') {
+        agentTerminalAt = omitRecordKey(agentTerminalAt, id);
+      } else if (finalStatus === 'sleeping' && !(id in agentTerminalAt)) {
+        agentTerminalAt = { ...agentTerminalAt, [id]: Date.now() };
+      } else if (finalStatus !== 'sleeping') {
+        agentTerminalAt = omitRecordKey(agentTerminalAt, id);
+      }
 
       return {
         agents: {
@@ -557,6 +657,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             errorMessage: finalStatus === 'error' ? resolvedErrorMessage : undefined,
           },
         },
+        agentTerminalAt,
         agentDetailedStatus: finalStatus !== 'running' ? restStatus : s.agentDetailedStatus,
       };
     });
@@ -580,6 +681,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             [agentId]: { ...a, status: 'running', exitCode: undefined, errorMessage: undefined },
           },
           agentSpawnedAt: { ...s.agentSpawnedAt, [agentId]: Date.now() },
+          agentTerminalAt: omitRecordKey(s.agentTerminalAt, agentId),
         };
       });
     }
@@ -641,29 +743,64 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }));
   },
 
-  /** Clear detailed statuses that haven't been updated in STALE_THRESHOLD_MS */
+  /** Periodic cleanup for stale detailed statuses and lingering completed quick agents */
   clearStaleStatuses: () => {
     set((state) => {
       const now = Date.now();
+      let workingState = state;
       const statuses = state.agentDetailedStatus;
-      const agents = state.agents;
       let changed = false;
-      const updated = { ...statuses };
+      let updated = statuses;
 
       for (const [agentId, status] of Object.entries(statuses)) {
-        const agent = agents[agentId];
+        const agent = state.agents[agentId];
         if (!agent || agent.status !== 'running') continue;
 
         const age = now - status.timestamp;
         // Permission states shouldn't auto-clear — agent is waiting for user
         if (status.state === 'needs_permission') continue;
         if (age > STALE_THRESHOLD_MS) {
+          if (updated === statuses) {
+            updated = { ...statuses };
+          }
           delete updated[agentId];
           changed = true;
         }
       }
 
-      return changed ? { agentDetailedStatus: updated } : state;
+      if (changed) {
+        workingState = { ...state, agentDetailedStatus: updated };
+      }
+
+      const protectedIdsSet = protectedAgentIds(workingState);
+      const completedQuickAgents = Object.values(workingState.agents)
+        .filter((agent) => (
+          agent.kind === 'quick' &&
+          agent.status === 'sleeping' &&
+          !protectedIdsSet.has(agent.id)
+        ))
+        .map((agent) => ({
+          id: agent.id,
+          terminalAt: workingState.agentTerminalAt[agent.id] ?? workingState.agentSpawnedAt[agent.id] ?? 0,
+        }))
+        .sort((left, right) => right.terminalAt - left.terminalAt);
+
+      const quickIdsToRemove = new Set<string>();
+      for (const agent of completedQuickAgents) {
+        if (agent.terminalAt > 0 && now - agent.terminalAt > COMPLETED_QUICK_AGENT_RETENTION_MS) {
+          quickIdsToRemove.add(agent.id);
+        }
+      }
+
+      for (const agent of completedQuickAgents.slice(MAX_COMPLETED_QUICK_AGENTS)) {
+        quickIdsToRemove.add(agent.id);
+      }
+
+      if (quickIdsToRemove.size === 0) {
+        return changed ? { agentDetailedStatus: updated } : state;
+      }
+
+      return removeAgentsFromState(workingState, quickIdsToRemove);
     });
   },
 


### PR DESCRIPTION
## Summary
- add a bounded cleanup backstop for lingering sleeping quick agents in `agentStore`
- clear per-agent metadata whenever an agent is removed so auxiliary maps do not accumulate
- add regression coverage for retention pruning, count capping, protected agents, and metadata cleanup

## Changes
- track quick-agent terminal timestamps so periodic cleanup can identify stale sleeping quick agents
- cap in-memory completed quick agents to the 20 most recent unprotected entries and age out anything older than 60 seconds
- reuse a shared removal helper so `agents`, activity, spawn timestamps, icons, cancellation flags, dialogs, and selection state stay in sync when an agent is removed
- expand `agentStore` tests for the new cleanup rules and metadata teardown behavior

## Test Plan
- [x] `npx vitest run --project renderer src/renderer/stores/agentStore.test.ts`
- [x] `npm run make`
- [x] `npm test`
- [x] `npm run lint`
- [x] Verified completed quick-agent history remains in `quickAgentStore` while live `agentStore` entries are pruned by the new backstop logic

## Manual Validation
- Optional smoke test: spawn several quick agents, let them complete, and verify they move into the Completed section without the live quick-session list growing indefinitely.

Closes #618