### PR TITLE
fix: show experimental features when preview channel is enabled

### DIFF
--- a/src/renderer/panels/AccessoryPanel.test.tsx
+++ b/src/renderer/panels/AccessoryPanel.test.tsx
@@ -1,18 +1,28 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useUIStore } from '../stores/uiStore';
+import { useUpdateStore } from '../stores/updateStore';
 import { AccessoryPanel } from './AccessoryPanel';
 
-function resetStores() {
+function resetStores(opts: { previewChannel?: boolean } = {}) {
   useUIStore.setState({
     explorerTab: 'settings',
     settingsContext: 'app',
     settingsSubPage: 'about',
   });
+  useUpdateStore.setState({
+    settings: {
+      autoUpdate: true,
+      previewChannel: opts.previewChannel ?? false,
+      lastCheck: null,
+      dismissedVersion: null,
+      lastSeenVersion: null,
+    },
+  });
 }
 
 describe('SettingsCategoryNav (via AccessoryPanel)', () => {
-  beforeEach(resetStores);
+  beforeEach(() => resetStores());
 
   it('settings category nav is scrollable when content overflows', () => {
     const { container } = render(<AccessoryPanel />);
@@ -31,7 +41,7 @@ describe('SettingsCategoryNav (via AccessoryPanel)', () => {
     unmount();
   });
 
-  it('hides Experimental nav item on stable builds', async () => {
+  it('hides Experimental nav item on stable builds without preview channel', async () => {
     window.clubhouse.app.getVersion = vi.fn().mockResolvedValue('1.0.0');
     const { unmount } = render(<AccessoryPanel />);
     // Wait for the version check to resolve
@@ -48,6 +58,27 @@ describe('SettingsCategoryNav (via AccessoryPanel)', () => {
     await waitFor(() => {
       expect(screen.getByText('Experimental')).toBeInTheDocument();
     });
+    unmount();
+  });
+
+  it('shows Experimental nav item on stable builds when preview channel is enabled', async () => {
+    resetStores({ previewChannel: true });
+    window.clubhouse.app.getVersion = vi.fn().mockResolvedValue('0.36.0');
+    const { unmount } = render(<AccessoryPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('Experimental')).toBeInTheDocument();
+    });
+    unmount();
+  });
+
+  it('hides Experimental nav item on stable builds when preview channel is disabled', async () => {
+    resetStores({ previewChannel: false });
+    window.clubhouse.app.getVersion = vi.fn().mockResolvedValue('0.36.0');
+    const { unmount } = render(<AccessoryPanel />);
+    await waitFor(() => {
+      expect(window.clubhouse.app.getVersion).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
     unmount();
   });
 });

--- a/src/renderer/panels/AccessoryPanel.tsx
+++ b/src/renderer/panels/AccessoryPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useUIStore } from '../stores/uiStore';
 import { usePluginStore } from '../plugins/plugin-store';
 import { useProjectStore } from '../stores/projectStore';
+import { useUpdateStore } from '../stores/updateStore';
 import { PluginAPIProvider } from '../plugins/plugin-context';
 import { createPluginAPI } from '../plugins/plugin-api-factory';
 import { getActiveContext } from '../plugins/plugin-loader';
@@ -18,11 +19,12 @@ function SettingsCategoryNav() {
   const settingsContext = useUIStore((s) => s.settingsContext);
   const settingsSubPage = useUIStore((s) => s.settingsSubPage);
   const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
+  const previewChannel = useUpdateStore((s) => s.settings.previewChannel);
   const [showExperimental, setShowExperimental] = useState(false);
 
   useEffect(() => {
-    window.clubhouse.app.getVersion().then((v) => setShowExperimental(isBetaBuild(v)));
-  }, []);
+    window.clubhouse.app.getVersion().then((v) => setShowExperimental(isBetaBuild(v) || previewChannel));
+  }, [previewChannel]);
 
   const navButton = (label: string, page: SettingsSubPage) => (
     <button


### PR DESCRIPTION
## Summary
- Experimental settings tab now shows when the user has the preview (beta) update channel enabled, not just when the current build has a prerelease version tag
- Fixes the case where beta users updating to a stable release (e.g. `v0.36.0-beta.4` → `v0.36.0`) would lose access to experimental features

## Changes
- **`AccessoryPanel.tsx`**: `SettingsCategoryNav` now reads `previewChannel` from the update store and shows the Experimental tab when `isBetaBuild(version) || previewChannel`
- **`AccessoryPanel.test.tsx`**: Added test cases for preview channel enabled/disabled on stable builds, updated existing test descriptions for clarity

## Test Plan
- [x] Experimental tab shows on beta builds (`0.36.0-beta.2`) — existing test
- [x] Experimental tab shows on RC builds (`0.37.0-rc.1`) — existing test  
- [x] Experimental tab shows on stable builds when preview channel is enabled — new test
- [x] Experimental tab hidden on stable builds when preview channel is disabled — new test
- [x] Typecheck passes
- [x] All 6796 tests pass
- [x] Lint clean (0 errors)

## Manual Validation
1. Enable the preview channel in Settings → Updates
2. Update to a stable release (or set version to a stable string in dev)
3. Verify the Experimental settings tab is still visible
4. Disable the preview channel — verify the tab disappears (on a stable build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)