### PR TITLE
Fix agent-system runtime registry cleanup

### DIFF
--- a/notes/issue-566-test-plan.md
+++ b/notes/issue-566-test-plan.md
@@ -1,13 +1,12 @@
 Issue #566 / M-15 Test Plan
 
 Acceptance criteria
-- Agent metadata is tracked through a single registry in `agent-system`.
-- Agent metadata is removed on both explicit kill and natural exit paths.
-- Headless and structured liveness checks defer to their managers instead of duplicate module-level sets.
+- Agent lifecycle metadata is owned by a single registry in `agent-system`.
+- Agent registry entries are removed on both natural exit and explicit kill paths.
+- Kill routing uses the registry's recorded runtime before falling back to manager-local liveness checks.
 
 Test cases
-- PTY spawn stores project path, resolved orchestrator, and nonce in the registry.
-- PTY exit callback restores config and removes tracked metadata.
-- Headless exit callback restores config and removes tracked metadata.
-- Structured exit callback removes tracked metadata.
-- Kill path still uses the tracked orchestrator when choosing the provider exit command.
+- PTY spawn stores project path, resolved orchestrator, runtime, and nonce in the registry.
+- PTY, headless, and structured exit callbacks all remove tracked metadata.
+- Killing a tracked headless or structured agent still routes to the correct manager even if that manager's own lookup is stale.
+- PTY kill continues to use the tracked orchestrator when selecting the provider exit command.

--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -568,6 +568,63 @@ describe('agent-system', () => {
       expect(mockPtyGracefulKill).toHaveBeenCalledWith('agent-1', '/quit\r');
     });
 
