### PR TITLE
perf(App): extract layout components to reduce root re-renders (#634)

### DIFF
--- a/src/renderer/App.structural.test.ts
+++ b/src/renderer/App.structural.test.ts
@@ -360,8 +360,10 @@ describe('App.tsx – global dialog presence in all return paths', () => {
 describe('App.tsx – selector discipline', () => {
   const selectors = findStoreSelectors(appFn.body!);
 
-  it('should have at most 15 store selector calls (layout-only)', () => {
-    expect(selectors.length).toBeLessThanOrEqual(15);
+  it('should have at most 5 store selector calls (routing-only)', () => {
+    // After extracting TitleBar, RailSection, and ProjectPanelLayout:
+    // projects, activeProjectId, explorerTab = 3 selectors
+    expect(selectors.length).toBeLessThanOrEqual(5);
   });
 
   it('should NOT subscribe to agentStore for event handler functions', () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { ProjectRail } from './panels/ProjectRail';
-import { ExplorerRail } from './panels/ExplorerRail';
-import { AccessoryPanel } from './panels/AccessoryPanel';
-import { MainContentView } from './panels/MainContentView';
-import { ResizeDivider } from './components/ResizeDivider';
-import { usePanelStore } from './stores/panelStore';
+import { TitleBar } from './components/TitleBar';
+import { RailSection } from './components/RailSection';
+import { ProjectPanelLayout } from './components/ProjectPanelLayout';
 import { Dashboard } from './features/projects/Dashboard';
 import { GitBanner } from './features/projects/GitBanner';
 import { useProjectStore } from './stores/projectStore';
@@ -30,25 +27,10 @@ import { ToastContainer } from './components/ToastContainer';
 import { useToastStore } from './stores/toastStore';
 
 export function App() {
-  // ── Layout state (only selectors needed for rendering) ──────────────────
+  // ── Routing state (minimal selectors for view switching) ────────────────
   const projects = useProjectStore((s) => s.projects);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const explorerTab = useUIStore((s) => s.explorerTab);
-  const activePluginId = explorerTab.startsWith('plugin:') ? explorerTab.slice('plugin:'.length) : null;
-  const activePluginEntry = usePluginStore((s) => activePluginId ? s.plugins[activePluginId] : undefined);
-  const isFullWidth = activePluginEntry?.manifest.contributes?.tab?.layout === 'full';
-
-  const explorerWidth = usePanelStore((s) => s.explorerWidth);
-  const explorerCollapsed = usePanelStore((s) => s.explorerCollapsed);
-  const accessoryWidth = usePanelStore((s) => s.accessoryWidth);
-  const accessoryCollapsed = usePanelStore((s) => s.accessoryCollapsed);
-  const resizeExplorer = usePanelStore((s) => s.resizeExplorer);
-  const resizeAccessory = usePanelStore((s) => s.resizeAccessory);
-  const toggleExplorerCollapse = usePanelStore((s) => s.toggleExplorerCollapse);
-  const toggleAccessoryCollapse = usePanelStore((s) => s.toggleAccessoryCollapse);
-  const railPinned = usePanelStore((s) => s.railPinned);
-  const resizeRail = usePanelStore((s) => s.resizeRail);
-  const toggleRailPin = usePanelStore((s) => s.toggleRailPin);
 
   // ── One-time initialization & event bridge ──────────────────────────────
   useEffect(() => {
@@ -60,7 +42,7 @@ export function App() {
     };
   }, []);
 
-  // ── Reactive effects (depend on state already subscribed for rendering) ─
+  // ── Reactive effects (depend on state already subscribed for routing) ───
 
   // Load durable agents for all projects so the dashboard shows them
   useEffect(() => {
@@ -123,59 +105,21 @@ export function App() {
     }
   }, [activeProjectId, projects]);
 
-  // ── Derived layout state ────────────────────────────────────────────────
+  // ── Derived routing state ──────────────────────────────────────────────
   const isAppPlugin = explorerTab.startsWith('plugin:app:');
   const isHelp = explorerTab === 'help';
   const isHome = activeProjectId === null && explorerTab !== 'settings' && !isAppPlugin && !isHelp;
-  const activeProject = projects.find((p) => p.id === activeProjectId);
-
-  const CORE_LABELS: Record<string, string> = {
-    agents: 'Agents',
-    settings: 'Settings',
-    help: 'Help',
-  };
-  const tabLabel = (() => {
-    if (!activePluginEntry) return CORE_LABELS[explorerTab] || explorerTab;
-    if (explorerTab.startsWith('plugin:app:')) {
-      return activePluginEntry.manifest.contributes?.railItem?.label || activePluginEntry.manifest.name || activePluginId;
-    }
-    return activePluginEntry.manifest.contributes?.tab?.label || activePluginEntry.manifest.name || activePluginId;
-  })();
-
-  const titleText = isHome
-    ? 'Home'
-    : activeProject
-      ? `${tabLabel} (${activeProject.displayName || activeProject.name})`
-      : tabLabel;
-
-  const isWin = window.clubhouse.platform === 'win32';
-  const titleBarClass = `h-[38px] flex-shrink-0 drag-region bg-ctp-mantle border-b border-surface-0 flex items-center justify-center${isWin ? ' win-overlay-padding' : ''}`;
-
-  const railGridColumns = railPinned
-    ? 'var(--rail-width, 68px) auto 1fr'
-    : 'var(--rail-width, 68px) 1fr';
 
   if (isHome) {
     return (
       <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
-        <div className={titleBarClass}>
-          <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
-        </div>
+        <TitleBar />
         <PermissionViolationBanner />
         <UpdateBanner />
         <PluginUpdateBanner />
-        <div className="flex-1 min-h-0 grid grid-rows-[1fr]" style={{ gridTemplateColumns: railGridColumns }}>
-          <ProjectRail />
-          {railPinned && (
-            <ResizeDivider
-              onResize={resizeRail}
-              onToggleCollapse={toggleRailPin}
-              collapsed={false}
-              collapseDirection="left"
-            />
-          )}
+        <RailSection>
           <Dashboard />
-        </div>
+        </RailSection>
         <CommandPalette />
         <QuickAgentDialog />
         <WhatsNewDialog />
@@ -190,24 +134,13 @@ export function App() {
     const appPluginId = explorerTab.slice('plugin:app:'.length);
     return (
       <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
-        <div className={titleBarClass}>
-          <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
-        </div>
+        <TitleBar />
         <PermissionViolationBanner />
         <UpdateBanner />
         <PluginUpdateBanner />
-        <div className="flex-1 min-h-0 grid grid-rows-[1fr]" style={{ gridTemplateColumns: railGridColumns }}>
-          <ProjectRail />
-          {railPinned && (
-            <ResizeDivider
-              onResize={resizeRail}
-              onToggleCollapse={toggleRailPin}
-              collapsed={false}
-              collapseDirection="left"
-            />
-          )}
+        <RailSection>
           <PluginContentView pluginId={appPluginId} mode="app" />
-        </div>
+        </RailSection>
         <CommandPalette />
         <QuickAgentDialog />
         <WhatsNewDialog />
@@ -221,24 +154,13 @@ export function App() {
   if (isHelp) {
     return (
       <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
-        <div className={titleBarClass}>
-          <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
-        </div>
+        <TitleBar />
         <PermissionViolationBanner />
         <UpdateBanner />
         <PluginUpdateBanner />
-        <div className="flex-1 min-h-0 grid grid-rows-[1fr]" style={{ gridTemplateColumns: railGridColumns }}>
-          <ProjectRail />
-          {railPinned && (
-            <ResizeDivider
-              onResize={resizeRail}
-              onToggleCollapse={toggleRailPin}
-              collapsed={false}
-              collapseDirection="left"
-            />
-          )}
+        <RailSection>
           <HelpView />
-        </div>
+        </RailSection>
         <CommandPalette />
         <QuickAgentDialog />
         <WhatsNewDialog />
@@ -251,59 +173,14 @@ export function App() {
 
   return (
     <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col">
-      {/* Title bar */}
-      <div className={titleBarClass}>
-        <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
-      </div>
-      {/* Permission violation banner */}
+      <TitleBar />
       <PermissionViolationBanner />
-      {/* Update banner */}
       <UpdateBanner />
-      {/* Plugin update banner */}
       <PluginUpdateBanner />
-      {/* Git banner */}
       <GitBanner />
-      {/* Main content grid */}
-      <div className="flex-1 min-h-0 grid grid-rows-[1fr]" style={{ gridTemplateColumns: railGridColumns }}>
-        <ProjectRail />
-        {railPinned && (
-          <ResizeDivider
-            onResize={resizeRail}
-            onToggleCollapse={toggleRailPin}
-            collapsed={false}
-            collapseDirection="left"
-          />
-        )}
-        <div className="flex flex-row min-h-0 min-w-0">
-          {!explorerCollapsed && (
-            <div style={{ width: explorerWidth }} className="flex-shrink-0 min-h-0">
-              <ExplorerRail />
-            </div>
-          )}
-          <ResizeDivider
-            onResize={resizeExplorer}
-            onToggleCollapse={toggleExplorerCollapse}
-            collapsed={explorerCollapsed}
-            collapseDirection="left"
-          />
-          {!isFullWidth && !accessoryCollapsed && (
-            <div style={{ width: accessoryWidth }} className="flex-shrink-0 min-h-0">
-              <AccessoryPanel />
-            </div>
-          )}
-          {!isFullWidth && (
-            <ResizeDivider
-              onResize={resizeAccessory}
-              onToggleCollapse={toggleAccessoryCollapse}
-              collapsed={accessoryCollapsed}
-              collapseDirection="left"
-            />
-          )}
-          <div className="flex-1 min-w-0 min-h-0">
-            <MainContentView />
-          </div>
-        </div>
-      </div>
+      <RailSection>
+        <ProjectPanelLayout />
+      </RailSection>
       <CommandPalette />
       <QuickAgentDialog />
       <WhatsNewDialog />

--- a/src/renderer/components/AppLayout.structural.test.ts
+++ b/src/renderer/components/AppLayout.structural.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Structural tests for the extracted App layout components.
+ *
+ * These verify that state subscriptions are properly isolated into
+ * child components so that resizing panels or computing the title
+ * does not force the root App component to re-render.
+ */
+
+// ─── AST Helpers ────────────────────────────────────────────────────────────
+
+function parseFile(filePath: string): ts.SourceFile {
+  const source = readFileSync(filePath, 'utf-8');
+  return ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function findNamedFunction(sf: ts.SourceFile, name: string): ts.FunctionDeclaration | undefined {
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === name) {
+      return stmt;
+    }
+  }
+  return undefined;
+}
+
+function findStoreSelectors(funcBody: ts.Block): Array<{ storeName: string; field: string | null }> {
+  const selectors: Array<{ storeName: string; field: string | null }> = [];
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      const name = node.expression.text;
+      if (/^use\w+Store$/.test(name) && node.arguments.length > 0 && ts.isArrowFunction(node.arguments[0])) {
+        const arrow = node.arguments[0] as ts.ArrowFunction;
+        let field: string | null = null;
+        if (ts.isPropertyAccessExpression(arrow.body)) {
+          field = arrow.body.name.text;
+        }
+        selectors.push({ storeName: name, field });
+      }
+    }
+    if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node)) return;
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(funcBody, visit);
+  return selectors;
+}
+
+function collectJsxTagNames(node: ts.Node): Set<string> {
+  const tags = new Set<string>();
+  function visit(n: ts.Node) {
+    if (ts.isJsxOpeningElement(n) || ts.isJsxSelfClosingElement(n)) {
+      if (ts.isIdentifier(n.tagName)) tags.add(n.tagName.text);
+    }
+    ts.forEachChild(n, visit);
+  }
+  visit(node);
+  return tags;
+}
+
+// ─── Parse source files ─────────────────────────────────────────────────────
+
+const titleBarAst = parseFile(join(__dirname, 'TitleBar.tsx'));
+const railSectionAst = parseFile(join(__dirname, 'RailSection.tsx'));
+const panelLayoutAst = parseFile(join(__dirname, 'ProjectPanelLayout.tsx'));
+
+const titleBarFn = findNamedFunction(titleBarAst, 'TitleBar')!;
+const railSectionFn = findNamedFunction(railSectionAst, 'RailSection')!;
+const panelLayoutFn = findNamedFunction(panelLayoutAst, 'ProjectPanelLayout')!;
+
+// ─── TitleBar ───────────────────────────────────────────────────────────────
+
+describe('TitleBar – selector isolation', () => {
+  const selectors = findStoreSelectors(titleBarFn.body!);
+
+  it('should subscribe to UI, project, and plugin stores for title computation', () => {
+    const storeNames = new Set(selectors.map((s) => s.storeName));
+    expect(storeNames.has('useUIStore'), 'TitleBar should subscribe to useUIStore').toBe(true);
+    expect(storeNames.has('useProjectStore'), 'TitleBar should subscribe to useProjectStore').toBe(true);
+    expect(storeNames.has('usePluginStore'), 'TitleBar should subscribe to usePluginStore').toBe(true);
+  });
+
+  it('should NOT subscribe to panel store', () => {
+    const storeNames = new Set(selectors.map((s) => s.storeName));
+    expect(storeNames.has('usePanelStore'), 'TitleBar should not subscribe to panel state').toBe(false);
+  });
+
+  it('should render a title-bar test-id', () => {
+    const tags = collectJsxTagNames(titleBarFn);
+    // The span with data-testid="title-bar" is in the JSX; verify the outer div exists
+    expect(tags.has('div') || tags.has('span')).toBe(true);
+  });
+});
+
+// ─── RailSection ────────────────────────────────────────────────────────────
+
+describe('RailSection – selector isolation', () => {
+  const selectors = findStoreSelectors(railSectionFn.body!);
+
+  it('should subscribe only to rail-related panel state', () => {
+    const fields = selectors.map((s) => s.field).filter(Boolean);
+    expect(fields).toContain('railPinned');
+    expect(fields).toContain('resizeRail');
+    expect(fields).toContain('toggleRailPin');
+  });
+
+  it('should subscribe exclusively to usePanelStore', () => {
+    const storeNames = [...new Set(selectors.map((s) => s.storeName))];
+    expect(storeNames).toEqual(['usePanelStore']);
+  });
+
+  it('should NOT subscribe to explorer or accessory panel state', () => {
+    const fields = selectors.map((s) => s.field).filter(Boolean);
+    const forbidden = ['explorerWidth', 'explorerCollapsed', 'accessoryWidth', 'accessoryCollapsed'];
+    for (const f of forbidden) {
+      expect(fields, `RailSection should not subscribe to ${f}`).not.toContain(f);
+    }
+  });
+
+  it('should render ProjectRail and ResizeDivider', () => {
+    const tags = collectJsxTagNames(railSectionFn);
+    expect(tags.has('ProjectRail'), 'Should render ProjectRail').toBe(true);
+    expect(tags.has('ResizeDivider'), 'Should render ResizeDivider').toBe(true);
+  });
+});
+
+// ─── ProjectPanelLayout ─────────────────────────────────────────────────────
+
+describe('ProjectPanelLayout – selector isolation', () => {
+  const selectors = findStoreSelectors(panelLayoutFn.body!);
+
+  it('should subscribe to explorer and accessory panel state', () => {
+    const fields = selectors.map((s) => s.field).filter(Boolean);
+    expect(fields).toContain('explorerWidth');
+    expect(fields).toContain('explorerCollapsed');
+    expect(fields).toContain('accessoryWidth');
+    expect(fields).toContain('accessoryCollapsed');
+    expect(fields).toContain('resizeExplorer');
+    expect(fields).toContain('resizeAccessory');
+    expect(fields).toContain('toggleExplorerCollapse');
+    expect(fields).toContain('toggleAccessoryCollapse');
+  });
+
+  it('should NOT subscribe to rail state', () => {
+    const fields = selectors.map((s) => s.field).filter(Boolean);
+    const forbidden = ['railPinned', 'resizeRail', 'toggleRailPin'];
+    for (const f of forbidden) {
+      expect(fields, `ProjectPanelLayout should not subscribe to ${f}`).not.toContain(f);
+    }
+  });
+
+  it('should render ExplorerRail, AccessoryPanel, MainContentView, and ResizeDivider', () => {
+    const tags = collectJsxTagNames(panelLayoutFn);
+    expect(tags.has('ExplorerRail'), 'Should render ExplorerRail').toBe(true);
+    expect(tags.has('AccessoryPanel'), 'Should render AccessoryPanel').toBe(true);
+    expect(tags.has('MainContentView'), 'Should render MainContentView').toBe(true);
+    expect(tags.has('ResizeDivider'), 'Should render ResizeDivider').toBe(true);
+  });
+
+  it('should subscribe to plugin store for full-width layout check', () => {
+    const storeNames = new Set(selectors.map((s) => s.storeName));
+    expect(storeNames.has('usePluginStore'), 'Should check plugin layout').toBe(true);
+  });
+});

--- a/src/renderer/components/ProjectPanelLayout.tsx
+++ b/src/renderer/components/ProjectPanelLayout.tsx
@@ -1,0 +1,60 @@
+import { ExplorerRail } from '../panels/ExplorerRail';
+import { AccessoryPanel } from '../panels/AccessoryPanel';
+import { MainContentView } from '../panels/MainContentView';
+import { ResizeDivider } from './ResizeDivider';
+import { usePanelStore } from '../stores/panelStore';
+import { useUIStore } from '../stores/uiStore';
+import { usePluginStore } from '../plugins/plugin-store';
+
+/**
+ * The three-panel project layout (explorer │ accessory │ main content).
+ * Subscribes to panel sizing state so that continuous resize-drag events
+ * only re-render this subtree, not the entire App component tree.
+ */
+export function ProjectPanelLayout() {
+  const explorerWidth = usePanelStore((s) => s.explorerWidth);
+  const explorerCollapsed = usePanelStore((s) => s.explorerCollapsed);
+  const accessoryWidth = usePanelStore((s) => s.accessoryWidth);
+  const accessoryCollapsed = usePanelStore((s) => s.accessoryCollapsed);
+  const resizeExplorer = usePanelStore((s) => s.resizeExplorer);
+  const resizeAccessory = usePanelStore((s) => s.resizeAccessory);
+  const toggleExplorerCollapse = usePanelStore((s) => s.toggleExplorerCollapse);
+  const toggleAccessoryCollapse = usePanelStore((s) => s.toggleAccessoryCollapse);
+
+  const explorerTab = useUIStore((s) => s.explorerTab);
+  const activePluginId = explorerTab.startsWith('plugin:') ? explorerTab.slice('plugin:'.length) : null;
+  const activePluginEntry = usePluginStore((s) => activePluginId ? s.plugins[activePluginId] : undefined);
+  const isFullWidth = activePluginEntry?.manifest.contributes?.tab?.layout === 'full';
+
+  return (
+    <div className="flex flex-row min-h-0 min-w-0">
+      {!explorerCollapsed && (
+        <div style={{ width: explorerWidth }} className="flex-shrink-0 min-h-0">
+          <ExplorerRail />
+        </div>
+      )}
+      <ResizeDivider
+        onResize={resizeExplorer}
+        onToggleCollapse={toggleExplorerCollapse}
+        collapsed={explorerCollapsed}
+        collapseDirection="left"
+      />
+      {!isFullWidth && !accessoryCollapsed && (
+        <div style={{ width: accessoryWidth }} className="flex-shrink-0 min-h-0">
+          <AccessoryPanel />
+        </div>
+      )}
+      {!isFullWidth && (
+        <ResizeDivider
+          onResize={resizeAccessory}
+          onToggleCollapse={toggleAccessoryCollapse}
+          collapsed={accessoryCollapsed}
+          collapseDirection="left"
+        />
+      )}
+      <div className="flex-1 min-w-0 min-h-0">
+        <MainContentView />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/RailSection.tsx
+++ b/src/renderer/components/RailSection.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { ProjectRail } from '../panels/ProjectRail';
+import { ResizeDivider } from './ResizeDivider';
+import { usePanelStore } from '../stores/panelStore';
+
+/**
+ * Wraps the ProjectRail and its optional resize divider in a CSS grid.
+ * Subscribes to rail-related panel state so that toggling the rail pin
+ * does not force the parent App to re-render its entire subtree.
+ */
+export function RailSection({ children }: { children: ReactNode }) {
+  const railPinned = usePanelStore((s) => s.railPinned);
+  const resizeRail = usePanelStore((s) => s.resizeRail);
+  const toggleRailPin = usePanelStore((s) => s.toggleRailPin);
+
+  const railGridColumns = railPinned
+    ? 'var(--rail-width, 68px) auto 1fr'
+    : 'var(--rail-width, 68px) 1fr';
+
+  return (
+    <div className="flex-1 min-h-0 grid grid-rows-[1fr]" style={{ gridTemplateColumns: railGridColumns }}>
+      <ProjectRail />
+      {railPinned && (
+        <ResizeDivider
+          onResize={resizeRail}
+          onToggleCollapse={toggleRailPin}
+          collapsed={false}
+          collapseDirection="left"
+        />
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,0 +1,50 @@
+import { useProjectStore } from '../stores/projectStore';
+import { useUIStore } from '../stores/uiStore';
+import { usePluginStore } from '../plugins/plugin-store';
+
+const CORE_LABELS: Record<string, string> = {
+  agents: 'Agents',
+  settings: 'Settings',
+  help: 'Help',
+};
+
+/**
+ * Title bar component that subscribes to its own state slices so that
+ * title-text recomputation does not force the parent App to re-render.
+ */
+export function TitleBar() {
+  const explorerTab = useUIStore((s) => s.explorerTab);
+  const projects = useProjectStore((s) => s.projects);
+  const activeProjectId = useProjectStore((s) => s.activeProjectId);
+
+  const activePluginId = explorerTab.startsWith('plugin:') ? explorerTab.slice('plugin:'.length) : null;
+  const activePluginEntry = usePluginStore((s) => activePluginId ? s.plugins[activePluginId] : undefined);
+
+  const isAppPlugin = explorerTab.startsWith('plugin:app:');
+  const isHelp = explorerTab === 'help';
+  const isHome = activeProjectId === null && explorerTab !== 'settings' && !isAppPlugin && !isHelp;
+  const activeProject = projects.find((p) => p.id === activeProjectId);
+
+  const tabLabel = (() => {
+    if (!activePluginEntry) return CORE_LABELS[explorerTab] || explorerTab;
+    if (explorerTab.startsWith('plugin:app:')) {
+      return activePluginEntry.manifest.contributes?.railItem?.label || activePluginEntry.manifest.name || activePluginId;
+    }
+    return activePluginEntry.manifest.contributes?.tab?.label || activePluginEntry.manifest.name || activePluginId;
+  })();
+
+  const titleText = isHome
+    ? 'Home'
+    : activeProject
+      ? `${tabLabel} (${activeProject.displayName || activeProject.name})`
+      : tabLabel;
+
+  const isWin = window.clubhouse.platform === 'win32';
+  const titleBarClass = `h-[38px] flex-shrink-0 drag-region bg-ctp-mantle border-b border-surface-0 flex items-center justify-center${isWin ? ' win-overlay-padding' : ''}`;
+
+  return (
+    <div className={titleBarClass}>
+      <span className="text-xs text-ctp-subtext0 select-none" data-testid="title-bar">{titleText}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `TitleBar`, `RailSection`, and `ProjectPanelLayout` from `App.tsx` to isolate state subscriptions
- Reduces App.tsx from 15 store selectors to 3 (routing-only), preventing panel resize drags from re-rendering the entire component tree
- Fixes #634

## Changes
- **`TitleBar`** (`src/renderer/components/TitleBar.tsx`): Owns title text computation, subscribes to `useUIStore`, `useProjectStore`, and `usePluginStore` independently
- **`RailSection`** (`src/renderer/components/RailSection.tsx`): Owns `railPinned`/`resizeRail`/`toggleRailPin` state and renders `ProjectRail` + optional `ResizeDivider`. Used in all 4 return paths via children prop
- **`ProjectPanelLayout`** (`src/renderer/components/ProjectPanelLayout.tsx`): Owns explorer/accessory panel sizing state (`explorerWidth`, `explorerCollapsed`, `accessoryWidth`, `accessoryCollapsed` + resize/toggle actions) and the `isFullWidth` plugin layout check. Only rendered in the MainProject path
- **`App.tsx`**: Now subscribes only to `projects`, `activeProjectId`, `explorerTab` — the minimum needed for view routing and the project-switch effect
- **`App.structural.test.ts`**: Updated selector threshold from ≤15 to ≤5
- **`AppLayout.structural.test.ts`**: New structural tests verifying each extracted component subscribes to exactly the stores it needs and renders the expected children

## Performance Impact
The biggest win is `ProjectPanelLayout`: during a panel resize drag, `explorerWidth`/`accessoryWidth` change on every mouse-move frame. Previously this re-rendered the entire App tree (all banners, dialogs, Dashboard, HelpView, etc.). Now only the panel layout subtree re-renders.

## Test Plan
- [x] All 259 test files pass (6477 tests)
- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] ESLint passes with no warnings
- [x] Structural tests verify selector isolation in each extracted component
- [x] Structural tests verify App.tsx still has exactly 4 return paths with all required global dialogs
- [ ] Manual: verify panel resize drag feels smooth and doesn't cause visible jank
- [ ] Manual: verify title bar updates correctly when switching projects/tabs/plugins
- [ ] Manual: verify rail pin toggle works in all views (Home, Help, AppPlugin, Project)

## Manual Validation
1. Open the app, switch between projects — title bar should update correctly
2. Toggle the rail pin in each view (Home, Help, Plugin, Project) — should show/hide the resize divider
3. Resize the explorer and accessory panels — should be smooth with no visible lag
4. Switch to the Home dashboard while resizing — no flicker or layout jumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)