### PR TITLE
Fix blocking agent config fs and git operations

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -213,7 +213,7 @@ app.on('before-quit', () => {
   flushPendingBroadcasts();
 
   // Flush any pending agent config writes to disk
-  flushAllAgentConfigs();
+  void flushAllAgentConfigs();
 
   stopPtyStaleSweep();
   stopHeadlessStaleSweep();

--- a/src/main/services/agent-config.test.ts
+++ b/src/main/services/agent-config.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as path from 'path';
 
-// Mock child_process (include execFile used by orchestrator providers)
-// exec is used by async createDurable (via execGitAsync); execSync by other functions
+// Mock child_process (include execFile used by async git operations)
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
   exec: vi.fn((_cmd: string, _opts: any, cb: (...args: unknown[]) => void) => {
     cb(null, '', '');
     return {};
   }),
-  execFile: vi.fn(),
+  execFile: vi.fn((_file: string, _args: string[], _opts: any, cb: (...args: unknown[]) => void) => {
+    cb(null, '', '');
+    return {};
+  }),
 }));
 
 // Mock fs
@@ -51,7 +53,7 @@ vi.mock('./fs-utils', () => ({
 }));
 
 import * as fsp from 'fs/promises';
-import { exec, execSync } from 'child_process';
+import { exec, execFile, execSync } from 'child_process';
 import { pathExists } from './fs-utils';
 import {
   listDurable,
@@ -422,7 +424,10 @@ describe('deleteDurable', () => {
     vi.mocked(fsp.readFile).mockResolvedValue(JSON.stringify(agents));
     vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => { writtenAgents = String(data); });
     vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
-    vi.mocked(execSync).mockReturnValue('');
+    vi.mocked(execFile).mockImplementation((_file: any, _args: any, _opts: any, cb: any) => {
+      cb(null, '', '');
+      return {} as any;
+    });
 
     await deleteDurable(PROJECT_PATH, 'durable_del');
     await flushAgentConfig(PROJECT_PATH);
@@ -442,12 +447,15 @@ describe('deleteDurable', () => {
     vi.mocked(fsp.readFile).mockResolvedValue(JSON.stringify(agents));
     vi.mocked(fsp.writeFile).mockResolvedValue(undefined);
     vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
-    vi.mocked(execSync).mockReturnValue('');
+    vi.mocked(execFile).mockImplementation((_file: any, args: any, _opts: any, cb: any) => {
+      cb(null, '', '');
+      return { args } as any;
+    });
 
     await deleteDurable(PROJECT_PATH, 'durable_git');
-    const calls = vi.mocked(execSync).mock.calls.map((c) => String(c[0]));
-    expect(calls.some((c) => c.includes('git worktree remove'))).toBe(true);
-    expect(calls.some((c) => c.includes('git branch -D'))).toBe(true);
+    const calls = vi.mocked(execFile).mock.calls.map((c) => c[1].join(' '));
+    expect(calls.some((c) => c.includes('worktree remove'))).toBe(true);
+    expect(calls.some((c) => c.includes('branch -D'))).toBe(true);
   });
 
   it('continues if git commands fail', async () => {
@@ -461,9 +469,12 @@ describe('deleteDurable', () => {
     vi.mocked(fsp.readFile).mockResolvedValue(JSON.stringify(agents));
     vi.mocked(fsp.writeFile).mockResolvedValue(undefined);
     vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
-    vi.mocked(execSync).mockImplementation(() => { throw new Error('git fail'); });
+    vi.mocked(execFile).mockImplementation((_file: any, _args: any, _opts: any, cb: any) => {
+      cb(new Error('git fail'), '', '');
+      return {} as any;
+    });
 
-    await expect(deleteDurable(PROJECT_PATH, 'durable_fail')).resolves.not.toThrow();
+    await expect(deleteDurable(PROJECT_PATH, 'durable_fail')).resolves.toBeUndefined();
   });
 
   it('rm if worktree still exists after git', async () => {
@@ -479,7 +490,10 @@ describe('deleteDurable', () => {
     vi.mocked(fsp.writeFile).mockResolvedValue(undefined);
     vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
     vi.mocked(fsp.rm).mockResolvedValue(undefined);
-    vi.mocked(execSync).mockReturnValue('');
+    vi.mocked(execFile).mockImplementation((_file: any, _args: any, _opts: any, cb: any) => {
+      cb(null, '', '');
+      return {} as any;
+    });
 
     await deleteDurable(PROJECT_PATH, 'durable_rm');
     expect(vi.mocked(fsp.rm)).toHaveBeenCalledWith('/test/wt', { recursive: true, force: true });
@@ -494,8 +508,8 @@ describe('deleteDurable', () => {
     vi.mocked(fsp.readFile).mockResolvedValue(JSON.stringify(agents));
     vi.mocked(fsp.writeFile).mockResolvedValue(undefined);
 
-    await expect(deleteDurable(PROJECT_PATH, 'nonexistent')).resolves.not.toThrow();
-    expect(vi.mocked(execSync)).not.toHaveBeenCalled();
+    await expect(deleteDurable(PROJECT_PATH, 'nonexistent')).resolves.toBeUndefined();
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
   });
 
   it('handles non-worktree agent (just unregisters)', async () => {
@@ -514,7 +528,7 @@ describe('deleteDurable', () => {
     const result = JSON.parse(writtenAgents);
     expect(result.length).toBe(0);
     // No git commands for non-worktree agents
-    expect(vi.mocked(execSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
   });
 });
 
@@ -687,15 +701,15 @@ describe('getWorktreeStatus', () => {
     vi.mocked(fsp.readFile).mockResolvedValue(JSON.stringify(agents));
 
     // Mock exec to simulate git commands
-    vi.mocked(exec).mockImplementation((cmd: any, _opts: any, cb: any) => {
-      const cmdStr = String(cmd);
-      if (cmdStr.includes('git status --porcelain')) {
+    vi.mocked(execFile).mockImplementation((_file: any, args: any, _opts: any, cb: any) => {
+      const cmdStr = args.join(' ');
+      if (cmdStr.includes('status --porcelain')) {
         cb(null, ' M src/file.ts\n?? newfile.ts\n', '');
-      } else if (cmdStr.includes('git rev-parse --verify main')) {
+      } else if (cmdStr.includes('rev-parse --verify main')) {
         cb(null, 'abc123\n', '');
-      } else if (cmdStr.includes('git remote')) {
+      } else if (cmdStr.includes('remote')) {
         cb(null, 'origin\n', '');
-      } else if (cmdStr.includes('git log')) {
+      } else if (cmdStr.includes('log')) {
         cb(null, 'abc123|abc1|fix bug|Author|2024-01-01 00:00:00 +0000\n', '');
       } else {
         cb(null, '', '');
@@ -725,7 +739,7 @@ describe('getWorktreeStatus', () => {
     vi.mocked(fsp.readFile).mockResolvedValue(JSON.stringify(agents));
 
     // All git commands fail
-    vi.mocked(exec).mockImplementation((_cmd: any, _opts: any, cb: any) => {
+    vi.mocked(execFile).mockImplementation((_file: any, _args: any, _opts: any, cb: any) => {
       cb(new Error('git failed'), '', '');
       return {} as any;
     });
@@ -753,6 +767,10 @@ describe('deleteCommitAndPush', () => {
     vi.mocked(execSync).mockImplementation((cmd: any) => {
       if (String(cmd).includes('git remote')) return 'origin\n';
       return '';
+    });
+    vi.mocked(execFile).mockImplementation((_file: any, _args: any, _opts: any, cb: any) => {
+      cb(null, '', '');
+      return {} as any;
     });
 
     const result = await deleteCommitAndPush(PROJECT_PATH, 'durable_dcp');

--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -1,4 +1,4 @@
-import { exec, execSync } from 'child_process';
+import { exec, execFile, execSync } from 'child_process';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { app } from 'electron';
@@ -12,6 +12,15 @@ import { pathExists } from './fs-utils';
 function execGitAsync(cmd: string, cwd: string): Promise<string> {
   return new Promise((resolve, reject) => {
     exec(cmd, { cwd, encoding: 'utf-8' }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+}
+
+function execGitFileAsync(args: string[], cwd: string, maxBuffer?: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { cwd, encoding: 'utf-8', maxBuffer }, (error, stdout) => {
       if (error) reject(error);
       else resolve(stdout);
     });
@@ -72,6 +81,7 @@ interface CacheEntry {
   agents: DurableAgentConfig[];
   dirty: boolean;
   flushTimer: ReturnType<typeof setTimeout> | null;
+  pendingFlush: Promise<void> | null;
 }
 
 const configCache = new Map<string, CacheEntry>();
@@ -103,10 +113,31 @@ async function flushEntry(projectPath: string, entry: CacheEntry): Promise<void>
     clearTimeout(entry.flushTimer);
     entry.flushTimer = null;
   }
-  if (entry.dirty) {
-    await writeAgentsToDisk(projectPath, entry.agents);
-    entry.dirty = false;
+  if (entry.pendingFlush) {
+    await entry.pendingFlush;
   }
+  if (!entry.dirty) {
+    return;
+  }
+
+  const flushPromise = writeAgentsToDisk(projectPath, entry.agents)
+    .then(() => {
+      entry.dirty = false;
+    })
+    .catch((err) => {
+      appLog('core:agent-config', 'error', 'Failed to write agents.json', {
+        meta: { projectPath, error: err instanceof Error ? err.message : String(err) },
+      });
+      throw err;
+    })
+    .finally(() => {
+      if (entry.pendingFlush === flushPromise) {
+        entry.pendingFlush = null;
+      }
+    });
+
+  entry.pendingFlush = flushPromise;
+  await flushPromise;
 }
 
 function scheduleFlush(projectPath: string, entry: CacheEntry): void {
@@ -114,14 +145,14 @@ function scheduleFlush(projectPath: string, entry: CacheEntry): void {
     clearTimeout(entry.flushTimer);
   }
   entry.flushTimer = setTimeout(() => {
-    flushEntry(projectPath, entry);
+    void flushEntry(projectPath, entry);
   }, FLUSH_DELAY_MS);
 }
 
 async function readAgents(projectPath: string): Promise<DurableAgentConfig[]> {
   let entry = configCache.get(projectPath);
   if (!entry) {
-    entry = { agents: await readAgentsFromDisk(projectPath), dirty: false, flushTimer: null };
+    entry = { agents: await readAgentsFromDisk(projectPath), dirty: false, flushTimer: null, pendingFlush: null };
     configCache.set(projectPath, entry);
   }
   return entry.agents;
@@ -130,12 +161,12 @@ async function readAgents(projectPath: string): Promise<DurableAgentConfig[]> {
 async function writeAgents(projectPath: string, agents: DurableAgentConfig[]): Promise<void> {
   let entry = configCache.get(projectPath);
   if (!entry) {
-    entry = { agents, dirty: true, flushTimer: null };
+    entry = { agents, dirty: true, flushTimer: null, pendingFlush: null };
     configCache.set(projectPath, entry);
   } else {
     entry.agents = agents;
-    entry.dirty = true;
   }
+  entry.dirty = true;
   scheduleFlush(projectPath, entry);
 }
 
@@ -149,9 +180,7 @@ export async function flushAgentConfig(projectPath: string): Promise<void> {
 
 /** Flush all pending writes across all project paths */
 export async function flushAllAgentConfigs(): Promise<void> {
-  for (const [projectPath, entry] of configCache) {
-    await flushEntry(projectPath, entry);
-  }
+  await Promise.all([...configCache.entries()].map(([projectPath, entry]) => flushEntry(projectPath, entry)));
 }
 
 /** Clear the in-memory cache (cancels pending timers without flushing). Useful for tests. */
@@ -475,10 +504,7 @@ export async function deleteDurable(projectPath: string, agentId: string): Promi
   const hasGit = await pathExists(path.join(projectPath, '.git'));
   if (hasGit) {
     try {
-      execSync(`git worktree remove "${agent.worktreePath}" --force`, {
-        cwd: projectPath,
-        encoding: 'utf-8',
-      });
+      await execGitFileAsync(['worktree', 'remove', agent.worktreePath, '--force'], projectPath);
     } catch (err) {
       appLog('core:agent-config', 'warn', 'Git worktree removal failed, will clean up manually', {
         meta: {
@@ -491,10 +517,7 @@ export async function deleteDurable(projectPath: string, agentId: string): Promi
     // Optionally delete branch
     if (agent.branch) {
       try {
-        execSync(`git branch -D "${agent.branch}"`, {
-          cwd: projectPath,
-          encoding: 'utf-8',
-        });
+        await execGitFileAsync(['branch', '-D', agent.branch], projectPath);
       } catch (err) {
         appLog('core:agent-config', 'warn', 'Git branch deletion failed', {
           meta: { agentId, branch: agent.branch, error: err instanceof Error ? err.message : String(err) },
@@ -516,7 +539,7 @@ async function detectBaseBranch(projectPath: string): Promise<string> {
   // Try main, then master, then fallback to HEAD
   for (const candidate of ['main', 'master']) {
     try {
-      await execGitAsync(`git rev-parse --verify ${candidate}`, projectPath);
+      await execGitFileAsync(['rev-parse', '--verify', candidate], projectPath);
       return candidate;
     } catch {
       // not found
@@ -568,9 +591,9 @@ export async function getWorktreeStatus(projectPath: string, agentId: string): P
 
   // Run git status, base branch detection, and remote check in parallel
   const [statusResult, base, remoteResult] = await Promise.all([
-    execGitAsync('git status --porcelain', wt).catch(() => ''),
+    execGitFileAsync(['status', '--porcelain'], wt).catch(() => ''),
     detectBaseBranch(projectPath),
-    execGitAsync('git remote', wt).catch(() => ''),
+    execGitFileAsync(['remote'], wt).catch(() => ''),
   ]);
 
   // Parse uncommitted files (use trimEnd to preserve leading status chars like " M")
@@ -581,8 +604,8 @@ export async function getWorktreeStatus(projectPath: string, agentId: string): P
   // Get unpushed commits (depends on base branch result)
   let unpushedCommits: GitLogEntry[] = [];
   try {
-    const logOut = await execGitAsync(
-      `git log ${base}..HEAD --format="%H|%h|%s|%an|%ai"`,
+    const logOut = await execGitFileAsync(
+      ['log', `${base}..HEAD`, '--format=%H|%h|%s|%an|%ai'],
       wt,
     );
     unpushedCommits = logOut.trim().split('\n').filter(Boolean)


### PR DESCRIPTION
## Summary
- move `agents.json` flushes onto async `fs.promises.writeFile` with tracked pending flushes
- replace blocking worktree status and durable deletion git calls with async `execFile`
- update IPC and service tests to await the new async deletion/flush behavior
- Fixes #602 

## Changes
- added `execGitFileAsync()` and switched `getWorktreeStatus()` to `execFile`-based git status, remote, log, and base-branch probes
- made `deleteDurable()` async and replaced `execSync`/`rmSync` with `execFile`/`fs.promises.rm`
- converted throttled config flushes to async writes and made immediate flush helpers async
- updated the delete commit/push and force-delete flows to await durable cleanup completion
- adjusted IPC handler shutdown call sites and tests for the async persistence/removal behavior

## Test Plan
- [x] `npm test -- --run src/main/services/agent-config.test.ts src/main/ipc/agent-handlers.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm test` (blocked by pre-existing sandbox-dependent failures in `annex-server`, `hook-server`, and one search/file-handler test)

## Manual Validation
- verify deleting a durable agent no longer blocks the UI while git worktree cleanup runs
- verify the delete dialog still reports worktree status and deletion outcomes correctly
- verify agent config edits still persist after debounce and app shutdown flushes
