### PR TITLE
fix: add 'widgets' permission to sessions plugin manifest

### DIFF
--- a/src/renderer/plugins/builtin/sessions/manifest.test.ts
+++ b/src/renderer/plugins/builtin/sessions/manifest.test.ts
@@ -27,7 +27,7 @@ describe('sessions plugin manifest', () => {
 
   it('declares required permissions', () => {
     expect(manifest.permissions).toEqual(
-      expect.arrayContaining(['agents', 'commands']),
+      expect.arrayContaining(['agents', 'commands', 'widgets']),
     );
   });
 

--- a/src/renderer/plugins/builtin/sessions/manifest.ts
+++ b/src/renderer/plugins/builtin/sessions/manifest.ts
@@ -10,7 +10,7 @@ export const manifest: PluginManifest = {
   author: 'Clubhouse',
   engine: { api: 0.8 },
   scope: 'project',
-  permissions: ['agents', 'commands'],
+  permissions: ['agents', 'commands', 'widgets'],
   contributes: {
     tab: { label: 'Sessions', title: 'Sessions', icon: SESSIONS_ICON, layout: 'sidebar-content' },
     commands: [],


### PR DESCRIPTION
## Summary
- The sessions plugin was being disabled at runtime with a red permission violation banner because `api.widgets` lacked the `widgets` permission
- Added `'widgets'` to the sessions plugin's `permissions` array so the API is granted instead of wrapped in a `permissionDeniedProxy`

## Changes
- `src/renderer/plugins/builtin/sessions/manifest.ts` — added `'widgets'` to the permissions array
- `src/renderer/plugins/builtin/sessions/manifest.test.ts` — updated the permission assertion to include `'widgets'`

## Test Plan
- [x] Sessions manifest test passes validation
- [x] Sessions manifest test asserts `['agents', 'commands', 'widgets']`
- [x] Full test suite passes (8211 tests)
- [x] TypeScript type check clean
- [x] Lint clean (no new warnings)

## Manual Validation
1. Enable the sessions experimental flag
2. Open a project and switch to the Sessions tab
3. Verify no red permission violation banner appears
4. Verify the plugin loads and renders the sidebar + main panel correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)