### PR TITLE
chore: bump version to 0.38.0-beta.12 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.38.0-beta.11",
+  "version": "0.38.0-beta.12",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Remote Agent & MCP Bug Fixes

# Bug Fixes
- Fixed blank terminal when switching back to a remote agent tab by adding a local PTY buffer cache
- Fixed MCP agent-to-agent message submission (Enter key) and added connectivity-aware communication tools
- Fixed browser MCP widget registration when webview mounts after binding