### PR TITLE
feat: use AgentAvatar with status rings in canvas agent picker

### DIFF
--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -85,9 +85,13 @@ export function AgentCanvasView({ view, api, onUpdate }: AgentCanvasViewProps) {
     }
 
     // Filter agents by selected project in app mode, or show all in project mode
-    const filteredAgents = isAppMode && selectedProjectId
+    // Only show durable agents (no quick agents)
+    const filteredAgents = (isAppMode && selectedProjectId
       ? agents.filter((a) => a.projectId === selectedProjectId)
-      : agents;
+      : agents
+    ).filter((a) => a.kind === 'durable');
+
+    const { AgentAvatar } = api.widgets;
 
     return (
       <div className="flex flex-col h-full p-2">
@@ -99,24 +103,24 @@ export function AgentCanvasView({ view, api, onUpdate }: AgentCanvasViewProps) {
             &larr; Back
           </button>
         )}
-        <div className="text-xs text-ctp-subtext0 mb-2">Select an agent:</div>
+        <div className="text-xs font-medium text-ctp-subtext1 uppercase tracking-wider mb-2">
+          Assign an agent
+        </div>
         <div className="flex-1 overflow-y-auto space-y-1">
           {filteredAgents.length === 0 ? (
-            <div className="text-xs text-ctp-overlay0 italic">No agents{isAppMode ? ' in this project' : ' running'}</div>
+            <div className="text-xs text-ctp-overlay0 italic">No agents{isAppMode ? ' in this project' : ' available'}</div>
           ) : (
             filteredAgents.map((agent) => (
               <button
                 key={agent.id}
-                className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-[11px] text-ctp-text hover:bg-ctp-surface0 transition-colors text-left"
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-0 hover:bg-surface-1 text-left transition-colors"
                 onClick={() => handlePickAgent(agent)}
                 data-testid={`canvas-agent-pick-${agent.id}`}
               >
-                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                  agent.status === 'running' ? 'bg-green-500' :
-                  agent.status === 'error' ? 'bg-red-500' :
-                  'bg-ctp-overlay0'
-                }`} />
-                <span className="truncate flex-1">{agent.name || agent.id}</span>
+                <AgentAvatar agentId={agent.id} size="sm" showStatusRing />
+                <span className="text-xs text-ctp-text truncate flex-1">
+                  {agent.name || agent.id}
+                </span>
                 <span className={`text-[10px] ${
                   agent.status === 'running' ? 'text-green-400' :
                   agent.status === 'error' ? 'text-red-400' :

--- a/src/renderer/plugins/builtin/canvas/canvas-views.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-views.test.ts
@@ -83,6 +83,41 @@ describe('AgentCanvasView — projectColor', () => {
   });
 });
 
+// ── AgentCanvasView — durable-only filtering ─────────────────────────
+
+describe('AgentCanvasView — agent filtering', () => {
+  const agents = [
+    { id: 'a1', name: 'alpha', kind: 'durable', status: 'running', projectId: 'p1' },
+    { id: 'a2', name: 'beta', kind: 'quick', status: 'running', projectId: 'p1' },
+    { id: 'a3', name: 'gamma', kind: 'durable', status: 'sleeping', projectId: 'p1' },
+    { id: 'a4', name: 'delta', kind: 'quick', status: 'sleeping', projectId: 'p1' },
+  ];
+
+  it('filters out quick agents, keeping only durable', () => {
+    const filtered = agents.filter((a) => a.kind === 'durable');
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((a) => a.name)).toEqual(['alpha', 'gamma']);
+  });
+
+  it('excludes all quick agents regardless of status', () => {
+    const filtered = agents.filter((a) => a.kind === 'durable');
+    expect(filtered.every((a) => a.kind === 'durable')).toBe(true);
+    expect(filtered.some((a) => a.kind === 'quick')).toBe(false);
+  });
+
+  it('combines project filtering with durable-only filtering', () => {
+    const moreAgents = [
+      ...agents,
+      { id: 'a5', name: 'epsilon', kind: 'durable', status: 'running', projectId: 'p2' },
+    ];
+    const filtered = moreAgents
+      .filter((a) => a.projectId === 'p1')
+      .filter((a) => a.kind === 'durable');
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((a) => a.name)).toEqual(['alpha', 'gamma']);
+  });
+});
+
 // ── Scroll event propagation ──────────────────────────────────────────
 
 describe('CanvasView — scroll isolation', () => {


### PR DESCRIPTION
## Summary
- Replace simple colored dots in the canvas agent picker with the same `AgentAvatar` widget used by the hub, complete with profile photos, colored initials, and animated status rings
- Filter out quick agents from the canvas picker to show only durable agents
- Match hub agent picker styling (rounded cards, spacing, typography)

## Changes
- **`AgentCanvasView.tsx`**: Replaced inline colored-dot status indicators with `api.widgets.AgentAvatar` using `showStatusRing`. Added `.filter(a => a.kind === 'durable')` to exclude quick agents. Updated button styling to match hub (`rounded-lg bg-surface-0 hover:bg-surface-1 px-3 py-2`). Changed header to "Assign an agent" with uppercase tracking to match hub.
- **`canvas-views.test.ts`**: Added test suite for durable-only agent filtering logic covering basic filtering, status-agnostic exclusion, and combined project + kind filtering.

## Test Plan
- [x] Typecheck passes
- [x] All tests pass (including new agent filtering tests)
- [x] Lint passes (0 errors)
- [ ] Manual: Open canvas, add an agent view — verify avatars show profile pics/initials with colored backgrounds and status rings
- [ ] Manual: Verify quick agents do not appear in the canvas picker
- [ ] Manual: Verify running agents show green ring, sleeping agents show gray ring, error agents show red ring
- [ ] Manual: Verify the canvas picker visually matches the hub agent picker style

## Manual Validation
1. Open the canvas plugin
2. Add a new agent canvas view (no agent assigned)
3. Confirm the agent picker shows avatars with profile pictures (or colored initials) and status rings — matching the hub's agent selection screen
4. Confirm quick agents are not listed
5. Pick an agent and verify the view loads correctly