### PR TITLE
fix: single-click interaction on unselected canvas widgets

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -458,16 +458,18 @@ export function CanvasViewComponent({
         </div>
       </div>
 
-      {/* Content area — block pointer events when not selected so keyboard
-          focus can't leak into widget internals (terminals, inputs).  Only
-          stop wheel propagation when this view is selected, so unselected
-          views let scroll events pan the canvas.
+      {/* Content area — allow pointer events so the first click on an
+          interactive element (button, input, terminal) works immediately
+          without requiring a separate click to select the widget first.
+          Keyboard isolation is handled by the workspace's focus management
+          (auto-focus on mount, reclaim on deselect via Escape / empty click).
+          Only stop wheel propagation when this view is selected, so
+          unselected views let scroll events pan the canvas.
           When the view is zoomed, the overlay renders a full-size copy of the
           content, so skip rendering here to prevent duplicate terminals from
           racing on PTY resize. */}
       <div
         className="flex-1 min-h-0 overflow-hidden rounded-b-lg"
-        style={isSelected ? undefined : { pointerEvents: 'none' }}
         onWheel={isSelected ? (e) => e.stopPropagation() : undefined}
       >
         {!isZoomed && renderContent()}

--- a/src/renderer/plugins/builtin/canvas/canvas-keyboard-focus.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-keyboard-focus.test.tsx
@@ -214,10 +214,10 @@ describe('canvas keyboard focus', () => {
   });
 });
 
-// ── Tests: widget content pointer-events isolation ───────────────────────
+// ── Tests: widget content pointer-events ─────────────────────────────────
 
-describe('canvas view pointer-events isolation', () => {
-  function renderView(isSelected: boolean) {
+describe('canvas view pointer-events', () => {
+  function renderView(isSelected: boolean, overrides: Partial<Parameters<typeof CanvasViewComponent>[0]> = {}) {
     return render(
       <CanvasViewComponent
         view={baseView}
@@ -234,17 +234,18 @@ describe('canvas view pointer-events isolation', () => {
         onDragEnd={vi.fn()}
         onResizeEnd={vi.fn()}
         onUpdate={vi.fn()}
+        {...overrides}
       />,
     );
   }
 
-  it('blocks pointer-events on content area when widget is not selected', () => {
+  it('does NOT block pointer-events on content area when widget is not selected', () => {
     renderView(false);
     const viewEl = screen.getByTestId(`canvas-view-${baseView.id}`);
-    // The content wrapper is the div after the title bar
     const contentWrapper = viewEl.querySelector('.flex-1.min-h-0.overflow-hidden.rounded-b-lg') as HTMLElement;
     expect(contentWrapper).not.toBeNull();
-    expect(contentWrapper.style.pointerEvents).toBe('none');
+    // pointer-events should not be set — content is interactive on first click
+    expect(contentWrapper.style.pointerEvents).toBe('');
   });
 
   it('allows pointer-events on content area when widget is selected', () => {
@@ -252,33 +253,24 @@ describe('canvas view pointer-events isolation', () => {
     const viewEl = screen.getByTestId(`canvas-view-${baseView.id}`);
     const contentWrapper = viewEl.querySelector('.flex-1.min-h-0.overflow-hidden.rounded-b-lg') as HTMLElement;
     expect(contentWrapper).not.toBeNull();
-    // When selected, pointer-events should not be set (defaults to auto)
     expect(contentWrapper.style.pointerEvents).toBe('');
   });
 
-  it('clicking an unselected widget calls onSelect but not content handlers', () => {
+  it('clicking an unselected widget calls onSelect', () => {
     const onSelect = vi.fn();
-    render(
-      <CanvasViewComponent
-        view={baseView}
-        api={stubApi()}
-        zoom={1}
-        isSelected={false}
-        onClose={vi.fn()}
-        onFocus={vi.fn()}
-        onSelect={onSelect}
-        onToggleSelect={vi.fn()}
-        onCenterView={vi.fn()}
-        onZoomView={vi.fn()}
-        onDragStart={vi.fn()}
-        onDragEnd={vi.fn()}
-        onResizeEnd={vi.fn()}
-        onUpdate={vi.fn()}
-      />,
-    );
+    renderView(false, { onSelect });
 
     const viewEl = screen.getByTestId(`canvas-view-${baseView.id}`);
     fireEvent.mouseDown(viewEl, { button: 0 });
     expect(onSelect).toHaveBeenCalled();
+  });
+
+  it('first click on content area of unselected widget is not blocked', () => {
+    renderView(false);
+    const viewEl = screen.getByTestId(`canvas-view-${baseView.id}`);
+    const contentWrapper = viewEl.querySelector('.flex-1.min-h-0.overflow-hidden.rounded-b-lg') as HTMLElement;
+    expect(contentWrapper).not.toBeNull();
+    // Pointer events are never blocked, so interactive elements receive the first click
+    expect(window.getComputedStyle(contentWrapper).pointerEvents).not.toBe('none');
   });
 });


### PR DESCRIPTION
## Summary
- Removes `pointer-events: none` from unselected canvas widget content areas, fixing the 2-click problem introduced in #910
- Interactive elements (buttons, inputs, terminals) now respond on the first click, and the widget is simultaneously selected via event bubbling
- Keyboard isolation is preserved — workspace auto-focus on mount and focus reclaim on deselect (Escape / empty-canvas click) prevent keyboard events from leaking

## Changes
- **CanvasView.tsx**: Removed `style={isSelected ? undefined : { pointerEvents: 'none' }}` from the content wrapper div. Updated comment to explain the new approach.
- **canvas-keyboard-focus.test.tsx**: Updated pointer-events tests to verify content is always interactive (never blocked by `pointer-events: none`). Added test confirming first click on unselected widget content is not blocked.

## Test Plan
- [x] Typecheck passes (`npm run typecheck`)
- [x] All unit/component tests pass (`npm test`)
- [x] No new lint errors in changed files
- [ ] Click a wake-up button on a sleeping agent widget — should fire on the first click
- [ ] Click into a terminal in an unselected widget — should focus for immediate typing
- [ ] Arrow keys pan the canvas when no widget is selected
- [ ] Escape deselects a widget and returns focus to workspace (arrow keys resume panning)
- [ ] Clicking empty canvas deselects and reclaims focus
- [ ] Wheel/scroll over unselected widget pans the canvas

## Manual Validation
1. Open a canvas with multiple widgets (at least one agent in sleeping state)
2. Click a button inside an unselected widget — it should activate immediately without needing a second click
3. Click into a terminal widget that isn't selected — you should be able to type immediately
4. Press Escape, then use arrow keys — canvas should pan
5. Verify scroll over unselected widgets still pans the canvas