### PR TITLE
fix: pass onExit to createSessionRecord for stale sweep cleanup

### DIFF
--- a/src/main/services/headless-manager.ts
+++ b/src/main/services/headless-manager.ts
@@ -240,6 +240,7 @@ function createSessionRecord(
   proc: ChildProcess,
   outputKind: HeadlessOutputKind,
   transcriptPath: string,
+  onExit?: (agentId: string, exitCode: number) => void,
 ): HeadlessSession {
   const parser = outputKind === 'stream-json' ? new JsonlParser() : null;
   return {
@@ -514,7 +515,7 @@ export async function spawnHeadless(
     appLog('core:headless', 'info', `Process spawned`, { meta: { agentId, pid: proc.pid } });
   }
 
-  const session = createSessionRecord(agentId, proc, outputKind, transcriptPath);
+  const session = createSessionRecord(agentId, proc, outputKind, transcriptPath, onExit);
   sessions.set(agentId, session);
 
   const logStream = fs.createWriteStream(transcriptPath, { flags: 'w' });


### PR DESCRIPTION
## Summary
- Pass the `onExit` callback through to `createSessionRecord` so it is stored on the session record as `onExitCallback`
- Fixes a memory leak where the stale sweeper could not invoke the exit callback when cleaning up dead sessions, leaving orphaned agent registry entries

## Test plan
- [x] All 101 headless-manager unit tests pass
- [x] Full test suite passes (6640 tests, 266 files)
- [x] Existing test at line 1440 (`sweep invokes onExit callback so registry is cleaned up`) validates the fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)