### PR TITLE
fix: use real agent IDs in MCP bindings + enriched logging

### DIFF
--- a/src/main/ipc/mcp-binding-handlers.ts
+++ b/src/main/ipc/mcp-binding-handlers.ts
@@ -42,11 +42,17 @@ export function registerMcpBindingHandlers(): void {
   });
 
   ipcMain.handle(IPC.MCP_BINDING.BIND, withValidatedArgs(
-    [stringArg(), objectArg<{ targetId: string; targetKind: string; label: string }>()],
+    [stringArg(), objectArg<{ targetId: string; targetKind: string; label: string; agentName?: string; targetName?: string }>()],
     (_event, agentId, target) => {
-      bindingManager.bind(agentId as string, target as { targetId: string; targetKind: 'browser' | 'agent' | 'terminal'; label: string });
+      bindingManager.bind(agentId as string, target as { targetId: string; targetKind: 'browser' | 'agent' | 'terminal'; label: string; agentName?: string; targetName?: string });
       appLog('core:mcp', 'info', 'Binding created', {
-        meta: { agentId, targetId: target.targetId, targetKind: target.targetKind },
+        meta: {
+          agentId,
+          agentName: target.agentName,
+          targetId: target.targetId,
+          targetName: target.targetName,
+          targetKind: target.targetKind,
+        },
       });
     },
   ));

