### PR TITLE
feat: move sessions plugin to experimental features and fix critical bugs

### DIFF
--- a/src/renderer/features/settings/ExperimentalSettingsView.tsx
+++ b/src/renderer/features/settings/ExperimentalSettingsView.tsx
@@ -22,6 +22,11 @@ const EXPERIMENTAL_FEATURES: Array<{
     label: 'Canvas',
     description: 'Free-form spatial workspace for arranging agent, file, and browser views on a pannable/zoomable surface. Requires app restart.',
   },
+  {
+    id: 'sessions',
+    label: 'Sessions',
+    description: 'Browse and replay historical agent conversation sessions with timeline playback. Requires app restart.',
+  },
 ];
 
 export function ExperimentalSettingsView() {

--- a/src/renderer/plugins/builtin/builtin-plugin-testing.test.ts
+++ b/src/renderer/plugins/builtin/builtin-plugin-testing.test.ts
@@ -92,14 +92,25 @@ describe('getBuiltinPlugins catch-all', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('does not include the sessions plugin (hidden for stable release)', () => {
+  it('does not include the sessions plugin without experimental flag', () => {
     const plugins = getBuiltinPlugins();
     const ids = plugins.map((p) => p.manifest.id);
     expect(ids).not.toContain('sessions');
   });
 
-  it('does not auto-enable the sessions plugin', () => {
+  it('does not auto-enable the sessions plugin without experimental flag', () => {
     const defaultIds = getDefaultEnabledIds();
     expect(defaultIds.has('sessions')).toBe(false);
+  });
+
+  it('includes sessions plugin when experimental flag is set', () => {
+    const plugins = getBuiltinPlugins({ sessions: true });
+    const ids = plugins.map((p) => p.manifest.id);
+    expect(ids).toContain('sessions');
+  });
+
+  it('auto-enables sessions plugin when experimental flag is set', () => {
+    const defaultIds = getDefaultEnabledIds({ sessions: true });
+    expect(defaultIds.has('sessions')).toBe(true);
   });
 });

--- a/src/renderer/plugins/builtin/index.ts
+++ b/src/renderer/plugins/builtin/index.ts
@@ -7,6 +7,8 @@ import { manifest as filesManifest } from './files/manifest';
 import * as filesModule from './files/main';
 import { manifest as canvasManifest } from './canvas/manifest';
 import * as canvasModule from './canvas/main';
+import { manifest as sessionsManifest } from './sessions/manifest';
+import * as sessionsModule from './sessions/main';
 
 export interface BuiltinPlugin {
   manifest: PluginManifest;
@@ -16,6 +18,7 @@ export interface BuiltinPlugin {
 /** Experimental feature flags that gate conditional built-in plugins. */
 export interface ExperimentalFlags {
   canvas?: boolean;
+  sessions?: boolean;
   [key: string]: boolean | undefined;
 }
 
@@ -33,6 +36,10 @@ export function getBuiltinPlugins(experimentalFlags: ExperimentalFlags = {}): Bu
     plugins.push({ manifest: canvasManifest, module: canvasModule });
   }
 
+  if (experimentalFlags.sessions) {
+    plugins.push({ manifest: sessionsManifest, module: sessionsModule });
+  }
+
   return plugins;
 }
 
@@ -41,6 +48,9 @@ export function getDefaultEnabledIds(experimentalFlags: ExperimentalFlags = {}):
   const ids = [...BASE_DEFAULT_IDS];
   if (experimentalFlags.canvas) {
     ids.push('canvas');
+  }
+  if (experimentalFlags.sessions) {
+    ids.push('sessions');
   }
   return new Set(ids);
 }

--- a/src/renderer/plugins/builtin/sessions/main.ts
+++ b/src/renderer/plugins/builtin/sessions/main.ts
@@ -115,8 +115,9 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
   }, [api, sessionLists]);
 
   const handleAgentClick = useCallback((agent: AgentInfo) => {
+    const wasExpanded = expandedAgents.has(agent.id);
     sessionsState.toggleExpandedAgent(agent.id);
-    if (!expandedAgents.has(agent.id)) {
+    if (!wasExpanded) {
       sessionsState.setSelectedAgent({
         agentId: agent.id,
         agentName: agent.name,
@@ -259,7 +260,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   const [totalEvents, setTotalEvents] = useState(0);
   const [loading, setLoading] = useState(false);
   const eventListRef = useRef<HTMLDivElement>(null);
-  const playbackTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const playbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Load session data when selection changes
   useEffect(() => {
@@ -311,7 +312,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   // Playback timer
   useEffect(() => {
     if (playbackTimerRef.current) {
-      clearInterval(playbackTimerRef.current);
+      clearTimeout(playbackTimerRef.current);
       playbackTimerRef.current = null;
     }
 
@@ -331,7 +332,8 @@ export function MainPanel({ api }: { api: PluginAPI }) {
     );
     const delay = Math.max(gap / playback.speed, 100); // minimum 100ms
 
-    playbackTimerRef.current = setInterval(() => {
+    playbackTimerRef.current = setTimeout(() => {
+      playbackTimerRef.current = null;
       const state = sessionsState.playback;
       const next = state.currentEventIndex + 1;
       if (next >= events.length) {
@@ -342,7 +344,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
     }, delay);
 
     return () => {
-      if (playbackTimerRef.current) clearInterval(playbackTimerRef.current);
+      if (playbackTimerRef.current) clearTimeout(playbackTimerRef.current);
     };
   }, [playback.playing, playback.currentEventIndex, playback.speed, events]);
 

--- a/src/renderer/plugins/builtin/sessions/state.test.ts
+++ b/src/renderer/plugins/builtin/sessions/state.test.ts
@@ -84,6 +84,13 @@ describe('sessionsState', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  it('toggleExpandedAgent produces a new Set reference (required for useSyncExternalStore)', () => {
+    const before = sessionsState.expandedAgents;
+    sessionsState.toggleExpandedAgent('a1');
+    const after = sessionsState.expandedAgents;
+    expect(before).not.toBe(after);
+  });
+
   // ── Playback ───────────────────────────────────────────────────────
 
   it('setPlaybackPlaying updates playing state', () => {

--- a/src/renderer/plugins/builtin/sessions/state.ts
+++ b/src/renderer/plugins/builtin/sessions/state.ts
@@ -38,11 +38,13 @@ export const sessionsState = {
   },
 
   toggleExpandedAgent(agentId: string): void {
-    if (this.expandedAgents.has(agentId)) {
-      this.expandedAgents.delete(agentId);
+    const next = new Set(this.expandedAgents);
+    if (next.has(agentId)) {
+      next.delete(agentId);
     } else {
-      this.expandedAgents.add(agentId);
+      next.add(agentId);
     }
+    this.expandedAgents = next;
     this.notify();
   },
 


### PR DESCRIPTION
## Summary
- Move the hidden/disabled sessions plugin into the experimental features system so users can opt-in via Settings > Experimental
- Fix three critical bugs that made the plugin completely non-functional
- Add tests for experimental gating and the core bug fix

## Changes

### Experimental Feature Gating
- **ExperimentalSettingsView.tsx**: Added `sessions` entry to `EXPERIMENTAL_FEATURES` array with toggle
- **builtin/index.ts**: Added `sessions?: boolean` to `ExperimentalFlags`, imported sessions plugin, conditionally registered in `getBuiltinPlugins()` and `getDefaultEnabledIds()`

### Bug Fix: `expandedAgents` Set mutation (state.ts)
- **Root cause**: `toggleExpandedAgent()` mutated the Set in-place (`.add()`/`.delete()`). Since `useSyncExternalStore` uses `Object.is()` referential equality, the same Set reference meant React never detected the change — expanding an agent was invisible to the UI.
- **Fix**: Create a new Set on each toggle so the reference changes.

### Bug Fix: Inverted `handleAgentClick` logic (main.ts)
- **Root cause**: Code called `toggleExpandedAgent()` first, then checked `!expandedAgents.has(agent.id)`. Post-toggle, expand→has=true→skip loading; collapse→has=false→load sessions. Completely backwards.
- **Fix**: Capture `wasExpanded` before the toggle call, then branch on that.

### Bug Fix: Playback timer (main.ts)
- **Root cause**: Used `setInterval` but the effect re-runs on every index change, creating/destroying intervals rapidly. Only one tick is needed per cycle.
- **Fix**: Switch to `setTimeout`.

### Tests
- Updated `builtin-plugin-testing.test.ts`: sessions excluded without flag, included with `{ sessions: true }`
- Added `state.test.ts` test: `toggleExpandedAgent` produces a new Set reference

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 290 test files, 7233 tests pass
- [x] `npm run lint` — 0 errors
- [ ] Manual: Enable sessions in Settings > Experimental, restart, verify Sessions tab appears
- [ ] Manual: Click agent in sidebar → should expand and show session list
- [ ] Manual: Click session → should load summary and event timeline
- [ ] Manual: Play button → events should step through with correct timing
- [ ] Manual: Disable sessions in experimental, restart → Sessions tab should disappear

## Manual Validation
1. Open Settings > Experimental (requires beta build)
2. Toggle "Sessions" on, click Restart
3. Open a project with agent history
4. Verify the Sessions tab appears in the sidebar
5. Expand an agent → session list should load
6. Click a session → summary card, timeline, and event list should render
7. Test playback controls (play/pause, speed, scrubbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)