### PR TITLE
fix: bracketed paste + delayed submit for multi-line A2A PTY messages

### DIFF
--- a/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../log-service', () => ({
 }));
 
 import { registerAgentTools } from './agent-tools';
-import { getScopedToolList, callTool, buildToolName, buildToolKey, _resetForTesting as resetTools } from '../tool-registry';
+import { getScopedToolList, callTool, buildToolName, _resetForTesting as resetTools } from '../tool-registry';
 import { bindingManager } from '../binding-manager';
 import type { McpBinding } from '../types';
 
@@ -134,9 +134,9 @@ describe('AgentTools', () => {
       expect(result.isError).toBeFalsy();
 
       // First write: bracketed paste wrapping
-      const firstWrite = mockPtyWrite.mock.calls[0][1];
-      expect(firstWrite).toMatch(/^\x1b\[200~/);
-      expect(firstWrite).toMatch(/\x1b\[201~$/);
+      const firstWrite = mockPtyWrite.mock.calls[0][1] as string;
+      expect(firstWrite.startsWith('\x1b[200~')).toBe(true);
+      expect(firstWrite.endsWith('\x1b[201~')).toBe(true);
       expect(firstWrite).toContain('[TASK:ml1]');
       expect(firstWrite).toContain('line one\nline two\nline three');
 
@@ -155,10 +155,10 @@ describe('AgentTools', () => {
       const result = await sendMessage('agent-1', sendToolName, { message: 'do something', task_id: 'bidir1' });
       expect(result.isError).toBeFalsy();
 
-      const firstWrite = mockPtyWrite.mock.calls[0][1];
+      const firstWrite = mockPtyWrite.mock.calls[0][1] as string;
       // Bidirectional appends \n\n---\n... so it should use bracketed paste
-      expect(firstWrite).toMatch(/^\x1b\[200~/);
-      expect(firstWrite).toMatch(/\x1b\[201~$/);
+      expect(firstWrite.startsWith('\x1b[200~')).toBe(true);
+      expect(firstWrite.endsWith('\x1b[201~')).toBe(true);
       expect(firstWrite).toContain('Reply to mega-camel via tool');
       expect(firstWrite).toContain('clubhouse__');
       expect(firstWrite).toContain('task_id="bidir1"');
@@ -218,9 +218,9 @@ describe('AgentTools', () => {
 
       // Only 1 write: bracketed paste, no \r
       expect(mockPtyWrite).toHaveBeenCalledTimes(1);
-      const written = mockPtyWrite.mock.calls[0][1];
-      expect(written).toMatch(/^\x1b\[200~/);
-      expect(written).toMatch(/\x1b\[201~$/);
+      const written = mockPtyWrite.mock.calls[0][1] as string;
+      expect(written.startsWith('\x1b[200~')).toBe(true);
+      expect(written.endsWith('\x1b[201~')).toBe(true);
     });
 
     it('performs post-send buffer check for delivery heuristic', async () => {

--- a/src/main/services/clubhouse-mcp/tools/agent-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.ts
@@ -2,7 +2,7 @@
  * Agent-to-Agent MCP Tools — allows linked agents to communicate.
  */
 
-import { registerToolTemplate, buildToolName, buildToolKey } from '../tool-registry';
+import { registerToolTemplate, buildToolName } from '../tool-registry';
 import { bindingManager } from '../binding-manager';
 import { agentRegistry } from '../../agent-registry';
 import * as ptyManager from '../../pty-manager';


### PR DESCRIPTION
## Summary
- **Fix multi-line message submission**: Messages containing newlines (e.g. bidirectional reply instructions, user multi-line content) were collapsing into Claude Code's `[multi-line X words Y lines]` preview and never submitting — the trailing `\r` was swallowed as part of the paste burst
- **Bracketed paste wrapping**: Multi-line messages are now wrapped in `\x1b[200~...\x1b[201~` so the receiving CLI treats the entire payload as a single paste event
- **Delayed Enter keystroke**: `\r` is sent as a separate write after 100ms delay, ensuring the terminal processes paste-end before seeing the submit
- **`force_submit` parameter**: New boolean option (default `true`) lets agents opt out of auto-submission when injecting text without submitting
- **Post-send buffer heuristic**: Snapshots the PTY buffer before and after submit to heuristically detect whether the receiving agent processed the input
- **Structured logging**: Logs at each step — multi-line detection, paste wrapping, delayed submit firing, and buffer check results

## Changes
- `agent-tools.ts`: Added `force_submit` input parameter, bracketed paste wrapping for multi-line messages, delayed `\r` submission via setTimeout, post-send buffer length check with logging, removed unused `buildToolKey` import
- `agent-tools.test.ts`: Added 7 new tests (single-line no bracketed paste, multi-line bracketed paste, bidirectional bracketed paste, force_submit=true/false for single and multi-line, buffer heuristic check), updated existing tests for two-phase write pattern (message + delayed `\r`), added `sendMessage` helper with fake timer advancement, fixed `no-control-regex` lint errors

## Test Plan
- [x] Single-line messages skip bracketed paste, send message + delayed `\r` (2 writes)
- [x] Multi-line messages wrap in `\x1b[200~...\x1b[201~` + delayed `\r`
- [x] Bidirectional reply instructions (contain `\n`) trigger bracketed paste
- [x] `force_submit=false` skips delayed `\r` for both single and multi-line
- [x] Post-send buffer heuristic calls `getBuffer` before and after submit
- [x] Auto-generated task_id, sender identity, error cases all still pass
- [x] All 33 tests pass, lint clean

## Manual Validation
- [ ] Send a single-line message between two linked agents — should submit immediately
- [ ] Send a multi-line message (or trigger bidirectional reply instructions) — should paste as a block and submit, not collapse into preview
- [ ] Send with `force_submit: false` — text should appear in input without submitting
- [ ] Check logs for `send_message: writing to PTY` and `post-submit buffer check` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)