### PR TITLE
refactor: encapsulate paired exit broadcasts into broadcastAgentExit

### DIFF
--- a/src/main/services/agent-exit-broadcast.test.ts
+++ b/src/main/services/agent-exit-broadcast.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../util/ipc-broadcast', () => ({
+  broadcastToAllWindows: vi.fn(),
+}));
+
+vi.mock('./annex-event-bus', () => ({
+  emitPtyExit: vi.fn(),
+}));
+
+import { broadcastToAllWindows } from '../util/ipc-broadcast';
+import * as annexEventBus from './annex-event-bus';
+import { broadcastAgentExit } from './agent-exit-broadcast';
+
+beforeEach(() => {
+  vi.mocked(broadcastToAllWindows).mockReset();
+  vi.mocked(annexEventBus.emitPtyExit).mockReset();
+});
+
+describe('broadcastAgentExit', () => {
+  it('broadcasts to renderer and annex event bus', () => {
+    broadcastAgentExit('agent-1', 0);
+
+    expect(broadcastToAllWindows).toHaveBeenCalledWith('pty:exit', 'agent-1', 0);
+    expect(annexEventBus.emitPtyExit).toHaveBeenCalledWith('agent-1', 0);
+  });
+
+  it('passes lastOutput to renderer broadcast when provided', () => {
+    broadcastAgentExit('agent-2', 1, 'some output');
+
+    expect(broadcastToAllWindows).toHaveBeenCalledWith('pty:exit', 'agent-2', 1, 'some output');
+    expect(annexEventBus.emitPtyExit).toHaveBeenCalledWith('agent-2', 1);
+  });
+
+  it('omits lastOutput argument when not provided', () => {
+    broadcastAgentExit('agent-3', 137);
+
+    // Should be called with exactly 3 args (no trailing undefined)
+    expect(broadcastToAllWindows).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(broadcastToAllWindows).mock.calls[0];
+    expect(call).toEqual(['pty:exit', 'agent-3', 137]);
+    expect(call).toHaveLength(3);
+  });
+
+  it('passes empty string lastOutput correctly', () => {
+    broadcastAgentExit('agent-4', 1, '');
+
+    expect(broadcastToAllWindows).toHaveBeenCalledWith('pty:exit', 'agent-4', 1, '');
+    expect(annexEventBus.emitPtyExit).toHaveBeenCalledWith('agent-4', 1);
+  });
+
+  it('always calls both targets exactly once', () => {
+    broadcastAgentExit('agent-5', 0);
+
+    expect(broadcastToAllWindows).toHaveBeenCalledTimes(1);
+    expect(annexEventBus.emitPtyExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/services/agent-exit-broadcast.ts
+++ b/src/main/services/agent-exit-broadcast.ts
@@ -1,0 +1,21 @@
+import { IPC } from '../../shared/ipc-channels';
+import { broadcastToAllWindows } from '../util/ipc-broadcast';
+import * as annexEventBus from './annex-event-bus';
+
+/**
+ * Broadcast an agent exit event to both the renderer (via IPC) and the annex
+ * event bus. These two notifications must always be paired — calling them
+ * individually risks one side missing the exit if a code path forgets one.
+ *
+ * @param agentId  - The agent whose process exited.
+ * @param exitCode - The process exit code.
+ * @param lastOutput - Optional last PTY output for renderer diagnostics.
+ */
+export function broadcastAgentExit(agentId: string, exitCode: number, lastOutput?: string): void {
+  if (lastOutput !== undefined) {
+    broadcastToAllWindows(IPC.PTY.EXIT, agentId, exitCode, lastOutput);
+  } else {
+    broadcastToAllWindows(IPC.PTY.EXIT, agentId, exitCode);
+  }
+  annexEventBus.emitPtyExit(agentId, exitCode);
+}

--- a/src/main/services/headless-manager.ts
+++ b/src/main/services/headless-manager.ts
@@ -10,6 +10,7 @@ import { getShellEnvironment, cleanSpawnEnv } from '../util/shell';
 import { appLog } from './log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import * as annexEventBus from './annex-event-bus';
+import { broadcastAgentExit } from './agent-exit-broadcast';
 import { HeadlessOutputKind } from '../orchestrators/types';
 import { StaleSweeper } from './stale-sweeper';
 
@@ -85,8 +86,7 @@ const staleSweeper = new StaleSweeper<HeadlessSession>(sessions, {
       meta: { agentId, exitCode: session.process.exitCode },
     });
     cleanupHeadlessSession(agentId);
-    broadcastToAllWindows(IPC.PTY.EXIT, agentId, session.process.exitCode ?? 1);
-    annexEventBus.emitPtyExit(agentId, session.process.exitCode ?? 1);
+    broadcastAgentExit(agentId, session.process.exitCode ?? 1);
   },
 });
 
@@ -417,8 +417,7 @@ export async function spawnHeadless(
 
       onExit?.(agentId, code ?? 0);
 
-      broadcastToAllWindows(IPC.PTY.EXIT, agentId, code ?? 0);
-      annexEventBus.emitPtyExit(agentId, code ?? 0);
+      broadcastAgentExit(agentId, code ?? 0);
     } else {
       appLog('core:headless', 'info', `Old process exited after session replacement — skipping cleanup`, {
         meta: { agentId, exitCode: code },
@@ -440,8 +439,7 @@ export async function spawnHeadless(
 
       onExit?.(agentId, 1);
 
-      broadcastToAllWindows(IPC.PTY.EXIT, agentId, 1);
-      annexEventBus.emitPtyExit(agentId, 1);
+      broadcastAgentExit(agentId, 1);
     }
   });
 }

--- a/src/main/services/pty-manager.ts
+++ b/src/main/services/pty-manager.ts
@@ -6,6 +6,7 @@ import { getShellEnvironment, getDefaultShell, cleanSpawnEnv } from '../util/she
 import { appLog } from './log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import * as annexEventBus from './annex-event-bus';
+import { broadcastAgentExit } from './agent-exit-broadcast';
 import { StaleSweeper } from './stale-sweeper';
 
 interface ManagedSession {
@@ -131,8 +132,7 @@ const staleSweeper = new StaleSweeper<ManagedSession>(sessions, {
       meta: { agentId, pid: session.process.pid },
     });
     cleanupSession(agentId);
-    broadcastToAllWindows(IPC.PTY.EXIT, agentId, 1, '');
-    annexEventBus.emitPtyExit(agentId, 1);
+    broadcastAgentExit(agentId, 1, '');
   },
 });
 
