### PR TITLE
fix: render plugin widget SVG icons in canvas context menu

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
@@ -117,7 +117,9 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
             data-testid={`canvas-context-menu-${widget.qualifiedType}`}
           >
             <span className="w-4 text-center font-mono text-ctp-overlay0">
-              {widget.declaration.icon || '+'}
+              {widget.declaration.icon
+                ? <span dangerouslySetInnerHTML={{ __html: widget.declaration.icon }} />
+                : '+'}
             </span>
             Add {widget.declaration.label}
           </button>
@@ -135,7 +137,9 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
                 data-testid={`canvas-context-menu-${widget.qualifiedType}`}
               >
                 <span className="w-4 text-center font-mono text-ctp-overlay0">
-                  {widget.declaration.icon || '+'}
+                  {widget.declaration.icon
+                    ? <span dangerouslySetInnerHTML={{ __html: widget.declaration.icon }} />
+                    : '+'}
                 </span>
                 Add {widget.declaration.label}
               </button>

--- a/src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CanvasContextMenu } from './CanvasContextMenu';
+import * as widgetRegistry from '../../canvas-widget-registry';
+import type { RegisteredCanvasWidget } from '../../canvas-widget-registry';
+
+// ── Mock the canvas-widget-registry ──────────────────────────────────
+
+vi.mock('../../canvas-widget-registry', () => ({
+  getRegisteredWidgetTypes: vi.fn(),
+  onRegistryChange: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+const TEST_SVG_ICON = '<svg width="18" height="18" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>';
+
+function makeWidget(overrides: Partial<RegisteredCanvasWidget> & { qualifiedType: string }): RegisteredCanvasWidget {
+  return {
+    pluginId: 'test-plugin',
+    declaration: {
+      id: 'test-widget',
+      label: 'Test Widget',
+      icon: TEST_SVG_ICON,
+    },
+    descriptor: {
+      id: 'test-widget',
+      component: () => null,
+    },
+    ...overrides,
+  };
+}
+
+describe('CanvasContextMenu plugin widget icons', () => {
+  const onSelect = vi.fn();
+  const onDismiss = vi.fn();
+
+  beforeEach(() => {
+    onSelect.mockReset();
+    onDismiss.mockReset();
+    vi.mocked(widgetRegistry.getRegisteredWidgetTypes).mockReturnValue([]);
+  });
+
+  it('renders promoted plugin widget SVG icon as HTML, not raw text', () => {
+    // plugin:files:file-viewer and plugin:terminal:shell are "promoted" widgets
+    vi.mocked(widgetRegistry.getRegisteredWidgetTypes).mockReturnValue([
+      makeWidget({
+        qualifiedType: 'plugin:terminal:shell',
+        pluginId: 'terminal',
+        declaration: { id: 'shell', label: 'Terminal', icon: TEST_SVG_ICON },
+      }),
+    ]);
+
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    const button = screen.getByTestId('canvas-context-menu-plugin:terminal:shell');
+    // The SVG should be rendered as actual HTML, not as escaped text
+    const svgElement = button.querySelector('svg');
+    expect(svgElement).not.toBeNull();
+    expect(svgElement!.getAttribute('width')).toBe('18');
+    // Ensure the raw SVG string is NOT visible as text
+    expect(button.textContent).not.toContain('<svg');
+    expect(button.textContent).not.toContain('</svg>');
+  });
+
+  it('renders other (3rd-party) plugin widget SVG icon as HTML, not raw text', () => {
+    vi.mocked(widgetRegistry.getRegisteredWidgetTypes).mockReturnValue([
+      makeWidget({
+        qualifiedType: 'plugin:my-plugin:chart',
+        pluginId: 'my-plugin',
+        declaration: { id: 'chart', label: 'Chart', icon: TEST_SVG_ICON },
+      }),
+    ]);
+
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    const button = screen.getByTestId('canvas-context-menu-plugin:my-plugin:chart');
+    const svgElement = button.querySelector('svg');
+    expect(svgElement).not.toBeNull();
+    expect(button.textContent).not.toContain('<svg');
+  });
+
+  it('falls back to "+" when no icon is provided', () => {
+    vi.mocked(widgetRegistry.getRegisteredWidgetTypes).mockReturnValue([
+      makeWidget({
+        qualifiedType: 'plugin:my-plugin:no-icon',
+        pluginId: 'my-plugin',
+        declaration: { id: 'no-icon', label: 'No Icon Widget' },
+      }),
+    ]);
+
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    const button = screen.getByTestId('canvas-context-menu-plugin:my-plugin:no-icon');
+    expect(button.textContent).toContain('+');
+    expect(button.querySelector('svg')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Plugin canvas widget icons in the right-click context menu were displaying raw SVG markup as text instead of rendering as actual icons
- Fixed by using `dangerouslySetInnerHTML` to render SVG icon strings, matching the existing pattern used in `ExplorerRail.tsx` and `ProjectRail.tsx`

## Changes
- **`src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx`** — Changed both promoted and 3rd-party plugin widget icon rendering from `{widget.declaration.icon}` (text interpolation) to `dangerouslySetInnerHTML={{ __html: widget.declaration.icon }}` (HTML rendering), with a fallback to `+` when no icon is provided
- **`src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx`** — New test file verifying that SVG icons render as HTML elements (not raw text) for both promoted and 3rd-party plugin widgets, and that the `+` fallback works when no icon is provided

## Test Plan
- [x] Promoted plugin widgets (terminal, files) render SVG icons as actual SVG elements
- [x] 3rd-party plugin widgets render SVG icons as actual SVG elements
- [x] Widgets without icons fall back to "+" character
- [x] Raw SVG text is never visible in menu item text content
- [x] All 7665 existing tests pass
- [x] TypeScript type check passes

## Manual Validation
1. Open a canvas workspace
2. Right-click on the canvas background
3. Verify that plugin-contributed widget items (e.g. Terminal, Files) show rendered icons instead of raw `<svg ...>` text