### PR TITLE
fix(test): add missing pid to node-pty mock

### DIFF
--- a/src/main/services/pty-manager.test.ts
+++ b/src/main/services/pty-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock node-pty
 const mockProcess = {
+  pid: 12345,
   onData: vi.fn(),
   onExit: vi.fn(),
   write: vi.fn(),
@@ -957,10 +958,14 @@ describe('pty-manager', () => {
 
       // Mock process.kill to throw (simulating dead process)
       const originalKill = process.kill;
-      process.kill = vi.fn(() => { throw new Error('ESRCH'); }) as any;
+      const killSpy = vi.fn(() => { throw new Error('ESRCH'); });
+      process.kill = killSpy as any;
 
       startStaleSweep();
       vi.advanceTimersByTime(30_000);
+
+      // Verify process.kill was called with the mock pid and signal 0
+      expect(killSpy).toHaveBeenCalledWith(mockProcess.pid, 0);
 
       // Session should have been cleaned up
       expect(isRunning('agent_stale_sweep')).toBe(false);
@@ -975,10 +980,14 @@ describe('pty-manager', () => {
 
       // Mock process.kill to succeed (process is alive)
       const originalKill = process.kill;
-      process.kill = vi.fn(() => true) as any;
+      const killSpy = vi.fn(() => true);
+      process.kill = killSpy as any;
 
       startStaleSweep();
       vi.advanceTimersByTime(30_000);
+
+      // Verify process.kill was called with the mock pid and signal 0
+      expect(killSpy).toHaveBeenCalledWith(mockProcess.pid, 0);
 
       // Session should still exist
       expect(isRunning('agent_alive_sweep')).toBe(true);


### PR DESCRIPTION
## Summary
- Adds missing `pid` property to the `mockProcess` object in `pty-manager.test.ts`
- Adds assertions to verify stale sweep passes the correct PID to `process.kill`

Closes #632

## Changes
- Added `pid: 12345` to the `mockProcess` mock at the top of the test file
- Enhanced the "sweep cleans up sessions whose processes have died" test to assert `process.kill` was called with `mockProcess.pid` and signal `0`
- Enhanced the "sweep does not remove sessions with live processes" test with the same assertion

## Test Plan
- [x] All 101 pty-manager tests pass
- [x] Stale sweep tests now verify PID is passed correctly (not `undefined`)
- [x] TypeScript type check passes
- [x] Lint passes

## Manual Validation
No manual validation needed — this is a test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)