### PR TITLE
feat: resizable/collapsible sidebar for canvas file & diff views

### DIFF
--- a/src/renderer/plugins/builtin/canvas/FileCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/FileCanvasView.tsx
@@ -3,6 +3,7 @@ import type { FileCanvasView as FileCanvasViewType, CanvasView } from './canvas-
 import type { PluginAPI } from '../../../../shared/plugin-types';
 import { CanvasFileTree } from './CanvasFileTree';
 import { ReadOnlyMonacoEditor } from './ReadOnlyMonacoEditor';
+import { ResizableSidebar } from './ResizableSidebar';
 
 interface FileCanvasViewProps {
   view: FileCanvasViewType;
@@ -176,7 +177,7 @@ export function FileCanvasView({ view, api, onUpdate }: FileCanvasViewProps) {
       {/* Split panel: tree + content */}
       <div className="flex flex-1 min-h-0">
         {/* File tree sidebar */}
-        <div className="w-[180px] flex-shrink-0 border-r border-surface-0 overflow-hidden flex flex-col bg-ctp-mantle/30">
+        <ResizableSidebar defaultWidth={180} minWidth={120} maxWidth={400} className="overflow-hidden flex flex-col bg-ctp-mantle/30">
           <CanvasFileTree
             api={api}
             projectPath={activeProject?.path || ''}
@@ -185,7 +186,7 @@ export function FileCanvasView({ view, api, onUpdate }: FileCanvasViewProps) {
             showHidden={showHidden}
             onSelectFile={handleSelectFile}
           />
-        </div>
+        </ResizableSidebar>
 
         {/* File content area */}
         <div className="flex-1 min-w-0 flex flex-col">

--- a/src/renderer/plugins/builtin/canvas/GitDiffCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/GitDiffCanvasView.tsx
@@ -4,6 +4,7 @@ import type { PluginAPI } from '../../../../shared/plugin-types';
 import type { GitInfo } from '../../../../shared/types';
 import { MonacoDiffEditor } from './MonacoDiffEditor';
 import { MenuPortal } from './MenuPortal';
+import { ResizableSidebar } from './ResizableSidebar';
 
 /** How often to poll git status (ms). */
 export const GIT_POLL_INTERVAL_MS = 3000;
@@ -428,7 +429,7 @@ export function GitDiffCanvasView({ view, api, onUpdate }: GitDiffCanvasViewProp
       {/* Split panel: file list + diff */}
       <div className="flex flex-1 min-h-0">
         {/* File list sidebar */}
-        <div className="w-[200px] flex-shrink-0 border-r border-surface-0 overflow-y-auto bg-ctp-mantle/30">
+        <ResizableSidebar defaultWidth={200} minWidth={120} maxWidth={400} className="overflow-y-auto bg-ctp-mantle/30">
           {loading ? (
             <div className="flex items-center justify-center h-full text-ctp-subtext0 text-xs">
               Loading&hellip;
@@ -474,7 +475,7 @@ export function GitDiffCanvasView({ view, api, onUpdate }: GitDiffCanvasViewProp
               })}
             </div>
           )}
-        </div>
+        </ResizableSidebar>
 
         {/* Diff content area */}
         <div className="flex-1 min-w-0 flex flex-col">

--- a/src/renderer/plugins/builtin/canvas/ResizableSidebar.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/ResizableSidebar.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import { ResizableSidebar, RAIL_WIDTH, DEFAULT_MIN_WIDTH, DEFAULT_MAX_WIDTH } from './ResizableSidebar';
+
+describe('ResizableSidebar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the sidebar at the default width', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    const sidebar = getByTestId('resizable-sidebar');
+    expect(sidebar).toBeInTheDocument();
+    expect(sidebar.style.width).toBe('200px');
+  });
+
+  it('renders children inside the sidebar', () => {
+    const { getByText } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>My sidebar content</div>
+      </ResizableSidebar>,
+    );
+    expect(getByText('My sidebar content')).toBeInTheDocument();
+  });
+
+  it('renders the resize divider', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    expect(getByTestId('resize-divider')).toBeInTheDocument();
+  });
+
+  it('resizes the sidebar on drag', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    const divider = getByTestId('resize-divider');
+    fireEvent.mouseDown(divider, { clientX: 200 });
+    fireEvent.mouseMove(document, { clientX: 250 });
+    fireEvent.mouseUp(document);
+
+    const sidebar = getByTestId('resizable-sidebar');
+    expect(sidebar.style.width).toBe('250px');
+  });
+
+  it('clamps width to minWidth', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200} minWidth={150}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    const divider = getByTestId('resize-divider');
+    fireEvent.mouseDown(divider, { clientX: 200 });
+    fireEvent.mouseMove(document, { clientX: 100 });
+    fireEvent.mouseUp(document);
+
+    const sidebar = getByTestId('resizable-sidebar');
+    expect(sidebar.style.width).toBe('150px');
+  });
+
+  it('clamps width to maxWidth', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200} maxWidth={300}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    const divider = getByTestId('resize-divider');
+    fireEvent.mouseDown(divider, { clientX: 200 });
+    fireEvent.mouseMove(document, { clientX: 500 });
+    fireEvent.mouseUp(document);
+
+    const sidebar = getByTestId('resizable-sidebar');
+    expect(sidebar.style.width).toBe('300px');
+  });
+
+  it('collapses to a rail on double-click of divider', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+
+    expect(queryByTestId('resizable-sidebar')).toBeNull();
+    const rail = getByTestId('resizable-sidebar-rail');
+    expect(rail).toBeInTheDocument();
+    expect(rail.style.width).toBe(`${RAIL_WIDTH}px`);
+  });
+
+  it('shows overlay on hover when collapsed', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Sidebar content</div>
+      </ResizableSidebar>,
+    );
+
+    // Collapse
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    expect(queryByTestId('resizable-sidebar-overlay')).toBeNull();
+
+    // Hover over rail
+    const rail = getByTestId('resizable-sidebar-rail');
+    fireEvent.mouseEnter(rail.querySelector('[title="Expand sidebar"]')!);
+
+    const overlay = getByTestId('resizable-sidebar-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay.style.width).toBe('200px');
+  });
+
+  it('hides overlay after mouse leaves with delay', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+
+    // Collapse and hover
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    const railInner = getByTestId('resizable-sidebar-rail').querySelector('[title="Expand sidebar"]')!;
+    fireEvent.mouseEnter(railInner);
+    expect(getByTestId('resizable-sidebar-overlay')).toBeInTheDocument();
+
+    // Leave the rail
+    fireEvent.mouseLeave(railInner);
+
+    // Overlay should still be visible during the 150ms delay
+    expect(queryByTestId('resizable-sidebar-overlay')).toBeInTheDocument();
+
+    // After the delay, overlay disappears
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(queryByTestId('resizable-sidebar-overlay')).toBeNull();
+  });
+
+  it('keeps overlay visible when moving from rail to overlay', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+
+    // Collapse and hover rail
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    const railInner = getByTestId('resizable-sidebar-rail').querySelector('[title="Expand sidebar"]')!;
+    fireEvent.mouseEnter(railInner);
+    fireEvent.mouseLeave(railInner);
+
+    // Move into overlay before timeout
+    const overlay = getByTestId('resizable-sidebar-overlay');
+    fireEvent.mouseEnter(overlay);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // Overlay should still be visible
+    expect(queryByTestId('resizable-sidebar-overlay')).toBeInTheDocument();
+  });
+
+  it('expands from collapsed state on rail click', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+
+    // Collapse
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    expect(queryByTestId('resizable-sidebar')).toBeNull();
+
+    // Click the rail to expand
+    const railInner = getByTestId('resizable-sidebar-rail').querySelector('[title="Expand sidebar"]')!;
+    fireEvent.click(railInner);
+
+    expect(getByTestId('resizable-sidebar')).toBeInTheDocument();
+    expect(queryByTestId('resizable-sidebar-rail')).toBeNull();
+  });
+
+  it('renders the expand icon in the rail', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200}>
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    expect(getByTestId('rail-expand-icon')).toBeInTheDocument();
+  });
+
+  it('uses default min/max values from constants', () => {
+    expect(DEFAULT_MIN_WIDTH).toBe(120);
+    expect(DEFAULT_MAX_WIDTH).toBe(400);
+    expect(RAIL_WIDTH).toBe(28);
+  });
+
+  it('applies className to sidebar container', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200} className="bg-ctp-mantle/30">
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+    expect(getByTestId('resizable-sidebar').className).toContain('bg-ctp-mantle/30');
+  });
+
+  it('applies className to overlay when collapsed and hovered', () => {
+    const { getByTestId } = render(
+      <ResizableSidebar defaultWidth={200} className="bg-ctp-mantle/30">
+        <div>Content</div>
+      </ResizableSidebar>,
+    );
+
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    const railInner = getByTestId('resizable-sidebar-rail').querySelector('[title="Expand sidebar"]')!;
+    fireEvent.mouseEnter(railInner);
+
+    expect(getByTestId('resizable-sidebar-overlay').className).toContain('bg-ctp-mantle/30');
+  });
+});

