### PR TITLE
fix: position pin button as absolute overlay instead of own row

### DIFF
--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -277,33 +277,24 @@ describe('ProjectRail pin button', () => {
     expect(pinBtn.className).toContain('text-ctp-subtext0');
   });
 
-  it('pin button is in its own flow container, not absolutely positioned', () => {
+  it('pin button is absolutely positioned in its own column, not a flow row', () => {
     usePanelStore.setState({ railPinned: true });
     render(<ProjectRail />);
     const pinBtn = screen.getByTestId('rail-pin-button');
-    // Pin button itself should not be absolutely positioned
-    expect(pinBtn.className).not.toContain('absolute');
-    // Parent wrapper should be a flex container that right-aligns the button
-    const wrapper = pinBtn.parentElement!;
-    expect(wrapper.className).toContain('flex');
-    expect(wrapper.className).toContain('justify-end');
+    // Pin button should be absolutely positioned top-right
+    expect(pinBtn.className).toContain('absolute');
+    expect(pinBtn.className).toContain('top-[20px]');
+    expect(pinBtn.className).toContain('right-[10px]');
   });
 
-  it('pin button wrapper collapses when rail is not expanded', () => {
-    render(<ProjectRail />);
-    const pinBtn = screen.getByTestId('rail-pin-button');
-    const wrapper = pinBtn.parentElement!;
-    expect(wrapper.className).toContain('h-0');
-    expect(wrapper.className).toContain('overflow-hidden');
-  });
-
-  it('pin button wrapper is visible when rail is expanded (pinned)', () => {
+  it('pin button does not shift rail items down (no wrapper row)', () => {
     usePanelStore.setState({ railPinned: true });
     render(<ProjectRail />);
     const pinBtn = screen.getByTestId('rail-pin-button');
-    const wrapper = pinBtn.parentElement!;
-    expect(wrapper.className).toContain('h-6');
-    expect(wrapper.className).not.toContain('h-0');
+    // Pin button is a direct child of the rail inner div, not inside a wrapper row
+    const parent = pinBtn.parentElement!;
+    expect(parent.className).toContain('relative');
+    expect(parent.className).toContain('flex-col');
   });
 });
 

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -405,48 +405,43 @@ export function ProjectRail() {
     >
       <div
         className={`
-          flex flex-col py-3 gap-2 bg-ctp-mantle border-r border-surface-0 h-full
+          relative flex flex-col py-3 gap-2 bg-ctp-mantle border-r border-surface-0 h-full
           transition-[width] duration-200 ease-in-out overflow-hidden pl-[14px] pr-[10px]
           ${!railPinned && overlaying ? 'absolute inset-y-0 left-0 z-30 shadow-xl shadow-black/20' : ''}
         `}
         style={{ width: computedWidth }}
       >
-        {/* Pin button row — visible when rail is expanded, own row above home */}
-        <div
-          className={`flex justify-end flex-shrink-0 -mb-1 transition-opacity duration-200 ${
-            expanded ? 'opacity-100 h-6' : 'opacity-0 h-0 overflow-hidden pointer-events-none'
-          }`}
+        {/* Pin button — absolutely positioned top-right, aligned with first rail item */}
+        <button
+          onClick={handlePinClick}
+          title={railPinned ? 'Unpin sidebar' : 'Pin sidebar open'}
+          data-testid="rail-pin-button"
+          className={`
+            absolute top-[20px] right-[10px] z-10
+            w-6 h-6 flex items-center justify-center rounded
+            transition-opacity duration-200 cursor-pointer
+            ${expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'}
+            ${railPinned
+              ? 'text-ctp-accent hover:bg-surface-1'
+              : 'text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-1'
+            }
+          `}
         >
-          <button
-            onClick={handlePinClick}
-            title={railPinned ? 'Unpin sidebar' : 'Pin sidebar open'}
-            data-testid="rail-pin-button"
-            className={`
-              w-6 h-6 flex items-center justify-center rounded
-              transition-opacity duration-200 cursor-pointer
-              ${expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'}
-              ${railPinned
-                ? 'text-ctp-accent hover:bg-surface-1'
-                : 'text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-1'
-              }
-            `}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill={railPinned ? 'currentColor' : 'none'}
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={railPinned ? '' : 'rotate-45'}
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill={railPinned ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className={railPinned ? '' : 'rotate-45'}
-            >
-              <path d="M12 17v5" />
-              <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z" />
-            </svg>
-          </button>
-        </div>
+            <path d="M12 17v5" />
+            <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z" />
+          </svg>
+        </button>
         {/* Home button */}
         {showHome && (
           <button


### PR DESCRIPTION
## Summary
- Pin button in the project rail was rendered as its own flex row, causing all rail items to shift down when the rail expanded
- Changed to absolute positioning so the pin button floats top-right aligned with the first rail item, in its own visual column with no overlap

## Changes
- **ProjectRail.tsx**: Removed the pin button wrapper `<div>` row; made the `<button>` itself absolutely positioned (`absolute top-[20px] right-[10px] z-10`) inside the rail inner div (which now has `relative`)
- **ProjectRail.test.tsx**: Updated 3 layout tests to verify the new absolute positioning instead of the old wrapper-row approach

## Test Plan
- [x] Pin button is absolutely positioned with `top-[20px] right-[10px]`
- [x] Pin button parent is the rail inner div (has `relative` and `flex-col`)
- [x] Pin button hidden (`opacity-0`, `pointer-events-none`) when rail is collapsed
- [x] Pin button visible (`opacity-100`) when rail is pinned
- [x] Click toggles pinned state
- [x] Icon fill/rotation matches pinned/unpinned state
- [x] All 6793 tests pass, typecheck clean, no lint errors

## Manual Validation
1. Launch the app, observe the rail is collapsed — pin button should be invisible
2. Hover over the rail to expand — pin button appears top-right, aligned with the Home icon
3. Verify the Home button and project list do NOT shift down when pin button appears
4. Pin the rail — pin button stays in place, icon fills in
5. Unpin — smooth transition back