### PR TITLE
perf(AgentList): move PTY activity tracking out of Zustand store

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -5,7 +5,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { useQuickAgentStore } from '../../stores/quickAgentStore';
 import { useUIStore } from '../../stores/uiStore';
-import { AgentList, useProjectAgentBuckets } from './AgentList';
+import { AgentList, useProjectAgentBuckets, activityTimestamps } from './AgentList';
 import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 
 // Mock child components
@@ -280,15 +280,12 @@ describe('useProjectAgentBuckets', () => {
 
 describe('AgentList onData throttle', () => {
   let onDataCallback: (agentId: string) => void;
-  let recordActivitySpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     resetStores();
-
-    recordActivitySpy = vi.fn();
-    useAgentStore.setState({ recordActivity: recordActivitySpy });
+    Object.keys(activityTimestamps).forEach((k) => delete activityTimestamps[k]);
 
     // Capture the onData callback when the component registers it
     window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: (agentId: string) => void) => {
@@ -301,11 +298,22 @@ describe('AgentList onData throttle', () => {
     vi.useRealTimers();
   });
 
-  it('fires recordActivity immediately on first onData call', () => {
+  it('records activity immediately on first onData call', () => {
     render(<AgentList />);
     act(() => { onDataCallback('agent-1'); });
-    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
-    expect(recordActivitySpy).toHaveBeenCalledWith('agent-1');
+    expect(activityTimestamps['agent-1']).toBeDefined();
+  });
+
+  it('does not trigger store recordActivity from PTY data', () => {
+    const recordActivitySpy = vi.fn();
+    useAgentStore.setState({ recordActivity: recordActivitySpy });
+
+    render(<AgentList />);
+    act(() => { onDataCallback('agent-1'); });
+
+    // Activity is tracked in module-level map, NOT the Zustand store
+    expect(recordActivitySpy).not.toHaveBeenCalled();
+    expect(activityTimestamps['agent-1']).toBeDefined();
   });
 
   it('throttles rapid onData calls to at most one per 150ms', () => {
@@ -313,44 +321,44 @@ describe('AgentList onData throttle', () => {
 
     // First call goes through immediately
     act(() => { onDataCallback('agent-1'); });
-    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+    const firstTimestamp = activityTimestamps['agent-1'];
+    expect(firstTimestamp).toBeDefined();
 
-    // Rapid subsequent calls within the throttle window should not fire immediately
+    // Rapid subsequent calls within the throttle window should not update
     act(() => {
+      vi.advanceTimersByTime(50);
       onDataCallback('agent-1');
       onDataCallback('agent-1');
       onDataCallback('agent-1');
     });
-    // Only 1 call so far (the initial one) + 1 trailing timer scheduled
-    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+    // Timestamp should not have changed yet (throttled)
+    expect(activityTimestamps['agent-1']).toBe(firstTimestamp);
 
     // After the throttle interval, the trailing call fires
     act(() => { vi.advanceTimersByTime(150); });
-    expect(recordActivitySpy).toHaveBeenCalledTimes(2);
+    expect(activityTimestamps['agent-1']).toBeGreaterThan(firstTimestamp!);
   });
 
   it('throttles independently per agent', () => {
     render(<AgentList />);
 
-    // Both agents fire immediately on first call
+    // Both agents record immediately on first call
     act(() => { onDataCallback('agent-1'); });
     act(() => { onDataCallback('agent-2'); });
-    expect(recordActivitySpy).toHaveBeenCalledTimes(2);
-    expect(recordActivitySpy).toHaveBeenCalledWith('agent-1');
-    expect(recordActivitySpy).toHaveBeenCalledWith('agent-2');
+    expect(activityTimestamps['agent-1']).toBeDefined();
+    expect(activityTimestamps['agent-2']).toBeDefined();
+    const ts1 = activityTimestamps['agent-1'];
 
-    // Rapid calls for agent-1 only — agent-2 is not affected
+    // Rapid calls for agent-1 only — should be throttled
     act(() => {
-      onDataCallback('agent-1');
+      vi.advanceTimersByTime(50);
       onDataCallback('agent-1');
     });
-    // Still 2 from above — agent-1's rapid calls are throttled
-    expect(recordActivitySpy).toHaveBeenCalledTimes(2);
+    expect(activityTimestamps['agent-1']).toBe(ts1);
 
-    // agent-2 can still fire after its own throttle window passes
+    // After throttle window, agent-1's trailing call fires
     act(() => { vi.advanceTimersByTime(150); });
-    // Now agent-1's trailing call fires
-    expect(recordActivitySpy).toHaveBeenCalledTimes(3);
+    expect(activityTimestamps['agent-1']).toBeGreaterThan(ts1!);
   });
 
   it('cleans up pending timers on unmount', () => {
@@ -358,39 +366,45 @@ describe('AgentList onData throttle', () => {
 
     // Fire initial + schedule a trailing call
     act(() => { onDataCallback('agent-1'); });
-    act(() => { onDataCallback('agent-1'); });
-    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+    const firstTs = activityTimestamps['agent-1'];
+    act(() => {
+      vi.advanceTimersByTime(50);
+      onDataCallback('agent-1');
+    });
 
     // Unmount before the trailing timer fires
     unmount();
 
     // Advance timers — the trailing call should NOT fire
     act(() => { vi.advanceTimersByTime(300); });
-    expect(recordActivitySpy).toHaveBeenCalledTimes(1);
+    expect(activityTimestamps['agent-1']).toBe(firstTs);
   });
 });
 
 describe('AgentList activity tick optimization', () => {
+  let onDataCallback: (agentId: string) => void;
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     resetStores();
-    window.clubhouse.pty.onData = vi.fn().mockReturnValue(() => {});
+    Object.keys(activityTimestamps).forEach((k) => delete activityTimestamps[k]);
+
+    window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: (agentId: string) => void) => {
+      onDataCallback = cb;
+      return () => {};
+    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('does not set up a tick interval when no agents have recent activity', () => {
+  it('does not set up a tick interval when no PTY data has arrived', () => {
     const setIntervalSpy = vi.spyOn(global, 'setInterval');
-
-    // agentActivity is empty — no recent activity
-    useAgentStore.setState({ agentActivity: {} });
 
     render(<AgentList />);
 
-    // setInterval may be called by other effects, but not the 2-second tick
     const tickIntervals = setIntervalSpy.mock.calls.filter(
       ([, ms]) => ms === 2000
     );
@@ -399,15 +413,13 @@ describe('AgentList activity tick optimization', () => {
     setIntervalSpy.mockRestore();
   });
 
-  it('sets up a tick interval when agents have recent activity', () => {
+  it('sets up a tick interval when PTY data arrives', () => {
     const setIntervalSpy = vi.spyOn(global, 'setInterval');
 
-    // Simulate recent activity on agent-1
-    useAgentStore.setState({
-      agentActivity: { 'agent-1': Date.now() },
-    });
-
     render(<AgentList />);
+
+    // Trigger PTY data to activate the tick
+    act(() => { onDataCallback('agent-1'); });
 
     const tickIntervals = setIntervalSpy.mock.calls.filter(
       ([, ms]) => ms === 2000
@@ -417,15 +429,19 @@ describe('AgentList activity tick optimization', () => {
     setIntervalSpy.mockRestore();
   });
 
-  it('does not set up a tick interval when all activity is stale', () => {
-    const setIntervalSpy = vi.spyOn(global, 'setInterval');
-
-    // Activity from 10 seconds ago — well past the 5s threshold
-    useAgentStore.setState({
-      agentActivity: { 'agent-1': Date.now() - 10000 },
-    });
-
+  it('stops the tick interval after all activity goes stale', () => {
     render(<AgentList />);
+
+    // Trigger activity
+    act(() => { onDataCallback('agent-1'); });
+
+    // Advance past the 5s stale threshold — tick checks every 2s
+    // After 6s the tick callback sees no recent activity and sets isTickActive=false
+    act(() => { vi.advanceTimersByTime(6000); });
+
+    // Verify the tick stopped by checking no more intervals are created
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+    act(() => { vi.advanceTimersByTime(4000); });
 
     const tickIntervals = setIntervalSpy.mock.calls.filter(
       ([, ms]) => ms === 2000
@@ -437,49 +453,48 @@ describe('AgentList activity tick optimization', () => {
 });
 
 describe('AgentList isThinking callback stability', () => {
+  let onDataCallback: (agentId: string) => void;
+
   beforeEach(() => {
     vi.clearAllMocks();
     resetStores();
     isThinkingCaptures.length = 0;
-    window.clubhouse.pty.onData = vi.fn().mockReturnValue(() => {});
+    Object.keys(activityTimestamps).forEach((k) => delete activityTimestamps[k]);
+
+    window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: (agentId: string) => void) => {
+      onDataCallback = cb;
+      return () => {};
+    });
   });
 
-  it('reflects thinking state when agentActivity has recent timestamp', () => {
-    useAgentStore.setState({
-      agentActivity: { 'agent-1': Date.now() },
-    });
+  it('reflects thinking state when activity timestamp is recent', () => {
+    // Pre-populate module-level activity timestamp before render
+    activityTimestamps['agent-1'] = Date.now();
 
     render(<AgentList />);
-    // The agent should be rendered as "thinking" since activity is recent
     const lastCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
     expect(lastCapture).toBe(true);
   });
 
-  it('updates thinking state when agentActivity changes from empty to active', () => {
-    useAgentStore.setState({ agentActivity: {} });
+  it('updates thinking state when PTY data arrives', () => {
+    vi.useFakeTimers();
     render(<AgentList />);
 
     // Initially not thinking
     const initialCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
     expect(initialCapture).toBe(false);
 
-    // Simulate activity update via store change
-    act(() => {
-      useAgentStore.setState({
-        agentActivity: { 'agent-1': Date.now() },
-      });
-    });
+    // Simulate PTY data — updates activityTimestamps and triggers re-render
+    act(() => { onDataCallback('agent-1'); });
 
-    // After agentActivity updates, the ref-based callback should read the new value
     const updatedCapture = isThinkingCaptures[isThinkingCaptures.length - 1];
     expect(updatedCapture).toBe(true);
+    vi.useRealTimers();
   });
 
   it('shows not-thinking when activity timestamp is stale', () => {
     // Activity from 10 seconds ago — well past the 3s threshold
-    useAgentStore.setState({
-      agentActivity: { 'agent-1': Date.now() - 10000 },
-    });
+    activityTimestamps['agent-1'] = Date.now() - 10000;
 
     render(<AgentList />);
     const lastCapture = isThinkingCaptures[isThinkingCaptures.length - 1];

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -15,6 +15,11 @@ import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 const EMPTY_COMPLETED: CompletedQuickAgent[] = [];
 const EMPTY_AGENTS: Agent[] = [];
 
+// Module-level activity map — bypasses Zustand to avoid store updates on
+// every PTY chunk. Re-renders are driven by a boolean idle→active transition
+// and a 2-second tick interval, not by individual activity recordings.
+export const activityTimestamps: Record<string, number> = {};
+
 type ProjectAgentBuckets = {
   projectAgents: Agent[];
   durableAgents: Agent[];
@@ -57,8 +62,6 @@ export function AgentList() {
   const spawnQuickAgent = useAgentStore((s) => s.spawnQuickAgent);
   const spawnDurableAgent = useAgentStore((s) => s.spawnDurableAgent);
   const loadDurableAgents = useAgentStore((s) => s.loadDurableAgents);
-  const agentActivity = useAgentStore((s) => s.agentActivity);
-  const recordActivity = useAgentStore((s) => s.recordActivity);
   const deleteDialogAgent = useAgentStore((s) => s.deleteDialogAgent);
   const reorderAgents = useAgentStore((s) => s.reorderAgents);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
@@ -87,18 +90,8 @@ export function AgentList() {
   const missionInputRef = useRef<HTMLInputElement>(null);
   const dropdownBtnRef = useRef<HTMLDivElement>(null);
   const [, setTick] = useState(0);
-
-  // Only tick when at least one project agent has recent activity, so we
-  // avoid unconditional 2-second re-renders when the app is idle.
-  const hasRecentActivity = useMemo(() => {
-    const now = Date.now();
-    return Object.keys(agentActivity).some((id) => {
-      const last = agentActivity[id];
-      // Use 5 s window (> the 3 s isThinking threshold) to keep ticking
-      // until all agents have fully transitioned out of "thinking" state.
-      return last !== undefined && now - last < 5000;
-    });
-  }, [agentActivity]);
+  const isTickActiveRef = useRef(false);
+  const [isTickActive, setIsTickActive] = useState(false);
 
   // Drag-to-reorder state for durable agents
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -128,24 +121,33 @@ export function AgentList() {
     }
   }, [activeProject, loadDurableAgents]);
 
-  // Track activity from pty data (throttled per agent to avoid excessive store updates)
+  // Track activity from pty data — writes to module-level map (no store
+  // updates) and flips isTickActive on the first event to start the tick.
   const lastActivityRef = useRef<Record<string, number>>({});
   useEffect(() => {
     const THROTTLE_MS = 150;
     const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    const record = (agentId: string) => {
+      activityTimestamps[agentId] = Date.now();
+      if (!isTickActiveRef.current) {
+        isTickActiveRef.current = true;
+        setIsTickActive(true);
+      }
+    };
 
     const unsub = window.clubhouse.pty.onData((agentId: string) => {
       const now = Date.now();
       const last = lastActivityRef.current[agentId] ?? 0;
       if (now - last >= THROTTLE_MS) {
         lastActivityRef.current[agentId] = now;
-        recordActivity(agentId);
+        record(agentId);
       } else if (!pendingTimers.has(agentId)) {
         // Schedule a trailing call so we don't miss the last burst of activity
         const delay = THROTTLE_MS - (now - last);
         pendingTimers.set(agentId, setTimeout(() => {
           lastActivityRef.current[agentId] = Date.now();
-          recordActivity(agentId);
+          record(agentId);
           pendingTimers.delete(agentId);
         }, delay));
       }
@@ -156,14 +158,26 @@ export function AgentList() {
       for (const timer of pendingTimers.values()) clearTimeout(timer);
       pendingTimers.clear();
     };
-  }, [recordActivity]);
+  }, []);
 
-  // Tick for activity status refresh — only while agents have recent activity
+  // Tick for activity status refresh — only while agents have recent activity.
+  // The tick also auto-stops after 5 s of inactivity so we don't re-render
+  // when the app is idle.
   useEffect(() => {
-    if (!hasRecentActivity) return;
-    const interval = setInterval(() => setTick((t) => t + 1), 2000);
+    if (!isTickActive) return;
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const anyRecent = Object.values(activityTimestamps).some(
+        (last) => now - last < 5000
+      );
+      if (!anyRecent) {
+        isTickActiveRef.current = false;
+        setIsTickActive(false);
+      }
+      setTick((t) => t + 1);
+    }, 2000);
     return () => clearInterval(interval);
-  }, [hasRecentActivity]);
+  }, [isTickActive]);
 
   const { durableAgents, quickAgents, orphanQuickAgents } = useProjectAgentBuckets(
     agents,
@@ -244,11 +258,8 @@ export function AgentList() {
     }
   };
 
-  const agentActivityRef = useRef(agentActivity);
-  agentActivityRef.current = agentActivity;
-
   const isThinking = useCallback((id: string) => {
-    const last = agentActivityRef.current[id];
+    const last = activityTimestamps[id];
     if (!last) return false;
     return Date.now() - last < 3000;
   }, []);


### PR DESCRIPTION
## Summary
- Moves PTY activity timestamps from Zustand store to a module-level map, eliminating store updates (and cascading re-renders) on every throttled PTY chunk
- Re-renders are now driven by a single boolean state transition (idle→active) + 2-second tick interval
- Reduces render frequency from ~7/s per active agent to ~0.5/s

Fixes #624

## Changes
- **`AgentList.tsx`**: Added module-level `activityTimestamps` map that bypasses Zustand. Replaced `agentActivity`/`recordActivity` store subscriptions with direct map writes. PTY `onData` handler now updates the map and flips `isTickActive` on the first event. The tick auto-stops after 5s of inactivity. Simplified `isThinking` to read directly from the map.
- **`AgentList.test.tsx`**: Updated all three test suites (`onData throttle`, `activity tick optimization`, `isThinking callback stability`) to work with the module-level approach. Added explicit test verifying store `recordActivity` is NOT called from PTY data.

## Test Plan
- [x] PTY onData records activity immediately on first call
- [x] PTY onData does NOT trigger store `recordActivity` (key perf test)
- [x] Rapid onData calls are throttled to at most 1 per 150ms
- [x] Throttling is independent per agent
- [x] Pending timers are cleaned up on unmount
- [x] No tick interval when no PTY data has arrived
- [x] Tick interval starts when PTY data arrives
- [x] Tick interval auto-stops after 5s of inactivity
- [x] isThinking reflects recent activity timestamps
- [x] isThinking updates when PTY data arrives
- [x] isThinking returns false for stale timestamps
- [x] All 6467 tests pass, typecheck clean, lint clean

## Manual Validation
1. Start an agent that produces fast terminal output (e.g. running a build)
2. Observe the agent list sidebar — thinking indicator should still appear/disappear correctly
3. With React DevTools profiler, verify AgentList no longer re-renders on every PTY chunk
4. Multiple agents running simultaneously should not cause cross-agent re-renders