### PR TITLE
feat: make review plugin an experimental feature

### DIFF
--- a/src/renderer/features/settings/ExperimentalSettingsView.tsx
+++ b/src/renderer/features/settings/ExperimentalSettingsView.tsx
@@ -32,6 +32,11 @@ const EXPERIMENTAL_FEATURES: Array<{
     label: 'Sessions',
     description: 'Browse and replay historical agent conversation sessions with timeline playback. Requires app restart.',
   },
+  {
+    id: 'review',
+    label: 'Review Carousel',
+    description: 'Full-screen swipe carousel for browsing and reviewing agents one at a time. Requires app restart.',
+  },
 ];
 
 export function ExperimentalSettingsView() {

--- a/src/renderer/plugins/builtin/builtin-plugin-testing.test.ts
+++ b/src/renderer/plugins/builtin/builtin-plugin-testing.test.ts
@@ -113,4 +113,26 @@ describe('getBuiltinPlugins catch-all', () => {
     const defaultIds = getDefaultEnabledIds({ sessions: true });
     expect(defaultIds.has('sessions')).toBe(true);
   });
+
+  it('does not include the review plugin without experimental flag', () => {
+    const plugins = getBuiltinPlugins();
+    const ids = plugins.map((p) => p.manifest.id);
+    expect(ids).not.toContain('review');
+  });
+
+  it('does not auto-enable the review plugin without experimental flag', () => {
+    const defaultIds = getDefaultEnabledIds();
+    expect(defaultIds.has('review')).toBe(false);
+  });
+
+  it('includes review plugin when experimental flag is set', () => {
+    const plugins = getBuiltinPlugins({ review: true });
+    const ids = plugins.map((p) => p.manifest.id);
+    expect(ids).toContain('review');
+  });
+
+  it('auto-enables review plugin when experimental flag is set', () => {
+    const defaultIds = getDefaultEnabledIds({ review: true });
+    expect(defaultIds.has('review')).toBe(true);
+  });
 });

--- a/src/renderer/plugins/builtin/index.ts
+++ b/src/renderer/plugins/builtin/index.ts
@@ -27,11 +27,12 @@ export interface BuiltinPlugin {
 export interface ExperimentalFlags {
   canvas?: boolean;
   sessions?: boolean;
+  review?: boolean;
   [key: string]: boolean | undefined;
 }
 
 /** Plugin IDs that are always enabled by default in a fresh install. */
-const BASE_DEFAULT_IDS = ['hub', 'terminal', 'files', 'browser', 'git', 'review'];
+const BASE_DEFAULT_IDS = ['hub', 'terminal', 'files', 'browser', 'git'];
 
 export function getBuiltinPlugins(experimentalFlags: ExperimentalFlags = {}): BuiltinPlugin[] {
   const plugins: BuiltinPlugin[] = [
@@ -40,8 +41,11 @@ export function getBuiltinPlugins(experimentalFlags: ExperimentalFlags = {}): Bu
     { manifest: filesManifest, module: filesModule },
     { manifest: browserManifest, module: browserModule },
     { manifest: gitManifest, module: gitModule },
-    { manifest: reviewManifest, module: reviewModule },
   ];
+
+  if (experimentalFlags.review) {
+    plugins.push({ manifest: reviewManifest, module: reviewModule });
+  }
 
   if (experimentalFlags.canvas) {
     plugins.push({ manifest: canvasManifest, module: canvasModule });
@@ -58,6 +62,9 @@ export function getBuiltinPlugins(experimentalFlags: ExperimentalFlags = {}): Bu
 /** Returns the set of builtin plugin IDs that should be auto-enabled on first install. */
 export function getDefaultEnabledIds(experimentalFlags: ExperimentalFlags = {}): ReadonlySet<string> {
   const ids = [...BASE_DEFAULT_IDS];
+  if (experimentalFlags.review) {
+    ids.push('review');
+  }
   if (experimentalFlags.canvas) {
     ids.push('canvas');
     ids.push('group-project');


### PR DESCRIPTION
## Summary
- Move the review builtin plugin behind an experimental feature flag so it is **not enabled by default**
- Add a "Review Carousel" toggle to the Experimental Settings page
- Add tests verifying the review plugin is correctly gated

## Changes
- **`src/renderer/plugins/builtin/index.ts`** — Removed `review` from `BASE_DEFAULT_IDS` and the base plugins array. Added `review?: boolean` to `ExperimentalFlags`. Review plugin and its default-enabled ID are now conditional on `experimentalFlags.review`, matching the existing canvas/sessions pattern.
- **`src/renderer/features/settings/ExperimentalSettingsView.tsx`** — Added a "Review Carousel" entry to `EXPERIMENTAL_FEATURES` so users can opt in via Settings > Experimental.
- **`src/renderer/plugins/builtin/builtin-plugin-testing.test.ts`** — Added 4 tests verifying review is excluded without the flag and included with it (both `getBuiltinPlugins` and `getDefaultEnabledIds`).

## Test Plan
- [x] `npm run typecheck` passes
- [x] All 8485 tests pass (`npm test`)
- [x] New tests verify review plugin is excluded by default and included when flag is set
- [ ] Manual: confirm review tab/rail item no longer appears without enabling the experimental flag
- [ ] Manual: enable "Review Carousel" in Settings > Experimental, restart, confirm it appears

## Manual Validation
1. Launch the app — the Review tab and rail item should **not** appear
2. Go to Settings > Experimental and enable "Review Carousel"
3. Restart the app — the Review tab and rail item should now appear
4. Disable the toggle and restart — Review should disappear again