### PR TITLE
fix: satellite resume button blocked by title bar drag

### DIFF
--- a/src/renderer/features/annex/SatelliteLockOverlay.tsx
+++ b/src/renderer/features/annex/SatelliteLockOverlay.tsx
@@ -87,7 +87,7 @@ export function SatelliteLockOverlay({ lockState, onDisconnect, onPause, onDisab
       )}
 
       {lockState.paused && (
-        <div className="fixed top-4 right-4 pointer-events-auto">
+        <div className="fixed top-12 right-4 pointer-events-auto" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-black/40 backdrop-blur-sm">
             <div
               className="w-3 h-3 rounded-full"


### PR DESCRIPTION
## Summary

- The "Resume" button on the satellite's paused badge was unclickable. The badge was positioned at `top-4` (16px from top), overlapping the 38px TitleBar drag region (`-webkit-app-region: drag`). The overlay's `pointer-events-none` made Electron's native drag handler see through it and intercept clicks before they reached the badge.
- Moved badge from `top-4` to `top-12` (48px) to clear the title bar, and added `-webkit-app-region: no-drag` to explicitly opt out of Electron's drag handling.

## Test plan

- [x] Types pass, 8,211 tests pass, lint clean
- [ ] Manual: on satellite, connect a controller, click Pause, then click Resume on the minimized badge — should restore full lock overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)