@@ -297,8 +297,7 @@ export function spawn(agentId: string, cwd: string, binary: string, args: string
     cleanupSession(agentId);
     onExit?.(agentId, exitCode, fullBuffer);
     // Include last PTY output so the renderer can show diagnostics on early exit
-    broadcastToAllWindows(IPC.PTY.EXIT, agentId, exitCode, ptyBuffer);
-    annexEventBus.emitPtyExit(agentId, exitCode);
+    broadcastAgentExit(agentId, exitCode, ptyBuffer);
   });
 }
 
@@ -420,8 +419,7 @@ export function gracefulKill(agentId: string, exitCommand: string = '/exit\r'): 
     const current = sessions.get(agentId);
     if (current && current.process === proc) {
       try { proc.kill(); } catch { /* dead */ }
-      broadcastToAllWindows(IPC.PTY.EXIT, agentId, 1, '');
-      annexEventBus.emitPtyExit(agentId, 1);
+      broadcastAgentExit(agentId, 1, '');
     }
     cleanupSession(agentId);
   }, 9000);


### PR DESCRIPTION
## Summary
- Introduces `broadcastAgentExit(agentId, exitCode, lastOutput?)` to encapsulate the always-paired `broadcastToAllWindows(IPC.PTY.EXIT, ...)` and `annexEventBus.emitPtyExit(...)` calls
- Replaces all 6 paired call sites across `pty-manager.ts` (3) and `headless-manager.ts` (3)
- Prevents future bugs where a new exit path forgets one of the two notifications, causing stale UI or missing annex events

## Changes
- **New file: `src/main/services/agent-exit-broadcast.ts`** — single function that broadcasts exit to both renderer and annex event bus
- **`src/main/services/pty-manager.ts`** — replaced 3 paired `broadcastToAllWindows`/`emitPtyExit` calls with `broadcastAgentExit` (staleSweeper onStale, spawn onExit, gracefulKill killTimer)
- **`src/main/services/headless-manager.ts`** — replaced 3 paired calls with `broadcastAgentExit` (staleSweeper onStale, process close handler, process error handler)
- **New file: `src/main/services/agent-exit-broadcast.test.ts`** — 5 test cases covering both targets called, lastOutput forwarding, argument shape correctness

## Test Plan
- [x] Unit tests for `broadcastAgentExit` verify both `broadcastToAllWindows` and `annexEventBus.emitPtyExit` are called
- [x] Tests verify `lastOutput` is forwarded to renderer but not to annex
- [x] Tests verify argument count is correct (no trailing `undefined` when `lastOutput` omitted)
- [x] All 6558 existing tests pass (no regressions)
- [x] TypeScript type check passes
- [x] ESLint passes

## Manual Validation
- Kill an agent and verify both the UI updates (agent shows as exited) and annex reports the exit event
- Trigger a stale sweep cleanup and verify the same dual notification

Fixes #545