### PR TITLE
feat: enrich agent canvas search metadata and add Enter-to-cycle

### DIFF
--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -35,13 +35,43 @@ export function AgentCanvasView({ view, api, onUpdate }: AgentCanvasViewProps) {
   );
 
   const handlePickAgent = useCallback((agent: AgentInfo) => {
+    const project = projects.find((p) => p.id === agent.projectId);
     onUpdate({
       agentId: agent.id,
       projectId: agent.projectId,
       title: agent.name || agent.id,
-      metadata: { agentId: agent.id, projectId: agent.projectId ?? null, agentName: agent.name ?? null },
+      metadata: {
+        agentId: agent.id,
+        projectId: agent.projectId ?? null,
+        agentName: agent.name ?? null,
+        projectName: project?.name ?? null,
+        orchestrator: agent.orchestrator ?? null,
+        model: agent.model ?? null,
+      },
     } as Partial<AgentCanvasViewType>);
-  }, [onUpdate]);
+  }, [onUpdate, projects]);
+
+  // Keep metadata in sync when the assigned agent's searchable properties change
+  useEffect(() => {
+    if (!assignedAgent) return;
+    const project = projects.find((p) => p.id === assignedAgent.projectId);
+    const prev = view.metadata;
+    const next = {
+      agentId: assignedAgent.id,
+      projectId: assignedAgent.projectId ?? null,
+      agentName: assignedAgent.name ?? null,
+      projectName: project?.name ?? null,
+      orchestrator: assignedAgent.orchestrator ?? null,
+      model: assignedAgent.model ?? null,
+    };
+    // Only update if something actually changed to avoid loops
+    const changed = Object.keys(next).some(
+      (k) => prev[k] !== next[k as keyof typeof next],
+    );
+    if (changed) {
+      onUpdate({ metadata: next } as Partial<AgentCanvasViewType>);
+    }
+  }, [assignedAgent, projects, view.metadata, onUpdate]);
 
   const handleBackToProjects = useCallback(() => {
     setSelectedProjectId(null);

--- a/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
@@ -45,6 +45,8 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
+  /** Tracks whether the user has started cycling through results via Enter. */
+  const [cycling, setCycling] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -58,9 +60,10 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
     });
   }, [views, query]);
 
-  // Reset selected index when results change
+  // Reset selected index and cycling state when query or results change
   useEffect(() => {
     setSelectedIndex(0);
+    setCycling(false);
   }, [filteredViews.length, query]);
 
   // Focus input when opened
@@ -83,6 +86,7 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
         setQuery('');
+        setCycling(false);
         focusWorkspace();
       }
     };
@@ -106,10 +110,12 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  /** Navigate to a result and close search (used by click). */
   const handleSelect = useCallback((viewId: string) => {
     onSelectView(viewId);
     setIsOpen(false);
     setQuery('');
+    setCycling(false);
     focusWorkspace();
   }, [onSelectView, focusWorkspace]);
 
@@ -122,20 +128,30 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (filteredViews[selectedIndex]) {
-        handleSelect(filteredViews[selectedIndex].id);
+      if (filteredViews.length === 0) return;
+      if (filteredViews.length === 1) {
+        // Only one match — navigate and close
+        handleSelect(filteredViews[0].id);
+        return;
       }
+      // Multiple matches: navigate to current, then advance for next Enter
+      const current = filteredViews[selectedIndex];
+      if (current) onSelectView(current.id);
+      setCycling(true);
+      setSelectedIndex((i) => (i + 1) % filteredViews.length);
     } else if (e.key === 'Escape') {
       setIsOpen(false);
       setQuery('');
+      setCycling(false);
       focusWorkspace();
     }
