### PR TITLE
fix: make Add Satellite button visible on dark themes

### DIFF
--- a/src/renderer/features/settings/AnnexControlSettingsView.tsx
+++ b/src/renderer/features/settings/AnnexControlSettingsView.tsx
@@ -28,8 +28,8 @@ export function AnnexControlSettingsView() {
             <div className="flex gap-2">
               <button
                 onClick={() => setShowPairing((v) => !v)}
-                className="px-3 py-1.5 text-xs rounded bg-ctp-blue text-ctp-base font-medium
-                  hover:bg-ctp-blue/80 transition-colors cursor-pointer"
+                className="px-3 py-1.5 text-xs rounded bg-surface-1 hover:bg-surface-2
+                  transition-colors cursor-pointer text-ctp-text font-medium border border-ctp-blue"
               >
                 {showPairing ? 'Cancel' : 'Add Satellite'}
               </button>


### PR DESCRIPTION
## Summary
- The "Add Satellite" button on the Annex Control settings page was invisible on dark themes
- `bg-ctp-blue text-ctp-base` renders as blue-on-blue in dark Catppuccin themes
- Switched to surface background with blue border accent, matching the adjacent Scan button

## Changes
- `src/renderer/features/settings/AnnexControlSettingsView.tsx`: Changed button className from `bg-ctp-blue text-ctp-base` to `bg-surface-1 hover:bg-surface-2 text-ctp-text border border-ctp-blue`

## Test Plan
- [x] Typecheck passes
- [x] 7503 unit tests pass
- [x] No new lint errors
- [ ] Button visible on dark themes (manual)
- [ ] Button visible on light themes (manual)
- [ ] Click toggles pairing wizard open/closed

## Manual Validation
1. Enable Annex experimental flag
2. Go to Settings → Annex Control
3. Verify "Add Satellite" button is visible next to "Scan"
4. Click it — should toggle the pairing wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)