--- a/src/renderer/plugins/builtin/canvas/ResizableSidebar.tsx
+++ b/src/renderer/plugins/builtin/canvas/ResizableSidebar.tsx
@@ -1,0 +1,134 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { ResizeDivider } from '../../../../renderer/components/ResizeDivider';
+
+/** Width of the collapsed rail in pixels. */
+export const RAIL_WIDTH = 28;
+
+/** Default minimum sidebar width in pixels. */
+export const DEFAULT_MIN_WIDTH = 120;
+
+/** Default maximum sidebar width in pixels. */
+export const DEFAULT_MAX_WIDTH = 400;
+
+interface ResizableSidebarProps {
+  /** Default width when first rendered. */
+  defaultWidth: number;
+  /** Minimum sidebar width (clamped during resize). */
+  minWidth?: number;
+  /** Maximum sidebar width (clamped during resize). */
+  maxWidth?: number;
+  /** Extra class names for the sidebar container. */
+  className?: string;
+  /** Sidebar content. */
+  children: React.ReactNode;
+}
+
+export function ResizableSidebar({
+  defaultWidth,
+  minWidth = DEFAULT_MIN_WIDTH,
+  maxWidth = DEFAULT_MAX_WIDTH,
+  className = '',
+  children,
+}: ResizableSidebarProps) {
+  const [width, setWidth] = useState(defaultWidth);
+  const [collapsed, setCollapsed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleResize = useCallback(
+    (delta: number) => {
+      setWidth((w) => Math.min(maxWidth, Math.max(minWidth, w + delta)));
+    },
+    [minWidth, maxWidth],
+  );
+
+  const toggleCollapse = useCallback(() => {
+    setCollapsed((prev) => !prev);
+    setHovered(false);
+  }, []);
+
+  const handleRailEnter = useCallback(() => {
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    setHovered(true);
+  }, []);
+
+  const handleRailLeave = useCallback(() => {
+    // Small delay so the user can move from rail into the overlay
+    hoverTimeoutRef.current = setTimeout(() => setHovered(false), 150);
+  }, []);
+
+  const handleOverlayEnter = useCallback(() => {
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    setHovered(true);
+  }, []);
+
+  const handleOverlayLeave = useCallback(() => {
+    hoverTimeoutRef.current = setTimeout(() => setHovered(false), 150);
+  }, []);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    };
+  }, []);
+
+  if (collapsed) {
+    return (
+      <div
+        className="relative flex-shrink-0"
+        style={{ width: RAIL_WIDTH }}
+        ref={containerRef}
+        data-testid="resizable-sidebar-rail"
+      >
+        {/* Collapsed rail */}
+        <div
+          className="h-full border-r border-surface-0 bg-ctp-mantle/30 flex items-center justify-center cursor-pointer"
+          onMouseEnter={handleRailEnter}
+          onMouseLeave={handleRailLeave}
+          onClick={toggleCollapse}
+          title="Expand sidebar"
+        >
+          <span
+            className="text-[8px] text-ctp-subtext0 select-none"
+            data-testid="rail-expand-icon"
+          >
+            &#x25B6;
+          </span>
+        </div>
+
+        {/* Hover overlay — floats over the content area */}
+        {hovered && (
+          <div
+            className={`absolute top-0 left-0 z-10 h-full shadow-xl border-r border-surface-0 ${className}`}
+            style={{ width }}
+            onMouseEnter={handleOverlayEnter}
+            onMouseLeave={handleOverlayLeave}
+            data-testid="resizable-sidebar-overlay"
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={`flex-shrink-0 ${className}`}
+        style={{ width }}
+        data-testid="resizable-sidebar"
+      >
+        {children}
+      </div>
+      <ResizeDivider
+        onResize={handleResize}
+        onToggleCollapse={toggleCollapse}
+        collapsed={collapsed}
+        collapseDirection="left"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Canvas git diff and file viewer cards now have resizable left sidebar panes with drag-to-resize and collapse-to-rail behavior
- When collapsed, hovering the thin rail reveals the sidebar as a floating overlay
- Reuses the existing `ResizeDivider` component for consistent drag/collapse UX

## Changes
- **New `ResizableSidebar` component** (`src/renderer/plugins/builtin/canvas/ResizableSidebar.tsx`): Wraps sidebar content with drag-to-resize (clamped min/max), double-click or chevron collapse to a 28px rail, and hover-to-reveal overlay when collapsed
- **`GitDiffCanvasView`**: Replaced fixed `w-[200px]` file list sidebar with `ResizableSidebar` (default 200px, min 120px, max 400px)
- **`FileCanvasView`**: Replaced fixed `w-[180px]` file tree sidebar with `ResizableSidebar` (default 180px, min 120px, max 400px)

## Test Plan
- [x] 15 new tests in `ResizableSidebar.test.tsx` covering:
  - Renders at default width
  - Renders children and resize divider
  - Drag-to-resize updates width
  - Width clamped to min/max bounds
  - Double-click collapses to rail
  - Hover reveals overlay at previous width
  - Overlay hides after mouse leave (with delay)
  - Moving from rail to overlay keeps it visible
  - Click rail to expand from collapsed state
  - Rail shows expand icon
  - className applied to both sidebar and overlay
- [x] All 292 test files pass (7270 tests)
- [x] TypeScript type check passes
- [x] ESLint passes (no new warnings)

## Manual Validation
1. Open a canvas, add a Git Diff view — drag the divider between file list and diff pane to resize
2. Double-click the divider or click the chevron to collapse the sidebar to a thin rail
3. Hover over the rail to see the file list as a floating overlay
4. Click the rail to permanently expand the sidebar
5. Repeat for the File Viewer canvas card with the file tree sidebar