### PR TITLE
fix: implement proper wake and resume over annex wire protocol

### DIFF
--- a/src/main/ipc/annex-client-handlers.ts
+++ b/src/main/ipc/annex-client-handlers.ts
@@ -96,11 +96,11 @@ export function registerAnnexClientHandlers(): void {
 
   // Proxy IPC: wake a sleeping agent on a satellite
   ipcMain.handle(IPC.ANNEX_CLIENT.AGENT_WAKE, withValidatedArgs(
-    [stringArg(), stringArg(), stringArg()],
-    (_event, satelliteId, agentId, message) => {
+    [stringArg(), stringArg(), objectArg({ optional: true })],
+    (_event, satelliteId, agentId, options) => {
       return annexClient.sendToSatellite(satelliteId, {
         type: 'agent:wake',
-        payload: { agentId, message },
+        payload: { agentId, ...options },
       });
     },
   ));

--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -657,13 +657,17 @@ describe('annex-server', () => {
       expect(JSON.parse(res.body)).toEqual({ error: 'agent_not_found' });
     });
 
-    it('POST /api/v1/agents/:id/wake returns 400 without message', async () => {
+    it('POST /api/v1/agents/:id/wake wakes without a mission', async () => {
       vi.mocked(projectStore.list).mockReturnValue([
         { id: 'proj_1', name: 'test', path: '/tmp/test' },
       ]);
       vi.mocked(agentConfigModule.listDurable).mockReturnValue([
-        { id: 'durable_1', name: 'agent-1', color: 'indigo', createdAt: '2025-01-01' } as any,
+        {
+          id: 'durable_1', name: 'agent-1', color: 'indigo', createdAt: '2025-01-01',
+          worktreePath: '/tmp/test/.clubhouse/agents/agent-1',
+        } as any,
       ]);
+      vi.mocked(ptyManagerModule.isRunning).mockReturnValue(false);
 
       const { port, token } = await startAndPair();
 
@@ -672,8 +676,46 @@ describe('annex-server', () => {
         {},
         authHeaders(token),
       );
-      expect(res.status).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: 'missing_message' });
+      expect(res.status).toBe(200);
+      expect(agentSystem.spawnAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'durable_1',
+          kind: 'durable',
+          mission: undefined,
+          resume: false,
+        }),
+      );
+    });
+
+    it('POST /api/v1/agents/:id/wake supports resume flag', async () => {
+      vi.mocked(projectStore.list).mockReturnValue([
+        { id: 'proj_1', name: 'test', path: '/tmp/test' },
+      ]);
+      vi.mocked(agentConfigModule.listDurable).mockReturnValue([
+        {
+          id: 'durable_1', name: 'agent-1', color: 'indigo', createdAt: '2025-01-01',
+          worktreePath: '/tmp/test/.clubhouse/agents/agent-1',
+          lastSessionId: 'session-abc',
+        } as any,
+      ]);
+      vi.mocked(ptyManagerModule.isRunning).mockReturnValue(false);
+
+      const { port, token } = await startAndPair();
+
+      const res = await request(
+        port, 'POST', '/api/v1/agents/durable_1/wake',
+        { resume: true },
+        authHeaders(token),
+      );
+      expect(res.status).toBe(200);
+      expect(agentSystem.spawnAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'durable_1',
+          kind: 'durable',
+          resume: true,
+          sessionId: 'session-abc',
+        }),
+      );
     });
   });
 

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -635,10 +635,7 @@ async function handleWakeAgent(
   body: Record<string, unknown>,
 ): Promise<void> {
   const message = body.message as string | undefined;
-  if (!message) {
-    sendJson(res, 400, { error: 'missing_message' });
-    return;
-  }
+  const resume = !!body.resume;
 
   const agentInfo = await findAgentAcrossProjects(agentId);
   if (!agentInfo) {
@@ -666,6 +663,8 @@ async function handleWakeAgent(
       mission: message,
       orchestrator: config.orchestrator,
       freeAgentMode: config.freeAgentMode,
+      resume,
+      sessionId: resume ? config.lastSessionId : undefined,
     });
 
     // Broadcast agent:woken
@@ -1234,9 +1233,12 @@ function handleWsMessage(ws: WebSocket, data: string): void {
 
     case 'agent:wake': {
       const agentId = payload.agentId as string;
-      const message = payload.message as string;
-      if (!agentId || !message) break;
-      handleWakeAgentWs(ws, agentId, message, payload.model as string | undefined);
+      if (!agentId) break;
+      handleWakeAgentWs(ws, agentId, {
+        resume: !!payload.resume,
+        mission: payload.mission as string | undefined,
+        model: payload.model as string | undefined,
+      });
       break;
     }
 
@@ -1296,7 +1298,11 @@ async function handleSpawnQuickAgentWs(
 }
 
 // WS-based agent wake (mirrors HTTP handler)
-async function handleWakeAgentWs(ws: WebSocket, agentId: string, message: string, model?: string): Promise<void> {
+async function handleWakeAgentWs(
+  ws: WebSocket,
+  agentId: string,
+  options: { resume?: boolean; mission?: string; model?: string },
+): Promise<void> {
   const agentInfo = await findAgentAcrossProjects(agentId);
   if (!agentInfo) {
     ws.send(JSON.stringify({ type: 'error', payload: { message: 'agent_not_found' } }));
@@ -1307,16 +1313,18 @@ async function handleWakeAgentWs(ws: WebSocket, agentId: string, message: string
     return;
   }
   const { config, project } = agentInfo;
-  const agentModel = model || config.model;
+  const agentModel = options.model || config.model;
   const cwd = config.worktreePath || project.path;
 
   try {
     await spawnAgent({
       agentId: config.id, projectPath: project.path, cwd,
-      kind: 'durable', model: agentModel, mission: message,
+      kind: 'durable', model: agentModel, mission: options.mission,
       orchestrator: config.orchestrator, freeAgentMode: config.freeAgentMode,
+      resume: options.resume,
+      sessionId: options.resume ? config.lastSessionId : undefined,
     });
-    broadcastAndBuffer('agent:woken', { agentId: config.id, message, source: 'annex-v2' });
+    broadcastAndBuffer('agent:woken', { agentId: config.id, source: 'annex-v2' });
     ws.send(JSON.stringify({ type: 'agent:wake:ack', payload: { agentId: config.id, status: 'starting' } }));
   } catch (err) {
     ws.send(JSON.stringify({ type: 'error', payload: { message: 'wake_failed' } }));

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -831,8 +831,8 @@ const api = {
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.AGENT_SPAWN, satelliteId, params),
     agentKill: (satelliteId: string, agentId: string) =>
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.AGENT_KILL, satelliteId, agentId),
-    agentWake: (satelliteId: string, agentId: string, message: string) =>
-      ipcRenderer.invoke(IPC.ANNEX_CLIENT.AGENT_WAKE, satelliteId, agentId, message),
+    agentWake: (satelliteId: string, agentId: string, options?: { resume?: boolean; mission?: string }) =>
+      ipcRenderer.invoke(IPC.ANNEX_CLIENT.AGENT_WAKE, satelliteId, agentId, options),
     ptyGetBuffer: (satelliteId: string, agentId: string): Promise<string> =>
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.PTY_GET_BUFFER, satelliteId, agentId),
     fileTree: (satelliteId: string, projectId: string, options?: { path?: string; depth?: number; includeHidden?: boolean }): Promise<unknown[]> =>

--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -182,7 +182,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
   const handleWake = useCallback(async () => {
     if (agent.status === 'running') return;
     if (isRemote && remoteParts) {
-      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId, 'Wake up');
+      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId);
       return;
     }
     if (!activeProject) return;
@@ -196,7 +196,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
   const handleWakeAndResume = useCallback(async () => {
     if (agent.status === 'running') return;
     if (isRemote && remoteParts) {
-      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId, 'Wake and resume');
+      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId, { resume: true });
       return;
     }
     if (!activeProject) return;

--- a/src/renderer/features/agents/SleepingAgent.tsx
+++ b/src/renderer/features/agents/SleepingAgent.tsx
@@ -25,7 +25,7 @@ export function SleepingAgent({ agent }: { agent: Agent }) {
 
   const handleWake = useCallback(async () => {
     if (isRemote && remoteParts) {
-      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId, 'Wake up');
+      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId);
       return;
     }
     if (!agentProject) return;
@@ -38,7 +38,7 @@ export function SleepingAgent({ agent }: { agent: Agent }) {
 
   const handleWakeAndResume = useCallback(async () => {
     if (isRemote && remoteParts) {
-      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId, 'Wake and resume');
+      await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId, { resume: true });
       setDropdownOpen(false);
       return;
     }

--- a/src/renderer/plugins/plugin-api-agents.ts
+++ b/src/renderer/plugins/plugin-api-agents.ts
@@ -92,7 +92,7 @@ export function createAgentsAPI(ctx: PluginContext, manifest?: PluginManifest): 
         await useAnnexClientStore.getState().sendAgentWake(
           remoteParts.satelliteId,
           remoteParts.agentId,
-          options?.mission || 'Wake up',
+          options?.mission ? { mission: options.mission } : undefined,
         );
         return;
       }

--- a/src/renderer/stores/annexClientStore.test.ts
+++ b/src/renderer/stores/annexClientStore.test.ts
@@ -270,14 +270,24 @@ describe('annexClientStore', () => {
   // -------------------------------------------------------------------------
 
   describe('sendAgentWake', () => {
-    it('delegates to IPC agentWake', async () => {
-      await getState().sendAgentWake('sat-1', 'agent-1', 'Wake up');
-      expect(mockAnnexClient.agentWake).toHaveBeenCalledWith('sat-1', 'agent-1', 'Wake up');
+    it('delegates to IPC agentWake with no options', async () => {
+      await getState().sendAgentWake('sat-1', 'agent-1');
+      expect(mockAnnexClient.agentWake).toHaveBeenCalledWith('sat-1', 'agent-1', undefined);
+    });
+
+    it('delegates to IPC agentWake with resume option', async () => {
+      await getState().sendAgentWake('sat-1', 'agent-1', { resume: true });
+      expect(mockAnnexClient.agentWake).toHaveBeenCalledWith('sat-1', 'agent-1', { resume: true });
+    });
+
+    it('delegates to IPC agentWake with mission option', async () => {
+      await getState().sendAgentWake('sat-1', 'agent-1', { mission: 'do something' });
+      expect(mockAnnexClient.agentWake).toHaveBeenCalledWith('sat-1', 'agent-1', { mission: 'do something' });
     });
 
     it('swallows IPC errors', async () => {
       mockAnnexClient.agentWake.mockRejectedValueOnce(new Error('IPC failed'));
-      await expect(getState().sendAgentWake('sat-1', 'agent-1', 'Wake up')).resolves.toBeUndefined();
+      await expect(getState().sendAgentWake('sat-1', 'agent-1')).resolves.toBeUndefined();
     });
   });
 

--- a/src/renderer/stores/annexClientStore.ts
+++ b/src/renderer/stores/annexClientStore.ts
@@ -65,7 +65,7 @@ interface AnnexClientStoreState {
   sendPtyResize: (satelliteId: string, agentId: string, cols: number, rows: number) => Promise<void>;
   sendAgentSpawn: (satelliteId: string, params: unknown) => Promise<void>;
   sendAgentKill: (satelliteId: string, agentId: string) => Promise<void>;
-  sendAgentWake: (satelliteId: string, agentId: string, message: string) => Promise<void>;
+  sendAgentWake: (satelliteId: string, agentId: string, options?: { resume?: boolean; mission?: string }) => Promise<void>;
   requestPtyBuffer: (satelliteId: string, agentId: string) => Promise<string>;
 }
 
@@ -160,9 +160,9 @@ export const useAnnexClientStore = create<AnnexClientStoreState>((set) => ({
     } catch { /* ignore */ }
   },
 
-  sendAgentWake: async (satelliteId, agentId, message) => {
+  sendAgentWake: async (satelliteId, agentId, options) => {
     try {
-      await window.clubhouse.annexClient.agentWake(satelliteId, agentId, message);
+      await window.clubhouse.annexClient.agentWake(satelliteId, agentId, options);
     } catch { /* ignore */ }
   },
 


### PR DESCRIPTION
## Summary
- Remote agent wake no longer sends a fake "Wake up" mission prompt — it starts the agent fresh with no mission, matching local behavior
- "Wake & Resume" over annex now properly resumes the previous session (passes `resume: true` and `sessionId` to `spawnAgent`) instead of just sending the string "Wake and resume" as a mission
- HTTP REST API wake endpoint no longer requires `message`; now supports optional `resume` flag

## Changes
- **Wire protocol** (`annex-server.ts`): `agent:wake` payload changed from `{ agentId, message }` to `{ agentId, resume?, mission? }`. Both WS and HTTP handlers pass `resume` and `sessionId` through to `spawnAgent`
- **IPC pipeline** (`annex-client-handlers.ts`, `preload/index.ts`, `annexClientStore.ts`): `agentWake` signature changed from `(satelliteId, agentId, message)` to `(satelliteId, agentId, options?)`
- **UI components** (`SleepingAgent.tsx`, `AgentListItem.tsx`): Wake calls `sendAgentWake(satId, agentId)` with no options; Resume calls `sendAgentWake(satId, agentId, { resume: true })`
- **Plugin API** (`plugin-api-agents.ts`): `resume()` no longer falls back to `'Wake up'` string; passes `{ mission }` only when explicitly provided

## Test Plan
- [x] Typecheck passes
- [x] All 8164 tests pass (335 test files)
- [x] Updated `annexClientStore.test.ts` — tests for no options, resume option, and mission option
- [x] Updated `annex-server.test.ts` — replaced "400 without message" test with "wake without mission succeeds" and added "resume flag" test
- [ ] Manual: wake a remote agent via annex — should start fresh with no mission in the terminal
- [ ] Manual: wake & resume a remote agent — should resume previous session context
- [ ] Manual: plugin API `agents.resume(id)` on a remote agent — should wake without mission
- [ ] Manual: plugin API `agents.resume(id, { mission: '...' })` — should wake with that specific mission

## Manual Validation
1. Connect to a satellite via annex
2. Sleep a remote durable agent
3. Click "Wake Up" — agent should start fresh, no "Wake up" message in its session
4. Sleep it again, click dropdown → "Wake & Resume" — agent should resume its previous session