### PR TITLE
fix: move pin button into own flow row to avoid home hub overlap

### DIFF
--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -276,6 +276,35 @@ describe('ProjectRail pin button', () => {
     const pinBtn = screen.getByTestId('rail-pin-button');
     expect(pinBtn.className).toContain('text-ctp-subtext0');
   });
+
+  it('pin button is in its own flow container, not absolutely positioned', () => {
+    usePanelStore.setState({ railPinned: true });
+    render(<ProjectRail />);
+    const pinBtn = screen.getByTestId('rail-pin-button');
+    // Pin button itself should not be absolutely positioned
+    expect(pinBtn.className).not.toContain('absolute');
+    // Parent wrapper should be a flex container that right-aligns the button
+    const wrapper = pinBtn.parentElement!;
+    expect(wrapper.className).toContain('flex');
+    expect(wrapper.className).toContain('justify-end');
+  });
+
+  it('pin button wrapper collapses when rail is not expanded', () => {
+    render(<ProjectRail />);
+    const pinBtn = screen.getByTestId('rail-pin-button');
+    const wrapper = pinBtn.parentElement!;
+    expect(wrapper.className).toContain('h-0');
+    expect(wrapper.className).toContain('overflow-hidden');
+  });
+
+  it('pin button wrapper is visible when rail is expanded (pinned)', () => {
+    usePanelStore.setState({ railPinned: true });
+    render(<ProjectRail />);
+    const pinBtn = screen.getByTestId('rail-pin-button');
+    const wrapper = pinBtn.parentElement!;
+    expect(wrapper.className).toContain('h-6');
+    expect(wrapper.className).not.toContain('h-0');
+  });
 });
 
 describe('ProjectRail pinned behavior', () => {

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -411,36 +411,42 @@ export function ProjectRail() {
         `}
         style={{ width: computedWidth }}
       >
-        {/* Pin button — visible when rail is expanded */}
-        <button
-          onClick={handlePinClick}
-          title={railPinned ? 'Unpin sidebar' : 'Pin sidebar open'}
-          data-testid="rail-pin-button"
-          className={`
-            absolute top-2 right-1 z-40 w-6 h-6 flex items-center justify-center rounded
-            transition-opacity duration-200 cursor-pointer
-            ${expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'}
-            ${railPinned
-              ? 'text-ctp-accent hover:bg-surface-1'
-              : 'text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-1'
-            }
-          `}
+        {/* Pin button row — visible when rail is expanded, own row above home */}
+        <div
+          className={`flex justify-end flex-shrink-0 -mb-1 transition-opacity duration-200 ${
+            expanded ? 'opacity-100 h-6' : 'opacity-0 h-0 overflow-hidden pointer-events-none'
+          }`}
         >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill={railPinned ? 'currentColor' : 'none'}
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className={railPinned ? '' : 'rotate-45'}
+          <button
+            onClick={handlePinClick}
+            title={railPinned ? 'Unpin sidebar' : 'Pin sidebar open'}
+            data-testid="rail-pin-button"
+            className={`
+              w-6 h-6 flex items-center justify-center rounded
+              transition-opacity duration-200 cursor-pointer
+              ${expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'}
+              ${railPinned
+                ? 'text-ctp-accent hover:bg-surface-1'
+                : 'text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-1'
+              }
+            `}
           >
-            <path d="M12 17v5" />
-            <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z" />
-          </svg>
-        </button>
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill={railPinned ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={railPinned ? '' : 'rotate-45'}
+            >
+              <path d="M12 17v5" />
+              <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z" />
+            </svg>
+          </button>
+        </div>
         {/* Home button */}
         {showHome && (
           <button


### PR DESCRIPTION
## Summary
- Fixed the pin icon overlapping with the home hub button's hit box when the project rail is expanded but not pinned
- Moved the pin button from absolute positioning into its own flex row with `justify-end`, giving it dedicated space above the home button

## Changes
- **`src/renderer/panels/ProjectRail.tsx`**: Wrapped the pin button in a dedicated `<div>` container that participates in the flex column flow instead of using `absolute top-2 right-1` positioning. The wrapper collapses to `h-0` when the rail is collapsed and expands to `h-6` when expanded, with a `-mb-1` to keep spacing tight.
- **`src/renderer/panels/ProjectRail.test.tsx`**: Added 3 new tests verifying the pin button is in a flow container (not absolute), its wrapper collapses when collapsed, and expands when the rail is pinned.

## Test Plan
- [x] Pin button renders and is clickable
- [x] Pin button is not absolutely positioned (no overlap with home hub)
- [x] Pin button wrapper collapses (`h-0`, `overflow-hidden`) when rail is collapsed
- [x] Pin button wrapper expands (`h-6`) when rail is expanded/pinned
- [x] All existing pin button tests pass (visibility, toggle, icon states, colors, titles)
- [x] Typecheck passes
- [x] All 6794 tests pass
- [x] Lint passes (0 errors)

## Manual Validation
1. Launch the app and hover over the collapsed project rail to expand it
2. Verify the pin icon appears in its own row above the home hub button
3. Click near the boundary between the pin icon and home hub — confirm they don't share a hit box
4. Pin the rail and verify the pin icon remains properly positioned
5. Unpin and collapse — verify the pin icon disappears cleanly