### PR TITLE
perf: throttle agent activity updates

### DIFF
--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock window.clubhouse
 vi.stubGlobal('window', {
@@ -75,6 +75,11 @@ describe('agentStore', () => {
       agentIcons: {},
       sessionNamePromptFor: null,
     });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   describe('updateAgentStatus', () => {
@@ -472,6 +477,78 @@ describe('agentStore', () => {
       getState().clearStaleStatuses();
 
       expect(getState().agents['q_active']).toBeDefined();
+    });
+  });
+
+  describe('recordActivity', () => {
+    it('coalesces rapid activity updates for the same agent', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      seedAgent({ id: 'a_activity' });
+
+      getState().recordActivity('a_activity');
+      const firstActivity = getState().agentActivity;
+      expect(firstActivity['a_activity']).toBe(now);
+
+      vi.advanceTimersByTime(50);
+      getState().recordActivity('a_activity');
+
+      expect(getState().agentActivity).toBe(firstActivity);
+      expect(getState().agentActivity['a_activity']).toBe(now);
+
+      vi.advanceTimersByTime(49);
+      expect(getState().agentActivity).toBe(firstActivity);
+
+      vi.advanceTimersByTime(1);
+      expect(getState().agentActivity).not.toBe(firstActivity);
+      expect(getState().agentActivity['a_activity']).toBe(now + 100);
+    });
+
+    it('tracks activity independently per agent while throttling bursts', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      seedAgent({ id: 'a_one' });
+      seedAgent({ id: 'a_two' });
+
+      getState().recordActivity('a_one');
+
+      vi.advanceTimersByTime(50);
+      getState().recordActivity('a_one');
+      getState().recordActivity('a_two');
+
+      expect(getState().agentActivity).toEqual({
+        a_one: now,
+        a_two: now + 50,
+      });
+
+      vi.advanceTimersByTime(50);
+      expect(getState().agentActivity).toEqual({
+        a_one: now + 100,
+        a_two: now + 50,
+      });
+    });
+
+    it('cancels pending trailing updates when an agent is removed', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      seedAgent({ id: 'a_removed' });
+
+      getState().recordActivity('a_removed');
+
+      vi.advanceTimersByTime(50);
+      getState().recordActivity('a_removed');
+
+      getState().removeAgent('a_removed');
+      vi.advanceTimersByTime(50);
+
+      expect(getState().agents['a_removed']).toBeUndefined();
+      expect(getState().agentActivity['a_removed']).toBeUndefined();
     });
   });
 

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -11,6 +11,7 @@ const STALE_THRESHOLD_MS = 30_000;
 /** Keep a small backstop of completed quick agents in-memory before pruning */
 const COMPLETED_QUICK_AGENT_RETENTION_MS = 60_000;
 const MAX_COMPLETED_QUICK_AGENTS = 20;
+const ACTIVITY_UPDATE_THROTTLE_MS = 100;
 
 export type DeleteMode = 'commit-push' | 'cleanup-branch' | 'save-patch' | 'force' | 'unregister';
 
@@ -158,7 +159,34 @@ function removeAgentsFromState(state: AgentState, idsToRemove: Iterable<string>)
   };
 }
 
-export const useAgentStore = create<AgentState>((set, get) => ({
+export const useAgentStore = create<AgentState>((set, get) => {
+  const pendingActivityTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const clearPendingActivityTimer = (id: string) => {
+    const timer = pendingActivityTimers.get(id);
+    if (!timer) return;
+    clearTimeout(timer);
+    pendingActivityTimers.delete(id);
+  };
+
+  const clearPendingActivityTimers = (ids: Iterable<string>) => {
+    for (const id of ids) {
+      clearPendingActivityTimer(id);
+    }
+  };
+
+  const commitActivity = (id: string, timestamp: number) => {
+    set((s) => {
+      if (!s.agents[id]) return s;
+      const previous = s.agentActivity[id];
+      if (previous !== undefined && timestamp <= previous) return s;
+      return {
+        agentActivity: { ...s.agentActivity, [id]: timestamp },
+      };
+    });
+  };
+
+  return ({
   agents: {},
   activeAgentId: null,
   agentSettingsOpenFor: null,
@@ -589,6 +617,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   removeAgent: (id) => {
+    clearPendingActivityTimer(id);
     set((s) => removeAgentsFromState(s, [id]));
   },
 
@@ -745,6 +774,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   /** Periodic cleanup for stale detailed statuses and lingering completed quick agents */
   clearStaleStatuses: () => {
+    const prunedQuickIds = new Set<string>();
     set((state) => {
       const now = Date.now();
       let workingState = state;
@@ -800,14 +830,42 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         return changed ? { agentDetailedStatus: updated } : state;
       }
 
+      for (const agentId of quickIdsToRemove) {
+        prunedQuickIds.add(agentId);
+      }
+
       return removeAgentsFromState(workingState, quickIdsToRemove);
     });
+    clearPendingActivityTimers(prunedQuickIds);
   },
 
   recordActivity: (id) => {
-    set((s) => ({
-      agentActivity: { ...s.agentActivity, [id]: Date.now() },
-    }));
+    const state = get();
+    if (!state.agents[id]) {
+      clearPendingActivityTimer(id);
+      return;
+    }
+
+    const now = Date.now();
+    const last = state.agentActivity[id] ?? 0;
+    const elapsed = now - last;
+
+    if (elapsed >= ACTIVITY_UPDATE_THROTTLE_MS) {
+      clearPendingActivityTimer(id);
+      commitActivity(id, now);
+      return;
+    }
+
+    if (pendingActivityTimers.has(id)) {
+      return;
+    }
+
+    const delay = ACTIVITY_UPDATE_THROTTLE_MS - elapsed;
+    const timer = setTimeout(() => {
+      pendingActivityTimers.delete(id);
+      commitActivity(id, Date.now());
+    }, delay);
+    pendingActivityTimers.set(id, timer);
   },
 
   reorderAgents: async (projectPath, orderedIds) => {
@@ -862,7 +920,8 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }));
     return tempId;
   },
-}));
+  });
+});
 
 /** Check if an agent was user-cancelled (consumes the flag) */
 export function consumeCancelled(agentId: string): boolean {


### PR DESCRIPTION
## Summary
- throttle `recordActivity` per agent so PTY bursts no longer replace the full `agentActivity` map on every event
- clear pending trailing activity timers when agents are removed or pruned to avoid stale updates re-adding activity
- add renderer store regression coverage for throttling, per-agent independence, and removal cleanup

## Changes
- add a 100ms store-level throttle in `src/renderer/stores/agentStore.ts`
- keep trailing updates per agent with internal timers while guarding commits against missing or stale agents
- clear pending activity timers from `removeAgent` and `clearStaleStatuses`
- add regression tests in `src/renderer/stores/agentStore.test.ts`
- closes #615

## Test Plan
- [x] `npx vitest run --project renderer src/renderer/stores/agentStore.test.ts src/renderer/features/agents/AgentList.test.tsx`
- [x] `npx eslint src/renderer/stores/agentStore.ts src/renderer/stores/agentStore.test.ts`
- [x] `npm run make`
- [x] `npm test`
- [x] `npm run lint`

## Manual Validation
- Start an agent that emits sustained PTY output and confirm the thinking indicator still appears while activity updates are coalesced instead of updating the store on every chunk.
