### PR TITLE
fix(annex): make pause floatie responsive to banner area

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { TitleBar } from './components/TitleBar';
 import { RailSection } from './components/RailSection';
 import { ProjectPanelLayout } from './components/ProjectPanelLayout';
@@ -44,6 +44,25 @@ export function App() {
   const lockControllerFingerprint = useLockStore((s) => s.controllerFingerprint);
   const lockTogglePause = useLockStore((s) => s.togglePause);
   const lockUnlock = useLockStore((s) => s.unlock);
+
+  // ── Banner area height measurement (for positioning the pause floatie) ──
+  const bannerObserverRef = useRef<ResizeObserver | null>(null);
+  const [bannerHeight, setBannerHeight] = useState(0);
+  const bannerRef = useCallback((node: HTMLDivElement | null) => {
+    if (bannerObserverRef.current) {
+      bannerObserverRef.current.disconnect();
+      bannerObserverRef.current = null;
+    }
+    if (!node) {
+      setBannerHeight(0);
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) => {
+      setBannerHeight(entry.contentRect.height);
+    });
+    observer.observe(node);
+    bannerObserverRef.current = observer;
+  }, []);
 
   // ── One-time initialization & event bridge ──────────────────────────────
   useEffect(() => {
@@ -187,6 +206,7 @@ export function App() {
       onDisconnect={handleLockDisconnect}
       onPause={handleLockPause}
       onDisableAndDisconnect={handleLockDisableAndDisconnect}
+      bannerOffset={bannerHeight}
     />
   );
 
@@ -195,9 +215,11 @@ export function App() {
       <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
         {lockOverlay}
         <TitleBar />
-        <PermissionViolationBanner />
-        <UpdateBanner />
-        <PluginUpdateBanner />
+        <div ref={bannerRef}>
+          <PermissionViolationBanner />
+          <UpdateBanner />
+          <PluginUpdateBanner />
+        </div>
         <RailSection>
           <Dashboard />
         </RailSection>
@@ -217,9 +239,11 @@ export function App() {
       <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
         {lockOverlay}
         <TitleBar />
-        <PermissionViolationBanner />
-        <UpdateBanner />
-        <PluginUpdateBanner />
+        <div ref={bannerRef}>
+          <PermissionViolationBanner />
+          <UpdateBanner />
+          <PluginUpdateBanner />
+        </div>
         <RailSection>
           <PluginContentView pluginId={appPluginId} mode="app" />
         </RailSection>
@@ -238,9 +262,11 @@ export function App() {
       <div className="h-screen w-screen overflow-hidden bg-ctp-base text-ctp-text flex flex-col">
         {lockOverlay}
         <TitleBar />
-        <PermissionViolationBanner />
-        <UpdateBanner />
-        <PluginUpdateBanner />
+        <div ref={bannerRef}>
+          <PermissionViolationBanner />
+          <UpdateBanner />
+          <PluginUpdateBanner />
+        </div>
         <RailSection>
           <HelpView />
         </RailSection>
@@ -258,10 +284,12 @@ export function App() {
     <div className="h-screen w-screen overflow-hidden text-ctp-text flex flex-col">
       {lockOverlay}
       <TitleBar />
-      <PermissionViolationBanner />
-      <UpdateBanner />
-      <PluginUpdateBanner />
-      <GitBanner />
+      <div ref={bannerRef}>
+        <PermissionViolationBanner />
+        <UpdateBanner />
+        <PluginUpdateBanner />
+        <GitBanner />
+      </div>
       <RailSection>
         <ProjectPanelLayout />
       </RailSection>

--- a/src/renderer/features/annex/SatelliteLockOverlay.test.tsx
+++ b/src/renderer/features/annex/SatelliteLockOverlay.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SatelliteLockOverlay } from './SatelliteLockOverlay';
+
+const baseLockState = {
+  locked: true,
+  paused: true,
+  controllerAlias: 'curious-tapir',
+  controllerIcon: '🦛',
+  controllerColor: 'indigo',
+  controllerFingerprint: 'abc123',
+};
+
+const noop = () => {};
+
+describe('SatelliteLockOverlay – pause floatie positioning', () => {
+  it('renders at default top (48px) when no bannerOffset is provided', () => {
+    render(
+      <SatelliteLockOverlay
+        lockState={baseLockState}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+      />,
+    );
+
+    const floatie = screen.getByTestId('satellite-pause-floatie');
+    expect(floatie.style.top).toBe('48px');
+  });
+
+  it('renders at default top (48px) when bannerOffset is 0', () => {
+    render(
+      <SatelliteLockOverlay
+        lockState={baseLockState}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+        bannerOffset={0}
+      />,
+    );
+
+    const floatie = screen.getByTestId('satellite-pause-floatie');
+    expect(floatie.style.top).toBe('48px');
+  });
+
+  it('shifts down by bannerOffset when banners are visible', () => {
+    render(
+      <SatelliteLockOverlay
+        lockState={baseLockState}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+        bannerOffset={72}
+      />,
+    );
+
+    const floatie = screen.getByTestId('satellite-pause-floatie');
+    expect(floatie.style.top).toBe('120px'); // 48 + 72
+  });
+
+  it('has a CSS transition on top for smooth animation', () => {
+    render(
+      <SatelliteLockOverlay
+        lockState={baseLockState}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+      />,
+    );
+
+    const floatie = screen.getByTestId('satellite-pause-floatie');
+    expect(floatie.className).toContain('transition-[top]');
+  });
+
+  it('does not render the floatie when not paused', () => {
+    render(
+      <SatelliteLockOverlay
+        lockState={{ ...baseLockState, paused: false }}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+      />,
+    );
+
+    expect(screen.queryByTestId('satellite-pause-floatie')).toBeNull();
+  });
+
+  it('does not render anything when not locked', () => {
+    const { container } = render(
+      <SatelliteLockOverlay
+        lockState={{ ...baseLockState, locked: false }}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+      />,
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/renderer/features/annex/SatelliteLockOverlay.tsx
+++ b/src/renderer/features/annex/SatelliteLockOverlay.tsx
@@ -20,6 +20,8 @@ interface Props {
   onDisconnect: () => void;
   onPause: () => void;
   onDisableAndDisconnect: () => void;
+  /** Pixel offset from the top to account for visible banners above. */
+  bannerOffset?: number;
 }
 
 function getColorHex(colorId: string): string {
@@ -27,7 +29,7 @@ function getColorHex(colorId: string): string {
   return color?.hex || '#6366f1';
 }
 
-export function SatelliteLockOverlay({ lockState, onDisconnect, onPause, onDisableAndDisconnect }: Props) {
+export function SatelliteLockOverlay({ lockState, onDisconnect, onPause, onDisableAndDisconnect, bannerOffset = 0 }: Props) {
   if (!lockState.locked) return null;
 
   const colorHex = getColorHex(lockState.controllerColor);
@@ -87,7 +89,11 @@ export function SatelliteLockOverlay({ lockState, onDisconnect, onPause, onDisab
       )}
 
       {lockState.paused && (
-        <div className="fixed top-12 right-4 pointer-events-auto" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+        <div
+          className="fixed right-4 pointer-events-auto transition-[top] duration-200 ease-in-out"
+          data-testid="satellite-pause-floatie"
+          style={{ top: `${48 + bannerOffset}px`, WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-black/40 backdrop-blur-sm">
             <div
               className="w-3 h-3 rounded-full"


### PR DESCRIPTION
## Summary
- The satellite pause floatie badge (shown when a remote controller is paused) was fixed at `top-12` (48px), causing it to overlap update/plugin banners when they appeared
- Now the floatie dynamically adjusts its vertical position based on the measured banner area height, smoothly sliding down with a CSS transition

## Changes
- **`SatelliteLockOverlay.tsx`**: Added `bannerOffset` prop; replaced static `top-12` class with dynamic inline `top` style (`48 + bannerOffset`px); added `transition-[top]` for smooth animation; added `data-testid` for testing
- **`App.tsx`**: Added callback ref + `ResizeObserver` to measure the banner container height (no new `useEffect` — uses callback ref pattern to stay within structural test limits); wrapped banner components (`PermissionViolationBanner`, `UpdateBanner`, `PluginUpdateBanner`) in a measured `<div ref={bannerRef}>` across all 4 return paths; passes `bannerOffset={bannerHeight}` to `SatelliteLockOverlay`
- **`SatelliteLockOverlay.test.tsx`** (new): 6 test cases covering default positioning, offset shifting, CSS transition presence, and render/no-render states

## Test Plan
- [x] Pause floatie renders at 48px from top when no banners are visible
- [x] Pause floatie shifts down by the banner area height when banners appear
- [x] CSS transition class is applied for smooth animation
- [x] Floatie does not render when not paused
- [x] Component returns null when not locked
- [x] App structural tests still pass (all 49 tests)
- [x] Lint passes on all changed files

## Manual Validation
1. Enable Annex, connect a remote controller, and press Pause
2. Verify the pause floatie badge appears near the top-right, below the title bar
3. Trigger an update banner (or plugin update) and confirm the floatie smoothly slides down to stay below the banners
4. Dismiss the banners and confirm the floatie smoothly slides back up