### PR TITLE
refactor: extract shared parseModelChoicesFromHelp (#541)

### DIFF
--- a/src/main/orchestrators/codex-cli-provider.ts
+++ b/src/main/orchestrators/codex-cli-provider.ts
@@ -11,7 +11,7 @@ import {
   HeadlessCapable,
 } from './types';
 import { BaseProvider } from './base-provider';
-import { homePath, humanizeModelId } from './shared';
+import { homePath, parseModelChoicesFromHelp } from './shared';
 import { getShellEnvironment, invalidateShellEnvironmentCache } from '../util/shell';
 
 const execFileAsync = promisify(execFile);
@@ -30,19 +30,7 @@ const FALLBACK_MODEL_OPTIONS = [
   { id: 'gpt-5', label: 'GPT 5' },
 ];
 
-/** Parse model choices from `codex --help` output */
-function parseModelChoicesFromHelp(helpText: string): Array<{ id: string; label: string }> | null {
-  // Codex --help lists models in a choices-like format
-  const match = helpText.match(/--model\s+(?:<\w+>)?\s*.*?\(choices:\s*([\s\S]*?)\)/);
-  if (!match) return null;
-  const raw = match[1].replace(/\n/g, ' ');
-  const ids = [...raw.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-  if (ids.length === 0) return null;
-  return [
-    { id: 'default', label: 'Default' },
-    ...ids.map((id) => ({ id, label: humanizeModelId(id) })),
-  ];
-}
+const CODEX_MODEL_CHOICES_PATTERN = /--model\s+(?:<\w+>)?\s*.*?\(choices:\s*([\s\S]*?)\)/;
 
 // Codex uses sandbox-based permissions rather than per-tool permissions.
 // These map to general categories for compatibility with the permission UI.
@@ -109,7 +97,7 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable {
 
   protected readonly modelFetchConfig = {
     args: ['--help'],
-    parser: parseModelChoicesFromHelp,
+    parser: (help: string) => parseModelChoicesFromHelp(help, CODEX_MODEL_CHOICES_PATTERN),
   };
 
   // ── Core interface ──────────────────────────────────────────────────────

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -15,7 +15,7 @@ import {
 } from './types';
 import { BaseProvider } from './base-provider';
 import { AcpAdapter } from './adapters';
-import { homePath, humanizeModelId } from './shared';
+import { homePath, parseModelChoicesFromHelp } from './shared';
 import { isClubhouseHookEntry } from '../services/config-pipeline';
 
 const TOOL_VERBS: Record<string, string> = {
@@ -35,18 +35,7 @@ const FALLBACK_MODEL_OPTIONS = [
   { id: 'gpt-5-mini', label: 'GPT 5 Mini' },
 ];
 
-/** Parse model choices from `copilot --help` output */
-function parseModelChoicesFromHelp(helpText: string): Array<{ id: string; label: string }> | null {
-  const match = helpText.match(/--model\s+<model>\s+.*?\(choices:\s*([\s\S]*?)\)/);
-  if (!match) return null;
-  const raw = match[1].replace(/\n/g, ' ');
-  const ids = [...raw.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-  if (ids.length === 0) return null;
-  return [
-    { id: 'default', label: 'Default' },
-    ...ids.map((id) => ({ id, label: humanizeModelId(id) })),
-  ];
-}
+const COPILOT_MODEL_CHOICES_PATTERN = /--model\s+<model>\s+.*?\(choices:\s*([\s\S]*?)\)/;
 
 const DEFAULT_DURABLE_PERMISSIONS = ['shell(git:*)', 'shell(npm:*)', 'shell(npx:*)'];
 const DEFAULT_QUICK_PERMISSIONS = ['shell(git:*)', 'shell(npm:*)', 'shell(npx:*)', 'read', 'edit', 'search'];
@@ -105,7 +94,7 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
 
   protected readonly modelFetchConfig = {
     args: ['--help'],
-    parser: parseModelChoicesFromHelp,
+    parser: (help: string) => parseModelChoicesFromHelp(help, COPILOT_MODEL_CHOICES_PATTERN),
   };
 
   // ── Core interface ──────────────────────────────────────────────────────

--- a/src/main/orchestrators/shared.test.ts
+++ b/src/main/orchestrators/shared.test.ts
@@ -21,7 +21,7 @@ vi.mock('../util/shell', () => ({
 
 import * as fs from 'fs';
 import { execSync } from 'child_process';
-import { findBinaryInPath, homePath, humanizeModelId, buildSummaryInstruction, readQuickSummary, applyLaunchWrapper } from './shared';
+import { findBinaryInPath, homePath, humanizeModelId, parseModelChoicesFromHelp, buildSummaryInstruction, readQuickSummary, applyLaunchWrapper } from './shared';
 import type { LaunchWrapperConfig } from '../../shared/types';
 
 describe('shared orchestrator utilities', () => {
@@ -226,6 +226,68 @@ describe('shared orchestrator utilities', () => {
       );
       expect(result.args).toEqual([
         'claude', '--mcp', 'ado', '--mcp', 'kusto', '--mcp', 'workiq', '--mcp', 'icm', '--',
+      ]);
+    });
+  });
+
+  describe('parseModelChoicesFromHelp', () => {
+    const COPILOT_PATTERN = /--model\s+<model>\s+.*?\(choices:\s*([\s\S]*?)\)/;
+    const CODEX_PATTERN = /--model\s+(?:<\w+>)?\s*.*?\(choices:\s*([\s\S]*?)\)/;
+
+    const COPILOT_HELP = `Usage: copilot [options]
+
+Options:
+  --model <model>   Model to use (choices: "gpt-5", "claude-sonnet-4.5",
+                    "claude-opus-4.6")
+  --help            Show help`;
+
+    const CODEX_HELP = `Usage: codex [options]
+
+Options:
+  --model <model>   Model to use (choices: "gpt-5.3-codex", "gpt-5.2-codex",
+                    "codex-mini-latest")
+  --help            Show help`;
+
+    it('parses model choices from Copilot help output', () => {
+      const result = parseModelChoicesFromHelp(COPILOT_HELP, COPILOT_PATTERN);
+      expect(result).toEqual([
+        { id: 'default', label: 'Default' },
+        { id: 'gpt-5', label: 'Gpt 5' },
+        { id: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5' },
+        { id: 'claude-opus-4.6', label: 'Claude Opus 4.6' },
+      ]);
+    });
+
+    it('parses model choices from Codex help output', () => {
+      const result = parseModelChoicesFromHelp(CODEX_HELP, CODEX_PATTERN);
+      expect(result).toEqual([
+        { id: 'default', label: 'Default' },
+        { id: 'gpt-5.3-codex', label: 'Gpt 5.3 Codex' },
+        { id: 'gpt-5.2-codex', label: 'Gpt 5.2 Codex' },
+        { id: 'codex-mini-latest', label: 'Codex Mini Latest' },
+      ]);
+    });
+
+    it('returns null when pattern does not match', () => {
+      expect(parseModelChoicesFromHelp('no model flag here', COPILOT_PATTERN)).toBeNull();
+    });
+
+    it('returns null when choices section has no quoted IDs', () => {
+      const help = '--model <model>   Model to use (choices: )';
+      expect(parseModelChoicesFromHelp(help, COPILOT_PATTERN)).toBeNull();
+    });
+
+    it('always prepends a default entry', () => {
+      const result = parseModelChoicesFromHelp(COPILOT_HELP, COPILOT_PATTERN);
+      expect(result![0]).toEqual({ id: 'default', label: 'Default' });
+    });
+
+    it('handles single model in choices', () => {
+      const help = '--model <model>   Model to use (choices: "only-one")';
+      const result = parseModelChoicesFromHelp(help, COPILOT_PATTERN);
+      expect(result).toEqual([
+        { id: 'default', label: 'Default' },
+        { id: 'only-one', label: 'Only One' },
       ]);
     });
   });

--- a/src/main/orchestrators/shared.ts
+++ b/src/main/orchestrators/shared.ts
@@ -166,6 +166,31 @@ export function applyLaunchWrapper(
   return { binary: config.binary, args };
 }
 
+/**
+ * Parse model choices from CLI `--help` output.
+ *
+ * Extracts quoted model IDs from a "(choices: ...)" section matched by the
+ * given regex pattern.  The pattern must have one capture group that isolates
+ * the choices list (the text inside the parentheses).
+ *
+ * Used by Copilot CLI and Codex CLI providers — each passes a slightly
+ * different regex to account for variations in their help output format.
+ */
+export function parseModelChoicesFromHelp(
+  helpText: string,
+  pattern: RegExp,
+): Array<{ id: string; label: string }> | null {
+  const match = helpText.match(pattern);
+  if (!match) return null;
+  const raw = match[1].replace(/\n/g, ' ');
+  const ids = [...raw.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (ids.length === 0) return null;
+  return [
+    { id: 'default', label: 'Default' },
+    ...ids.map((id) => ({ id, label: humanizeModelId(id) })),
+  ];
+}
+
 /** Common home-relative path builder */
 export function homePath(...segments: string[]): string {
   return path.join(app.getPath('home'), ...segments);


### PR DESCRIPTION
## Summary
- Extract duplicated `parseModelChoicesFromHelp` function from `copilot-cli-provider.ts` and `codex-cli-provider.ts` into a single shared utility in `shared.ts`
- The shared function accepts a regex pattern parameter, allowing each provider to specify its own help output format
- Fixes #541

## Changes
- **`src/main/orchestrators/shared.ts`**: Added `parseModelChoicesFromHelp(helpText, pattern)` — a parameterized function that extracts quoted model IDs from a CLI `--help` choices section matched by the given regex
- **`src/main/orchestrators/copilot-cli-provider.ts`**: Replaced local `parseModelChoicesFromHelp` with import from shared; regex pattern extracted to `COPILOT_MODEL_CHOICES_PATTERN` constant
- **`src/main/orchestrators/codex-cli-provider.ts`**: Replaced local `parseModelChoicesFromHelp` with import from shared; regex pattern extracted to `CODEX_MODEL_CHOICES_PATTERN` constant
- **`src/main/orchestrators/shared.test.ts`**: Added 6 test cases covering both provider patterns, null cases, single model, and default entry behavior

## Test Plan
- [x] Parses model choices from Copilot-style help output
- [x] Parses model choices from Codex-style help output
- [x] Returns null when pattern does not match
- [x] Returns null when choices section has no quoted IDs
- [x] Always prepends a default entry
- [x] Handles single model in choices
- [x] All 6625 existing tests pass
- [x] TypeScript compiles cleanly
- [x] Lint passes

## Manual Validation
No manual validation needed — this is a pure refactor with no behavior change. The extracted function is tested directly and both providers continue to use their original regex patterns.