### PR TITLE
refactor: break circular dependency between hook-server and agent-system (#573)

### DIFF
--- a/src/main/services/agent-registry.test.ts
+++ b/src/main/services/agent-registry.test.ts
@@ -25,7 +25,7 @@ vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
 }));
 
-import * as path from 'path';
+import * as fsp from 'fs/promises';
 import {
   agentRegistry,
   getAgentProjectPath,
@@ -36,7 +36,6 @@ import {
   readProjectOrchestrator,
   DEFAULT_ORCHESTRATOR,
 } from './agent-registry';
-import * as fsp from 'fs/promises';
 
 describe('agent-registry', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Extracts shared agent registry state and orchestrator resolution into a new `agent-registry.ts` module
- Breaks the circular import cycle between `hook-server.ts` and `agent-system.ts`
- Maintains full backward compatibility via re-exports from `agent-system.ts`

## Changes
- **New file: `src/main/services/agent-registry.ts`** — Contains `AgentRegistry` class, singleton instance, accessor functions (`getAgentProjectPath`, `getAgentOrchestrator`, `getAgentNonce`, `untrackAgent`), `resolveOrchestrator`, `readProjectOrchestrator`, and `DEFAULT_ORCHESTRATOR`
- **Updated: `src/main/services/hook-server.ts`** — Imports from `./agent-registry` instead of `./agent-system`
- **Updated: `src/main/services/agent-system.ts`** — Imports registry from `./agent-registry` and re-exports public API for backward compatibility. All existing consumers continue to work without changes.
- **Updated: `src/main/services/hook-server.test.ts`** — Updated mock target from `./agent-system` to `./agent-registry`
- **New file: `src/main/services/agent-registry.test.ts`** — Tests for the extracted registry accessors and `resolveOrchestrator`

### Dependency graph (before)
```
hook-server.ts ──imports──> agent-system.ts
agent-system.ts ──imports──> hook-server.ts  (CIRCULAR)
```

### Dependency graph (after)
```
hook-server.ts ──imports──> agent-registry.ts
agent-system.ts ──imports──> agent-registry.ts
agent-system.ts ──imports──> hook-server.ts  (no cycle)
```

## Test Plan
- [x] All 263 test files pass (6563 tests)
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] ESLint passes (no new warnings)
- [x] Existing consumers of `agent-system.ts` exports unchanged (re-exports preserve API)
- [x] `hook-server.test.ts` updated and passing
- [x] New `agent-registry.test.ts` covers registry accessors and `resolveOrchestrator`

## Manual Validation
- Verify agent spawn still works (registry state is shared correctly)
- Verify hook events still flow from CLI → hook-server → renderer

Fixes #573