### PR TITLE
fix: consolidate SpawnMode type to shared/types.ts

### DIFF
--- a/src/main/services/headless-settings.ts
+++ b/src/main/services/headless-settings.ts
@@ -1,6 +1,7 @@
 import { createSettingsStore } from './settings-store';
+import type { SpawnMode } from '../../shared/types';
 
-export type SpawnMode = 'headless' | 'interactive' | 'structured';
+export type { SpawnMode };
 
 export interface HeadlessSettings {
   /** @deprecated Use `defaultMode` instead. Kept for migration from older settings. */

--- a/src/renderer/stores/headlessStore.ts
+++ b/src/renderer/stores/headlessStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 import { optimisticUpdate } from './optimistic-update';
+import type { SpawnMode } from '../../shared/types';
 
-export type SpawnMode = 'headless' | 'interactive' | 'structured';
+export type { SpawnMode };
 
 interface HeadlessState {
   defaultMode: SpawnMode;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,6 +8,8 @@ export type OrchestratorId = 'claude-code' | (string & {});
 
 export type AgentExecutionMode = 'pty' | 'headless' | 'structured';
 
+export type SpawnMode = 'headless' | 'interactive' | 'structured';
+
 export interface ProviderCapabilities {
   headless: boolean;
   structuredOutput: boolean;


### PR DESCRIPTION
## Summary
- Moves `SpawnMode` type definition from two independent locations to `src/shared/types.ts`
- Both `headless-settings.ts` (main) and `headlessStore.ts` (renderer) now import and re-export from shared
- Prevents type drift between main and renderer processes

Closes #600

## Changes
- **`src/shared/types.ts`**: Added `SpawnMode = 'headless' | 'interactive' | 'structured'` type export
- **`src/main/services/headless-settings.ts`**: Replaced inline type definition with import from shared; re-exports for backward compatibility
- **`src/renderer/stores/headlessStore.ts`**: Replaced inline type definition with import from shared; re-exports for backward compatibility

## Test Plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 6513 tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Existing imports (e.g. `OrchestratorSettingsView.tsx`) continue to work via re-exports

## Manual Validation
No runtime behavior changes — this is a type-only refactor. Verify that the settings UI for spawn mode selection still works correctly.