### PR TITLE
fix(ipc): add consistent input validation to all IPC handlers

### DIFF
--- a/src/main/ipc/agent-handlers.test.ts
+++ b/src/main/ipc/agent-handlers.test.ts
@@ -267,7 +267,7 @@ describe('agent-handlers', () => {
   it('SPAWN_AGENT logs and rethrows on error', async () => {
     vi.mocked(agentSystem.spawnAgent).mockRejectedValueOnce(new Error('spawn failed'));
     const handler = handlers.get(IPC.AGENT.SPAWN_AGENT)!;
-    await expect(handler({}, { agentId: 'a1', kind: 'durable', orchestrator: 'claude-code' })).rejects.toThrow('spawn failed');
+    await expect(handler({}, { agentId: 'a1', projectPath: '/p', cwd: '/p', kind: 'durable', orchestrator: 'claude-code' })).rejects.toThrow('spawn failed');
     expect(appLog).toHaveBeenCalledWith('core:ipc', 'error', 'Agent spawn failed', expect.objectContaining({
       meta: expect.objectContaining({ agentId: 'a1', error: 'spawn failed' }),
     }));
@@ -347,5 +347,37 @@ describe('agent-handlers', () => {
     const result = await handler({}, 'a1');
     expect(agentSystem.isHeadlessAgent).toHaveBeenCalledWith('a1');
     expect(result).toBe(false);
+  });
+
+  // --- Input validation ---
+
+  it('rejects non-string projectPath for LIST_DURABLE', () => {
+    const handler = handlers.get(IPC.AGENT.LIST_DURABLE)!;
+    expect(() => handler({}, 123)).toThrow('must be a string');
+  });
+
+  it('rejects non-string agentId for DELETE_DURABLE', () => {
+    const handler = handlers.get(IPC.AGENT.DELETE_DURABLE)!;
+    expect(() => handler({}, '/project', null)).toThrow('must be a string');
+  });
+
+  it('rejects non-object updates for UPDATE_DURABLE', () => {
+    const handler = handlers.get(IPC.AGENT.UPDATE_DURABLE)!;
+    expect(() => handler({}, '/project', 'a1', 'not-an-object')).toThrow('must be an object');
+  });
+
+  it('rejects SPAWN_AGENT with missing required fields', () => {
+    const handler = handlers.get(IPC.AGENT.SPAWN_AGENT)!;
+    expect(() => handler({}, { agentId: 'a1' })).toThrow('projectPath must be a non-empty string');
+  });
+
+  it('rejects SPAWN_AGENT with non-object param', () => {
+    const handler = handlers.get(IPC.AGENT.SPAWN_AGENT)!;
+    expect(() => handler({}, 'not-an-object')).toThrow('must be an object');
+  });
+
+  it('rejects non-integer offset for READ_TRANSCRIPT_PAGE', () => {
+    const handler = handlers.get(IPC.AGENT.READ_TRANSCRIPT_PAGE)!;
+    expect(() => handler({}, 'a1', 1.5, 10)).toThrow('must be an integer');
   });
 });

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -12,34 +12,50 @@ import * as structuredManager from '../services/structured-manager';
 import { buildSummaryInstruction, readQuickSummary } from '../orchestrators/shared';
 import { normalizeSessionEvents, buildSessionSummary, paginateEvents } from '../services/session-reader';
 import { appLog } from '../services/log-service';
+import { withValidatedArgs, stringArg, objectArg, arrayArg, numberArg, booleanArg } from './validation';
 
 type DurableConfigUpdates = Parameters<typeof agentConfig.updateDurableConfig>[2];
 
 export function registerAgentHandlers(): void {
-  ipcMain.handle(IPC.AGENT.LIST_DURABLE, async (_event, projectPath: string) => {
-    return agentConfig.listDurable(projectPath);
-  });
+  ipcMain.handle(IPC.AGENT.LIST_DURABLE, withValidatedArgs(
+    [stringArg()],
+    async (_event, projectPath) => {
+      return agentConfig.listDurable(projectPath);
+    },
+  ));
 
   ipcMain.handle(
     IPC.AGENT.CREATE_DURABLE,
-    async (_event, projectPath: string, name: string, color: string, model?: string, useWorktree?: boolean, orchestrator?: string, freeAgentMode?: boolean, mcpIds?: string[]) => {
-      return agentConfig.createDurable(projectPath, name, color, model, useWorktree, orchestrator, freeAgentMode, mcpIds);
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), stringArg(), stringArg({ optional: true }), booleanArg({ optional: true }), stringArg({ optional: true }), booleanArg({ optional: true }), arrayArg(stringArg(), { optional: true })],
+      async (_event, projectPath, name, color, model, useWorktree, orchestrator, freeAgentMode, mcpIds) => {
+        return agentConfig.createDurable(projectPath, name, color, model, useWorktree, orchestrator, freeAgentMode, mcpIds);
+      },
+    ),
   );
 
-  ipcMain.handle(IPC.AGENT.DELETE_DURABLE, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.deleteDurable(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_DURABLE, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.deleteDurable(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.RENAME_DURABLE, async (_event, projectPath: string, agentId: string, newName: string) => {
-    return agentConfig.renameDurable(projectPath, agentId, newName);
-  });
+  ipcMain.handle(IPC.AGENT.RENAME_DURABLE, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg()],
+    async (_event, projectPath, agentId, newName) => {
+      return agentConfig.renameDurable(projectPath, agentId, newName);
+    },
+  ));
 
   ipcMain.handle(
     IPC.AGENT.UPDATE_DURABLE,
-    async (_event, projectPath: string, agentId: string, updates: { name?: string; color?: string; icon?: string | null }) => {
-      return agentConfig.updateDurable(projectPath, agentId, updates);
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), objectArg<{ name?: string; color?: string; icon?: string | null }>()],
+      async (_event, projectPath, agentId, updates) => {
+        return agentConfig.updateDurable(projectPath, agentId, updates);
+      },
+    ),
   );
 
   ipcMain.handle(IPC.AGENT.PICK_ICON, async () => {
@@ -63,226 +79,326 @@ export function registerAgentHandlers(): void {
     return `data:${mime};base64,${data.toString('base64')}`;
   });
 
-  ipcMain.handle(IPC.AGENT.SAVE_ICON, async (_event, projectPath: string, agentId: string, dataUrl: string) => {
-    return agentConfig.saveAgentIcon(projectPath, agentId, dataUrl);
-  });
+  ipcMain.handle(IPC.AGENT.SAVE_ICON, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg()],
+    async (_event, projectPath, agentId, dataUrl) => {
+      return agentConfig.saveAgentIcon(projectPath, agentId, dataUrl);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_ICON, async (_event, filename: string) => {
-    return agentConfig.readAgentIconData(filename);
-  });
+  ipcMain.handle(IPC.AGENT.READ_ICON, withValidatedArgs(
+    [stringArg()],
+    async (_event, filename) => {
+      return agentConfig.readAgentIconData(filename);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.REMOVE_ICON, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.removeAgentIcon(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.REMOVE_ICON, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.removeAgentIcon(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.GET_DURABLE_CONFIG, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.getDurableConfig(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.GET_DURABLE_CONFIG, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.getDurableConfig(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.UPDATE_DURABLE_CONFIG, async (_event, projectPath: string, agentId: string, updates: DurableConfigUpdates) => {
-    return agentConfig.updateDurableConfig(projectPath, agentId, updates);
-  });
+  ipcMain.handle(IPC.AGENT.UPDATE_DURABLE_CONFIG, withValidatedArgs(
+    [stringArg(), stringArg(), objectArg<DurableConfigUpdates>()],
+    async (_event, projectPath, agentId, updates) => {
+      return agentConfig.updateDurableConfig(projectPath, agentId, updates);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.REORDER_DURABLE, async (_event, projectPath: string, orderedIds: string[]) => {
-    return agentConfig.reorderDurable(projectPath, orderedIds);
-  });
+  ipcMain.handle(IPC.AGENT.REORDER_DURABLE, withValidatedArgs(
+    [stringArg(), arrayArg(stringArg())],
+    async (_event, projectPath, orderedIds) => {
+      return agentConfig.reorderDurable(projectPath, orderedIds);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.GET_WORKTREE_STATUS, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.getWorktreeStatus(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.GET_WORKTREE_STATUS, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.getWorktreeStatus(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_COMMIT_PUSH, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.deleteCommitAndPush(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_COMMIT_PUSH, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.deleteCommitAndPush(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_CLEANUP_BRANCH, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.deleteWithCleanupBranch(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_CLEANUP_BRANCH, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.deleteWithCleanupBranch(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_SAVE_PATCH, async (_event, projectPath: string, agentId: string) => {
-    const win = BrowserWindow.getFocusedWindow();
-    if (!win) return { ok: false, message: 'cancelled' };
-    const result = await dialog.showSaveDialog(win, {
-      title: 'Save patch file',
-      defaultPath: `agent-${agentId}.patch`,
-      filters: [{ name: 'Patch files', extensions: ['patch'] }],
-    });
+  ipcMain.handle(IPC.AGENT.DELETE_SAVE_PATCH, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      const win = BrowserWindow.getFocusedWindow();
+      if (!win) return { ok: false, message: 'cancelled' };
+      const result = await dialog.showSaveDialog(win, {
+        title: 'Save patch file',
+        defaultPath: `agent-${agentId}.patch`,
+        filters: [{ name: 'Patch files', extensions: ['patch'] }],
+      });
 
-    if (result.canceled || !result.filePath) {
-      return { ok: false, message: 'cancelled' };
-    }
+      if (result.canceled || !result.filePath) {
+        return { ok: false, message: 'cancelled' };
+      }
 
-    return agentConfig.deleteSaveAsPatch(projectPath, agentId, result.filePath);
-  });
+      return agentConfig.deleteSaveAsPatch(projectPath, agentId, result.filePath);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_FORCE, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.deleteForce(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_FORCE, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.deleteForce(projectPath, agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_UNREGISTER, async (_event, projectPath: string, agentId: string) => {
-    return agentConfig.deleteUnregister(projectPath, agentId);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_UNREGISTER, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      return agentConfig.deleteUnregister(projectPath, agentId);
+    },
+  ));
 
   // --- Orchestrator-based handlers ---
 
-  ipcMain.handle(IPC.AGENT.SPAWN_AGENT, async (_event, params: SpawnAgentParams) => {
-    try {
-      await agentSystem.spawnAgent(params);
-    } catch (err) {
-      appLog('core:ipc', 'error', 'Agent spawn failed', {
-        meta: {
-          agentId: params.agentId,
-          kind: params.kind,
-          orchestrator: params.orchestrator,
-          error: err instanceof Error ? err.message : String(err),
-          stack: err instanceof Error ? err.stack : undefined,
-        },
-      });
-      throw err;
-    }
-  });
+  ipcMain.handle(IPC.AGENT.SPAWN_AGENT, withValidatedArgs(
+    [objectArg<SpawnAgentParams>({
+      validate: (v, name) => {
+        if (typeof v.agentId !== 'string' || !v.agentId) throw new Error(`${name}.agentId must be a non-empty string`);
+        if (typeof v.projectPath !== 'string' || !v.projectPath) throw new Error(`${name}.projectPath must be a non-empty string`);
+        if (typeof v.cwd !== 'string' || !v.cwd) throw new Error(`${name}.cwd must be a non-empty string`);
+        if (typeof v.kind !== 'string' || !v.kind) throw new Error(`${name}.kind must be a non-empty string`);
+      },
+    })],
+    async (_event, params) => {
+      try {
+        await agentSystem.spawnAgent(params);
+      } catch (err) {
+        appLog('core:ipc', 'error', 'Agent spawn failed', {
+          meta: {
+            agentId: params.agentId,
+            kind: params.kind,
+            orchestrator: params.orchestrator,
+            error: err instanceof Error ? err.message : String(err),
+            stack: err instanceof Error ? err.stack : undefined,
+          },
+        });
+        throw err;
+      }
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.KILL_AGENT, async (_event, agentId: string, projectPath: string) => {
-    await agentSystem.killAgent(agentId, projectPath);
-  });
+  ipcMain.handle(IPC.AGENT.KILL_AGENT, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, agentId, projectPath) => {
+      await agentSystem.killAgent(agentId, projectPath);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_QUICK_SUMMARY, async (_event, agentId: string) => {
-    return readQuickSummary(agentId);
-  });
+  ipcMain.handle(IPC.AGENT.READ_QUICK_SUMMARY, withValidatedArgs(
+    [stringArg()],
+    async (_event, agentId) => {
+      return readQuickSummary(agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.GET_MODEL_OPTIONS, async (_event, projectPath: string, orchestrator?: string) => {
-    const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
-    return provider.getModelOptions();
-  });
+  ipcMain.handle(IPC.AGENT.GET_MODEL_OPTIONS, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, projectPath, orchestrator) => {
+      const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
+      return provider.getModelOptions();
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.CHECK_ORCHESTRATOR, async (_event, projectPath?: string, orchestrator?: string) => {
-    return agentSystem.checkAvailability(projectPath, orchestrator);
-  });
+  ipcMain.handle(IPC.AGENT.CHECK_ORCHESTRATOR, withValidatedArgs(
+    [stringArg({ optional: true }), stringArg({ optional: true })],
+    async (_event, projectPath, orchestrator) => {
+      return agentSystem.checkAvailability(projectPath, orchestrator);
+    },
+  ));
 
   ipcMain.handle(IPC.AGENT.GET_ORCHESTRATORS, async () => {
     return agentSystem.getAvailableOrchestrators();
   });
 
-  ipcMain.handle(IPC.AGENT.GET_TOOL_VERB, async (_event, toolName: string, projectPath: string, orchestrator?: string) => {
-    const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
-    return provider.toolVerb(toolName) || `Using ${toolName}`;
-  });
+  ipcMain.handle(IPC.AGENT.GET_TOOL_VERB, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    async (_event, toolName, projectPath, orchestrator) => {
+      const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
+      return provider.toolVerb(toolName) || `Using ${toolName}`;
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.GET_SUMMARY_INSTRUCTION, async (_event, agentId: string) => {
-    return buildSummaryInstruction(agentId);
-  });
+  ipcMain.handle(IPC.AGENT.GET_SUMMARY_INSTRUCTION, withValidatedArgs(
+    [stringArg()],
+    async (_event, agentId) => {
+      return buildSummaryInstruction(agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_TRANSCRIPT, async (_event, agentId: string) => {
-    return headlessManager.readTranscript(agentId);
-  });
+  ipcMain.handle(IPC.AGENT.READ_TRANSCRIPT, withValidatedArgs(
+    [stringArg()],
+    async (_event, agentId) => {
+      return headlessManager.readTranscript(agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.GET_TRANSCRIPT_INFO, async (_event, agentId: string) => {
-    return headlessManager.getTranscriptInfo(agentId);
-  });
+  ipcMain.handle(IPC.AGENT.GET_TRANSCRIPT_INFO, withValidatedArgs(
+    [stringArg()],
+    async (_event, agentId) => {
+      return headlessManager.getTranscriptInfo(agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_TRANSCRIPT_PAGE, async (_event, agentId: string, offset: number, limit: number) => {
-    return headlessManager.readTranscriptPage(agentId, offset, limit);
-  });
+  ipcMain.handle(IPC.AGENT.READ_TRANSCRIPT_PAGE, withValidatedArgs(
+    [stringArg(), numberArg({ integer: true, min: 0 }), numberArg({ integer: true, min: 1 })],
+    async (_event, agentId, offset, limit) => {
+      return headlessManager.readTranscriptPage(agentId, offset, limit);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.IS_HEADLESS_AGENT, async (_event, agentId: string) => {
-    return agentSystem.isHeadlessAgent(agentId);
-  });
+  ipcMain.handle(IPC.AGENT.IS_HEADLESS_AGENT, withValidatedArgs(
+    [stringArg()],
+    async (_event, agentId) => {
+      return agentSystem.isHeadlessAgent(agentId);
+    },
+  ));
 
   // --- Session management handlers ---
 
   ipcMain.handle(
     IPC.AGENT.LIST_SESSIONS,
-    async (_event, projectPath: string, agentId: string, orchestrator?: string) => {
-      return agentSystem.listSessions(projectPath, agentId, orchestrator);
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), stringArg({ optional: true })],
+      async (_event, projectPath, agentId, orchestrator) => {
+        return agentSystem.listSessions(projectPath, agentId, orchestrator);
+      },
+    ),
   );
 
   ipcMain.handle(
     IPC.AGENT.UPDATE_SESSION_NAME,
-    async (_event, projectPath: string, agentId: string, sessionId: string, friendlyName: string | null) => {
-      return agentConfig.updateSessionName(projectPath, agentId, sessionId, friendlyName);
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), stringArg(), stringArg({ optional: true })],
+      async (_event, projectPath, agentId, sessionId, friendlyName) => {
+        return agentConfig.updateSessionName(projectPath, agentId, sessionId, friendlyName ?? null);
+      },
+    ),
   );
 
   // --- Session transcript handlers ---
 
   ipcMain.handle(
     IPC.AGENT.READ_SESSION_TRANSCRIPT,
-    async (_event, projectPath: string, agentId: string, sessionId: string, offset: number, limit: number, orchestrator?: string) => {
-      try {
-        const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
-        if (!isSessionCapable(provider)) return null;
-        const config = await agentConfig.getDurableConfig(projectPath, agentId);
-        const cwd = config?.worktreePath || projectPath;
-        const rawEvents = await provider.readSessionTranscript(sessionId, cwd);
-        if (!rawEvents) return null;
-        const events = normalizeSessionEvents(rawEvents);
-        return paginateEvents(events, offset, limit);
-      } catch (err) {
-        appLog('core:ipc', 'warn', 'Failed to read session transcript', {
-          meta: { agentId, sessionId, error: err instanceof Error ? err.message : String(err) },
-        });
-        return null;
-      }
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), stringArg(), numberArg({ integer: true, min: 0 }), numberArg({ integer: true, min: 1 }), stringArg({ optional: true })],
+      async (_event, projectPath, agentId, sessionId, offset, limit, orchestrator) => {
+        try {
+          const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
+          if (!isSessionCapable(provider)) return null;
+          const config = await agentConfig.getDurableConfig(projectPath, agentId);
+          const cwd = config?.worktreePath || projectPath;
+          const rawEvents = await provider.readSessionTranscript(sessionId, cwd);
+          if (!rawEvents) return null;
+          const events = normalizeSessionEvents(rawEvents);
+          return paginateEvents(events, offset, limit);
+        } catch (err) {
+          appLog('core:ipc', 'warn', 'Failed to read session transcript', {
+            meta: { agentId, sessionId, error: err instanceof Error ? err.message : String(err) },
+          });
+          return null;
+        }
+      },
+    ),
   );
 
   ipcMain.handle(
     IPC.AGENT.GET_SESSION_SUMMARY,
-    async (_event, projectPath: string, agentId: string, sessionId: string, orchestrator?: string) => {
-      try {
-        const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
-        if (!isSessionCapable(provider)) return null;
-        const config = await agentConfig.getDurableConfig(projectPath, agentId);
-        const cwd = config?.worktreePath || projectPath;
-        const rawEvents = await provider.readSessionTranscript(sessionId, cwd);
-        if (!rawEvents) return null;
-        const events = normalizeSessionEvents(rawEvents);
-        return buildSessionSummary(events, provider.id);
-      } catch (err) {
-        appLog('core:ipc', 'warn', 'Failed to get session summary', {
-          meta: { agentId, sessionId, error: err instanceof Error ? err.message : String(err) },
-        });
-        return null;
-      }
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), stringArg(), stringArg({ optional: true })],
+      async (_event, projectPath, agentId, sessionId, orchestrator) => {
+        try {
+          const provider = await agentSystem.resolveOrchestrator(projectPath, orchestrator);
+          if (!isSessionCapable(provider)) return null;
+          const config = await agentConfig.getDurableConfig(projectPath, agentId);
+          const cwd = config?.worktreePath || projectPath;
+          const rawEvents = await provider.readSessionTranscript(sessionId, cwd);
+          if (!rawEvents) return null;
+          const events = normalizeSessionEvents(rawEvents);
+          return buildSessionSummary(events, provider.id);
+        } catch (err) {
+          appLog('core:ipc', 'warn', 'Failed to get session summary', {
+            meta: { agentId, sessionId, error: err instanceof Error ? err.message : String(err) },
+          });
+          return null;
+        }
+      },
+    ),
   );
 
   // --- Structured mode handlers ---
 
-  ipcMain.handle(IPC.AGENT.START_STRUCTURED, async (_event, agentId: string, opts: StructuredSessionOpts) => {
-    try {
-      const orchestratorId = agentSystem.getAgentOrchestrator(agentId);
-      const projectPath = agentSystem.getAgentProjectPath(agentId);
-      if (!projectPath) throw new Error(`No project path found for agent ${agentId}`);
+  ipcMain.handle(IPC.AGENT.START_STRUCTURED, withValidatedArgs(
+    [stringArg(), objectArg<StructuredSessionOpts>()],
+    async (_event, agentId, opts) => {
+      try {
+        const orchestratorId = agentSystem.getAgentOrchestrator(agentId);
+        const projectPath = agentSystem.getAgentProjectPath(agentId);
+        if (!projectPath) throw new Error(`No project path found for agent ${agentId}`);
 
-      const provider = await agentSystem.resolveOrchestrator(projectPath, orchestratorId);
-      if (!isStructuredCapable(provider)) {
-        throw new Error(`${provider.displayName} does not support structured mode`);
+        const provider = await agentSystem.resolveOrchestrator(projectPath, orchestratorId);
+        if (!isStructuredCapable(provider)) {
+          throw new Error(`${provider.displayName} does not support structured mode`);
+        }
+
+        const adapter = provider.createStructuredAdapter();
+        await structuredManager.startStructuredSession(agentId, adapter, opts);
+      } catch (err) {
+        appLog('core:ipc', 'error', 'Structured session start failed', {
+          meta: { agentId, error: err instanceof Error ? err.message : String(err) },
+        });
+        throw err;
       }
+    },
+  ));
 
-      const adapter = provider.createStructuredAdapter();
-      await structuredManager.startStructuredSession(agentId, adapter, opts);
-    } catch (err) {
-      appLog('core:ipc', 'error', 'Structured session start failed', {
-        meta: { agentId, error: err instanceof Error ? err.message : String(err) },
-      });
-      throw err;
-    }
-  });
+  ipcMain.handle(IPC.AGENT.CANCEL_STRUCTURED, withValidatedArgs(
+    [stringArg()],
+    async (_event, agentId) => {
+      await structuredManager.cancelSession(agentId);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.CANCEL_STRUCTURED, async (_event, agentId: string) => {
-    await structuredManager.cancelSession(agentId);
-  });
-
-  ipcMain.handle(IPC.AGENT.SEND_STRUCTURED_MESSAGE, async (_event, agentId: string, message: string) => {
-    await structuredManager.sendMessage(agentId, message);
-  });
+  ipcMain.handle(IPC.AGENT.SEND_STRUCTURED_MESSAGE, withValidatedArgs(
+    [stringArg(), stringArg({ minLength: 0 })],
+    async (_event, agentId, message) => {
+      await structuredManager.sendMessage(agentId, message);
+    },
+  ));
 
   ipcMain.handle(
     IPC.AGENT.RESPOND_PERMISSION,
-    async (_event, agentId: string, requestId: string, approved: boolean, reason?: string) => {
-      await structuredManager.respondToPermission(agentId, requestId, approved, reason);
-    }
+    withValidatedArgs(
+      [stringArg(), stringArg(), booleanArg(), stringArg({ optional: true })],
+      async (_event, agentId, requestId, approved, reason) => {
+        await structuredManager.respondToPermission(agentId, requestId, approved, reason);
+      },
+    ),
   );
 }

--- a/src/main/ipc/agent-settings-handlers.test.ts
+++ b/src/main/ipc/agent-settings-handlers.test.ts
@@ -413,4 +413,36 @@ describe('agent-settings-handlers', () => {
     expect(result).toEqual({ ok: false, message: 'Agent not found', propagatedCount: 0 });
     expect(propagateChanges).not.toHaveBeenCalled();
   });
+
+  // --- Input validation ---
+
+  it('rejects non-string worktreePath for READ_INSTRUCTIONS', () => {
+    const handler = handlers.get(IPC.AGENT.READ_INSTRUCTIONS)!;
+    expect(() => handler({}, 123)).toThrow('must be a string');
+  });
+
+  it('rejects non-string content for SAVE_INSTRUCTIONS', () => {
+    const handler = handlers.get(IPC.AGENT.SAVE_INSTRUCTIONS)!;
+    expect(() => handler({}, '/worktree', null)).toThrow('must be a string');
+  });
+
+  it('rejects non-boolean isSource for CREATE_SKILL', () => {
+    const handler = handlers.get(IPC.AGENT.CREATE_SKILL)!;
+    expect(() => handler({}, '/base', 'skill', 'not-bool')).toThrow('must be a boolean');
+  });
+
+  it('rejects non-object permissions for SAVE_PERMISSIONS', () => {
+    const handler = handlers.get(IPC.AGENT.SAVE_PERMISSIONS)!;
+    expect(() => handler({}, '/worktree', 'not-an-object')).toThrow('must be an object');
+  });
+
+  it('rejects non-object defaults for WRITE_PROJECT_AGENT_DEFAULTS', () => {
+    const handler = handlers.get(IPC.AGENT.WRITE_PROJECT_AGENT_DEFAULTS)!;
+    expect(() => handler({}, '/project', 'not-an-object')).toThrow('must be an object');
+  });
+
+  it('rejects non-array selectedItemIds for PROPAGATE_CONFIG_CHANGES', () => {
+    const handler = handlers.get(IPC.AGENT.PROPAGATE_CONFIG_CHANGES)!;
+    expect(() => handler({}, '/project', 'a1', 'not-an-array')).toThrow('must be an array');
+  });
 });

--- a/src/main/ipc/agent-settings-handlers.ts
+++ b/src/main/ipc/agent-settings-handlers.ts
@@ -7,6 +7,7 @@ import { getDurableConfig } from '../services/agent-config';
 import { materializeAgent, previewMaterialization, resetProjectAgentDefaults } from '../services/materialization-service';
 import { computeConfigDiff, propagateChanges } from '../services/config-diff-service';
 import { appLog } from '../services/log-service';
+import { withValidatedArgs, stringArg, objectArg, arrayArg, booleanArg } from './validation';
 
 /**
  * Resolve orchestrator conventions for a project path.
@@ -24,182 +25,284 @@ async function getConventions(projectPath?: string): Promise<SettingsConventions
 }
 
 export function registerAgentSettingsHandlers(): void {
-  ipcMain.handle(IPC.AGENT.READ_INSTRUCTIONS, async (_event, worktreePath: string, projectPath?: string) => {
-    if (projectPath) {
-      const provider = await resolveOrchestrator(projectPath);
-      return provider.readInstructions(worktreePath);
-    }
-    return agentSettings.readClaudeMd(worktreePath);
-  });
+  ipcMain.handle(IPC.AGENT.READ_INSTRUCTIONS, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      if (projectPath) {
+        const provider = await resolveOrchestrator(projectPath);
+        return provider.readInstructions(worktreePath);
+      }
+      return agentSettings.readClaudeMd(worktreePath);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.SAVE_INSTRUCTIONS, async (_event, worktreePath: string, content: string, projectPath?: string) => {
-    if (projectPath) {
-      const provider = await resolveOrchestrator(projectPath);
-      provider.writeInstructions(worktreePath, content);
-    } else {
-      await agentSettings.writeClaudeMd(worktreePath, content);
-    }
-  });
+  ipcMain.handle(IPC.AGENT.SAVE_INSTRUCTIONS, withValidatedArgs(
+    [stringArg(), stringArg({ minLength: 0 }), stringArg({ optional: true })],
+    async (_event, worktreePath, content, projectPath) => {
+      if (projectPath) {
+        const provider = await resolveOrchestrator(projectPath);
+        provider.writeInstructions(worktreePath, content);
+      } else {
+        await agentSettings.writeClaudeMd(worktreePath, content);
+      }
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_MCP_CONFIG, async (_event, worktreePath: string, projectPath?: string) => {
-    return agentSettings.readMcpConfig(worktreePath, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.READ_MCP_CONFIG, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      return agentSettings.readMcpConfig(worktreePath, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.LIST_SKILLS, async (_event, worktreePath: string, projectPath?: string) => {
-    return agentSettings.listSkills(worktreePath, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.LIST_SKILLS, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      return agentSettings.listSkills(worktreePath, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.LIST_AGENT_TEMPLATES, async (_event, worktreePath: string, projectPath?: string) => {
-    return agentSettings.listAgentTemplates(worktreePath, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.LIST_AGENT_TEMPLATES, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      return agentSettings.listAgentTemplates(worktreePath, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.LIST_SOURCE_SKILLS, async (_event, projectPath: string) => {
-    return agentSettings.listSourceSkills(projectPath);
-  });
+  ipcMain.handle(IPC.AGENT.LIST_SOURCE_SKILLS, withValidatedArgs(
+    [stringArg()],
+    async (_event, projectPath) => {
+      return agentSettings.listSourceSkills(projectPath);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.LIST_SOURCE_AGENT_TEMPLATES, async (_event, projectPath: string) => {
-    return agentSettings.listSourceAgentTemplates(projectPath);
-  });
+  ipcMain.handle(IPC.AGENT.LIST_SOURCE_AGENT_TEMPLATES, withValidatedArgs(
+    [stringArg()],
+    async (_event, projectPath) => {
+      return agentSettings.listSourceAgentTemplates(projectPath);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.CREATE_SKILL, async (_event, basePath: string, name: string, isSource: boolean, projectPath?: string) => {
-    return agentSettings.createSkillDir(basePath, name, isSource, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.CREATE_SKILL, withValidatedArgs(
+    [stringArg(), stringArg(), booleanArg(), stringArg({ optional: true })],
+    async (_event, basePath, name, isSource, projectPath) => {
+      return agentSettings.createSkillDir(basePath, name, isSource, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.CREATE_AGENT_TEMPLATE, async (_event, basePath: string, name: string, isSource: boolean, projectPath?: string) => {
-    return agentSettings.createAgentTemplateDir(basePath, name, isSource, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.CREATE_AGENT_TEMPLATE, withValidatedArgs(
+    [stringArg(), stringArg(), booleanArg(), stringArg({ optional: true })],
+    async (_event, basePath, name, isSource, projectPath) => {
+      return agentSettings.createAgentTemplateDir(basePath, name, isSource, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_PERMISSIONS, async (_event, worktreePath: string, projectPath?: string) => {
-    return agentSettings.readPermissions(worktreePath, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.READ_PERMISSIONS, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      return agentSettings.readPermissions(worktreePath, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.SAVE_PERMISSIONS, async (_event, worktreePath: string, permissions: { allow?: string[]; deny?: string[] }, projectPath?: string) => {
-    await agentSettings.writePermissions(worktreePath, permissions, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.SAVE_PERMISSIONS, withValidatedArgs(
+    [stringArg(), objectArg<{ allow?: string[]; deny?: string[] }>(), stringArg({ optional: true })],
+    async (_event, worktreePath, permissions, projectPath) => {
+      await agentSettings.writePermissions(worktreePath, permissions, await getConventions(projectPath));
+    },
+  ));
 
   // --- Skill content CRUD ---
 
-  ipcMain.handle(IPC.AGENT.READ_SKILL_CONTENT, async (_event, worktreePath: string, skillName: string, projectPath?: string) => {
-    return agentSettings.readSkillContent(worktreePath, skillName, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.READ_SKILL_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, skillName, projectPath) => {
+      return agentSettings.readSkillContent(worktreePath, skillName, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.WRITE_SKILL_CONTENT, async (_event, worktreePath: string, skillName: string, content: string, projectPath?: string) => {
-    await agentSettings.writeSkillContent(worktreePath, skillName, content, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.WRITE_SKILL_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ minLength: 0 }), stringArg({ optional: true })],
+    async (_event, worktreePath, skillName, content, projectPath) => {
+      await agentSettings.writeSkillContent(worktreePath, skillName, content, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_SKILL, async (_event, worktreePath: string, skillName: string, projectPath?: string) => {
-    await agentSettings.deleteSkill(worktreePath, skillName, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_SKILL, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, skillName, projectPath) => {
+      await agentSettings.deleteSkill(worktreePath, skillName, await getConventions(projectPath));
+    },
+  ));
 
   // --- Agent template content CRUD ---
 
-  ipcMain.handle(IPC.AGENT.READ_AGENT_TEMPLATE_CONTENT, async (_event, worktreePath: string, agentName: string, projectPath?: string) => {
-    return agentSettings.readAgentTemplateContent(worktreePath, agentName, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.READ_AGENT_TEMPLATE_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, agentName, projectPath) => {
+      return agentSettings.readAgentTemplateContent(worktreePath, agentName, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.WRITE_AGENT_TEMPLATE_CONTENT, async (_event, worktreePath: string, agentName: string, content: string, projectPath?: string) => {
-    await agentSettings.writeAgentTemplateContent(worktreePath, agentName, content, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.WRITE_AGENT_TEMPLATE_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ minLength: 0 }), stringArg({ optional: true })],
+    async (_event, worktreePath, agentName, content, projectPath) => {
+      await agentSettings.writeAgentTemplateContent(worktreePath, agentName, content, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_AGENT_TEMPLATE, async (_event, worktreePath: string, agentName: string, projectPath?: string) => {
-    await agentSettings.deleteAgentTemplate(worktreePath, agentName, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_AGENT_TEMPLATE, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, agentName, projectPath) => {
+      await agentSettings.deleteAgentTemplate(worktreePath, agentName, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.LIST_AGENT_TEMPLATE_FILES, async (_event, worktreePath: string, projectPath?: string) => {
-    return agentSettings.listAgentTemplateFiles(worktreePath, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.LIST_AGENT_TEMPLATE_FILES, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      return agentSettings.listAgentTemplateFiles(worktreePath, await getConventions(projectPath));
+    },
+  ));
 
   // --- MCP raw JSON ---
 
-  ipcMain.handle(IPC.AGENT.READ_MCP_RAW_JSON, async (_event, worktreePath: string, projectPath?: string) => {
-    return agentSettings.readMcpRawJson(worktreePath, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.READ_MCP_RAW_JSON, withValidatedArgs(
+    [stringArg(), stringArg({ optional: true })],
+    async (_event, worktreePath, projectPath) => {
+      return agentSettings.readMcpRawJson(worktreePath, await getConventions(projectPath));
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.WRITE_MCP_RAW_JSON, async (_event, worktreePath: string, content: string, projectPath?: string) => {
-    return agentSettings.writeMcpRawJson(worktreePath, content, await getConventions(projectPath));
-  });
+  ipcMain.handle(IPC.AGENT.WRITE_MCP_RAW_JSON, withValidatedArgs(
+    [stringArg(), stringArg({ minLength: 0 }), stringArg({ optional: true })],
+    async (_event, worktreePath, content, projectPath) => {
+      return agentSettings.writeMcpRawJson(worktreePath, content, await getConventions(projectPath));
+    },
+  ));
 
   // --- Project-level agent defaults ---
 
-  ipcMain.handle(IPC.AGENT.READ_PROJECT_AGENT_DEFAULTS, async (_event, projectPath: string) => {
-    return agentSettings.readProjectAgentDefaults(projectPath);
-  });
+  ipcMain.handle(IPC.AGENT.READ_PROJECT_AGENT_DEFAULTS, withValidatedArgs(
+    [stringArg()],
+    async (_event, projectPath) => {
+      return agentSettings.readProjectAgentDefaults(projectPath);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.WRITE_PROJECT_AGENT_DEFAULTS, async (_event, projectPath: string, defaults: any) => {
-    await agentSettings.writeProjectAgentDefaults(projectPath, defaults);
-  });
+  ipcMain.handle(IPC.AGENT.WRITE_PROJECT_AGENT_DEFAULTS, withValidatedArgs(
+    [stringArg(), objectArg()],
+    async (_event, projectPath, defaults) => {
+      await agentSettings.writeProjectAgentDefaults(projectPath, defaults);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.RESET_PROJECT_AGENT_DEFAULTS, async (_event, projectPath: string) => {
-    await resetProjectAgentDefaults(projectPath);
-  });
+  ipcMain.handle(IPC.AGENT.RESET_PROJECT_AGENT_DEFAULTS, withValidatedArgs(
+    [stringArg()],
+    async (_event, projectPath) => {
+      await resetProjectAgentDefaults(projectPath);
+    },
+  ));
 
   // --- Orchestrator conventions ---
 
-  ipcMain.handle(IPC.AGENT.GET_CONVENTIONS, async (_event, projectPath: string) => {
-    try {
-      const provider = await resolveOrchestrator(projectPath);
-      return provider.conventions;
-    } catch (err) {
-      appLog('core:agent-settings', 'warn', `Failed to get conventions for ${projectPath}`, { meta: { error: err instanceof Error ? err.message : String(err) } });
-      return null;
-    }
-  });
+  ipcMain.handle(IPC.AGENT.GET_CONVENTIONS, withValidatedArgs(
+    [stringArg()],
+    async (_event, projectPath) => {
+      try {
+        const provider = await resolveOrchestrator(projectPath);
+        return provider.conventions;
+      } catch (err) {
+        appLog('core:agent-settings', 'warn', `Failed to get conventions for ${projectPath}`, { meta: { error: err instanceof Error ? err.message : String(err) } });
+        return null;
+      }
+    },
+  ));
 
   // --- Source skill/template content CRUD ---
 
-  ipcMain.handle(IPC.AGENT.READ_SOURCE_SKILL_CONTENT, async (_event, projectPath: string, skillName: string) => {
-    return agentSettings.readSourceSkillContent(projectPath, skillName);
-  });
+  ipcMain.handle(IPC.AGENT.READ_SOURCE_SKILL_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, skillName) => {
+      return agentSettings.readSourceSkillContent(projectPath, skillName);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.WRITE_SOURCE_SKILL_CONTENT, async (_event, projectPath: string, skillName: string, content: string) => {
-    await agentSettings.writeSourceSkillContent(projectPath, skillName, content);
-  });
+  ipcMain.handle(IPC.AGENT.WRITE_SOURCE_SKILL_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ minLength: 0 })],
+    async (_event, projectPath, skillName, content) => {
+      await agentSettings.writeSourceSkillContent(projectPath, skillName, content);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_SOURCE_SKILL, async (_event, projectPath: string, skillName: string) => {
-    await agentSettings.deleteSourceSkill(projectPath, skillName);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_SOURCE_SKILL, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, skillName) => {
+      await agentSettings.deleteSourceSkill(projectPath, skillName);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.READ_SOURCE_AGENT_TEMPLATE_CONTENT, async (_event, projectPath: string, agentName: string) => {
-    return agentSettings.readSourceAgentTemplateContent(projectPath, agentName);
-  });
+  ipcMain.handle(IPC.AGENT.READ_SOURCE_AGENT_TEMPLATE_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentName) => {
+      return agentSettings.readSourceAgentTemplateContent(projectPath, agentName);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.WRITE_SOURCE_AGENT_TEMPLATE_CONTENT, async (_event, projectPath: string, agentName: string, content: string) => {
-    await agentSettings.writeSourceAgentTemplateContent(projectPath, agentName, content);
-  });
+  ipcMain.handle(IPC.AGENT.WRITE_SOURCE_AGENT_TEMPLATE_CONTENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ minLength: 0 })],
+    async (_event, projectPath, agentName, content) => {
+      await agentSettings.writeSourceAgentTemplateContent(projectPath, agentName, content);
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.DELETE_SOURCE_AGENT_TEMPLATE, async (_event, projectPath: string, agentName: string) => {
-    await agentSettings.deleteSourceAgentTemplate(projectPath, agentName);
-  });
+  ipcMain.handle(IPC.AGENT.DELETE_SOURCE_AGENT_TEMPLATE, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentName) => {
+      await agentSettings.deleteSourceAgentTemplate(projectPath, agentName);
+    },
+  ));
 
   // --- Materialization ---
 
-  ipcMain.handle(IPC.AGENT.MATERIALIZE_AGENT, async (_event, projectPath: string, agentId: string) => {
-    const agent = await getDurableConfig(projectPath, agentId);
-    if (!agent) return;
-    const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
-    await materializeAgent({ projectPath, agent, provider });
-  });
+  ipcMain.handle(IPC.AGENT.MATERIALIZE_AGENT, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      const agent = await getDurableConfig(projectPath, agentId);
+      if (!agent) return;
+      const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
+      await materializeAgent({ projectPath, agent, provider });
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.PREVIEW_MATERIALIZATION, async (_event, projectPath: string, agentId: string) => {
-    const agent = await getDurableConfig(projectPath, agentId);
-    if (!agent) return null;
-    const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
-    return previewMaterialization({ projectPath, agent, provider });
-  });
+  ipcMain.handle(IPC.AGENT.PREVIEW_MATERIALIZATION, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      const agent = await getDurableConfig(projectPath, agentId);
+      if (!agent) return null;
+      const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
+      return previewMaterialization({ projectPath, agent, provider });
+    },
+  ));
 
   // --- Config diff detection ---
 
-  ipcMain.handle(IPC.AGENT.COMPUTE_CONFIG_DIFF, async (_event, projectPath: string, agentId: string) => {
-    const agent = await getDurableConfig(projectPath, agentId);
-    if (!agent) return { agentId, agentName: '', hasDiffs: false, items: [] };
-    const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
-    return computeConfigDiff({ projectPath, agentId, provider });
-  });
+  ipcMain.handle(IPC.AGENT.COMPUTE_CONFIG_DIFF, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      const agent = await getDurableConfig(projectPath, agentId);
+      if (!agent) return { agentId, agentName: '', hasDiffs: false, items: [] };
+      const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
+      return computeConfigDiff({ projectPath, agentId, provider });
+    },
+  ));
 
-  ipcMain.handle(IPC.AGENT.PROPAGATE_CONFIG_CHANGES, async (_event, projectPath: string, agentId: string, selectedItemIds: string[]) => {
-    const agent = await getDurableConfig(projectPath, agentId);
-    if (!agent) return { ok: false, message: 'Agent not found', propagatedCount: 0 };
-    const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
-    return propagateChanges({ projectPath, agentId, selectedItemIds, provider });
-  });
+  ipcMain.handle(IPC.AGENT.PROPAGATE_CONFIG_CHANGES, withValidatedArgs(
+    [stringArg(), stringArg(), arrayArg(stringArg())],
+    async (_event, projectPath, agentId, selectedItemIds) => {
+      const agent = await getDurableConfig(projectPath, agentId);
+      if (!agent) return { ok: false, message: 'Agent not found', propagatedCount: 0 };
+      const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
+      return propagateChanges({ projectPath, agentId, selectedItemIds, provider });
+    },
+  ));
 }

--- a/src/main/ipc/annex-handlers.test.ts
+++ b/src/main/ipc/annex-handlers.test.ts
@@ -118,6 +118,18 @@ describe('annex-handlers', () => {
     expect(broadcastToAllWindows).toHaveBeenCalledWith(IPC.ANNEX.STATUS_CHANGED, expect.anything());
     expect(result).toEqual({ advertising: true, port: 3000, pin: '1234', connectedCount: 0 });
   });
+
+  // --- Input validation ---
+
+  it('rejects non-object settings for SAVE_SETTINGS', () => {
+    const handler = handlers.get(IPC.ANNEX.SAVE_SETTINGS)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
+
+  it('rejects null for SAVE_SETTINGS', () => {
+    const handler = handlers.get(IPC.ANNEX.SAVE_SETTINGS)!;
+    expect(() => handler({}, null)).toThrow('must be an object');
+  });
 });
 
 describe('maybeStartAnnex', () => {

--- a/src/main/ipc/annex-handlers.ts
+++ b/src/main/ipc/annex-handlers.ts
@@ -5,6 +5,7 @@ import * as annexSettings from '../services/annex-settings';
 import * as annexServer from '../services/annex-server';
 import { appLog } from '../services/log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
+import { withValidatedArgs, objectArg } from './validation';
 
 function broadcastStatusChanged(): void {
   const status = annexServer.getStatus();
@@ -16,7 +17,9 @@ export function registerAnnexHandlers(): void {
     return annexSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.ANNEX.SAVE_SETTINGS, async (_event, settings: AnnexSettings) => {
+  ipcMain.handle(IPC.ANNEX.SAVE_SETTINGS, withValidatedArgs(
+    [objectArg<AnnexSettings>()],
+    async (_event, settings) => {
     const previous = annexSettings.getSettings();
     await annexSettings.saveSettings(settings);
 
@@ -37,7 +40,7 @@ export function registerAnnexHandlers(): void {
 
     // Notify renderer of status change
     broadcastStatusChanged();
-  });
+  }));
 
   ipcMain.handle(IPC.ANNEX.GET_STATUS, () => {
     return annexServer.getStatus();

--- a/src/main/ipc/app-handlers.test.ts
+++ b/src/main/ipc/app-handlers.test.ts
@@ -570,4 +570,41 @@ describe('app-handlers', () => {
     await handler({}, { enabled: true }, '/project');
     expect(ensureDefaultTemplates).toHaveBeenCalledWith('/project');
   });
+
+  // --- Input validation ---
+
+  it('rejects non-string URL for OPEN_EXTERNAL_URL', () => {
+    const handler = handleHandlers.get(IPC.APP.OPEN_EXTERNAL_URL)!;
+    expect(() => handler({}, 123)).toThrow('must be a string');
+  });
+
+  it('rejects non-object for SAVE_NOTIFICATION_SETTINGS', () => {
+    const handler = handleHandlers.get(IPC.APP.SAVE_NOTIFICATION_SETTINGS)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
+
+  it('rejects non-boolean for SEND_NOTIFICATION silent param', () => {
+    const handler = handleHandlers.get(IPC.APP.SEND_NOTIFICATION)!;
+    expect(() => handler({}, 'Title', 'Body', 'not-boolean')).toThrow('must be a boolean');
+  });
+
+  it('rejects non-number for SET_DOCK_BADGE', () => {
+    const handler = handleHandlers.get(IPC.APP.SET_DOCK_BADGE)!;
+    expect(() => handler({}, 'not-a-number')).toThrow('must be a number');
+  });
+
+  it('rejects non-object for SAVE_UPDATE_SETTINGS', () => {
+    const handler = handleHandlers.get(IPC.APP.SAVE_UPDATE_SETTINGS)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
+
+  it('rejects non-string for DELETE_SOUND_PACK', () => {
+    const handler = handleHandlers.get(IPC.APP.DELETE_SOUND_PACK)!;
+    expect(() => handler({}, null)).toThrow('must be a string');
+  });
+
+  it('rejects non-object for LOG_WRITE', () => {
+    const handler = onHandlers.get(IPC.LOG.LOG_WRITE)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
 });

--- a/src/main/ipc/app-handlers.ts
+++ b/src/main/ipc/app-handlers.ts
@@ -18,11 +18,15 @@ import { ClipboardSettings, ClubhouseModeSettings, SoundEvent, SoundSettings, Up
 import { ensureDefaultTemplates, enableExclusions, disableExclusions } from '../services/materialization-service';
 import { resolveOrchestrator } from '../services/agent-system';
 import * as annexServer from '../services/annex-server';
+import { withValidatedArgs, stringArg, objectArg, numberArg, booleanArg } from './validation';
 
 export function registerAppHandlers(): void {
-  ipcMain.handle(IPC.APP.OPEN_EXTERNAL_URL, (_event, url: string) => {
-    return shell.openExternal(url);
-  });
+  ipcMain.handle(IPC.APP.OPEN_EXTERNAL_URL, withValidatedArgs(
+    [stringArg()],
+    (_event, url) => {
+      return shell.openExternal(url);
+    },
+  ));
 
   ipcMain.handle(IPC.APP.GET_VERSION, () => {
     return app.getVersion();
@@ -45,63 +49,96 @@ export function registerAppHandlers(): void {
     return notificationService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_NOTIFICATION_SETTINGS, async (_event, settings: NotificationSettings) => {
-    await notificationService.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_NOTIFICATION_SETTINGS, withValidatedArgs(
+    [objectArg<NotificationSettings>()],
+    async (_event, settings) => {
+      await notificationService.saveSettings(settings);
+    },
+  ));
 
-  ipcMain.handle(IPC.APP.SEND_NOTIFICATION, (_event, title: string, body: string, silent: boolean, agentId?: string, projectId?: string) => {
-    notificationService.sendNotification(title, body, silent, agentId, projectId);
-  });
+  ipcMain.handle(IPC.APP.SEND_NOTIFICATION, withValidatedArgs(
+    [stringArg(), stringArg({ minLength: 0 }), booleanArg(), stringArg({ optional: true }), stringArg({ optional: true })],
+    (_event, title, body, silent, agentId, projectId) => {
+      notificationService.sendNotification(title, body, silent, agentId, projectId);
+    },
+  ));
 
-  ipcMain.handle(IPC.APP.CLOSE_NOTIFICATION, (_event, agentId: string, projectId: string) => {
-    notificationService.closeNotification(agentId, projectId);
-  });
+  ipcMain.handle(IPC.APP.CLOSE_NOTIFICATION, withValidatedArgs(
+    [stringArg(), stringArg()],
+    (_event, agentId, projectId) => {
+      notificationService.closeNotification(agentId, projectId);
+    },
+  ));
 
   ipcMain.handle(IPC.APP.GET_THEME, () => {
     return themeService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_THEME, async (_event, settings: { themeId: string }) => {
-    await themeService.saveSettings(settings as any);
-    annexServer.broadcastThemeChanged();
-  });
+  ipcMain.handle(IPC.APP.SAVE_THEME, withValidatedArgs(
+    [objectArg<{ themeId: string }>({
+      validate: (v, name) => {
+        if (typeof v.themeId !== 'string' || !v.themeId) throw new Error(`${name}.themeId must be a non-empty string`);
+      },
+    })],
+    async (_event, settings) => {
+      await themeService.saveSettings(settings as any);
+      annexServer.broadcastThemeChanged();
+    },
+  ));
 
   // Update the Windows title bar overlay colors on ALL windows when the theme changes
-  ipcMain.handle(IPC.APP.UPDATE_TITLE_BAR_OVERLAY, (_event, colors: { color: string; symbolColor: string }) => {
-    if (process.platform !== 'win32') return;
-    for (const win of BrowserWindow.getAllWindows()) {
-      if (!win.isDestroyed()) {
-        win.setTitleBarOverlay({
-          color: colors.color,
-          symbolColor: colors.symbolColor,
-        });
+  ipcMain.handle(IPC.APP.UPDATE_TITLE_BAR_OVERLAY, withValidatedArgs(
+    [objectArg<{ color: string; symbolColor: string }>({
+      validate: (v, name) => {
+        if (typeof v.color !== 'string') throw new Error(`${name}.color must be a string`);
+        if (typeof v.symbolColor !== 'string') throw new Error(`${name}.symbolColor must be a string`);
+      },
+    })],
+    (_event, colors) => {
+      if (process.platform !== 'win32') return;
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed()) {
+          win.setTitleBarOverlay({
+            color: colors.color,
+            symbolColor: colors.symbolColor,
+          });
+        }
       }
-    }
-  });
+    },
+  ));
 
   ipcMain.handle(IPC.APP.GET_ORCHESTRATOR_SETTINGS, () => {
     return orchestratorSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_ORCHESTRATOR_SETTINGS, async (_event, settings: orchestratorSettings.OrchestratorSettings) => {
-    await orchestratorSettings.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_ORCHESTRATOR_SETTINGS, withValidatedArgs(
+    [objectArg<orchestratorSettings.OrchestratorSettings>()],
+    async (_event, settings) => {
+      await orchestratorSettings.saveSettings(settings);
+    },
+  ));
 
   ipcMain.handle(IPC.APP.GET_HEADLESS_SETTINGS, () => {
     return headlessSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_HEADLESS_SETTINGS, async (_event, settings: headlessSettings.HeadlessSettings) => {
-    await headlessSettings.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_HEADLESS_SETTINGS, withValidatedArgs(
+    [objectArg<headlessSettings.HeadlessSettings>()],
+    async (_event, settings) => {
+      await headlessSettings.saveSettings(settings);
+    },
+  ));
 
   ipcMain.handle(IPC.APP.GET_BADGE_SETTINGS, () => {
     return badgeSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_BADGE_SETTINGS, async (_event, settings: BadgeSettings) => {
-    await badgeSettings.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_BADGE_SETTINGS, withValidatedArgs(
+    [objectArg<BadgeSettings>()],
+    async (_event, settings) => {
+      await badgeSettings.saveSettings(settings);
+    },
+  ));
 
   // Clipboard settings are now managed via createManagedSettings() in settings-handlers.ts.
   // Legacy IPC channels preserved for backward compatibility with any external consumers.
@@ -109,31 +146,40 @@ export function registerAppHandlers(): void {
     return clipboardSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_CLIPBOARD_SETTINGS, async (_event, settings: ClipboardSettings) => {
-    await clipboardSettings.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_CLIPBOARD_SETTINGS, withValidatedArgs(
+    [objectArg<ClipboardSettings>()],
+    async (_event, settings) => {
+      await clipboardSettings.saveSettings(settings);
+    },
+  ));
 
-  ipcMain.handle(IPC.APP.SET_DOCK_BADGE, (_event, count: number) => {
-    if (process.platform === 'darwin') {
-      app.dock.setBadge(count > 0 ? String(count) : '');
-    } else {
-      app.setBadgeCount(count);
-    }
-  });
+  ipcMain.handle(IPC.APP.SET_DOCK_BADGE, withValidatedArgs(
+    [numberArg({ integer: true, min: 0 })],
+    (_event, count) => {
+      if (process.platform === 'darwin') {
+        app.dock.setBadge(count > 0 ? String(count) : '');
+      } else {
+        app.setBadgeCount(count);
+      }
+    },
+  ));
 
   // --- Auto-update ---
   ipcMain.handle(IPC.APP.GET_UPDATE_SETTINGS, () => {
     return autoUpdateService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_UPDATE_SETTINGS, async (_event, settings: UpdateSettings) => {
-    await autoUpdateService.saveSettings(settings);
-    if (settings.autoUpdate) {
-      await autoUpdateService.startPeriodicChecks();
-    } else {
-      autoUpdateService.stopPeriodicChecks();
-    }
-  });
+  ipcMain.handle(IPC.APP.SAVE_UPDATE_SETTINGS, withValidatedArgs(
+    [objectArg<UpdateSettings>()],
+    async (_event, settings) => {
+      await autoUpdateService.saveSettings(settings);
+      if (settings.autoUpdate) {
+        await autoUpdateService.startPeriodicChecks();
+      } else {
+        autoUpdateService.stopPeriodicChecks();
+      }
+    },
+  ));
 
   ipcMain.handle(IPC.APP.CHECK_FOR_UPDATES, () => {
     return autoUpdateService.checkForUpdates(true);
@@ -160,17 +206,23 @@ export function registerAppHandlers(): void {
   });
 
   // --- Logging ---
-  ipcMain.on(IPC.LOG.LOG_WRITE, (_event, entry: LogEntry) => {
-    logService.log(entry);
-  });
+  ipcMain.on(IPC.LOG.LOG_WRITE, withValidatedArgs(
+    [objectArg<LogEntry>()],
+    (_event, entry) => {
+      logService.log(entry);
+    },
+  ));
 
   ipcMain.handle(IPC.LOG.GET_LOG_SETTINGS, () => {
     return logSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.LOG.SAVE_LOG_SETTINGS, async (_event, settings: LoggingSettings) => {
-    await logSettings.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.LOG.SAVE_LOG_SETTINGS, withValidatedArgs(
+    [objectArg<LoggingSettings>()],
+    async (_event, settings) => {
+      await logSettings.saveSettings(settings);
+    },
+  ));
 
   ipcMain.handle(IPC.LOG.GET_LOG_NAMESPACES, () => {
     return logService.getNamespaces();
@@ -185,9 +237,12 @@ export function registerAppHandlers(): void {
     return soundService.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_SOUND_SETTINGS, async (_event, settings: SoundSettings) => {
-    await soundService.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_SOUND_SETTINGS, withValidatedArgs(
+    [objectArg<SoundSettings>()],
+    async (_event, settings) => {
+      await soundService.saveSettings(settings);
+    },
+  ));
 
   ipcMain.handle(IPC.APP.LIST_SOUND_PACKS, () => {
     return soundService.getAllSoundPacks();
@@ -197,53 +252,65 @@ export function registerAppHandlers(): void {
     return soundService.importSoundPack();
   });
 
-  ipcMain.handle(IPC.APP.DELETE_SOUND_PACK, (_event, packId: string) => {
-    return soundService.deleteSoundPack(packId);
-  });
+  ipcMain.handle(IPC.APP.DELETE_SOUND_PACK, withValidatedArgs(
+    [stringArg()],
+    (_event, packId) => {
+      return soundService.deleteSoundPack(packId);
+    },
+  ));
 
-  ipcMain.handle(IPC.APP.GET_SOUND_DATA, (_event, packId: string, event: SoundEvent) => {
-    return soundService.getSoundData(packId, event);
-  });
+  ipcMain.handle(IPC.APP.GET_SOUND_DATA, withValidatedArgs(
+    [stringArg(), stringArg()],
+    (_event, packId, event) => {
+      return soundService.getSoundData(packId, event as SoundEvent);
+    },
+  ));
 
   // --- Session Settings ---
   ipcMain.handle(IPC.APP.GET_SESSION_SETTINGS, () => {
     return sessionSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_SESSION_SETTINGS, async (_event, settings: sessionSettings.SessionSettings) => {
-    await sessionSettings.saveSettings(settings);
-  });
+  ipcMain.handle(IPC.APP.SAVE_SESSION_SETTINGS, withValidatedArgs(
+    [objectArg<sessionSettings.SessionSettings>()],
+    async (_event, settings) => {
+      await sessionSettings.saveSettings(settings);
+    },
+  ));
 
   // --- Clubhouse Mode ---
   ipcMain.handle(IPC.APP.GET_CLUBHOUSE_MODE_SETTINGS, () => {
     return clubhouseModeSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.APP.SAVE_CLUBHOUSE_MODE_SETTINGS, async (_event, settings: ClubhouseModeSettings, projectPath?: string) => {
-    const previousEnabled = projectPath
-      ? clubhouseModeSettings.isClubhouseModeEnabled(projectPath)
-      : clubhouseModeSettings.getSettings().enabled;
+  ipcMain.handle(IPC.APP.SAVE_CLUBHOUSE_MODE_SETTINGS, withValidatedArgs(
+    [objectArg<ClubhouseModeSettings>(), stringArg({ optional: true })],
+    async (_event, settings, projectPath) => {
+      const previousEnabled = projectPath
+        ? clubhouseModeSettings.isClubhouseModeEnabled(projectPath)
+        : clubhouseModeSettings.getSettings().enabled;
 
-    await clubhouseModeSettings.saveSettings(settings);
+      await clubhouseModeSettings.saveSettings(settings);
 
-    const nowEnabled = projectPath
-      ? clubhouseModeSettings.isClubhouseModeEnabled(projectPath)
-      : settings.enabled;
+      const nowEnabled = projectPath
+        ? clubhouseModeSettings.isClubhouseModeEnabled(projectPath)
+        : settings.enabled;
 
-    // On first enable: create default templates and enable git excludes
-    if (!previousEnabled && nowEnabled && projectPath) {
-      await ensureDefaultTemplates(projectPath);
-      try {
-        const provider = await resolveOrchestrator(projectPath);
-        enableExclusions(projectPath, provider);
-      } catch {
-        // Orchestrator not available
+      // On first enable: create default templates and enable git excludes
+      if (!previousEnabled && nowEnabled && projectPath) {
+        await ensureDefaultTemplates(projectPath);
+        try {
+          const provider = await resolveOrchestrator(projectPath);
+          enableExclusions(projectPath, provider);
+        } catch {
+          // Orchestrator not available
+        }
       }
-    }
 
-    // On disable: remove git excludes
-    if (previousEnabled && !nowEnabled && projectPath) {
-      await disableExclusions(projectPath);
-    }
-  });
+      // On disable: remove git excludes
+      if (previousEnabled && !nowEnabled && projectPath) {
+        await disableExclusions(projectPath);
+      }
+    },
+  ));
 }

--- a/src/main/ipc/marketplace-handlers.test.ts
+++ b/src/main/ipc/marketplace-handlers.test.ts
@@ -113,4 +113,36 @@ describe('marketplace-handlers', () => {
     expect(customMarketplaceService.toggleCustomMarketplace).toHaveBeenCalledWith(req);
     expect(result.enabled).toBe(false);
   });
+
+  // --- Input validation ---
+
+  it('rejects non-object for INSTALL_PLUGIN', () => {
+    const handler = handlers.get(IPC.MARKETPLACE.INSTALL_PLUGIN)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
+
+  it('rejects INSTALL_PLUGIN with missing pluginId', () => {
+    const handler = handlers.get(IPC.MARKETPLACE.INSTALL_PLUGIN)!;
+    expect(() => handler({}, { version: '1.0', assetUrl: 'url', sha256: 'abc' })).toThrow('pluginId must be a non-empty string');
+  });
+
+  it('rejects non-object for UPDATE_PLUGIN', () => {
+    const handler = handlers.get(IPC.MARKETPLACE.UPDATE_PLUGIN)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
+
+  it('rejects ADD_CUSTOM with missing name', () => {
+    const handler = handlers.get(IPC.MARKETPLACE.ADD_CUSTOM)!;
+    expect(() => handler({}, { url: 'https://example.com' })).toThrow('name must be a non-empty string');
+  });
+
+  it('rejects REMOVE_CUSTOM with missing id', () => {
+    const handler = handlers.get(IPC.MARKETPLACE.REMOVE_CUSTOM)!;
+    expect(() => handler({}, {})).toThrow('id must be a non-empty string');
+  });
+
+  it('rejects TOGGLE_CUSTOM with non-boolean enabled', () => {
+    const handler = handlers.get(IPC.MARKETPLACE.TOGGLE_CUSTOM)!;
+    expect(() => handler({}, { id: 'cm-1', enabled: 'yes' })).toThrow('enabled must be a boolean');
+  });
 });

--- a/src/main/ipc/marketplace-handlers.ts
+++ b/src/main/ipc/marketplace-handlers.ts
@@ -10,38 +10,79 @@ import type {
   CustomMarketplaceRemoveRequest,
   CustomMarketplaceToggleRequest,
 } from '../../shared/marketplace-types';
+import { withValidatedArgs, objectArg } from './validation';
 
 export function registerMarketplaceHandlers(): void {
   ipcMain.handle(IPC.MARKETPLACE.FETCH_REGISTRY, async () => {
     return marketplaceService.fetchRegistry();
   });
 
-  ipcMain.handle(IPC.MARKETPLACE.INSTALL_PLUGIN, async (_event, req: MarketplaceInstallRequest) => {
-    return marketplaceService.installPlugin(req);
-  });
+  ipcMain.handle(IPC.MARKETPLACE.INSTALL_PLUGIN, withValidatedArgs(
+    [objectArg<MarketplaceInstallRequest>({
+      validate: (v, name) => {
+        if (typeof v.pluginId !== 'string' || !v.pluginId) throw new Error(`${name}.pluginId must be a non-empty string`);
+        if (typeof v.version !== 'string' || !v.version) throw new Error(`${name}.version must be a non-empty string`);
+        if (typeof v.assetUrl !== 'string' || !v.assetUrl) throw new Error(`${name}.assetUrl must be a non-empty string`);
+        if (typeof v.sha256 !== 'string' || !v.sha256) throw new Error(`${name}.sha256 must be a non-empty string`);
+      },
+    })],
+    async (_event, req) => {
+      return marketplaceService.installPlugin(req);
+    },
+  ));
 
   ipcMain.handle(IPC.MARKETPLACE.CHECK_PLUGIN_UPDATES, async () => {
     return pluginUpdateService.checkForPluginUpdates();
   });
 
-  ipcMain.handle(IPC.MARKETPLACE.UPDATE_PLUGIN, async (_event, req: PluginUpdateRequest) => {
-    return pluginUpdateService.updatePlugin(req.pluginId);
-  });
+  ipcMain.handle(IPC.MARKETPLACE.UPDATE_PLUGIN, withValidatedArgs(
+    [objectArg<PluginUpdateRequest>({
+      validate: (v, name) => {
+        if (typeof v.pluginId !== 'string' || !v.pluginId) throw new Error(`${name}.pluginId must be a non-empty string`);
+      },
+    })],
+    async (_event, req) => {
+      return pluginUpdateService.updatePlugin(req.pluginId);
+    },
+  ));
 
   // Custom marketplace CRUD
   ipcMain.handle(IPC.MARKETPLACE.LIST_CUSTOM, async () => {
     return customMarketplaceService.listCustomMarketplaces();
   });
 
-  ipcMain.handle(IPC.MARKETPLACE.ADD_CUSTOM, async (_event, req: CustomMarketplaceAddRequest) => {
-    return customMarketplaceService.addCustomMarketplace(req);
-  });
+  ipcMain.handle(IPC.MARKETPLACE.ADD_CUSTOM, withValidatedArgs(
+    [objectArg<CustomMarketplaceAddRequest>({
+      validate: (v, name) => {
+        if (typeof v.name !== 'string' || !v.name) throw new Error(`${name}.name must be a non-empty string`);
+        if (typeof v.url !== 'string' || !v.url) throw new Error(`${name}.url must be a non-empty string`);
+      },
+    })],
+    async (_event, req) => {
+      return customMarketplaceService.addCustomMarketplace(req);
+    },
+  ));
 
-  ipcMain.handle(IPC.MARKETPLACE.REMOVE_CUSTOM, async (_event, req: CustomMarketplaceRemoveRequest) => {
-    return customMarketplaceService.removeCustomMarketplace(req);
-  });
+  ipcMain.handle(IPC.MARKETPLACE.REMOVE_CUSTOM, withValidatedArgs(
+    [objectArg<CustomMarketplaceRemoveRequest>({
+      validate: (v, name) => {
+        if (typeof v.id !== 'string' || !v.id) throw new Error(`${name}.id must be a non-empty string`);
+      },
+    })],
+    async (_event, req) => {
+      return customMarketplaceService.removeCustomMarketplace(req);
+    },
+  ));
 
-  ipcMain.handle(IPC.MARKETPLACE.TOGGLE_CUSTOM, async (_event, req: CustomMarketplaceToggleRequest) => {
-    return customMarketplaceService.toggleCustomMarketplace(req);
-  });
+  ipcMain.handle(IPC.MARKETPLACE.TOGGLE_CUSTOM, withValidatedArgs(
+    [objectArg<CustomMarketplaceToggleRequest>({
+      validate: (v, name) => {
+        if (typeof v.id !== 'string' || !v.id) throw new Error(`${name}.id must be a non-empty string`);
+        if (typeof v.enabled !== 'boolean') throw new Error(`${name}.enabled must be a boolean`);
+      },
+    })],
+    async (_event, req) => {
+      return customMarketplaceService.toggleCustomMarketplace(req);
+    },
+  ));
 }

--- a/src/main/ipc/profile-handlers.test.ts
+++ b/src/main/ipc/profile-handlers.test.ts
@@ -83,9 +83,9 @@ describe('profile-handlers', () => {
       expect(mockDeleteProfile).toHaveBeenCalledWith('prof-123');
     });
 
-    it('handles empty string profileId', () => {
-      handlers['profile:delete-profile']({}, '');
-      expect(mockDeleteProfile).toHaveBeenCalledWith('');
+    it('rejects empty string profileId', () => {
+      expect(() => handlers['profile:delete-profile']({}, '')).toThrow('must be at least 1 character');
+      expect(mockDeleteProfile).not.toHaveBeenCalled();
     });
   });
 
@@ -112,6 +112,25 @@ describe('profile-handlers', () => {
 
       const result = handlers['profile:get-profile-env-keys']({}, 'claude-code');
       expect(result).toEqual([]);
+    });
+  });
+
+  // --- Input validation ---
+
+  describe('validation', () => {
+    it('rejects non-object for SAVE_PROFILE', () => {
+      expect(() => handlers['profile:save-profile']({}, 'not-object')).toThrow('must be an object');
+      expect(mockSaveProfile).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-string for DELETE_PROFILE', () => {
+      expect(() => handlers['profile:delete-profile']({}, 123)).toThrow('must be a string');
+      expect(mockDeleteProfile).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-string for GET_PROFILE_ENV_KEYS', () => {
+      expect(() => handlers['profile:get-profile-env-keys']({}, null)).toThrow('must be a string');
+      expect(mockGetProvider).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/ipc/profile-handlers.ts
+++ b/src/main/ipc/profile-handlers.ts
@@ -3,23 +3,33 @@ import { IPC } from '../../shared/ipc-channels';
 import { OrchestratorProfile } from '../../shared/types';
 import * as profileSettings from '../services/profile-settings';
 import { getProvider } from '../orchestrators';
+import { withValidatedArgs, stringArg, objectArg } from './validation';
 
 export function registerProfileHandlers(): void {
   ipcMain.handle(IPC.PROFILE.GET_SETTINGS, () => {
     return profileSettings.getSettings();
   });
 
-  ipcMain.handle(IPC.PROFILE.SAVE_PROFILE, async (_event, profile: OrchestratorProfile) => {
-    await profileSettings.saveProfile(profile);
-  });
+  ipcMain.handle(IPC.PROFILE.SAVE_PROFILE, withValidatedArgs(
+    [objectArg<OrchestratorProfile>()],
+    async (_event, profile) => {
+      await profileSettings.saveProfile(profile);
+    },
+  ));
 
-  ipcMain.handle(IPC.PROFILE.DELETE_PROFILE, async (_event, profileId: string) => {
-    await profileSettings.deleteProfile(profileId);
-  });
+  ipcMain.handle(IPC.PROFILE.DELETE_PROFILE, withValidatedArgs(
+    [stringArg()],
+    async (_event, profileId) => {
+      await profileSettings.deleteProfile(profileId);
+    },
+  ));
 
-  ipcMain.handle(IPC.PROFILE.GET_PROFILE_ENV_KEYS, (_event, orchestratorId: string) => {
-    const provider = getProvider(orchestratorId);
-    if (!provider) return [];
-    return provider.getProfileEnvKeys();
-  });
+  ipcMain.handle(IPC.PROFILE.GET_PROFILE_ENV_KEYS, withValidatedArgs(
+    [stringArg()],
+    (_event, orchestratorId) => {
+      const provider = getProvider(orchestratorId);
+      if (!provider) return [];
+      return provider.getProfileEnvKeys();
+    },
+  ));
 }

--- a/src/main/ipc/validation.test.ts
+++ b/src/main/ipc/validation.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { stringArg } from './validation';
+import { stringArg, booleanArg } from './validation';
+
+describe('booleanArg', () => {
+  it('rejects non-boolean values', () => {
+    const validator = booleanArg();
+    expect(() => validator('true', 'test')).toThrow('must be a boolean');
+    expect(() => validator(1, 'test')).toThrow('must be a boolean');
+    expect(() => validator(null, 'test')).toThrow('must be a boolean');
+  });
+
+  it('accepts boolean values', () => {
+    const validator = booleanArg();
+    expect(validator(true, 'test')).toBe(true);
+    expect(validator(false, 'test')).toBe(false);
+  });
+
+  it('allows undefined when optional', () => {
+    const validator = booleanArg({ optional: true });
+    expect(validator(undefined, 'test')).toBeUndefined();
+    expect(validator(true, 'test')).toBe(true);
+  });
+
+  it('rejects undefined when not optional', () => {
+    const validator = booleanArg();
+    expect(() => validator(undefined, 'test')).toThrow('must be a boolean');
+  });
+});
 
 describe('stringArg', () => {
   it('rejects non-string values', () => {

--- a/src/main/ipc/validation.ts
+++ b/src/main/ipc/validation.ts
@@ -35,8 +35,13 @@ export function stringArg(options: { minLength?: number; maxLength?: number; opt
   };
 }
 
-export function booleanArg(): ArgValidator<boolean> {
+export function booleanArg(options: { optional: true }): ArgValidator<boolean | undefined>;
+export function booleanArg(options?: { optional?: false }): ArgValidator<boolean>;
+export function booleanArg(options: { optional?: boolean } = {}): ArgValidator<boolean | undefined> {
+  const { optional = false } = options;
+
   return (value, argName) => {
+    if (optional && value === undefined) return undefined;
     if (typeof value !== 'boolean') {
       fail(argName, `must be a boolean, received ${describeType(value)}`);
     }

--- a/src/main/ipc/window-handlers.test.ts
+++ b/src/main/ipc/window-handlers.test.ts
@@ -465,6 +465,23 @@ describe('window-handlers', () => {
 
   // ── Hub mutation forwarding ──────────────────────────────────────────
 
+  // --- Input validation ---
+
+  it('rejects non-object params for CREATE_POPOUT', () => {
+    const handler = handlers.get(IPC.WINDOW.CREATE_POPOUT)!;
+    expect(() => handler({}, 'not-object')).toThrow('must be an object');
+  });
+
+  it('rejects invalid type for CREATE_POPOUT', () => {
+    const handler = handlers.get(IPC.WINDOW.CREATE_POPOUT)!;
+    expect(() => handler({}, { type: 'invalid' })).toThrow("must be 'agent' or 'hub'");
+  });
+
+  it('rejects non-number windowId for CLOSE_POPOUT', () => {
+    const handler = handlers.get(IPC.WINDOW.CLOSE_POPOUT)!;
+    expect(() => handler({}, 'not-a-number')).toThrow('must be a number');
+  });
+
   it('HUB_MUTATION is forwarded to the main window', async () => {
     const mainWin = new (BrowserWindow as any)({});
     // Create a popout so mainWin is distinguishable

--- a/src/main/ipc/window-handlers.ts
+++ b/src/main/ipc/window-handlers.ts
@@ -3,6 +3,7 @@ import { IPC } from '../../shared/ipc-channels';
 import { getSettings as getThemeSettings } from '../services/theme-service';
 import { getThemeColorsForTitleBar } from '../title-bar-colors';
 import { appLog } from '../services/log-service';
+import { withValidatedArgs, stringArg, numberArg, objectArg } from './validation';
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
@@ -125,7 +126,13 @@ function broadcastToPopouts(channel: string, ...args: any[]): void {
 }
 
 export function registerWindowHandlers(): void {
-  ipcMain.handle(IPC.WINDOW.CREATE_POPOUT, (_event, params: PopoutParams) => {
+  ipcMain.handle(IPC.WINDOW.CREATE_POPOUT, withValidatedArgs(
+    [objectArg<PopoutParams>({
+      validate: (v, name) => {
+        if (v.type !== 'agent' && v.type !== 'hub') throw new Error(`${name}.type must be 'agent' or 'hub'`);
+      },
+    })],
+    (_event, params) => {
     const themeColors = getThemeColors();
     const isWin = process.platform === 'win32';
 
@@ -181,15 +188,17 @@ export function registerWindowHandlers(): void {
     });
 
     return windowId;
-  });
+  }));
 
-  ipcMain.handle(IPC.WINDOW.CLOSE_POPOUT, (_event, windowId: number) => {
+  ipcMain.handle(IPC.WINDOW.CLOSE_POPOUT, withValidatedArgs(
+    [numberArg({ integer: true })],
+    (_event, windowId) => {
     const entry = popoutWindows.get(windowId);
     if (entry && !entry.window.isDestroyed()) {
       entry.window.close();
     }
     popoutWindows.delete(windowId);
-  });
+  }));
 
   ipcMain.handle(IPC.WINDOW.LIST_POPOUTS, () => {
     const list: Array<{ windowId: number; params: PopoutParams }> = [];
@@ -208,7 +217,9 @@ export function registerWindowHandlers(): void {
     return list;
   });
 
-  ipcMain.handle(IPC.WINDOW.FOCUS_MAIN, (_event, agentId?: string) => {
+  ipcMain.handle(IPC.WINDOW.FOCUS_MAIN, withValidatedArgs(
+    [stringArg({ optional: true })],
+    (_event, agentId) => {
     const mainWindow = findMainWindow();
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
@@ -217,7 +228,7 @@ export function registerWindowHandlers(): void {
         mainWindow.webContents.send(IPC.WINDOW.NAVIGATE_TO_AGENT, agentId);
       }
     }
-  });
+  }));
 
   // ── Agent state sync ────────────────────────────────────────────────────
   //
@@ -247,7 +258,9 @@ export function registerWindowHandlers(): void {
   // Same pattern: cache from HUB_STATE_CHANGED broadcasts, serve from
   // cache on GET_HUB_STATE, fall back to batched relay with 1.5s timeout.
 
-  ipcMain.handle(IPC.WINDOW.GET_HUB_STATE, (_event, hubId: string, scope: string, projectId?: string) => {
+  ipcMain.handle(IPC.WINDOW.GET_HUB_STATE, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    (_event, hubId, scope, projectId) => {
     const cached = cachedHubState.get(hubId);
     if (cached) return cached;
 
@@ -275,7 +288,7 @@ export function registerWindowHandlers(): void {
       ipcMain.once(channel as any, handler);
       mainWindow.webContents.send(IPC.WINDOW.REQUEST_HUB_STATE, requestId, hubId, scope, projectId);
     });
-  });
+  }));
 
   // Forward hub state relay responses from the main renderer
   ipcMain.on(IPC.WINDOW.HUB_STATE_RESPONSE, (_event, requestId: string, state: any) => {


### PR DESCRIPTION
## Summary

- Adds `withValidatedArgs` input validation wrappers to all 7 previously-unvalidated IPC handler files, closing the gap identified in #578
- Extends `booleanArg()` validator with optional support to match the existing `stringArg`/`numberArg` pattern
- Adds 37 new validation rejection tests to ensure invalid inputs are caught at the IPC boundary

Closes #578

## Changes

**Handler files updated (7):**
- `agent-handlers.ts` — 30+ handlers now validate all string, object, number, boolean, and array args
- `agent-settings-handlers.ts` — 30+ handlers validate paths, names, content strings, booleans, objects
- `app-handlers.ts` — Settings save handlers validate object args; notification/badge/sound handlers validate primitives
- `window-handlers.ts` — `CREATE_POPOUT` validates PopoutParams (including enum check on `type`), `CLOSE_POPOUT` validates windowId, `GET_HUB_STATE` validates strings
- `annex-handlers.ts` — `SAVE_SETTINGS` validates settings object
- `marketplace-handlers.ts` — All mutation handlers validate request objects with deep field checks (pluginId, version, sha256, etc.)
- `profile-handlers.ts` — `SAVE_PROFILE`, `DELETE_PROFILE`, `GET_PROFILE_ENV_KEYS` validate their args

**Validation infrastructure:**
- `validation.ts` — Added optional overloads to `booleanArg()` (was the only primitive validator without optional support)

**Test files updated (8):**
- Added validation rejection tests to all 7 handler test files + `validation.test.ts`
- Fixed 2 existing tests that passed invalid data now correctly rejected by validation

**Coverage before/after:**

| Handler File | Before | After |
|---|---|---|
| agent-handlers | 0% | 100% |
| agent-settings-handlers | 0% | 100% |
| app-handlers | 0% | 100% |
| window-handlers | 0% | 100% |
| annex-handlers | 0% | 100% |
| marketplace-handlers | 0% | 100% |
| profile-handlers | 0% | 100% |
| file-handlers | 100% | 100% |
| git-handlers | 100% | 100% |
| pty-handlers | 100% | 100% |
| process-handlers | 100% | 100% |
| plugin-handlers | 100% | 100% |
| project-handlers | ~80% | ~80% |

## Test Plan

- [x] All 6550 existing tests pass (no regressions)
- [x] 37 new validation rejection tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Handlers with no arguments (getters) are correctly left unwrapped
- [x] Dialog-only handlers (PICK_ICON, IMPORT_SOUND_PACK) correctly left unwrapped
- [x] Optional args (projectPath, orchestrator) correctly allow undefined
- [x] Content args (instructions, skill content) use minLength: 0 to allow empty strings

## Manual Validation

No manual validation needed — this is a defensive change that rejects malformed IPC inputs before they reach service logic. All behavior for valid inputs is unchanged (confirmed by passing all existing tests).