### PR TITLE
fix: send Enter twice for multi-line PTY paste to ensure submission

### DIFF
--- a/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
@@ -44,13 +44,15 @@ function agentToolName(binding: McpBinding, suffix: string): string {
 
 /**
  * Helper: call send_message and advance fake timers so the delayed \r
- * and post-send buffer check resolve. Must be called within a fake-timer
- * context (vi.useFakeTimers).
+ * retries and buffer checks all resolve. Must be called within a
+ * fake-timer context (vi.useFakeTimers).
+ *
+ * Timeline: 200ms (1st \r) + 200ms (retry check / 2nd \r) + 200ms (final buffer check) = 600ms
  */
 async function sendMessage(agentId: string, toolName: string, args: Record<string, unknown>) {
   const promise = callTool(agentId, toolName, args);
-  // 100ms for the delayed \r, then 200ms for the buffer check
-  await vi.advanceTimersByTimeAsync(300);
+  // Advance through all three setTimeout stages
+  await vi.advanceTimersByTimeAsync(600);
   return promise;
 }
 
@@ -181,11 +183,29 @@ describe('AgentTools', () => {
       expect(result.content[0].text).toContain('poll read_output');
     });
 
-    it('sends delayed \\r for submission by default (force_submit=true)', async () => {
+    it('sends delayed \\r and retries with second \\r when buffer does not grow (force_submit=true)', async () => {
       mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
+      // Buffer stays empty → first \r doesn't trigger processing → retry
+      mockPtyGetBuffer.mockReturnValue('');
       await sendMessage('agent-1', sendToolName, { message: 'hello', task_id: 'fs1' });
 
-      // Should have 2 writes: message + delayed \r
+      // Should have 3 writes: message + 1st \r + 2nd \r (retry)
+      expect(mockPtyWrite).toHaveBeenCalledTimes(3);
+      expect(mockPtyWrite.mock.calls[1][1]).toBe('\r');
+      expect(mockPtyWrite.mock.calls[2][1]).toBe('\r');
+    });
+
+    it('skips second \\r when first Enter triggers processing (buffer grows)', async () => {
+      mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
+      // Simulate buffer growing after first \r
+      let callCount = 0;
+      mockPtyGetBuffer.mockImplementation(() => {
+        callCount++;
+        return callCount <= 1 ? 'short' : 'short + agent processed message output';
+      });
+      await sendMessage('agent-1', sendToolName, { message: 'hello', task_id: 'fs2' });
+
+      // Should have 2 writes: message + 1st \r (no retry needed)
       expect(mockPtyWrite).toHaveBeenCalledTimes(2);
       expect(mockPtyWrite.mock.calls[1][1]).toBe('\r');
     });
@@ -223,21 +243,21 @@ describe('AgentTools', () => {
       expect(written.endsWith('\x1b[201~')).toBe(true);
     });
 
-    it('performs post-send buffer check for delivery heuristic', async () => {
+    it('performs post-send buffer checks for delivery heuristic', async () => {
       mockAgentRegistryGet.mockReturnValue({ runtime: 'pty' });
-      // Simulate buffer growing after submit (agent processed the message)
+      // Simulate buffer NOT growing after first \r, then growing after second
       let callCount = 0;
       mockPtyGetBuffer.mockImplementation(() => {
         callCount++;
-        // First call (before submit): short buffer
-        // Second call (after submit): longer buffer
-        return callCount <= 1 ? 'short' : 'short + agent processed message output';
+        // Calls 1-2 (before + after first \r): same length → triggers retry
+        // Call 3 (after second \r): longer
+        return callCount <= 2 ? 'short' : 'short + agent processed message output';
       });
 
       const result = await sendMessage('agent-1', sendToolName, { message: 'hello', task_id: 'buf1' });
       expect(result.isError).toBeFalsy();
-      // getBuffer should have been called twice (before and after submit)
-      expect(mockPtyGetBuffer).toHaveBeenCalledTimes(2);
+      // getBuffer: once before submit, once after 1st \r, once after 2nd \r
+      expect(mockPtyGetBuffer).toHaveBeenCalledTimes(3);
     });
 
     it('includes sender name without project when project not set', async () => {

--- a/src/main/services/clubhouse-mcp/tools/agent-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.ts
@@ -121,23 +121,54 @@ export function registerAgentTools(): void {
             // heuristically check whether the receiving agent processed the input.
             const bufferBefore = ptyManager.getBuffer(targetId)?.length ?? 0;
 
-            // Send \r (Enter) after a brief delay as a *separate* write so the
-            // receiving terminal processes paste-end before seeing the submit.
+            // Claude Code's multi-line paste preview requires Enter to accept
+            // the pasted content, then a *second* Enter to actually submit.
+            // We send \r twice with delays:
+            //   1st \r (200ms): exits the paste preview / accepts pasted text
+            //   2nd \r (200ms later): submits the message to the AI
+            // The second \r is only sent if the buffer hasn't grown (meaning
+            // the first Enter didn't trigger processing). If it did grow, the
+            // message was already submitted and the retry is skipped.
             await new Promise<void>((resolve) => {
               setTimeout(() => {
                 ptyManager.write(targetId, '\r');
 
-                // Check buffer growth after another short delay to heuristically
-                // determine whether the agent started processing the message.
+                appLog('core:mcp', 'info', 'send_message: first Enter sent (accept paste)', {
+                  meta: { targetAgent: targetId, taskId },
+                });
+
+                // Check if the first \r triggered processing; if not, send
+                // a second \r to submit.
                 setTimeout(() => {
-                  const bufferAfter = ptyManager.getBuffer(targetId)?.length ?? 0;
-                  const bufferGrew = bufferAfter > bufferBefore;
-                  appLog('core:mcp', 'info', 'send_message: post-submit buffer check', {
-                    meta: { targetAgent: targetId, taskId, bufferBefore, bufferAfter, bufferGrew },
+                  const bufferAfterFirst = ptyManager.getBuffer(targetId)?.length ?? 0;
+                  const firstEnterWorked = bufferAfterFirst > bufferBefore;
+
+                  if (firstEnterWorked) {
+                    appLog('core:mcp', 'info', 'send_message: first Enter triggered processing, skipping retry', {
+                      meta: { targetAgent: targetId, taskId, bufferBefore, bufferAfterFirst },
+                    });
+                    resolve();
+                    return;
+                  }
+
+                  // Second Enter — submit the message
+                  ptyManager.write(targetId, '\r');
+
+                  appLog('core:mcp', 'info', 'send_message: second Enter sent (submit)', {
+                    meta: { targetAgent: targetId, taskId, bufferBefore, bufferAfterFirst },
                   });
-                  resolve();
+
+                  // Final buffer check
+                  setTimeout(() => {
+                    const bufferAfterSecond = ptyManager.getBuffer(targetId)?.length ?? 0;
+                    const secondEnterWorked = bufferAfterSecond > bufferBefore;
+                    appLog('core:mcp', 'info', 'send_message: post-submit buffer check', {
+                      meta: { targetAgent: targetId, taskId, bufferBefore, bufferAfterSecond, secondEnterWorked },
+                    });
+                    resolve();
+                  }, 200);
                 }, 200);
-              }, 100);
+              }, 200);
             });
           }
         } else if (reg.runtime === 'structured') {


### PR DESCRIPTION
## Summary
- **Fix multi-line A2A message submission**: The bracketed paste fix (#978) sent a single `\r` after 100ms, which exits Claude Code's multi-line paste preview but doesn't actually submit the message — the user had to manually click the terminal and press Enter
- **Two-phase Enter with retry**: Now sends `\r` twice with 200ms delays — first to accept the paste preview, second to submit — with a buffer-growth heuristic to skip the retry if the first Enter was sufficient
- **Increased base delay**: 100ms → 200ms for the initial Enter, giving Claude Code more time to process the bracketed paste content

## Changes
- **`agent-tools.ts`**: Replaced single delayed `\r` with two-phase Enter sequence: 1st `\r` at 200ms (accept paste), buffer check at 400ms, conditional 2nd `\r` (submit), final buffer check at 600ms. Added structured logging for each phase.
- **`agent-tools.test.ts`**: Updated `sendMessage` helper timer to 600ms for new three-stage timeline. Added test for retry behavior (buffer doesn't grow → second `\r` sent). Added test for skip-retry behavior (buffer grows → no second `\r`). Updated buffer heuristic test for 3-call pattern.

## Test Plan
- [x] Single-line messages: skip bracketed paste, send message + delayed `\r` + retry `\r` (buffer empty → 3 writes)
- [x] Buffer growth after first `\r`: skips second `\r` (2 writes only)
- [x] Multi-line messages: bracketed paste wrapping + two-phase Enter
- [x] `force_submit=false`: no `\r` sent at all (1 write)
- [x] Post-send buffer heuristic: `getBuffer` called 3 times (before, after 1st, after 2nd)
- [x] All 34 tests pass, 8408 total suite tests pass
- [x] Typecheck clean, lint clean (no new warnings)

## Manual Validation
- [ ] Send a multi-line message (or any bidirectional message with reply instructions) between two linked agents — should paste and **submit automatically** without manual Enter
- [ ] Send a single-line unidirectional message — should still submit normally
- [ ] Check logs for `first Enter sent`, `second Enter sent` or `skipping retry` entries to confirm which path was taken
- [ ] Verify `force_submit: false` still injects text without submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)