### PR TITLE
fix: resolve group-project target views in WireOverlay

### DIFF
--- a/src/renderer/plugins/builtin/canvas/WireOverlay.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireOverlay.test.tsx
@@ -33,6 +33,21 @@ function makePluginView(id: string, x = 300, y = 0): PluginCanvasView {
   };
 }
 
+function makeGroupProjectView(id: string, groupProjectId: string, x = 300, y = 0): PluginCanvasView {
+  return {
+    id,
+    type: 'plugin',
+    pluginWidgetType: 'plugin:group-project:group-project-card',
+    pluginId: 'group-project',
+    position: { x, y },
+    size: { width: 200, height: 200 },
+    title: `Group Project ${id}`,
+    displayName: `Group Project ${id}`,
+    zIndex: 1,
+    metadata: { groupProjectId },
+  };
+}
+
 describe('WireOverlay', () => {
   it('renders nothing when bindings array is empty', () => {
     const { container } = render(
@@ -228,6 +243,60 @@ describe('WireOverlay', () => {
     );
 
     expect(container.querySelector('#wire-path-agent-1--b1')).toBeTruthy();
+  });
+
+  it('renders a wire to a group-project plugin view', () => {
+    const views: CanvasView[] = [
+      makeAgentView('a1', 'agent-1', 0, 0),
+      makeGroupProjectView('gp-view-1', 'gp_abc123', 400, 0),
+    ];
+    const bindings: McpBindingEntry[] = [
+      { agentId: 'agent-1', targetId: 'gp_abc123', targetKind: 'group-project', label: 'My Project' },
+    ];
+
+    const { container } = render(
+      <WireOverlay views={views} bindings={bindings} />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    const pathEl = container.querySelector('[data-testid="wire-path-agent-1--gp_abc123"]');
+    expect(pathEl).toBeTruthy();
+    expect(pathEl?.getAttribute('d')).toContain('M');
+    expect(pathEl?.getAttribute('d')).toContain('C');
+  });
+
+  it('renders flow dots for group-project wire', () => {
+    const views: CanvasView[] = [
+      makeAgentView('a1', 'agent-1', 0, 0),
+      makeGroupProjectView('gp-view-1', 'gp_abc123', 400, 0),
+    ];
+    const bindings: McpBindingEntry[] = [
+      { agentId: 'agent-1', targetId: 'gp_abc123', targetKind: 'group-project', label: 'My Project' },
+    ];
+
+    const { container } = render(
+      <WireOverlay views={views} bindings={bindings} />,
+    );
+
+    const fwdDots = container.querySelectorAll('[data-testid^="wire-dot-fwd-"]');
+    expect(fwdDots.length).toBe(2);
+  });
+
+  it('skips group-project binding when no matching view exists', () => {
+    const views: CanvasView[] = [
+      makeAgentView('a1', 'agent-1', 0, 0),
+      makeGroupProjectView('gp-view-1', 'gp_other', 400, 0),
+    ];
+    const bindings: McpBindingEntry[] = [
+      { agentId: 'agent-1', targetId: 'gp_nonexistent', targetKind: 'group-project', label: 'Missing' },
+    ];
+
+    const { container } = render(
+      <WireOverlay views={views} bindings={bindings} />,
+    );
+
+    expect(container.querySelector('svg')).toBeNull();
   });
 
   it('sets data-bidir attribute on bidirectional wire group', () => {

--- a/src/renderer/plugins/builtin/canvas/WireOverlay.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireOverlay.tsx
@@ -56,11 +56,20 @@ function resolveBindingViews(
   }
   if (!source) return null;
 
-  // Look up target by view id first, then by agentId for agent-to-agent bindings
+  // Look up target by view id first, then by agentId for agent-to-agent bindings,
+  // then by metadata.groupProjectId for group-project bindings.
   let target = viewMap.get(binding.targetId);
   if (!target && binding.targetKind === 'agent') {
     for (const v of viewMap.values()) {
       if (v.type === 'agent' && (v as AgentCanvasViewType).agentId === binding.targetId) {
+        target = v;
+        break;
+      }
+    }
+  }
+  if (!target && binding.targetKind === 'group-project') {
+    for (const v of viewMap.values()) {
+      if (v.type === 'plugin' && v.metadata?.groupProjectId === binding.targetId) {
         target = v;
         break;
       }


### PR DESCRIPTION
## Summary
- Group project canvas widgets were not rendering wires because `WireOverlay.resolveBindingViews` couldn't resolve group-project binding targets to their canvas views
- Added a fallback lookup that matches plugin views by `metadata.groupProjectId` when `targetKind` is `'group-project'`
- Wires to group projects now render with full animations (physics, flow dots, activity tracking) — same as agent and browser wires

## Changes
- **`WireOverlay.tsx`**: Added group-project fallback in `resolveBindingViews` — when `targetKind === 'group-project'`, scans plugin views for matching `metadata.groupProjectId`
- **`WireOverlay.test.tsx`**: Added 3 test cases:
  - Renders a wire path to a group-project plugin view
  - Renders flow dots for group-project wires
  - Skips group-project binding when no matching view exists

## Root Cause
Wire creation (`useWiring.ts`) correctly stores `groupProjectId` as `targetId` for group-project bindings. But `resolveBindingViews` only had a fallback for agent-to-agent bindings (lookup by `agentId`). The `viewMap` is keyed by canvas view ID (`cv_*`), not by `groupProjectId`, so `viewMap.get(binding.targetId)` always returned `undefined` for group-project targets.

## Test Plan
- [x] Typecheck passes
- [x] All 8410 tests pass (348 test files)
- [x] Lint clean (no new warnings)
- [ ] Manual: drag a wire from an agent to a group project widget — wire should render with physics and flow dots
- [ ] Manual: verify wire follows the group project widget during drag
- [ ] Manual: verify wire config popover works when clicking the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)