--- a/src/main/services/clubhouse-mcp/binding-manager.ts
+++ b/src/main/services/clubhouse-mcp/binding-manager.ts
@@ -13,7 +13,7 @@ class BindingManager {
   private listeners = new Set<BindingChangeListener>();
 
   /** Add a binding for an agent. */
-  bind(agentId: string, target: { targetId: string; targetKind: BindingTargetKind; label: string }): void {
+  bind(agentId: string, target: { targetId: string; targetKind: BindingTargetKind; label: string; agentName?: string; targetName?: string }): void {
     let agentBindings = this.bindings.get(agentId);
     if (!agentBindings) {
       agentBindings = [];

--- a/src/main/services/clubhouse-mcp/bridge-server.ts
+++ b/src/main/services/clubhouse-mcp/bridge-server.ts
@@ -111,8 +111,8 @@ function handleInitialize(id: number | string | null): JsonRpcResponse {
 /** Handle tools/list request. */
 function handleToolsList(agentId: string, id: number | string | null): JsonRpcResponse {
   const tools = getScopedToolList(agentId);
-  appLog('core:mcp', 'debug', 'Tools list requested', {
-    meta: { agentId, toolCount: tools.length },
+  appLog('core:mcp', 'info', 'Tools list requested', {
+    meta: { agentId, toolCount: tools.length, toolNames: tools.map(t => t.name) },
   });
   return jsonRpcSuccess(id, { tools });
 }
@@ -130,18 +130,25 @@ async function handleToolsCall(
     return jsonRpcError(id, -32602, 'Missing tool name');
   }
 
-  appLog('core:mcp', 'debug', 'Tool call', {
-    meta: { agentId, toolName },
+  appLog('core:mcp', 'info', 'Tool call', {
+    meta: { agentId, toolName, args: Object.keys(args) },
   });
 
   try {
     const result = await callTool(agentId, toolName, args);
-    appLog('core:mcp', 'debug', 'Tool call completed', {
-      meta: { agentId, toolName, isError: result.isError || false },
+    const errorText = result.isError
+      ? result.content?.find(c => c.type === 'text')?.text
+      : undefined;
+    appLog('core:mcp', result.isError ? 'warn' : 'info', `Tool call ${result.isError ? 'returned error' : 'completed'}`, {
+      meta: {
+        agentId,
+        toolName,
+        ...(errorText ? { errorDetail: errorText } : {}),
+      },
     });
     return jsonRpcSuccess(id, result);
   } catch (err) {
-    appLog('core:mcp', 'error', 'Tool call failed', {
+    appLog('core:mcp', 'error', 'Tool call threw exception', {
       meta: { agentId, toolName, error: err instanceof Error ? err.message : String(err) },
     });
     return jsonRpcError(id, -32000, err instanceof Error ? err.message : String(err));

--- a/src/main/services/clubhouse-mcp/tool-registry.ts
+++ b/src/main/services/clubhouse-mcp/tool-registry.ts
@@ -5,6 +5,7 @@
 
 import type { McpToolDefinition, McpToolResult, BindingTargetKind } from './types';
 import { bindingManager } from './binding-manager';
+import { appLog } from '../log-service';
 
 /**
  * Tool templates keyed by targetKind.
@@ -84,6 +85,9 @@ export async function callTool(
 ): Promise<McpToolResult> {
   const parsed = parseToolName(toolName);
   if (!parsed) {
+    appLog('core:mcp', 'warn', 'Tool call: failed to parse tool name', {
+      meta: { agentId, toolName },
+    });
     return {
       content: [{ type: 'text', text: `Unknown tool: ${toolName}` }],
       isError: true,
@@ -94,6 +98,13 @@ export async function callTool(
   const bindings = bindingManager.getBindingsForAgent(agentId);
   const binding = bindings.find(b => sanitizeId(b.targetId) === parsed.targetId);
   if (!binding) {
+    appLog('core:mcp', 'warn', 'Tool call: no binding matches target', {
+      meta: {
+        agentId,
+        parsedTarget: parsed.targetId,
+        availableBindings: bindings.map(b => ({ targetId: b.targetId, sanitized: sanitizeId(b.targetId), targetKind: b.targetKind })),
+      },
+    });
     return {
       content: [{ type: 'text', text: `No binding found for target: ${parsed.targetId}` }],
       isError: true,

--- a/src/main/services/clubhouse-mcp/tools/agent-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.ts
@@ -36,8 +36,14 @@ export function registerAgentTools(): void {
 
       const reg = agentRegistry.get(targetId);
       if (!reg) {
+        appLog('core:mcp', 'warn', 'send_message: target agent not found in registry', {
+          meta: { sourceAgent: agentId, targetAgent: targetId },
+        });
         return { content: [{ type: 'text', text: `Agent ${targetId} is not running` }], isError: true };
       }
+      appLog('core:mcp', 'info', 'send_message: target resolved', {
+        meta: { sourceAgent: agentId, targetAgent: targetId, runtime: reg.runtime },
+      });
 
       try {
         if (reg.runtime === 'pty') {
@@ -69,7 +75,7 @@ export function registerAgentTools(): void {
         properties: {},
       },
     },
-    async (targetId, _agentId, _args): Promise<McpToolResult> => {
+    async (targetId, agentId, _args): Promise<McpToolResult> => {
       const reg = agentRegistry.get(targetId);
       const running = !!reg;
 
@@ -77,6 +83,10 @@ export function registerAgentTools(): void {
         running,
         runtime: reg?.runtime || null,
       };
+
+      appLog('core:mcp', 'info', 'get_status: resolved', {
+        meta: { sourceAgent: agentId, targetAgent: targetId, running, runtime: reg?.runtime },
+      });
 
       return { content: [{ type: 'text', text: JSON.stringify(status, null, 2) }] };
     },
@@ -98,9 +108,12 @@ export function registerAgentTools(): void {
         },
       },
     },
-    async (targetId, _agentId, args): Promise<McpToolResult> => {
+    async (targetId, agentId, args): Promise<McpToolResult> => {
       const reg = agentRegistry.get(targetId);
       if (!reg) {
+        appLog('core:mcp', 'warn', 'read_output: target agent not found in registry', {
+          meta: { sourceAgent: agentId, targetAgent: targetId },
+        });
         return { content: [{ type: 'text', text: `Agent ${targetId} is not running` }], isError: true };
       }
 

--- a/src/main/services/clubhouse-mcp/types.ts
+++ b/src/main/services/clubhouse-mcp/types.ts
@@ -11,6 +11,10 @@ export interface McpBinding {
   targetId: string;
   targetKind: BindingTargetKind;
   label: string;
+  /** Human-readable name of the source agent (e.g. "scrappy-robin"). */
+  agentName?: string;
+  /** Human-readable name of the target (e.g. "faithful-urchin" for agents). */
+  targetName?: string;
 }
 
 /** MCP JSON-RPC request envelope. */

--- a/src/renderer/plugins/builtin/canvas/useWiring.ts
+++ b/src/renderer/plugins/builtin/canvas/useWiring.ts
@@ -99,10 +99,19 @@ export function useWiring(
       const hitView = hitTestViews(canvasPos, viewsRef.current);
 
       if (hitView && isValidWireTarget(wireDrag.sourceView, hitView) && wireDrag.sourceView.agentId) {
+        const kind = targetKind(hitView);
+        // For agent targets, use the real agent ID (durable_*/quick_*) not the
+        // canvas view ID (cv_*). Canvas view IDs are ephemeral, tab-scoped, and
+        // not resolvable by the main process agent registry.
+        const resolvedTargetId = kind === 'agent'
+          ? (hitView as AgentCanvasViewType).agentId ?? hitView.id
+          : hitView.id;
         bind(wireDrag.sourceView.agentId, {
-          targetId: hitView.id,
-          targetKind: targetKind(hitView),
+          targetId: resolvedTargetId,
+          targetKind: kind,
           label: hitView.displayName || hitView.title,
+          agentName: wireDrag.sourceView.displayName || wireDrag.sourceView.title,
+          targetName: hitView.displayName || hitView.title,
         });
       }
 

--- a/src/renderer/stores/mcpBindingStore.ts
+++ b/src/renderer/stores/mcpBindingStore.ts
@@ -5,12 +5,16 @@ export interface McpBindingEntry {
   targetId: string;
   targetKind: 'browser' | 'agent' | 'terminal';
   label: string;
+  /** Human-readable name of the source agent (e.g. "scrappy-robin"). */
+  agentName?: string;
+  /** Human-readable name of the target (e.g. "faithful-urchin" for agents). */
+  targetName?: string;
 }
 
 interface McpBindingStoreState {
   bindings: McpBindingEntry[];
   loadBindings: () => Promise<void>;
-  bind: (agentId: string, target: { targetId: string; targetKind: string; label: string }) => Promise<void>;
+  bind: (agentId: string, target: { targetId: string; targetKind: string; label: string; agentName?: string; targetName?: string }) => Promise<void>;
   unbind: (agentId: string, targetId: string) => Promise<void>;
   registerWebview: (widgetId: string, webContentsId: number) => Promise<void>;
   unregisterWebview: (widgetId: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- **Root cause fix**: `useWiring.ts` was passing canvas view IDs (`cv_7`) as `targetId` for agent-to-agent MCP bindings. The main process agent registry keys by spawn IDs (`durable_*`/`quick_*`), so `send_message` and `read_output` tool calls always failed with "agent not running" while `get_status` silently returned `{ running: false }`.
- **Enriched bindings**: `McpBinding` now carries `agentName` and `targetName` so bindings are human-readable in logs and UI (e.g. "scrappy-robin → faithful-urchin" instead of opaque IDs).
- **Comprehensive MCP logging**: Tool calls log error detail text (not just `isError: true`), `tools/list` logs tool names, tool resolution failures log available bindings for debugging, and agent-tools handlers log registry lookup context.

## Test plan

- [x] Typecheck passes
- [x] All 8211 tests pass (336 files)
- [x] No new lint errors
- [ ] Manual: Create agent-to-agent wire on canvas → verify binding uses durable agent ID, not cv_* ID
- [ ] Manual: Check logs for enriched binding info (agentName, targetName in binding created log)
- [ ] Manual: Trigger a tool call error → verify error detail appears in logs (not just `isError: true`)
- [ ] Manual: Verify `send_message` / `read_output` succeed between two running agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)