### PR TITLE
fix: resolve CI failures in MCP bridge PR #923

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1022,7 +1022,6 @@ const api = {
       return () => { ipcRenderer.removeListener(IPC.WINDOW.POPOUTS_CHANGED, listener); };
     },
   },
-};
 
   mcpBinding: {
     getBindings: () =>

--- a/src/renderer/stores/mcpBindingStore.ts
+++ b/src/renderer/stores/mcpBindingStore.ts
@@ -48,6 +48,6 @@ export const useMcpBindingStore = create<McpBindingStoreState>((set) => ({
 /** Initialize listener for binding changes from main process. */
 export function initMcpBindingListener(): () => void {
   return window.clubhouse.mcpBinding.onBindingsChanged((bindings) => {
-    useMcpBindingStore.setState({ bindings });
+    useMcpBindingStore.setState({ bindings: bindings as McpBindingEntry[] });
   });
 }


### PR DESCRIPTION
## Summary

- Fixes all 6 CI failures (typecheck x3, E2E x2, API surface check) in PR #923
- **Root cause**: the `mcpBinding` block in `src/preload/index.ts` was placed *after* the closing `};` of the `api` object, making it a standalone invalid block expression instead of a property of the preload API
- Adds type cast for `McpBindingEntry[]` in the store listener to satisfy the narrower `targetKind` union type

## Changes

| File | Fix |
|------|-----|
| `src/preload/index.ts` | Removed premature `};` so `mcpBinding` is inside the `api` object |
| `src/renderer/stores/mcpBindingStore.ts` | Cast IPC payload to `McpBindingEntry[]` for type narrowing |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 7726 tests passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)