### PR TITLE
perf: batch HeadlessAgentView feed updates via rAF

### DIFF
--- a/src/renderer/features/agents/HeadlessAgentView.test.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.test.tsx
@@ -25,8 +25,12 @@ function resetStore(spawnedAt?: number) {
 
 async function flushAsyncWork() {
   await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
+    // Yield enough microtask ticks for multi-page transcript syncs
+    // to complete before flushing the batched requestAnimationFrame.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    vi.advanceTimersByTime(16); // flush requestAnimationFrame
     await Promise.resolve();
   });
 }
@@ -362,6 +366,39 @@ describe('HeadlessAgentView', () => {
     await flushAsyncWork();
     const callsAfter5s = vi.mocked(window.clubhouse.agent.readTranscriptPage).mock.calls.length;
     expect(callsAfter5s).toBe(2);
+  });
+
+  it('batches rapid notification events into a single state flush', async () => {
+    let hookCallback: (agentId: string, event: Record<string, unknown>) => void = () => {};
+    window.clubhouse.agent.onHookEvent = vi.fn((cb) => {
+      hookCallback = cb;
+      return vi.fn();
+    });
+    window.clubhouse.agent.readTranscriptPage = vi.fn().mockResolvedValue({
+      events: [],
+      totalEvents: 0,
+    });
+
+    render(<HeadlessAgentView agent={headlessAgent} />);
+    await flushAsyncWork();
+
+    // Fire 5 notification events synchronously — they should be batched
+    // into a single requestAnimationFrame flush instead of 5 array copies.
+    act(() => {
+      for (let i = 0; i < 5; i++) {
+        hookCallback(headlessAgent.id, {
+          kind: 'notification',
+          message: `batch-msg-${i}`,
+          timestamp: Date.now(),
+        });
+      }
+    });
+    await flushAsyncWork();
+
+    // All 5 notifications should appear
+    for (let i = 0; i < 5; i++) {
+      expect(screen.getByText(`batch-msg-${i}`)).toBeInTheDocument();
+    }
   });
 
   it('freezes the timer when the agent is no longer running', () => {

--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -269,8 +269,21 @@ export function HeadlessAgentView({ agent }: Props) {
   const syncingTranscriptRef = useRef(false);
   const syncRequestedRef = useRef(false);
   const lastHookTimestampRef = useRef(0);
+  const flushRafRef = useRef(0);
+  const feedBufferRef = useRef<FeedItem[]>([]);
   const killAgent = useAgentStore((s) => s.killAgent);
   const spawnedAt = useAgentStore((s) => s.agentSpawnedAt[agent.id]);
+
+  // Batch feed-item state updates: push to buffer ref (O(1)), flush to state
+  // once per animation frame to avoid copying the full array on every event.
+  const scheduleFlush = useCallback(() => {
+    if (flushRafRef.current) return;
+    flushRafRef.current = requestAnimationFrame(() => {
+      flushRafRef.current = 0;
+      feedBufferRef.current = capFeedItems(feedBufferRef.current);
+      setFeedItems([...feedBufferRef.current]);
+    });
+  }, []);
 
   // Elapsed time counter — use the store's spawn timestamp so remounts
   // don't reset the timer (fixes #185).
@@ -283,13 +296,11 @@ export function HeadlessAgentView({ agent }: Props) {
   }, [agent.id, spawnedAt, agent.status]);
 
   const appendNotificationItem = useCallback((message: string, ts: number) => {
-    setFeedItems((prev) => {
-      return capFeedItems([
-        ...prev,
-        createNotificationFeedItem(message, ts, notificationCountsRef.current),
-      ]);
-    });
-  }, []);
+    feedBufferRef.current.push(
+      createNotificationFeedItem(message, ts, notificationCountsRef.current),
+    );
+    scheduleFlush();
+  }, [scheduleFlush]);
 
   // Sync transcript incrementally — hook events trigger immediate syncs while a
   // low-frequency fallback poll (5 s) catches anything hooks miss.
@@ -306,6 +317,7 @@ export function HeadlessAgentView({ agent }: Props) {
     syncingTranscriptRef.current = false;
     syncRequestedRef.current = false;
     lastHookTimestampRef.current = 0;
+    feedBufferRef.current = [];
     setFeedItems([]);
 
     async function syncTranscript(): Promise<void> {
@@ -340,7 +352,8 @@ export function HeadlessAgentView({ agent }: Props) {
           );
 
           if (newItems.length > 0) {
-            setFeedItems((prev) => capFeedItems([...prev, ...newItems]));
+            feedBufferRef.current.push(...newItems);
+            scheduleFlush();
           }
 
           if (transcriptOffsetRef.current >= page.totalEvents) return;
@@ -386,6 +399,10 @@ export function HeadlessAgentView({ agent }: Props) {
       cancelled = true;
       removeListener();
       clearInterval(fallbackInterval);
+      if (flushRafRef.current) {
+        cancelAnimationFrame(flushRafRef.current);
+        flushRafRef.current = 0;
+      }
     };
   }, [agent.id, appendNotificationItem]);
 


### PR DESCRIPTION
## Summary
- Replace per-event array copies in `HeadlessAgentView` with a ref-based buffer that flushes to React state once per animation frame
- Reduces O(n×k) allocation per frame to a single O(n) copy, eliminating GC pressure during active agent output

Fixes #629

## Changes
- **`HeadlessAgentView.tsx`**: Added `feedBufferRef` and `flushRafRef` refs. New `scheduleFlush` callback uses `requestAnimationFrame` to coalesce rapid pushes into a single state update. Both `appendNotificationItem` and `syncTranscript` now push to the buffer (O(1) amortized) instead of spreading into a new array. Effect cleanup cancels any pending rAF.
- **`HeadlessAgentView.test.tsx`**: Updated `flushAsyncWork` helper to yield enough microtask ticks for multi-page transcript syncs before flushing rAF. Added test verifying that multiple rapid notification events are batched correctly.

## Test Plan
- [x] All 15 HeadlessAgentView tests pass (including new batching test)
- [x] Full test suite passes (6447 tests across 258 files)
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Feed items still capped at MAX_FEED_ITEMS (200)
- [x] Transcript pagination still works incrementally
- [x] Fallback polling suppression/resumption behavior preserved
- [x] Timer baseline preserved across remounts

## Manual Validation
1. Launch a headless agent with an active workload
2. Observe the Live Activity feed updates smoothly without UI jank
3. Verify items are capped at 200 during long-running sessions
4. Stop and restart the agent — timer and feed should reset correctly