-  }, [filteredViews, selectedIndex, handleSelect, focusWorkspace]);
+  }, [filteredViews, selectedIndex, handleSelect, onSelectView, focusWorkspace]);
 
   const handleToggle = useCallback(() => {
     setIsOpen((prev) => {
       if (prev) {
         setQuery('');
+        setCycling(false);
         focusWorkspace();
       }
       return !prev;
@@ -182,6 +198,12 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
             <line x1="21" y1="21" x2="16.65" y2="16.65" />
           </svg>
         </div>
+        {/* Match counter — shown when cycling through multiple results */}
+        {cycling && query.trim() && filteredViews.length > 1 && (
+          <span className="text-[10px] text-ctp-overlay0 tabular-nums whitespace-nowrap" data-testid="canvas-search-match-count">
+            {((selectedIndex - 1 + filteredViews.length) % filteredViews.length) + 1} / {filteredViews.length}
+          </span>
+        )}
         <button
           onClick={handleToggle}
           className={btnClass}

--- a/src/renderer/plugins/builtin/canvas/canvas-search-shortcut.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-search-shortcut.test.tsx
@@ -33,15 +33,46 @@ const views: CanvasView[] = [
   } as CanvasView,
 ];
 
+/** Three agent views sharing the "agent" type for cycling tests. */
+const multiAgentViews: CanvasView[] = [
+  {
+    ...baseView,
+    id: 'cv_a1',
+    type: 'agent',
+    title: 'Agent',
+    displayName: 'Agent',
+    metadata: { agentName: 'alpha' },
+    agentId: 'agent_a1',
+  } as CanvasView,
+  {
+    ...baseView,
+    id: 'cv_a2',
+    type: 'agent',
+    title: 'Agent',
+    displayName: 'Agent (2)',
+    metadata: { agentName: 'beta' },
+    agentId: 'agent_a2',
+  } as CanvasView,
+  {
+    ...baseView,
+    id: 'cv_a3',
+    type: 'agent',
+    title: 'Agent',
+    displayName: 'Agent (3)',
+    metadata: { agentName: 'gamma' },
+    agentId: 'agent_a3',
+  } as CanvasView,
+];
+
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 /** Wrap CanvasSearch inside DOM that mirrors the real canvas panel structure. */
-function renderWithCanvasPanel(onSelectView = vi.fn()) {
+function renderWithCanvasPanel(onSelectView = vi.fn(), viewList = views) {
   return render(
     <div data-testid="canvas-panel">
       <div data-testid="canvas-workspace" tabIndex={-1}>
         <div data-testid="canvas-controls">
-          <CanvasSearch views={views} onSelectView={onSelectView} />
+          <CanvasSearch views={viewList} onSelectView={onSelectView} />
         </div>
       </div>
     </div>,
@@ -206,5 +237,102 @@ describe('canvas search — Cmd/Ctrl+F shortcut', () => {
     // Should NOT open because there's no canvas-panel ancestor
     expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
     expect(screen.queryByTestId('canvas-search-input')).not.toBeInTheDocument();
+  });
+});
+
+describe('canvas search — Enter-to-cycle through multiple matches', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function openSearchAndType(onSelectView: ReturnType<typeof vi.fn>, query: string) {
+    renderWithCanvasPanel(onSelectView, multiAgentViews);
+    const workspace = screen.getByTestId('canvas-workspace');
+    act(() => workspace.focus());
+    pressMetaF();
+    const input = screen.getByTestId('canvas-search-input');
+    fireEvent.change(input, { target: { value: query } });
+    return input;
+  }
+
+  it('navigates to first match on Enter, then cycles on subsequent presses', () => {
+    const onSelectView = vi.fn();
+    const input = openSearchAndType(onSelectView, 'agent');
+
+    // First Enter: navigate to first match (cv_a1)
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelectView).toHaveBeenCalledTimes(1);
+    expect(onSelectView).toHaveBeenCalledWith('cv_a1');
+
+    // Second Enter: navigate to second match (cv_a2)
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelectView).toHaveBeenCalledTimes(2);
+    expect(onSelectView).toHaveBeenCalledWith('cv_a2');
+
+    // Third Enter: navigate to third match (cv_a3)
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelectView).toHaveBeenCalledTimes(3);
+    expect(onSelectView).toHaveBeenCalledWith('cv_a3');
+  });
+
+  it('wraps around after the last match', () => {
+    const onSelectView = vi.fn();
+    const input = openSearchAndType(onSelectView, 'agent');
+
+    // Cycle through all 3 matches
+    fireEvent.keyDown(input, { key: 'Enter' }); // cv_a1
+    fireEvent.keyDown(input, { key: 'Enter' }); // cv_a2
+    fireEvent.keyDown(input, { key: 'Enter' }); // cv_a3
+
+    // Fourth Enter should wrap back to first
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelectView).toHaveBeenCalledTimes(4);
+    expect(onSelectView).toHaveBeenLastCalledWith('cv_a1');
+  });
+
+  it('does not close search when cycling with multiple matches', () => {
+    const onSelectView = vi.fn();
+    const input = openSearchAndType(onSelectView, 'agent');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Search should still be open
+    expect(screen.getByTestId('canvas-search-input')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-search-results')).toBeInTheDocument();
+  });
+
+  it('closes search on Enter when there is exactly one match', () => {
+    const onSelectView = vi.fn();
+    const input = openSearchAndType(onSelectView, 'alpha');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSelectView).toHaveBeenCalledWith('cv_a1');
+    // Search should be closed
+    expect(screen.getByTestId('canvas-search-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-search-input')).not.toBeInTheDocument();
+  });
+
+  it('shows match counter when cycling', () => {
+    const onSelectView = vi.fn();
+    const input = openSearchAndType(onSelectView, 'agent');
+
+    // No counter before first Enter
+    expect(screen.queryByTestId('canvas-search-match-count')).not.toBeInTheDocument();
+
+    // First Enter: should show "1 / 3"
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const counter = screen.getByTestId('canvas-search-match-count');
+    expect(counter.textContent).toContain('1');
+    expect(counter.textContent).toContain('3');
+  });
+
+  it('does nothing on Enter when no results match', () => {
+    const onSelectView = vi.fn();
+    const input = openSearchAndType(onSelectView, 'nonexistent');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSelectView).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/plugins/builtin/canvas/canvas-search.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-search.test.ts
@@ -55,7 +55,12 @@ const agentView: AgentCanvasView = {
   type: 'agent',
   title: 'Agent',
   displayName: 'My Agent',
-  metadata: { agentName: 'curious-tapir' },
+  metadata: {
+    agentName: 'curious-tapir',
+    projectName: 'Clubhouse',
+    orchestrator: 'claude-code',
+    model: 'claude-sonnet-4-5-20250514',
+  },
   agentId: 'agent_123',
 };
 
@@ -123,6 +128,21 @@ describe('canvas search — buildSearchableText', () => {
   it('includes metadata values in searchable text', () => {
     const text = buildSearchableText(agentView);
     expect(text).toContain('curious-tapir');
+  });
+
+  it('includes projectName in searchable text for agent views', () => {
+    const text = buildSearchableText(agentView);
+    expect(text).toContain('clubhouse');
+  });
+
+  it('includes orchestrator in searchable text for agent views', () => {
+    const text = buildSearchableText(agentView);
+    expect(text).toContain('claude-code');
+  });
+
+  it('includes model in searchable text for agent views', () => {
+    const text = buildSearchableText(agentView);
+    expect(text).toContain('claude-sonnet-4-5-20250514');
   });
 
   it('includes filePath for file views', () => {
@@ -215,5 +235,29 @@ describe('canvas search — filterViews', () => {
     const result = filterViews(allViews, 'readme');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('cv_4');
+  });
+
+  it('filters agent by project name', () => {
+    const result = filterViews(allViews, 'clubhouse');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_1');
+  });
+
+  it('filters agent by orchestrator', () => {
+    const result = filterViews(allViews, 'claude-code');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_1');
+  });
+
+  it('filters agent by model name', () => {
+    const result = filterViews(allViews, 'sonnet');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_1');
+  });
+
+  it('combines project name + agent name for precise search', () => {
+    const result = filterViews(allViews, 'clubhouse curious');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('cv_1');
   });
 });


### PR DESCRIPTION
## Summary
- Agent canvas widgets now populate `projectName`, `orchestrator`, and `model` in metadata so canvas search can find agents by project name, CLI provider, or model
- Search Enter key cycles through multiple matches instead of closing — first Enter navigates to match 1, subsequent presses advance with wrap-around, and a match counter (e.g. "2 / 5") appears
- Metadata stays in sync reactively when agent properties change (model switch, etc.)

## Changes
- **AgentCanvasView.tsx**: `handlePickAgent` now resolves the project name and includes `projectName`, `orchestrator`, and `model` in metadata. Added `useEffect` to keep metadata in sync when the assigned agent's properties change.
- **CanvasSearch.tsx**: Added `cycling` state. Enter with multiple matches navigates to current result and advances index (wrapping around) without closing search. Enter with a single match still closes. Match counter (`N / M`) shown while cycling. Cycling resets when query changes.
- **canvas-search.test.ts**: Updated agent fixture with enriched metadata. Added tests for searching by `projectName`, `orchestrator`, `model`, and combined terms.
- **canvas-search-shortcut.test.tsx**: Added `multiAgentViews` fixture (3 agents). Added test suite for Enter-to-cycle: sequential navigation, wrap-around, search stays open, single-match close, counter display, no-op on zero results.

## Test Plan
- [x] `buildSearchableText` includes projectName, orchestrator, model for agent views
- [x] `filterViews` matches agents by project name, orchestrator, model, and combined terms
- [x] Enter with multiple matches navigates to first, then cycles through subsequent
- [x] Wrap-around works after last match
- [x] Search stays open while cycling (does not close)
- [x] Enter with exactly one match closes search
- [x] Match counter appears after first Enter with multiple matches
- [x] Enter does nothing when no results match
- [x] All 41 canvas search tests pass
- [x] Full suite: 7541 tests pass, typecheck clean, lint clean (pre-existing only)

## Manual Validation
1. Open canvas, add 2+ agent widgets assigned to different agents
2. Open search (Cmd+F), type a project name — verify agents from that project appear
3. Type an orchestrator name (e.g. "claude") — verify matching agents appear
4. Search a term matching multiple cards, press Enter repeatedly — verify it cycles through matches without closing, showing "N / M" counter
5. Search a term matching exactly one card, press Enter — verify it navigates and closes