### PR TITLE
fix: make Cmd+F open canvas search from the command toolbar

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
@@ -68,6 +68,12 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
     }
   }, [isOpen]);
 
+  // Return focus to the workspace so Cmd+F continues to work after close
+  const focusWorkspace = useCallback(() => {
+    const workspace = document.querySelector<HTMLElement>('[data-testid="canvas-workspace"]');
+    workspace?.focus();
+  }, []);
+
   // Close on click outside
   useEffect(() => {
     if (!isOpen) return;
@@ -75,19 +81,20 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
         setQuery('');
+        focusWorkspace();
       }
     };
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [isOpen]);
+  }, [isOpen, focusWorkspace]);
 
   // Keyboard shortcut: Cmd/Ctrl+F to open search when canvas is focused
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
-        // Only intercept if we're inside the canvas workspace
-        const workspace = document.querySelector('[data-testid="canvas-workspace"]');
-        if (workspace && workspace.contains(document.activeElement || document.body)) {
+        // Intercept if focus is within the canvas panel (workspace + tab bar)
+        const panel = document.querySelector('[data-testid="canvas-panel"]');
+        if (panel && panel.contains(document.activeElement)) {
           e.preventDefault();
           setIsOpen(true);
         }
@@ -101,7 +108,8 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
     onSelectView(viewId);
     setIsOpen(false);
     setQuery('');
-  }, [onSelectView]);
+    focusWorkspace();
+  }, [onSelectView, focusWorkspace]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
@@ -118,15 +126,19 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
     } else if (e.key === 'Escape') {
       setIsOpen(false);
       setQuery('');
+      focusWorkspace();
     }
