### PR TITLE
fix(test): use synchronous mocks in git-handler tests

### DIFF
--- a/src/main/ipc/git-handlers.test.ts
+++ b/src/main/ipc/git-handlers.test.ts
@@ -5,20 +5,20 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('../services/git-service', () => ({
-  getGitInfo: vi.fn(async () => ({ branch: 'main' })),
-  checkout: vi.fn(async () => {}),
-  stage: vi.fn(async () => {}),
-  unstage: vi.fn(async () => {}),
-  stageAll: vi.fn(async () => {}),
-  unstageAll: vi.fn(async () => {}),
-  discardFile: vi.fn(async () => {}),
-  commit: vi.fn(async () => {}),
-  push: vi.fn(async () => {}),
-  pull: vi.fn(async () => {}),
-  getFileDiff: vi.fn(async () => 'diff --git a/file'),
-  createBranch: vi.fn(async () => {}),
-  stash: vi.fn(async () => {}),
-  stashPop: vi.fn(async () => {}),
+  getGitInfo: vi.fn(() => ({ branch: 'main' })),
+  checkout: vi.fn(),
+  stage: vi.fn(),
+  unstage: vi.fn(),
+  stageAll: vi.fn(),
+  unstageAll: vi.fn(),
+  discardFile: vi.fn(),
+  commit: vi.fn(),
+  push: vi.fn(),
+  pull: vi.fn(),
+  getFileDiff: vi.fn(() => 'diff --git a/file'),
+  createBranch: vi.fn(),
+  stash: vi.fn(),
+  stashPop: vi.fn(),
 }));
 
 import { ipcMain } from 'electron';


### PR DESCRIPTION
Closes #628

## Summary
- Git handler test mocks used `async () => ...` wrappers, masking the fact that the handlers' own async machinery (`deferInvocation`, `ipcMain.handle`) should handle Promise wrapping
- Changed all mock implementations to return synchronous values (`vi.fn()` / `vi.fn(() => value)`) instead of async ones

## Changes
- `src/main/ipc/git-handlers.test.ts`: Replaced 14 `vi.fn(async () => ...)` mock factories with synchronous equivalents
  - `getGitInfo`: `vi.fn(() => ({ branch: 'main' }))` (sync return)
  - `getFileDiff`: `vi.fn(() => 'diff --git a/file')` (sync return)
  - All void-returning mocks: plain `vi.fn()` (returns `undefined` synchronously)

## Test Plan
- [x] All 17 git-handler tests pass with synchronous mocks
- [x] Full test suite (6490 tests) passes
- [x] Typecheck passes
- [x] Lint passes

## Manual Validation
No manual validation needed — this is a test-only change with no production code impact.