+    it('uses tracked headless runtime even if the manager lookup is stale', async () => {
+      mockGetSpawnMode.mockReturnValue('headless');
+      mockProvider.buildHeadlessCommand = vi.fn(() =>
+        Promise.resolve({
+          binary: '/usr/bin/claude',
+          args: ['--headless'],
+          env: {},
+          outputKind: 'stream-json' as const,
+        }),
+      );
+
+      await spawnAgent({
+        agentId: 'test-headless',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'quick',
+        mission: 'test',
+      });
+
+      mockIsHeadless.mockReturnValue(false);
+
+      await killAgent('test-headless', '/project');
+
+      expect(mockHeadlessKill).toHaveBeenCalledWith('test-headless');
+      expect(mockPtyGracefulKill).not.toHaveBeenCalled();
+
+      delete (mockProvider as any).buildHeadlessCommand;
+    });
+
+    it('uses tracked structured runtime even if the manager lookup is stale', async () => {
+      mockGetSpawnMode.mockReturnValue('structured');
+      const mockAdapter = { start: vi.fn(), sendMessage: vi.fn(), respondToPermission: vi.fn(), cancel: vi.fn(), dispose: vi.fn() };
+      mockProvider.createStructuredAdapter = vi.fn(() => mockAdapter);
+      mockProvider.getCapabilities.mockReturnValue({
+        headless: true, structuredOutput: true, hooks: true,
+        sessionResume: true, permissions: true, structuredMode: true,
+      });
+
+      await spawnAgent({
+        agentId: 'test-structured',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'quick',
+        mission: 'test',
+      });
+
+      mockIsStructuredSession.mockReturnValue(false);
+
+      await killAgent('test-structured', '/project');
+
+      expect(mockCancelSession).toHaveBeenCalledWith('test-structured');
+      expect(mockPtyGracefulKill).not.toHaveBeenCalled();
+      expect(mockHeadlessKill).not.toHaveBeenCalled();
+
+      delete (mockProvider as any).createStructuredAdapter;
+    });
+
     it('does not reject when gracefulKill throws (process already dead)', async () => {
       mockPtyGracefulKill.mockImplementationOnce(() => { throw new Error('process already dead'); });
       await expect(killAgent('agent-1', '/project')).resolves.toBeUndefined();

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -19,9 +19,12 @@ import type { LaunchWrapperConfig } from '../../shared/types';
 
 const DEFAULT_ORCHESTRATOR: OrchestratorId = 'claude-code';
 
+type AgentRuntime = 'pty' | 'headless' | 'structured';
+
 interface AgentRegistration {
   projectPath: string;
   orchestrator: OrchestratorId;
+  runtime: AgentRuntime;
   nonce?: string;
 }
 
@@ -40,6 +43,12 @@ class AgentRegistry {
     const registration = this.registrations.get(agentId);
     if (!registration) return;
     registration.nonce = nonce;
+  }
+
+  setRuntime(agentId: string, runtime: AgentRuntime): void {
+    const registration = this.registrations.get(agentId);
+    if (!registration) return;
+    registration.runtime = runtime;
   }
 
   untrack(agentId: string): void {
@@ -154,6 +163,7 @@ export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
   agentRegistry.register(params.agentId, {
     projectPath: params.projectPath,
     orchestrator: provider.id as OrchestratorId,
+    runtime: 'pty',
   });
 
   try {
@@ -190,6 +200,7 @@ export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
     // TODO: Apply launch wrapper transform to structured path once adapter architecture supports external binary override
     const spawnMode = headlessSettings.getSpawnMode(params.projectPath);
     if (spawnMode === 'structured' && params.kind === 'quick' && isStructuredCapable(provider)) {
+      agentRegistry.setRuntime(params.agentId, 'structured');
       const adapter = provider.createStructuredAdapter();
       await structuredManager.startStructuredSession(params.agentId, adapter, {
         mission: params.mission || '',
@@ -220,6 +231,7 @@ export async function spawnAgent(params: SpawnAgentParams): Promise<void> {
       });
 
       if (headlessResult) {
+        agentRegistry.setRuntime(params.agentId, 'headless');
         // Apply launch wrapper transform if configured
         let { binary: headlessBin, args: headlessArgs } = headlessResult;
         if (wrapperConfig && wrapperConfig.orchestratorMap[provider.id]) {
@@ -359,18 +371,19 @@ async function spawnPtyAgent(
 export async function killAgent(agentId: string, projectPath: string, orchestrator?: OrchestratorId): Promise<void> {
   appLog('core:agent', 'info', 'Killing agent', { meta: { agentId } });
   try {
-    if (structuredManager.isStructuredSession(agentId)) {
+    const tracked = agentRegistry.get(agentId);
+
+    if (tracked?.runtime === 'structured' || (!tracked && structuredManager.isStructuredSession(agentId))) {
       untrackAgent(agentId);
       await structuredManager.cancelSession(agentId);
       return;
     }
-    if (headlessManager.isHeadless(agentId)) {
+    if (tracked?.runtime === 'headless' || (!tracked && headlessManager.isHeadless(agentId))) {
       untrackAgent(agentId);
       headlessManager.kill(agentId);
       return;
     }
-    const tracked = agentRegistry.get(agentId)?.orchestrator;
-    const provider = await resolveOrchestrator(projectPath, tracked || orchestrator);
+    const provider = await resolveOrchestrator(projectPath, tracked?.orchestrator || orchestrator);
     const exitCmd = provider.getExitCommand();
     ptyManager.gracefulKill(agentId, exitCmd);
   } catch (err) {


### PR DESCRIPTION
## Summary
- move agent kill routing onto the central agent registry by recording the spawned runtime
- keep natural-exit cleanup in the existing exit callbacks while removing dependence on stale manager-local liveness checks
- add regression coverage for stale headless/structured manager lookups and document the test plan

## Test Plan
- [x] npm test -- src/main/services/agent-system.test.ts
- [x] npm test -- src/main/services/headless-integration.test.ts
- [x] npm run lint
- [ ] npm run build *(fails in this repo: missing script "build")*
- [ ] npm test *(repo baseline failures outside this change in hook-server, file-handlers, and search-service tests)*
