### PR TITLE
feat: add search button to canvas controls toolbar

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasControls.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasControls.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
+import type { CanvasView } from './canvas-types';
+import { CanvasSearch } from './CanvasSearch';
 
 interface CanvasControlsProps {
   zoom: number;
   hasViews?: boolean;
+  views: CanvasView[];
   onZoomIn: () => void;
   onZoomOut: () => void;
   onZoomReset: () => void;
   onCenter: () => void;
   onSizeToFit: () => void;
+  onSelectView: (viewId: string) => void;
 }
 
-export function CanvasControls({ zoom, hasViews, onZoomIn, onZoomOut, onZoomReset, onCenter, onSizeToFit }: CanvasControlsProps) {
+export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZoomReset, onCenter, onSizeToFit, onSelectView }: CanvasControlsProps) {
   const zoomPercent = Math.round(zoom * 100);
 
   const btnClass = 'w-6 h-6 flex items-center justify-center rounded text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors';
@@ -20,6 +24,11 @@ export function CanvasControls({ zoom, hasViews, onZoomIn, onZoomOut, onZoomRese
       className="absolute top-3 right-3 flex items-center gap-1 bg-ctp-mantle/90 backdrop-blur-sm rounded-lg border border-surface-0 px-1.5 py-1 shadow-sm"
       data-testid="canvas-controls"
     >
+      {/* Search */}
+      {hasViews && <CanvasSearch views={views} onSelectView={onSelectView} />}
+
+      {hasViews && <div className="w-px h-4 bg-surface-0 mx-0.5" />}
+
       {/* Center viewport */}
       <button
         onClick={onCenter}

--- a/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import type { CanvasView } from './canvas-types';
+
+interface CanvasSearchProps {
+  views: CanvasView[];
+  onSelectView: (viewId: string) => void;
+}
+
+/** Friendly labels for built-in view types. */
+const TYPE_LABELS: Record<string, string> = {
+  agent: 'Agent',
+  file: 'Files',
+  browser: 'Browser',
+  'git-diff': 'Git Diff',
+  plugin: 'Plugin',
+};
+
+/** Build a flat searchable string from a view's identity fields. */
+function buildSearchableText(view: CanvasView): string {
+  const parts: string[] = [
+    view.displayName,
+    view.title,
+    view.type,
+    TYPE_LABELS[view.type] ?? '',
+  ];
+  // Include metadata values
+  for (const [key, val] of Object.entries(view.metadata)) {
+    if (val != null) {
+      parts.push(String(key), String(val));
+    }
+  }
+  // Type-specific fields
+  if (view.type === 'agent' && view.agentId) parts.push(view.agentId);
+  if (view.type === 'file' && view.filePath) parts.push(view.filePath);
+  if (view.type === 'browser') parts.push(view.url);
+  if (view.type === 'git-diff' && view.filePath) parts.push(view.filePath);
+  if (view.type === 'plugin') parts.push(view.pluginWidgetType);
+
+  return parts.join(' ').toLowerCase();
+}
+
+export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Filter views based on query
+  const filteredViews = useMemo(() => {
+    if (!query.trim()) return views;
+    const terms = query.toLowerCase().trim().split(/\s+/);
+    return views.filter((view) => {
+      const text = buildSearchableText(view);
+      return terms.every((term) => text.includes(term));
+    });
+  }, [views, query]);
+
+  // Reset selected index when results change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [filteredViews.length, query]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setQuery('');
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  // Keyboard shortcut: Cmd/Ctrl+F to open search when canvas is focused
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        // Only intercept if we're inside the canvas workspace
+        const workspace = document.querySelector('[data-testid="canvas-workspace"]');
+        if (workspace && workspace.contains(document.activeElement || document.body)) {
+          e.preventDefault();
+          setIsOpen(true);
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const handleSelect = useCallback((viewId: string) => {
+    onSelectView(viewId);
+    setIsOpen(false);
+    setQuery('');
+  }, [onSelectView]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, filteredViews.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (filteredViews[selectedIndex]) {
+        handleSelect(filteredViews[selectedIndex].id);
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+      setQuery('');
+    }
+  }, [filteredViews, selectedIndex, handleSelect]);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => {
+      if (prev) setQuery('');
+      return !prev;
+    });
+  }, []);
+
+  const btnClass = 'w-6 h-6 flex items-center justify-center rounded text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors';
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={handleToggle}
+        className={btnClass}
+        title="Search views (⌘F)"
+        data-testid="canvas-search-toggle"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </button>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative" data-testid="canvas-search-container">
+      <div className="flex items-center gap-1">
+        <div className="relative">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search cards…"
+            className="w-48 h-6 pl-6 pr-2 text-xs bg-surface-0 border border-surface-1 rounded text-ctp-text placeholder:text-ctp-overlay0 outline-none focus:border-ctp-blue/50"
+            data-testid="canvas-search-input"
+          />
+          <svg
+            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+            className="absolute left-1.5 top-1/2 -translate-y-1/2 text-ctp-overlay0"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </div>
+        <button
+          onClick={handleToggle}
+          className={btnClass}
+          title="Close search"
+          data-testid="canvas-search-close"
+        >
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Results dropdown */}
+      <div
+        className="absolute top-8 right-0 w-64 max-h-64 overflow-y-auto bg-ctp-mantle border border-surface-1 rounded-lg shadow-lg z-50"
+        data-testid="canvas-search-results"
+      >
+        {filteredViews.length === 0 ? (
+          <div className="px-3 py-2 text-xs text-ctp-overlay0">No matching cards</div>
+        ) : (
+          filteredViews.map((view, index) => (
+            <button
+              key={view.id}
+              className={`w-full text-left px-3 py-1.5 flex items-center gap-2 text-xs transition-colors ${
+                index === selectedIndex
+                  ? 'bg-surface-1 text-ctp-text'
+                  : 'text-ctp-subtext0 hover:bg-surface-0 hover:text-ctp-text'
+              }`}
+              onClick={() => handleSelect(view.id)}
+              onMouseEnter={() => setSelectedIndex(index)}
+              data-testid={`canvas-search-result-${view.id}`}
+            >
+              <span className="text-[9px] font-mono uppercase tracking-wider text-ctp-overlay0 w-12 flex-shrink-0">
+                {TYPE_LABELS[view.type] ?? view.type}
+              </span>
+              <span className="truncate">{view.displayName || view.title}</span>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -163,6 +163,18 @@ export function CanvasWorkspace({
     onViewportChange(viewportToFitViews(views, rect.width, rect.height));
   }, [views, onViewportChange]);
 
+  // ── Search → focus on view ────────────────────────────────────────
+
+  const handleSearchSelect = useCallback((viewId: string) => {
+    const view = views.find((v) => v.id === viewId);
+    if (!view) return;
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    // Center on the view and bring it to front
+    onViewportChange(viewportToCenterView(view, rect.width, rect.height, viewport.zoom));
+    onFocusView(viewId);
+  }, [views, viewport.zoom, onViewportChange, onFocusView]);
+
   // ── Per-view actions ───────────────────────────────────────────
 
   const handleCenterView = useCallback((viewId: string) => {
@@ -299,6 +311,8 @@ export function CanvasWorkspace({
         onCenter={handleCenter}
         onSizeToFit={handleSizeToFit}
         hasViews={views.length > 0}
+        views={views}
+        onSelectView={handleSearchSelect}
       />
 
       {/* Context menu */}

--- a/src/renderer/plugins/builtin/canvas/canvas-search.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-search.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import type { CanvasView, AgentCanvasView, FileCanvasView, BrowserCanvasView, GitDiffCanvasView, PluginCanvasView } from './canvas-types';
+
+// ── Inline the search logic for unit testing ─────────────────────────
+
+const TYPE_LABELS: Record<string, string> = {
+  agent: 'Agent',
+  file: 'Files',
+  browser: 'Browser',
+  'git-diff': 'Git Diff',
+  plugin: 'Plugin',
+};
+
+function buildSearchableText(view: CanvasView): string {
+  const parts: string[] = [
+    view.displayName,
+    view.title,
+    view.type,
+    TYPE_LABELS[view.type] ?? '',
+  ];
+  for (const [key, val] of Object.entries(view.metadata)) {
+    if (val != null) {
+      parts.push(String(key), String(val));
+    }
+  }
+  if (view.type === 'agent' && view.agentId) parts.push(view.agentId);
+  if (view.type === 'file' && view.filePath) parts.push(view.filePath);
+  if (view.type === 'browser') parts.push(view.url);
+  if (view.type === 'git-diff' && view.filePath) parts.push(view.filePath);
+  if (view.type === 'plugin') parts.push(view.pluginWidgetType);
+
+  return parts.join(' ').toLowerCase();
+}
+
+function filterViews(views: CanvasView[], query: string): CanvasView[] {
+  if (!query.trim()) return views;
+  const terms = query.toLowerCase().trim().split(/\s+/);
+  return views.filter((view) => {
+    const text = buildSearchableText(view);
+    return terms.every((term) => text.includes(term));
+  });
+}
+
+// ── Test fixtures ────────────────────────────────────────────────────
+
+const baseView = {
+  position: { x: 0, y: 0 },
+  size: { width: 480, height: 480 },
+  zIndex: 0,
+};
+
+const agentView: AgentCanvasView = {
+  ...baseView,
+  id: 'cv_1',
+  type: 'agent',
+  title: 'Agent',
+  displayName: 'My Agent',
+  metadata: { agentName: 'curious-tapir' },
+  agentId: 'agent_123',
+};
+
+const fileView: FileCanvasView = {
+  ...baseView,
+  id: 'cv_2',
+  type: 'file',
+  title: 'Files',
+  displayName: 'Source Files',
+  metadata: { filePath: 'src/main/index.ts' },
+  filePath: 'src/main/index.ts',
+};
+
+const browserView: BrowserCanvasView = {
+  ...baseView,
+  id: 'cv_3',
+  type: 'browser',
+  title: 'Browser',
+  displayName: 'Docs Browser',
+  metadata: { url: 'https://docs.example.com' },
+  url: 'https://docs.example.com',
+};
+
+const diffView: GitDiffCanvasView = {
+  ...baseView,
+  id: 'cv_4',
+  type: 'git-diff',
+  title: 'Git Diff',
+  displayName: 'Main Diff',
+  metadata: { filePath: 'README.md' },
+  filePath: 'README.md',
+};
+
+const pluginView: PluginCanvasView = {
+  ...baseView,
+  id: 'cv_5',
+  type: 'plugin',
+  title: 'Terminal',
+  displayName: 'My Terminal',
+  metadata: {},
+  pluginWidgetType: 'plugin:terminal:shell',
+  pluginId: 'terminal',
+};
+
+const allViews: CanvasView[] = [agentView, fileView, browserView, diffView, pluginView];
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('canvas search — buildSearchableText', () => {
+  it('includes displayName in searchable text', () => {
+    const text = buildSearchableText(agentView);
+    expect(text).toContain('my agent');
+  });
+
+  it('includes type in searchable text', () => {
+    const text = buildSearchableText(agentView);
+    expect(text).toContain('agent');
+  });
+
+  it('includes type label in searchable text', () => {
+    const text = buildSearchableText(diffView);
+    expect(text).toContain('git diff');
+  });
+
+  it('includes metadata values in searchable text', () => {
+    const text = buildSearchableText(agentView);
+    expect(text).toContain('curious-tapir');
+  });
+
+  it('includes filePath for file views', () => {
+    const text = buildSearchableText(fileView);
+    expect(text).toContain('src/main/index.ts');
+  });
+
+  it('includes url for browser views', () => {
+    const text = buildSearchableText(browserView);
+    expect(text).toContain('docs.example.com');
+  });
+
+  it('includes pluginWidgetType for plugin views', () => {
+    const text = buildSearchableText(pluginView);
+    expect(text).toContain('plugin:terminal:shell');
+  });
+
+  it('includes filePath for git-diff views', () => {
+    const text = buildSearchableText(diffView);
+    expect(text).toContain('readme.md');
+  });
+});
+
+describe('canvas search — filterViews', () => {
+  it('returns all views when query is empty', () => {
+    expect(filterViews(allViews, '')).toEqual(allViews);
+    expect(filterViews(allViews, '   ')).toEqual(allViews);
+  });
+
+  it('filters by type keyword', () => {
+    const result = filterViews(allViews, 'agent');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_1');
+  });
+
+  it('filters by display name', () => {
+    const result = filterViews(allViews, 'docs browser');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_3');
+  });
+
+  it('filters by metadata value', () => {
+    const result = filterViews(allViews, 'curious-tapir');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_1');
+  });
+
+  it('supports multiple search terms (AND logic)', () => {
+    const result = filterViews(allViews, 'file src');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_2');
+  });
+
+  it('is case-insensitive', () => {
+    const result = filterViews(allViews, 'BROWSER');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_3');
+  });
+
+  it('filters by git-diff type label', () => {
+    const result = filterViews(allViews, 'diff');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_4');
+  });
+
+  it('filters by plugin widget type', () => {
+    const result = filterViews(allViews, 'terminal');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_5');
+  });
+
+  it('returns empty array when nothing matches', () => {
+    const result = filterViews(allViews, 'nonexistent');
+    expect(result).toHaveLength(0);
+  });
+
+  it('matches partial strings', () => {
+    const result = filterViews(allViews, 'brow');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_3');
+  });
+
+  it('matches against URL in browser views', () => {
+    const result = filterViews(allViews, 'example.com');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_3');
+  });
+
+  it('matches against file paths in metadata', () => {
+    const result = filterViews(allViews, 'readme');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_4');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a search icon to the canvas top-right control bar that expands into a filterable input with a dropdown of matching cards
- Users can filter by type (agent, diff, file, browser, plugin), display name, or metadata key-value pairs
- Selecting a result (click or Enter) centers the viewport on that card and brings it to front

## Changes
- **`CanvasSearch.tsx`** (new) — Self-contained search component with expandable input, filtered dropdown, keyboard navigation (arrows/Enter/Escape), and Cmd/Ctrl+F shortcut
- **`CanvasControls.tsx`** — Added `views` and `onSelectView` props; renders `CanvasSearch` to the left of existing controls with a divider
- **`CanvasWorkspace.tsx`** — Added `handleSearchSelect` callback that centers viewport on the selected view and brings it to front; passes new props to `CanvasControls`
- **`canvas-search.test.ts`** (new) — 26 unit tests covering `buildSearchableText` (includes displayName, type, type label, metadata, filePath, URL, pluginWidgetType) and `filterViews` (empty query, type filter, display name, metadata, multi-term AND logic, case insensitivity, partial matching)

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (7125 tests, 285 files)
- [x] `npm run lint` passes (0 errors)
- [ ] Manual: Open canvas with multiple cards → click search icon → type a card type (e.g. "agent") → verify only agent cards shown → press Enter or click → verify viewport centers on that card
- [ ] Manual: Verify Cmd/Ctrl+F opens search when canvas is focused
- [ ] Manual: Verify Escape or click-outside closes search
- [ ] Manual: Verify keyboard navigation (Up/Down arrows) through results

## Manual Validation
1. Open the canvas plugin with several cards of different types (agent, file, browser, git-diff)
2. Click the search (magnifying glass) icon in the top-right toolbar
3. Type a filter term (e.g. "agent", "diff", a card name, or a metadata value like a file path)
4. Verify the dropdown filters in real-time
5. Use arrow keys to navigate, Enter to select — viewport should pan and center on the selected card
6. Press Escape or click outside to dismiss