-  }, [filteredViews, selectedIndex, handleSelect]);
+  }, [filteredViews, selectedIndex, handleSelect, focusWorkspace]);
 
   const handleToggle = useCallback(() => {
     setIsOpen((prev) => {
-      if (prev) setQuery('');
+      if (prev) {
+        setQuery('');
+        focusWorkspace();
+      }
       return !prev;
     });
-  }, []);
+  }, [focusWorkspace]);
 
   const btnClass = 'w-6 h-6 flex items-center justify-center rounded text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors';
 

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -231,7 +231,8 @@ export function CanvasWorkspace({
   return (
     <div
       ref={containerRef}
-      className="relative w-full h-full overflow-hidden select-none bg-ctp-crust"
+      className="relative w-full h-full overflow-hidden select-none bg-ctp-crust focus:outline-none"
+      tabIndex={-1}
       style={dotGridStyle}
       onMouseDown={handleMouseDown}
       onWheel={handleWheel}

--- a/src/renderer/plugins/builtin/canvas/canvas-search-shortcut.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-search-shortcut.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CanvasSearch } from './CanvasSearch';
+import type { CanvasView } from './canvas-types';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const baseView = {
+  position: { x: 0, y: 0 },
+  size: { width: 480, height: 480 },
+  zIndex: 0,
+};
+
+const views: CanvasView[] = [
+  {
+    ...baseView,
+    id: 'cv_1',
+    type: 'agent',
+    title: 'Agent',
+    displayName: 'My Agent',
+    metadata: {},
+    agentId: 'agent_1',
+  } as CanvasView,
+  {
+    ...baseView,
+    id: 'cv_2',
+    type: 'file',
+    title: 'Files',
+    displayName: 'Source Files',
+    metadata: {},
+    filePath: 'src/index.ts',
+  } as CanvasView,
+];
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/** Wrap CanvasSearch inside DOM that mirrors the real canvas panel structure. */
+function renderWithCanvasPanel(onSelectView = vi.fn()) {
+  return render(
+    <div data-testid="canvas-panel">
+      <div data-testid="canvas-workspace" tabIndex={-1}>
+        <div data-testid="canvas-controls">
+          <CanvasSearch views={views} onSelectView={onSelectView} />
+        </div>
+      </div>
+    </div>,
+  );
+}
+
+function pressMetaF() {
+  fireEvent.keyDown(document, { key: 'f', metaKey: true });
+}
+
+function pressCtrlF() {
+  fireEvent.keyDown(document, { key: 'f', ctrlKey: true });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('canvas search — Cmd/Ctrl+F shortcut', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens search when Cmd+F is pressed with focus inside the canvas workspace', () => {
+    renderWithCanvasPanel();
+    const workspace = screen.getByTestId('canvas-workspace');
+
+    // Focus the workspace (simulates user clicking on the canvas background)
+    act(() => workspace.focus());
+    expect(document.activeElement).toBe(workspace);
+
+    // Verify search is initially closed (toggle button visible)
+    expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
+
+    // Press Cmd+F
+    pressMetaF();
+
+    // Search input should now be visible
+    expect(screen.getByTestId('canvas-search-input')).toBeInTheDocument();
+  });
+
+  it('opens search when Ctrl+F is pressed (Windows/Linux)', () => {
+    renderWithCanvasPanel();
+    const workspace = screen.getByTestId('canvas-workspace');
+    act(() => workspace.focus());
+
+    pressCtrlF();
+
+    expect(screen.getByTestId('canvas-search-input')).toBeInTheDocument();
+  });
+
+  it('does NOT open search when Cmd+F is pressed with focus outside the canvas', () => {
+    render(
+      <div>
+        <button data-testid="outside-button">Outside</button>
+        <div data-testid="canvas-panel">
+          <div data-testid="canvas-workspace" tabIndex={-1}>
+            <div data-testid="canvas-controls">
+              <CanvasSearch views={views} onSelectView={vi.fn()} />
+            </div>
+          </div>
+        </div>
+      </div>,
+    );
+
+    // Focus the outside button
+    const outsideBtn = screen.getByTestId('outside-button');
+    act(() => outsideBtn.focus());
+    expect(document.activeElement).toBe(outsideBtn);
+
+    pressMetaF();
+
+    // Search should remain closed
+    expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-search-input')).not.toBeInTheDocument();
+  });
+
+  it('opens search when focus is on a child element inside the canvas panel', () => {
+    render(
+      <div data-testid="canvas-panel">
+        <button data-testid="tab-bar-button">Tab</button>
+        <div data-testid="canvas-workspace" tabIndex={-1}>
+          <div data-testid="canvas-controls">
+            <CanvasSearch views={views} onSelectView={vi.fn()} />
+          </div>
+        </div>
+      </div>,
+    );
+
+    // Focus a button in the tab bar area (inside canvas-panel but outside workspace)
+    const tabBtn = screen.getByTestId('tab-bar-button');
+    act(() => tabBtn.focus());
+
+    pressMetaF();
+
+    // Search should open since focus is within the canvas panel
+    expect(screen.getByTestId('canvas-search-input')).toBeInTheDocument();
+  });
+
+  it('returns focus to workspace when search is closed via Escape', () => {
+    renderWithCanvasPanel();
+    const workspace = screen.getByTestId('canvas-workspace');
+    act(() => workspace.focus());
+
+    // Open search
+    pressMetaF();
+    expect(screen.getByTestId('canvas-search-input')).toBeInTheDocument();
+
+    // Press Escape to close
+    const input = screen.getByTestId('canvas-search-input');
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    // Search should be closed and workspace should have focus
+    expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
+    expect(document.activeElement).toBe(workspace);
+  });
+
+  it('returns focus to workspace when a search result is selected', () => {
+    const onSelectView = vi.fn();
+    renderWithCanvasPanel(onSelectView);
+    const workspace = screen.getByTestId('canvas-workspace');
+    act(() => workspace.focus());
+
+    // Open search
+    pressMetaF();
+
+    // Click on first result
+    const result = screen.getByTestId('canvas-search-result-cv_1');
+    fireEvent.click(result);
+
+    expect(onSelectView).toHaveBeenCalledWith('cv_1');
+    expect(document.activeElement).toBe(workspace);
+  });
+
+  it('returns focus to workspace when toggle button closes search', () => {
+    renderWithCanvasPanel();
+    const workspace = screen.getByTestId('canvas-workspace');
+    act(() => workspace.focus());
+
+    // Open search
+    pressMetaF();
+    expect(screen.getByTestId('canvas-search-input')).toBeInTheDocument();
+
+    // Click close button
+    fireEvent.click(screen.getByTestId('canvas-search-close'));
+
+    expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
+    expect(document.activeElement).toBe(workspace);
+  });
+
+  it('does NOT open when CanvasSearch is not within a canvas-panel', () => {
+    // Render without the canvas-panel wrapper
+    render(
+      <div data-testid="canvas-workspace" tabIndex={-1}>
+        <CanvasSearch views={views} onSelectView={vi.fn()} />
+      </div>,
+    );
+
+    const workspace = screen.getByTestId('canvas-workspace');
+    act(() => workspace.focus());
+
+    pressMetaF();
+
+    // Should NOT open because there's no canvas-panel ancestor
+    expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-search-input')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/plugins/builtin/canvas/main.ts
+++ b/src/renderer/plugins/builtin/canvas/main.ts
@@ -182,7 +182,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
     }, 'Loading canvas...');
   }
 
-  return React.createElement('div', { className: 'flex flex-col h-full w-full' },
+  return React.createElement('div', { className: 'flex flex-col h-full w-full', 'data-testid': 'canvas-panel' },
     React.createElement(CanvasTabBar, {
       canvases,
       activeCanvasId,


### PR DESCRIPTION
## Summary
- Fix Cmd+F keyboard shortcut to properly open the search in the canvas command toolbar
- The shortcut was broken because the focus detection checked `workspace.contains(document.body)`, which is always false (body is an ancestor of workspace, not a descendant)

## Changes
- **CanvasWorkspace.tsx**: Add `tabIndex={-1}` so the workspace div can receive focus when clicked, and suppress focus outline
- **main.ts**: Add `data-testid="canvas-panel"` to the MainPanel root div for broader focus detection
- **CanvasSearch.tsx**: 
  - Update Cmd+F handler to check `canvas-panel` container instead of just the workspace, covering tab bar interactions too
  - Return focus to workspace when search closes (Escape, result select, toggle close, click outside) so the shortcut remains functional without re-clicking
  - Add `focusWorkspace` helper used by all close paths

## Test Plan
- [x] Cmd+F opens search when focus is inside the canvas workspace
- [x] Ctrl+F opens search (Windows/Linux path)
- [x] Cmd+F does NOT open search when focus is outside the canvas panel
- [x] Cmd+F opens search when focus is on a child element inside the canvas panel (e.g. tab bar)
- [x] Focus returns to workspace when search is closed via Escape
- [x] Focus returns to workspace when a search result is selected
- [x] Focus returns to workspace when the toggle close button is clicked
- [x] Shortcut does not fire when CanvasSearch is rendered without a canvas-panel ancestor

## Manual Validation
1. Open the canvas with at least one card
2. Click on the canvas background, then press Cmd+F — search should open
3. Press Escape — search closes, pressing Cmd+F again should re-open
4. Click on a tab in the tab bar, press Cmd+F — search should open
5. Click outside the canvas panel entirely, press Cmd+F — search should NOT open