### PR TITLE
Fix agent-focus sound coupling

### DIFF
--- a/src/renderer/app-event-bridge.test.ts
+++ b/src/renderer/app-event-bridge.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+type StoreSubscriber = (...args: unknown[]) => void;
+
 // ─── Mock window.clubhouse ──────────────────────────────────────────────────
 
 const mockRemovers = {
@@ -55,9 +57,30 @@ vi.stubGlobal('window', {
 
 // ─── Mock stores ────────────────────────────────────────────────────────────
 
-const agentSubscribers: (() => void)[] = [];
-const projectSubscribers: (() => void)[] = [];
-const uiSubscribers: (() => void)[] = [];
+const agentSubscribers: StoreSubscriber[] = [];
+const projectSubscribers: StoreSubscriber[] = [];
+const uiSubscribers: StoreSubscriber[] = [];
+const mockPlaySound = vi.fn();
+
+function createAgentState(overrides: Record<string, unknown> = {}) {
+  return {
+    agents: {},
+    activeAgentId: null,
+    agentDetailedStatus: {},
+    agentIcons: {},
+    ...overrides,
+  };
+}
+
+function createAgent(id: string, projectId: string) {
+  return {
+    id,
+    name: `Agent ${id}`,
+    projectId,
+    status: 'running',
+    kind: 'durable',
+  };
+}
 
 vi.mock('./stores/agentStore', () => ({
   useAgentStore: Object.assign(
@@ -75,9 +98,10 @@ vi.mock('./stores/agentStore', () => ({
         setActiveAgent: vi.fn(),
         restoreProjectAgent: vi.fn(),
         openConfigChangesDialog: vi.fn(),
+        setSessionNamePrompt: vi.fn(),
       })),
       setState: vi.fn(),
-      subscribe: vi.fn((cb: () => void) => {
+      subscribe: vi.fn((cb: StoreSubscriber) => {
         agentSubscribers.push(cb);
         return vi.fn();
       }),
@@ -95,7 +119,7 @@ vi.mock('./stores/projectStore', () => ({
         projects: [],
         setActiveProject: vi.fn(),
       })),
-      subscribe: vi.fn((cb: () => void) => {
+      subscribe: vi.fn((cb: StoreSubscriber) => {
         projectSubscribers.push(cb);
         return vi.fn();
       }),
@@ -114,7 +138,7 @@ vi.mock('./stores/uiStore', () => ({
         setSettingsSubPage: vi.fn(),
         setExplorerTab: vi.fn(),
       })),
-      subscribe: vi.fn((cb: () => void) => {
+      subscribe: vi.fn((cb: StoreSubscriber) => {
         uiSubscribers.push(cb);
         return vi.fn();
       }),
@@ -196,6 +220,17 @@ vi.mock('./plugins/builtin/hub/hub-sync', () => ({
   applyHubMutation: vi.fn(),
 }));
 
+vi.mock('./stores/soundStore', () => ({
+  useSoundStore: Object.assign(
+    vi.fn(),
+    {
+      getState: vi.fn(() => ({
+        playSound: mockPlaySound,
+      })),
+    },
+  ),
+}));
+
 import { initAppEventBridge } from './app-event-bridge';
 import { useAgentStore } from './stores/agentStore';
 import { useProjectStore } from './stores/projectStore';
@@ -207,6 +242,8 @@ describe('initAppEventBridge', () => {
   let cleanup: () => void;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockPlaySound.mockResolvedValue(undefined);
     agentSubscribers.length = 0;
     projectSubscribers.length = 0;
     uiSubscribers.length = 0;
@@ -267,5 +304,41 @@ describe('initAppEventBridge', () => {
     });
 
     expect(useAgentStore.getState).toHaveBeenCalled();
+  });
+
+  it('plays agent-focus when the active agent changes', () => {
+    const agents = {
+      a1: createAgent('a1', 'proj-1'),
+      a2: createAgent('a2', 'proj-2'),
+    };
+    const prevState = createAgentState({ activeAgentId: 'a1', agents });
+    const nextState = createAgentState({ activeAgentId: 'a2', agents });
+
+    for (const subscriber of agentSubscribers) {
+      subscriber(nextState, prevState);
+    }
+
+    expect(mockPlaySound).toHaveBeenCalledWith('agent-focus', 'proj-2');
+  });
+
+  it('does not play agent-focus when the active agent is unchanged or cleared', () => {
+    const agents = {
+      a1: createAgent('a1', 'proj-1'),
+    };
+    const activeState = createAgentState({ activeAgentId: 'a1', agents });
+    const clearedState = createAgentState({ agents });
+
+    for (const subscriber of agentSubscribers) {
+      subscriber(activeState, createAgentState());
+    }
+
+    mockPlaySound.mockClear();
+
+    for (const subscriber of agentSubscribers) {
+      subscriber(activeState, activeState);
+      subscriber(clearedState, activeState);
+    }
+
+    expect(mockPlaySound).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/app-event-bridge.ts
+++ b/src/renderer/app-event-bridge.ts
@@ -397,6 +397,21 @@ function initAgentStatusEmitter(): () => void {
   return unsub;
 }
 
+// ─── Active Agent Sound Effects ───────────────────────────────────────────────
+
+function initActiveAgentSound(): () => void {
+  let prevActiveAgentId = useAgentStore.getState().activeAgentId;
+  const unsub = useAgentStore.subscribe((state) => {
+    const nextActiveAgentId = state.activeAgentId;
+    if (nextActiveAgentId && nextActiveAgentId !== prevActiveAgentId) {
+      const agent = state.agents[nextActiveAgentId];
+      useSoundStore.getState().playSound('agent-focus', agent?.projectId);
+    }
+    prevActiveAgentId = nextActiveAgentId;
+  });
+  return unsub;
+}
+
 // ─── Notification Clearing ──────────────────────────────────────────────────
 
 function initNotificationClearing(): () => void {
@@ -495,6 +510,7 @@ export function initAppEventBridge(): () => void {
   cleanups.push(initAnnexSpawnListener());
   cleanups.push(initAgentStateBroadcast());
   cleanups.push(initAgentStatusEmitter());
+  cleanups.push(initActiveAgentSound());
   cleanups.push(initNotificationClearing());
   cleanups.push(initStaleStatusCleanup());
   cleanups.push(initKeyboardShortcuts());

--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+const mockPlaySound = vi.fn();
+
 // Mock window.clubhouse
 vi.stubGlobal('window', {
   clubhouse: {
@@ -31,6 +33,17 @@ vi.stubGlobal('window', {
     },
   },
 });
+
+vi.mock('./soundStore', () => ({
+  useSoundStore: Object.assign(
+    vi.fn(),
+    {
+      getState: vi.fn(() => ({
+        playSound: mockPlaySound,
+      })),
+    },
+  ),
+}));
 
 import { useAgentStore } from './agentStore';
 import { Agent, AgentHookEvent } from '../../shared/types';
@@ -700,6 +713,15 @@ describe('agentStore', () => {
   });
 
   describe('per-project active agent persistence', () => {
+    it('setActiveAgent does not trigger sound playback directly', async () => {
+      seedAgent({ id: 'a1', projectId: 'proj_1' });
+
+      getState().setActiveAgent('a1', 'proj_1');
+      await vi.dynamicImportSettled();
+
+      expect(mockPlaySound).not.toHaveBeenCalled();
+    });
+
     it('setActiveAgent with projectId saves to projectActiveAgent', () => {
       seedAgent({ id: 'a1', projectId: 'proj_1' });
       getState().setActiveAgent('a1', 'proj_1');

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -203,18 +203,9 @@ export const useAgentStore = create<AgentState>((set, get) => {
   sessionNamePromptFor: null,
 
   setActiveAgent: (id, projectId?) => {
-    const prev = get().activeAgentId;
     set({ activeAgentId: id, agentSettingsOpenFor: null });
     if (projectId) {
       set((s) => ({ projectActiveAgent: { ...s.projectActiveAgent, [projectId]: id } }));
-    }
-    // Play focus sound when switching to a different agent
-    if (id && id !== prev) {
-      const agent = get().agents[id];
-      // Lazy import to avoid circular dependency
-      import('./soundStore').then(({ useSoundStore }) => {
-        useSoundStore.getState().playSound('agent-focus', agent?.projectId);
-      });
     }
   },
 


### PR DESCRIPTION
## Summary
- remove the lazy `soundStore` import from `agentStore.setActiveAgent()`
- move `agent-focus` playback into `initAppEventBridge()` so cross-store side effects live in the bridge layer
- add regression tests for both the decoupled store behavior and the bridge-triggered sound playback

## Changes
- removed the runtime `import('./soundStore')` workaround from `src/renderer/stores/agentStore.ts`
- added an `initActiveAgentSound()` subscription in `src/renderer/app-event-bridge.ts` to play `agent-focus` when the active agent changes
- added a store-level regression test to ensure `setActiveAgent()` no longer reaches into `soundStore`
- expanded `app-event-bridge` coverage to assert focus sounds fire for real agent changes and not for unchanged or cleared selections

## Test Plan
- [x] `npx vitest run --project renderer src/renderer/stores/agentStore.test.ts src/renderer/app-event-bridge.test.ts`
- [x] `npx eslint src/renderer/stores/agentStore.ts src/renderer/app-event-bridge.ts src/renderer/stores/agentStore.test.ts src/renderer/app-event-bridge.test.ts`
- [x] `npm run make`
- [x] `npm test`
- [x] `npm run lint`

## Manual Validation
- no extra manual validation was required beyond the automated checks

## Issue
- fixes #569
- finding: `M-16`
