### PR TITLE
fix: MCP agent-to-agent PTY submission and connectivity-aware comms

### DIFF
--- a/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
@@ -47,29 +47,43 @@ describe('AgentTools', () => {
   });
 
   describe('tool registration', () => {
-    it('registers send_message, get_status, and read_output tools', () => {
+    it('registers send_message, get_status, read_output, and check_connectivity tools', () => {
       const tools = getScopedToolList('agent-1');
-      expect(tools).toHaveLength(3);
+      expect(tools).toHaveLength(4);
       const names = tools.map(t => t.name);
       expect(names).toContain('agent__agent_2__send_message');
       expect(names).toContain('agent__agent_2__get_status');
       expect(names).toContain('agent__agent_2__read_output');
+      expect(names).toContain('agent__agent_2__check_connectivity');
     });
   });
 
   describe('send_message', () => {
-    it('sends message to PTY agent', async () => {
+    it('sends tagged message to PTY agent with \\r', async () => {
+      mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
+      const result = await callTool('agent-1', 'agent__agent_2__send_message', { message: 'hello', task_id: 'test123' });
+      expect(result.isError).toBeFalsy();
+      expect(mockPtyWrite).toHaveBeenCalledWith('agent-2', '[TASK:test123] hello\r');
+      expect(result.content[0].text).toContain('task_id=test123');
+    });
+
+    it('auto-generates task_id when not provided', async () => {
       mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
       const result = await callTool('agent-1', 'agent__agent_2__send_message', { message: 'hello' });
       expect(result.isError).toBeFalsy();
-      expect(mockPtyWrite).toHaveBeenCalledWith('agent-2', 'hello\n');
+      // Should have auto-generated a task_id starting with t_
+      expect(result.content[0].text).toMatch(/task_id=t_/);
+      // PTY write should contain the tagged message with \r
+      const writeCall = mockPtyWrite.mock.calls[0];
+      expect(writeCall[1]).toMatch(/^\[TASK:t_[a-z0-9]+\] hello\r$/);
     });
 
-    it('sends message to structured agent', async () => {
+    it('sends tagged message to structured agent', async () => {
       mockAgentRegistryGet.mockReturnValue({ runtime: 'structured' });
-      const result = await callTool('agent-1', 'agent__agent_2__send_message', { message: 'hello' });
+      const result = await callTool('agent-1', 'agent__agent_2__send_message', { message: 'hello', task_id: 'abc' });
       expect(result.isError).toBeFalsy();
-      expect(mockStructuredSendMessage).toHaveBeenCalledWith('agent-2', 'hello');
+      expect(mockStructuredSendMessage).toHaveBeenCalledWith('agent-2', '[TASK:abc] hello');
+      expect(result.content[0].text).toContain('task_id=abc');
     });
 
     it('returns error when agent not running', async () => {
@@ -204,15 +218,45 @@ describe('AgentTools', () => {
       bindingManager.bind('agent-1', { targetId: 'agent-3', targetKind: 'agent', label: 'Agent 3' });
 
       const tools = getScopedToolList('agent-1');
-      // 3 tools for agent-2 + 3 tools for agent-3 = 6
-      expect(tools).toHaveLength(6);
+      // 4 tools for agent-2 + 4 tools for agent-3 = 8
+      expect(tools).toHaveLength(8);
 
-      const r1 = await callTool('agent-1', 'agent__agent_2__send_message', { message: 'to-2' });
-      const r2 = await callTool('agent-1', 'agent__agent_3__send_message', { message: 'to-3' });
+      const r1 = await callTool('agent-1', 'agent__agent_2__send_message', { message: 'to-2', task_id: 'x1' });
+      const r2 = await callTool('agent-1', 'agent__agent_3__send_message', { message: 'to-3', task_id: 'x2' });
       expect(r1.isError).toBeFalsy();
       expect(r2.isError).toBeFalsy();
-      expect(mockPtyWrite).toHaveBeenCalledWith('agent-2', 'to-2\n');
-      expect(mockPtyWrite).toHaveBeenCalledWith('agent-3', 'to-3\n');
+      expect(mockPtyWrite).toHaveBeenCalledWith('agent-2', '[TASK:x1] to-2\r');
+      expect(mockPtyWrite).toHaveBeenCalledWith('agent-3', '[TASK:x2] to-3\r');
+    });
+  });
+
+  describe('check_connectivity', () => {
+    it('returns unidirectional when no reverse binding exists', async () => {
+      mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
+      const result = await callTool('agent-1', 'agent__agent_2__check_connectivity', {});
+      expect(result.isError).toBeFalsy();
+      const data = JSON.parse(result.content[0].text!);
+      expect(data.direction).toBe('unidirectional');
+      expect(data.guidance).toContain('CANNOT send messages back');
+    });
+
+    it('returns bidirectional when reverse binding exists', async () => {
+      mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
+      // Create the reverse binding: agent-2 → agent-1
+      bindingManager.bind('agent-2', { targetId: 'agent-1', targetKind: 'agent', label: 'Agent 1' });
+
+      const result = await callTool('agent-1', 'agent__agent_2__check_connectivity', {});
+      expect(result.isError).toBeFalsy();
+      const data = JSON.parse(result.content[0].text!);
+      expect(data.direction).toBe('bidirectional');
+      expect(data.guidance).toContain('send messages back to you directly');
+    });
+
+    it('returns error when target agent not running', async () => {
+      mockAgentRegistryGet.mockReturnValue(undefined);
+      const result = await callTool('agent-1', 'agent__agent_2__check_connectivity', {});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not running');
     });
   });
 });

--- a/src/main/services/clubhouse-mcp/tools/agent-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.ts
@@ -3,6 +3,7 @@
  */
 
 import { registerToolTemplate } from '../tool-registry';
+import { bindingManager } from '../binding-manager';
 import { agentRegistry } from '../../agent-registry';
 import * as ptyManager from '../../pty-manager';
 import * as structuredManager from '../../structured-manager';
@@ -16,13 +17,32 @@ export function registerAgentTools(): void {
     'agent',
     'send_message',
     {
-      description: 'Send a message to the linked agent. The message will appear as input to the agent.',
+      description:
+        'Send a message to the linked agent. The message is injected as terminal input and submitted.\n\n' +
+        'IMPORTANT — this is asynchronous. The target agent will process the message on its own timeline ' +
+        'and may be in the middle of other work. There is no inline response.\n\n' +
+        'To get a response:\n' +
+        '1. Use check_connectivity to determine if the link is bidirectional or unidirectional.\n' +
+        '2. Include a task_id so the target can tag its reply (e.g. "TASK_RESULT:<task_id>: …").\n' +
+        '3. If UNIDIRECTIONAL: poll read_output and search for your task_id marker. Output may contain ' +
+        'unrelated content — filter by the marker. Allow time for the agent to process.\n' +
+        '4. If BIDIRECTIONAL: the target agent can send_message back to you directly with the task_id. ' +
+        'You may still poll read_output as a fallback.\n\n' +
+        'Instruct the target agent to prefix its answer with "TASK_RESULT:<task_id>: " so you can ' +
+        'locate it in the output stream.',
       inputSchema: {
         type: 'object',
         properties: {
           message: {
             type: 'string',
             description: 'The message to send to the agent.',
+          },
+          task_id: {
+            type: 'string',
+            description:
+              'Optional correlation ID. If provided, the message is prefixed with [TASK:<task_id>] ' +
+              'so the target agent knows to tag its response with TASK_RESULT:<task_id>. ' +
+              'If omitted, one is auto-generated and returned.',
           },
         },
         required: ['message'],
@@ -34,6 +54,8 @@ export function registerAgentTools(): void {
         return { content: [{ type: 'text', text: 'Missing required argument: message' }], isError: true };
       }
 
+      const taskId = (args.task_id as string) || `t_${Date.now().toString(36)}`;
+
       const reg = agentRegistry.get(targetId);
       if (!reg) {
         appLog('core:mcp', 'warn', 'send_message: target agent not found in registry', {
@@ -42,16 +64,18 @@ export function registerAgentTools(): void {
         return { content: [{ type: 'text', text: `Agent ${targetId} is not running` }], isError: true };
       }
       appLog('core:mcp', 'info', 'send_message: target resolved', {
-        meta: { sourceAgent: agentId, targetAgent: targetId, runtime: reg.runtime },
+        meta: { sourceAgent: agentId, targetAgent: targetId, runtime: reg.runtime, taskId },
       });
+
+      const taggedMessage = `[TASK:${taskId}] ${message}`;
 
       try {
         if (reg.runtime === 'pty') {
-          ptyManager.write(targetId, message + '\n');
-          return { content: [{ type: 'text', text: 'Message sent successfully' }] };
+          ptyManager.write(targetId, taggedMessage + '\r');
+          return { content: [{ type: 'text', text: `Message sent. task_id=${taskId} — look for TASK_RESULT:${taskId} in output.` }] };
         } else if (reg.runtime === 'structured') {
-          await structuredManager.sendMessage(targetId, message);
-          return { content: [{ type: 'text', text: 'Message sent successfully' }] };
+          await structuredManager.sendMessage(targetId, taggedMessage);
+          return { content: [{ type: 'text', text: `Message sent. task_id=${taskId} — look for TASK_RESULT:${taskId} in response.` }] };
         } else {
           return { content: [{ type: 'text', text: `Agent runtime "${reg.runtime}" does not support input` }], isError: true };
         }
@@ -97,7 +121,16 @@ export function registerAgentTools(): void {
     'agent',
     'read_output',
     {
-      description: 'Read recent output from the linked agent.',
+      description:
+        'Read recent terminal output from the linked agent.\n\n' +
+        'Use this to poll for responses after send_message. The output is a raw terminal buffer ' +
+        'and will contain ALL agent output — tool calls, reasoning, status messages, and any replies.\n\n' +
+        'To find a specific response, search the output for the TASK_RESULT:<task_id> marker you ' +
+        'requested in your send_message. The agent may not have responded yet — if you don\'t see ' +
+        'the marker, wait and poll again. Typical response times range from seconds to minutes ' +
+        'depending on task complexity.\n\n' +
+        'Tip: start with fewer lines (50) and increase if needed. The buffer is circular so very ' +
+        'old output may have been evicted.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -136,6 +169,62 @@ export function registerAgentTools(): void {
       } catch (err) {
         return { content: [{ type: 'text', text: `Failed to read output: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }
+    },
+  );
+
+  // agent__<targetId>__check_connectivity
+  registerToolTemplate(
+    'agent',
+    'check_connectivity',
+    {
+      description:
+        'Check whether communication with the linked agent is bidirectional or unidirectional.\n\n' +
+        'Returns a JSON object with:\n' +
+        '- direction: "bidirectional" or "unidirectional"\n' +
+        '- guidance: how to handle responses based on the direction\n\n' +
+        'BIDIRECTIONAL means the target agent also has a link back to you and can call send_message ' +
+        'to deliver responses directly into your input. You can include a task_id and the target ' +
+        'will send back a message tagged with TASK_RESULT:<task_id>.\n\n' +
+        'UNIDIRECTIONAL means the target agent cannot send messages back to you. You must poll ' +
+        'read_output to find responses. Always include a task_id in your send_message and instruct ' +
+        'the target to output "TASK_RESULT:<task_id>: <response>" so you can locate it in the ' +
+        'output buffer. The buffer contains all terminal output so filter carefully by the marker.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+    async (targetId, agentId, _args): Promise<McpToolResult> => {
+      const reg = agentRegistry.get(targetId);
+      if (!reg) {
+        return { content: [{ type: 'text', text: `Agent ${targetId} is not running` }], isError: true };
+      }
+
+      // Check if the target has a binding back to the caller
+      const reverseBindings = bindingManager.getBindingsForAgent(targetId);
+      const hasBidirectional = reverseBindings.some(b => b.targetId === agentId);
+
+      const direction = hasBidirectional ? 'bidirectional' : 'unidirectional';
+
+      const guidance = hasBidirectional
+        ? 'The target agent can send messages back to you directly via send_message. ' +
+          'Include a task_id in your message and the target can respond with a message tagged ' +
+          'TASK_RESULT:<task_id>. You may also poll read_output as a fallback.'
+        : 'The target agent CANNOT send messages back to you. You must poll read_output to find responses. ' +
+          'Always include a task_id and instruct the target to print "TASK_RESULT:<task_id>: <answer>" ' +
+          'in its output. Poll read_output periodically and search for your task_id marker. ' +
+          'Allow time — the agent may be busy with other work. Output may contain unrelated content.';
+
+      appLog('core:mcp', 'info', 'check_connectivity: resolved', {
+        meta: { sourceAgent: agentId, targetAgent: targetId, direction },
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ direction, target: targetId, guidance }, null, 2),
+        }],
+      };
     },
   );
 }


### PR DESCRIPTION
## Summary
- **Fix PTY message submission**: Changed `\n` → `\r` in `send_message` so messages actually submit (Enter key) in the target agent's terminal instead of just inserting a newline
- **Add task correlation**: `send_message` now accepts an optional `task_id` (auto-generated if omitted) and prefixes messages with `[TASK:<id>]` so targets can tag responses with `TASK_RESULT:<id>`
- **Add `check_connectivity` tool**: Agents can query whether communication with a target is bidirectional (target has a reverse binding and can `send_message` back) or unidirectional (must poll `read_output` for responses)
- **Enriched tool descriptions**: All agent-to-agent tool descriptions now explain async semantics, polling patterns, marker conventions, and directionality-aware workflows so LLM agents understand how to use them effectively

## Test plan
- [x] All 23 agent-tools tests pass (3 new for `check_connectivity`)
- [x] Updated existing tests for `\r`, tagged messages, and 4-tool registration
- [ ] Manual: verify `send_message` submits in target PTY
- [ ] Manual: verify `check_connectivity` returns correct direction based on binding topology

🤖 Generated with [Claude Code](https://claude.com/claude-code)