### PR TITLE
fix: show remote project name and agents when satellite project selected

### DIFF
--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -10,6 +10,7 @@ import { QuickAgentGhostCompact } from './QuickAgentGhost';
 import { useModelOptions } from '../../hooks/useModelOptions';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { useEffectiveOrchestrators } from '../../hooks/useEffectiveOrchestrators';
+import { useRemoteProjectStore } from '../../stores/remoteProjectStore';
 import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 
 const EMPTY_COMPLETED: CompletedQuickAgent[] = [];
@@ -56,7 +57,8 @@ export function useProjectAgentBuckets(
 }
 
 export function AgentList() {
-  const agents = useAgentStore((s) => s.agents);
+  const localAgents = useAgentStore((s) => s.agents);
+  const remoteAgents = useRemoteProjectStore((s) => s.remoteAgents);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const setActiveAgent = useAgentStore((s) => s.setActiveAgent);
   const spawnQuickAgent = useAgentStore((s) => s.spawnQuickAgent);
@@ -66,10 +68,23 @@ export function AgentList() {
   const reorderAgents = useAgentStore((s) => s.reorderAgents);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const projects = useProjectStore((s) => s.projects);
+  const satelliteProjects = useRemoteProjectStore((s) => s.satelliteProjects);
   const { options: MODEL_OPTIONS } = useModelOptions();
   const allOrchestrators = useOrchestratorStore((s) => s.allOrchestrators);
 
-  const activeProject = projects.find((p) => p.id === activeProjectId);
+  const isRemote = activeProjectId?.startsWith('remote:') ?? false;
+  const agents = isRemote ? remoteAgents : localAgents;
+  const activeProject = useMemo(() => {
+    if (!activeProjectId) return undefined;
+    if (isRemote) {
+      for (const rps of Object.values(satelliteProjects)) {
+        const found = rps.find((p) => p.id === activeProjectId);
+        if (found) return found;
+      }
+      return undefined;
+    }
+    return projects.find((p) => p.id === activeProjectId);
+  }, [activeProjectId, isRemote, projects, satelliteProjects]);
   const { effectiveOrchestrators: enabledOrchestrators, activeProfile, isOrchestratorInProfile } = useEffectiveOrchestrators(activeProject?.path);
   const allCompleted = useQuickAgentStore((s) => s.completedAgents);
   const completedAgents = useMemo(

--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState, useRef, useCallback, useMemo } from 'react';
 import { useUIStore } from '../stores/uiStore';
 import { useProjectStore } from '../stores/projectStore';
+import { useRemoteProjectStore } from '../stores/remoteProjectStore';
 import { usePluginStore } from '../plugins/plugin-store';
 import { useBadgeStore, aggregateBadges } from '../stores/badgeStore';
 import { useBadgeSettingsStore } from '../stores/badgeSettingsStore';
@@ -166,7 +167,18 @@ export function ExplorerRail() {
   const setExplorerTab = useUIStore((s) => s.setExplorerTab);
   const projects = useProjectStore((s) => s.projects);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
-  const activeProject = projects.find((p) => p.id === activeProjectId);
+  const satelliteProjects = useRemoteProjectStore((s) => s.satelliteProjects);
+  const activeProject = useMemo(() => {
+    if (!activeProjectId) return undefined;
+    if (activeProjectId.startsWith('remote:')) {
+      for (const rps of Object.values(satelliteProjects)) {
+        const found = rps.find((p) => p.id === activeProjectId);
+        if (found) return found;
+      }
+      return undefined;
+    }
+    return projects.find((p) => p.id === activeProjectId);
+  }, [activeProjectId, projects, satelliteProjects]);
   const allPlugins = usePluginStore((s) => s.plugins);
   const enabledPluginIds = usePluginStore(
     (s) => (activeProjectId ? s.projectEnabled[activeProjectId] : undefined) ?? EMPTY_STRING_ARRAY,

--- a/src/renderer/panels/MainContentView.tsx
+++ b/src/renderer/panels/MainContentView.tsx
@@ -29,13 +29,15 @@ import { GettingStartedSettingsView } from '../features/settings/GettingStartedS
 import { KeyboardShortcutsSettingsView } from '../features/settings/KeyboardShortcutsSettingsView';
 import { EditorSettingsView } from '../features/settings/EditorSettingsView';
 import { ExperimentalSettingsView } from '../features/settings/ExperimentalSettingsView';
+import { useRemoteProjectStore } from '../stores/remoteProjectStore';
 
 export function MainContentView() {
   const explorerTab = useUIStore((s) => s.explorerTab);
   const settingsSubPage = useUIStore((s) => s.settingsSubPage);
   const settingsContext = useUIStore((s) => s.settingsContext);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
-  const agents = useAgentStore((s) => s.agents);
+  const localAgents = useAgentStore((s) => s.agents);
+  const remoteAgents = useRemoteProjectStore((s) => s.remoteAgents);
   const agentSettingsOpenFor = useAgentStore((s) => s.agentSettingsOpenFor);
   const selectedCompletedId = useQuickAgentStore((s) => s.selectedCompletedId);
   const completedAgentsMap = useQuickAgentStore((s) => s.completedAgents);
@@ -43,6 +45,8 @@ export function MainContentView() {
   const dismissCompleted = useQuickAgentStore((s) => s.dismissCompleted);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const { findAgentPopout } = usePopouts();
+  const isRemoteProject = activeProjectId?.startsWith('remote:') ?? false;
+  const agents = isRemoteProject ? { ...localAgents, ...remoteAgents } : localAgents;
 
   // Track whether the agent terminal should receive focus.
   // Must transition false→true to trigger AgentTerminal's focus useEffect,


### PR DESCRIPTION
## Summary
- Clicking a satellite project in the rail showed "No Project" header and empty agent list
- The `activeProjectId` for remote projects has format `remote:<satId>:<projId>` which doesn't exist in the local `projectStore`
- Three components needed to look up remote data from `remoteProjectStore` when the active project is remote

## Changes
- **ExplorerRail.tsx**: Look up active project from `remoteProjectStore.satelliteProjects` when ID starts with `remote:` — fixes "No Project" header
- **AgentList.tsx**: Read agents from `remoteProjectStore.remoteAgents` when active project is remote — fixes empty agent sidebar  
- **MainContentView.tsx**: Merge remote agents into the agents lookup so active agent can be found and terminal displayed

All lookups use `useMemo` with `satelliteProjects` state (not `getAllRemoteProjects()` getter) to avoid the Zustand selector safety violation caught by the static analysis test.

## Test Plan
- [x] Typecheck passes
- [x] 7503 unit tests pass (including Zustand selector safety)
- [x] No new lint errors
- [ ] Click satellite project → header shows project name (not "No Project")
- [ ] Click satellite project → agent list shows remote agents
- [ ] Click a remote agent → terminal view renders
- [ ] Local projects still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)