### PR TITLE
fix: resolve race condition in terminal canvas worktree picker

### DIFF
--- a/src/renderer/plugins/builtin/canvas/TerminalCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/TerminalCanvasView.tsx
@@ -36,9 +36,10 @@ export function TerminalCanvasView({ view, api, onUpdate }: TerminalCanvasViewPr
     [projects, activeProjectId],
   );
 
-  // Worktree state
+  // Worktree state — initialise loading as true so the auto-skip check
+  // cannot fire before the worktree fetch effect has completed.
   const [worktrees, setWorktrees] = useState<GitWorktreeEntry[]>([]);
-  const [loadingWorktrees, setLoadingWorktrees] = useState(false);
+  const [loadingWorktrees, setLoadingWorktrees] = useState(true);
 
   // Terminal state
   const [status, setStatus] = useState<TerminalStatus>('starting');
@@ -120,6 +121,10 @@ export function TerminalCanvasView({ view, api, onUpdate }: TerminalCanvasViewPr
 
   const handleSelectProject = useCallback((projectId: string) => {
     const project = projects.find((p) => p.id === projectId);
+    // Reset worktree state so the auto-skip cannot fire before the fetch
+    // effect runs for the newly selected project.
+    setWorktrees([]);
+    setLoadingWorktrees(true);
     onUpdate({
       projectId,
       cwd: undefined,

--- a/src/renderer/plugins/builtin/canvas/terminal-canvas-view.test.ts
+++ b/src/renderer/plugins/builtin/canvas/terminal-canvas-view.test.ts
@@ -114,3 +114,51 @@ describe('CanvasViewType — terminal', () => {
     expect(view.type).toBe('terminal');
   });
 });
+
+// ── Worktree auto-skip guard ────────────────────────────────────────
+//
+// The auto-skip logic in TerminalCanvasView decides whether to bypass the
+// worktree picker and jump straight to the terminal.  A race condition
+// previously caused it to skip even when worktrees existed because the
+// fetch had not completed before the first render evaluated the guard.
+//
+// We extract the decision predicate here and verify it against the
+// relevant state combinations.
+
+describe('TerminalCanvasView — worktree auto-skip guard', () => {
+  /**
+   * Mirrors the auto-skip condition from TerminalCanvasView.
+   * Returns true when the component should auto-select the project root
+   * (i.e. skip the worktree picker).
+   */
+  function shouldAutoSkip(
+    worktreeCount: number,
+    loadingWorktrees: boolean,
+    hasProjectPath: boolean,
+  ): boolean {
+    const hasMultipleWorktrees = worktreeCount > 1;
+    return !hasMultipleWorktrees && !loadingWorktrees && hasProjectPath;
+  }
+
+  it('does NOT auto-skip while worktrees are loading', () => {
+    // This is the critical case: worktrees haven't been fetched yet.
+    // loadingWorktrees must block the auto-skip.
+    expect(shouldAutoSkip(0, true, true)).toBe(false);
+  });
+
+  it('auto-skips when loading is done and only one worktree exists', () => {
+    expect(shouldAutoSkip(1, false, true)).toBe(true);
+  });
+
+  it('auto-skips when loading is done and no worktrees returned', () => {
+    expect(shouldAutoSkip(0, false, true)).toBe(true);
+  });
+
+  it('does NOT auto-skip when multiple worktrees exist', () => {
+    expect(shouldAutoSkip(3, false, true)).toBe(false);
+  });
+
+  it('does NOT auto-skip without a project path', () => {
+    expect(shouldAutoSkip(0, false, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed a race condition where the canvas terminal widget's worktree picker was being skipped even when multiple worktrees exist
- The auto-skip guard fired before the worktree fetch effect had a chance to complete, causing it to always jump straight to the terminal

## Changes
- **`TerminalCanvasView.tsx`**: Initialise `loadingWorktrees` as `true` instead of `false` so the auto-skip guard is blocked until the first worktree fetch completes. Also reset worktree state in `handleSelectProject` to prevent stale state from triggering auto-skip on project switches.
- **`terminal-canvas-view.test.ts`**: Added test suite for the worktree auto-skip guard logic covering the key state combinations (loading, multiple worktrees, no project path).

## Root Cause
On the first render after project selection, `worktrees` is `[]` (initial state) and `loadingWorktrees` is `false` (initial state). The auto-skip condition `!hasMultipleWorktrees && !loadingWorktrees && activeProject?.path` evaluated to `true` and fired a microtask to set `cwd` — before the `useEffect` that fetches worktrees had a chance to run (React effects run after render, microtasks run during).

## Test Plan
- [x] Auto-skip guard does NOT fire while `loadingWorktrees` is true
- [x] Auto-skip guard fires when loading is done and ≤1 worktree exists
- [x] Auto-skip guard does NOT fire when multiple worktrees exist
- [x] Auto-skip guard does NOT fire without a project path
- [x] Typecheck passes
- [x] All existing tests pass

## Manual Validation
1. Open the canvas, add a Terminal view
2. Select a project that has git worktrees (e.g., the Clubhouse repo with agent worktrees)
3. Verify the worktree picker appears listing all worktrees
4. Select a worktree and verify the terminal opens in that directory
5. Click back to projects, select a project with no worktrees, verify it auto-skips to terminal