### PR TITLE
fix: increase test timeouts for Windows CI

### DIFF
--- a/src/main/services/file-service.test.ts
+++ b/src/main/services/file-service.test.ts
@@ -69,7 +69,7 @@ describe('file-service', () => {
       expect(tree).toEqual([]);
     });
 
-    it('respects maxFiles limit', async () => {
+    it('respects maxFiles limit', { timeout: 15_000 }, async () => {
       // Create many files
       for (let i = 0; i < 20; i++) {
         fs.writeFileSync(path.join(tmpDir, `file-${i}.txt`), `content ${i}`);

--- a/src/main/services/search-service.test.ts
+++ b/src/main/services/search-service.test.ts
@@ -168,7 +168,7 @@ describe('search-service', () => {
     }
   });
 
-  it('uses reduced default max results (1000) to prevent large payloads', async () => {
+  it('uses reduced default max results (1000) to prevent large payloads', { timeout: 15_000 }, async () => {
     // Create many small files with matches
     const dir = path.join(tmpDir, 'many');
     await fs.mkdir(dir);


### PR DESCRIPTION
## Summary
- Increased test timeout to 15s for `file-service.test.ts > readTree > respects maxFiles limit`
- Increased test timeout to 15s for `search-service.test.ts > uses reduced default max results (1000)`

Both tests create many temporary files and exceed the default 5s Vitest timeout on Windows CI runners (the "Validate Update Scripts (windows-latest)" job). The ENOTEMPTY cleanup error in search-service was a side-effect of the timeout — Windows still held file handles during afterEach teardown.

## Test plan
- [x] Both test files pass locally (36/36)
- [ ] Validate Update Scripts (windows-latest) passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)