### PR TITLE
feat: canvas agent sleep button in title bar

### DIFF
--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -47,12 +47,6 @@ export function AgentCanvasView({ view, api, onUpdate }: AgentCanvasViewProps) {
     setSelectedProjectId(null);
   }, []);
 
-  const handleStop = useCallback(async () => {
-    if (view.agentId) {
-      await api.agents.kill(view.agentId);
-    }
-  }, [view.agentId, api]);
-
   // No agent assigned — show picker
   if (!view.agentId || !assignedAgent) {
     // App mode: two-step picker (project -> agents)
@@ -154,16 +148,6 @@ export function AgentCanvasView({ view, api, onUpdate }: AgentCanvasViewProps) {
         {React.createElement(api.widgets.AgentTerminal, {
           agentId: view.agentId,
         })}
-        <div className="absolute top-1 right-1 z-10">
-          <button
-            onClick={handleStop}
-            className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
-            title="Stop agent"
-            data-testid="canvas-agent-stop"
-          >
-            Stop
-          </button>
-        </div>
       </div>
     );
   }

--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -121,6 +121,14 @@ export function CanvasViewComponent({
     return buildProjectContext(view, projects);
   }, [api, view]);
 
+  const isAgentRunning = agentInfo != null && (agentInfo.status === 'running' || agentInfo.status === 'creating');
+
+  const handleSleep = useCallback(async () => {
+    if (view.type !== 'agent') return;
+    const agentId = (view as AgentCanvasViewType).agentId;
+    if (agentId) await api.agents.kill(agentId);
+  }, [view, api]);
+
   // ── Attention CSS class — uses outline so the glow goes OUTSIDE the card ──
 
   const attentionClass = attention
@@ -337,6 +345,18 @@ export function CanvasViewComponent({
 
         {/* Quick action buttons */}
         <div className="flex items-center gap-0.5 flex-shrink-0">
+          {isAgentRunning && (
+            <button
+              className="w-5 h-5 flex items-center justify-center rounded text-ctp-overlay0 hover:bg-blue-500/20 hover:text-blue-400 transition-colors"
+              onClick={(e) => { e.stopPropagation(); handleSleep(); }}
+              title="Sleep agent"
+              data-testid="canvas-view-sleep"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+              </svg>
+            </button>
+          )}
           <button
             className="w-5 h-5 flex items-center justify-center rounded text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text transition-colors"
             onClick={(e) => { e.stopPropagation(); onCenterView(); }}

--- a/src/renderer/plugins/builtin/canvas/canvas-title-bar.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-title-bar.test.ts
@@ -100,6 +100,50 @@ describe('Canvas title bar — buildProjectContext', () => {
   });
 });
 
+// ── Sleep button visibility logic ──────────────────────────────────
+
+describe('Canvas title bar — sleep button visibility', () => {
+  /**
+   * Mirrors the logic in CanvasView that determines whether the sleep
+   * button renders in the title bar:
+   *   const isAgentRunning = agentInfo != null && (agentInfo.status === 'running' || agentInfo.status === 'creating');
+   */
+  function shouldShowSleepButton(
+    viewType: string,
+    agentStatus: string | null,
+  ): boolean {
+    if (viewType !== 'agent') return false;
+    return agentStatus === 'running' || agentStatus === 'creating';
+  }
+
+  it('shows sleep button for a running agent', () => {
+    expect(shouldShowSleepButton('agent', 'running')).toBe(true);
+  });
+
+  it('shows sleep button for a creating agent', () => {
+    expect(shouldShowSleepButton('agent', 'creating')).toBe(true);
+  });
+
+  it('hides sleep button for a sleeping agent', () => {
+    expect(shouldShowSleepButton('agent', 'sleeping')).toBe(false);
+  });
+
+  it('hides sleep button for an error agent', () => {
+    expect(shouldShowSleepButton('agent', 'error')).toBe(false);
+  });
+
+  it('hides sleep button when agent info is null', () => {
+    expect(shouldShowSleepButton('agent', null)).toBe(false);
+  });
+
+  it('hides sleep button for non-agent view types', () => {
+    expect(shouldShowSleepButton('file', 'running')).toBe(false);
+    expect(shouldShowSleepButton('browser', 'running')).toBe(false);
+    expect(shouldShowSleepButton('git-diff', 'running')).toBe(false);
+    expect(shouldShowSleepButton('plugin', 'running')).toBe(false);
+  });
+});
+
 // ── Plugin widget type extraction ───────────────────────────────────
 
 function extractPluginWidgetType(pluginWidgetType: string): string {


### PR DESCRIPTION
## Summary
- Adds a sleep (moon icon) button to the canvas card title bar for running agents
- Removes the redundant "Stop" overlay button from the agent content area
- Sleep button appears only when the agent is running or creating

## Changes
- **CanvasView.tsx**: Added `isAgentRunning` derived state and `handleSleep` callback; renders a moon-icon button in the title bar quick-action group (before Center/Zoom/Close) when the assigned agent is active
- **AgentCanvasView.tsx**: Removed the `handleStop` callback and the absolute-positioned Stop button overlay from the running-agent content area — this control now lives in the shared title bar
- **canvas-title-bar.test.ts**: Added 6 tests covering sleep button visibility logic (shown for running/creating agents, hidden for sleeping/error/null agents and non-agent view types)

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 298 files, 7390 tests pass (including new sleep button tests)
- [x] `npm run lint` — no new errors
- [ ] Manual: open canvas, add an agent card, start the agent → moon button appears in title bar
- [ ] Manual: click sleep button → agent transitions to sleeping state, button disappears
- [ ] Manual: sleeping agent card shows no sleep button in title bar
- [ ] Manual: non-agent canvas cards (file, browser, git-diff) show no sleep button

## Manual Validation
1. Open a canvas workspace and add an agent card
2. Start the agent — verify a moon icon button appears in the title bar (left of center/zoom/close)
3. Click the moon button — agent should stop and show the SleepingAgent widget
4. Verify no "Stop" text button overlays the terminal content while running
5. Add a file or browser card — verify no sleep button appears in their title bars