### PR TITLE
fix: use text-white on pairing confirm button for visibility

### DIFF
--- a/src/renderer/features/settings/PairingWizard.test.tsx
+++ b/src/renderer/features/settings/PairingWizard.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PairingWizard } from './PairingWizard';
+import { useAnnexClientStore } from '../../stores/annexClientStore';
+
+const mockOnClose = vi.fn();
+const mockPairWith = vi.fn().mockResolvedValue({ success: true });
+
+function resetStores() {
+  useAnnexClientStore.setState({
+    discoveredServices: [
+      {
+        fingerprint: 'abc123',
+        alias: 'Test Machine',
+        icon: '🖥',
+        color: '#aaa',
+        host: '192.168.1.42',
+        mainPort: 9000,
+        pairingPort: 9001,
+        publicKey: 'pk-test',
+      },
+    ],
+    loadDiscovered: vi.fn(),
+    scan: vi.fn(),
+    pairWith: mockPairWith,
+  });
+}
+
+describe('PairingWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+  });
+
+  it('renders discovered services', () => {
+    render(<PairingWizard onClose={mockOnClose} />);
+    expect(screen.getByText('Test Machine')).toBeInTheDocument();
+  });
+
+  it('shows pin entry step when a service is selected', () => {
+    render(<PairingWizard onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('Test Machine'));
+    expect(screen.getByText(/Enter the PIN/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pair' })).toBeInTheDocument();
+  });
+
+  it('Pair button uses white text for visibility on blue background', () => {
+    render(<PairingWizard onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('Test Machine'));
+    const pairBtn = screen.getByRole('button', { name: 'Pair' });
+    expect(pairBtn.className).toContain('text-white');
+    expect(pairBtn.className).not.toContain('text-ctp-base');
+  });
+});

--- a/src/renderer/features/settings/PairingWizard.tsx
+++ b/src/renderer/features/settings/PairingWizard.tsx
@@ -136,7 +136,7 @@ export function PairingWizard({ onClose }: PairingWizardProps) {
             <button
               onClick={handlePair}
               disabled={pairing || pin.length < 4}
-              className="px-4 py-2 text-xs rounded bg-ctp-blue text-ctp-base font-medium
+              className="px-4 py-2 text-xs rounded bg-ctp-blue text-white font-medium
                 hover:bg-ctp-blue/80 transition-colors cursor-pointer
                 disabled:opacity-50 disabled:cursor-not-allowed"
             >


### PR DESCRIPTION
## Summary
- Fix invisible Pair button in the Annex Control pairing wizard by changing `text-ctp-base` to `text-white`
- In dark Catppuccin themes, `ctp-base` is near-black, making button text invisible against the blue background

## Changes
- `PairingWizard.tsx`: Changed Pair button text color from `text-ctp-base` to `text-white`, matching the convention used by all other primary action buttons in the codebase
- Added `PairingWizard.test.tsx` with tests verifying the button renders correctly and uses `text-white`

## Test Plan
- [x] Pair button uses `text-white` (not `text-ctp-base`) — verified by unit test
- [x] PairingWizard renders discovered services
- [x] Pin entry step appears when a service is selected
- [x] All existing tests pass
- [x] Lint passes

## Manual Validation
1. Open Settings → Annex Control → Add Satellite
2. Select a discovered service to enter pin entry step
3. Verify the "Pair" button text is clearly visible (white text on blue background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)