### PR TITLE
fix: compensate mouse coordinates for canvas CSS scale transform

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -130,6 +130,8 @@ export function CanvasViewComponent({
   const zoomRef = useRef(zoom);
   zoomRef.current = zoom;
 
+  const contentRef = useRef<HTMLDivElement>(null);
+
   const currentPos = resizeState?.position ?? dragPos ?? view.position;
   const currentSize = resizeState?.size ?? view.size;
 
@@ -321,6 +323,44 @@ export function CanvasViewComponent({
       window.removeEventListener('mouseup', handleMouseUp);
     };
   }, [resizeState, zoom, onResizeEnd]);
+
+  // ── Mouse coordinate compensation for CSS scale(zoom) ─────────
+  // The canvas workspace wraps all views in `transform: scale(zoom)`.
+  // Interactive children (xterm.js terminals, Monaco editors) compute
+  // cell/character positions from `clientX/Y` and cached cell dimensions
+  // that are in the *unscaled* coordinate space.  At zoom ≠ 1 the
+  // screen-space mouse offset divided by unscaled cell size yields the
+  // wrong row/col — e.g. at zoom 0.75, clicking row 10 maps to row 7,
+  // making the selection highlight appear "a few lines too high".
+  //
+  // Fix: intercept mouse events in the capture phase (before xterm/Monaco
+  // handlers) and divide the offset from the element edge by zoom so that
+  // the value reaching the library matches the unscaled cell grid.
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+
+    const adjustEvent = (e: MouseEvent) => {
+      const z = zoomRef.current;
+      if (z === 1) return;
+      const rect = el.getBoundingClientRect();
+      const adjustedX = rect.left + (e.clientX - rect.left) / z;
+      const adjustedY = rect.top + (e.clientY - rect.top) / z;
+      Object.defineProperty(e, 'clientX', { value: adjustedX, configurable: true });
+      Object.defineProperty(e, 'clientY', { value: adjustedY, configurable: true });
+    };
+
+    const events: string[] = ['mousedown', 'mouseup', 'mousemove', 'click', 'dblclick', 'contextmenu'];
+    for (const type of events) {
+      el.addEventListener(type, adjustEvent as EventListener, true);
+    }
+
+    return () => {
+      for (const type of events) {
+        el.removeEventListener(type, adjustEvent as EventListener, true);
+      }
+    };
+  }, []);
 
   // ── Content based on view type ─────────────────────────────────
 
@@ -684,6 +724,7 @@ export function CanvasViewComponent({
           content, so skip rendering here to prevent duplicate terminals from
           racing on PTY resize. */}
       <div
+        ref={contentRef}
         className="flex-1 min-h-0 overflow-hidden rounded-b-lg"
         onWheel={isSelected ? (e) => e.stopPropagation() : undefined}
       >

--- a/src/renderer/plugins/builtin/canvas/canvas-zoom-mouse-adjust.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-zoom-mouse-adjust.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CanvasViewComponent } from './CanvasView';
+import type { CanvasView } from './canvas-types';
+import type { PluginAPI } from '../../../../shared/plugin-types';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const baseView: CanvasView = {
+  id: 'cv_zoom_1',
+  type: 'agent',
+  title: 'Agent',
+  displayName: 'Zoom Test',
+  position: { x: 100, y: 100 },
+  size: { width: 400, height: 300 },
+  zIndex: 0,
+  metadata: {},
+  agentId: 'agent_1',
+} as CanvasView;
+
+function stubApi(): PluginAPI {
+  return {
+    agents: {
+      list: () => [],
+      onAnyChange: () => ({ dispose: () => {} }),
+      getDetailedStatus: () => null,
+    },
+    projects: { list: () => [] },
+    context: { mode: 'project', projectId: 'p1' },
+    widgets: {
+      AgentAvatar: () => null,
+      AgentTerminal: () => null,
+      SleepingAgent: () => null,
+    },
+    settings: {
+      get: () => undefined,
+      getAll: () => ({}),
+      set: () => {},
+      onChange: () => ({ dispose: () => {} }),
+    },
+  } as unknown as PluginAPI;
+}
+
+const noop = () => {};
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('canvas zoom mouse coordinate adjustment', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderView(zoom: number) {
+    return render(
+      <CanvasViewComponent
+        view={baseView}
+        api={stubApi()}
+        zoom={zoom}
+        isSelected={false}
+        onClose={noop}
+        onFocus={noop}
+        onSelect={noop}
+        onToggleSelect={noop}
+        onCenterView={noop}
+        onZoomView={noop}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onResizeEnd={noop}
+        onUpdate={noop}
+      />,
+    );
+  }
+
+  /**
+   * Helper: dispatch a MouseEvent on a target element and return the
+   * clientX/clientY that downstream listeners would see.  We add a
+   * bubble-phase listener (which fires AFTER the capture-phase adjuster)
+   * to read the final property values.
+   */
+  function dispatchAndCapture(
+    target: Element,
+    type: string,
+    clientX: number,
+    clientY: number,
+  ): { clientX: number; clientY: number } {
+    const result = { clientX: 0, clientY: 0 };
+
+    // Bubble-phase listener reads the (possibly overridden) values
+    const listener = (e: Event) => {
+      const me = e as MouseEvent;
+      result.clientX = me.clientX;
+      result.clientY = me.clientY;
+    };
+    target.addEventListener(type, listener, false);
+
+    const event = new MouseEvent(type, {
+      clientX,
+      clientY,
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(event);
+
+    target.removeEventListener(type, listener, false);
+    return result;
+  }
+
+  it('does not adjust mouse coordinates at zoom = 1', () => {
+    const { container } = renderView(1);
+    const contentArea = container.querySelector('.flex-1.min-h-0.overflow-hidden');
+    expect(contentArea).toBeTruthy();
+
+    // Mock getBoundingClientRect on the content area
+    vi.spyOn(contentArea!, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      top: 50,
+      right: 500,
+      bottom: 350,
+      width: 400,
+      height: 300,
+      x: 100,
+      y: 50,
+      toJSON: () => {},
+    });
+
+    const captured = dispatchAndCapture(contentArea!, 'mousedown', 300, 200);
+    expect(captured.clientX).toBe(300);
+    expect(captured.clientY).toBe(200);
+  });
+
+  it('adjusts mouse coordinates at zoom < 1 (e.g. 0.5)', () => {
+    const { container } = renderView(0.5);
+    const contentArea = container.querySelector('.flex-1.min-h-0.overflow-hidden');
+    expect(contentArea).toBeTruthy();
+
+    // At zoom 0.5 the element's visual bounds are scaled:
+    // layout (100,50)→(500,350) → visual (50,25)→(250,175)
+    // getBoundingClientRect returns the scaled visual bounds.
+    vi.spyOn(contentArea!, 'getBoundingClientRect').mockReturnValue({
+      left: 50,
+      top: 25,
+      right: 250,
+      bottom: 175,
+      width: 200,
+      height: 150,
+      x: 50,
+      y: 25,
+      toJSON: () => {},
+    });
+
+    // Click at screen position (150, 100) which is offset (100, 75) from visual left/top.
+    // Adjusted: left + offset/zoom = 50 + 100/0.5 = 250, 25 + 75/0.5 = 175
+    const captured = dispatchAndCapture(contentArea!, 'mousedown', 150, 100);
+    expect(captured.clientX).toBe(250);
+    expect(captured.clientY).toBe(175);
+  });
+
+  it('adjusts mouse coordinates at zoom > 1 (e.g. 2.0)', () => {
+    const { container } = renderView(2);
+    const contentArea = container.querySelector('.flex-1.min-h-0.overflow-hidden');
+    expect(contentArea).toBeTruthy();
+
+    // At zoom 2 the visual bounds are doubled:
+    // layout (100,50)→(500,350) → visual (200,100)→(1000,700)
+    vi.spyOn(contentArea!, 'getBoundingClientRect').mockReturnValue({
+      left: 200,
+      top: 100,
+      right: 1000,
+      bottom: 700,
+      width: 800,
+      height: 600,
+      x: 200,
+      y: 100,
+      toJSON: () => {},
+    });
+
+    // Click at screen (600, 400) → offset (400, 300) from visual left/top.
+    // Adjusted: 200 + 400/2 = 400, 100 + 300/2 = 250
+    const captured = dispatchAndCapture(contentArea!, 'mousedown', 600, 400);
+    expect(captured.clientX).toBe(400);
+    expect(captured.clientY).toBe(250);
+  });
+
+  it('adjusts all mouse event types', () => {
+    const { container } = renderView(0.5);
+    const contentArea = container.querySelector('.flex-1.min-h-0.overflow-hidden');
+    expect(contentArea).toBeTruthy();
+
+    vi.spyOn(contentArea!, 'getBoundingClientRect').mockReturnValue({
+      left: 50,
+      top: 25,
+      right: 250,
+      bottom: 175,
+      width: 200,
+      height: 150,
+      x: 50,
+      y: 25,
+      toJSON: () => {},
+    });
+
+    const eventTypes = ['mousedown', 'mouseup', 'mousemove', 'click', 'dblclick', 'contextmenu'];
+    for (const type of eventTypes) {
+      const captured = dispatchAndCapture(contentArea!, type, 150, 100);
+      expect(captured.clientX).toBe(250);
+      expect(captured.clientY).toBe(175);
+    }
+  });
+
+  it('adjusts coordinates on child elements (events bubble up)', () => {
+    const { container } = renderView(0.75);
+    const contentArea = container.querySelector('.flex-1.min-h-0.overflow-hidden');
+    expect(contentArea).toBeTruthy();
+
+    // At zoom 0.75: visual bounds scaled
+    vi.spyOn(contentArea!, 'getBoundingClientRect').mockReturnValue({
+      left: 75,
+      top: 37.5,
+      right: 375,
+      bottom: 262.5,
+      width: 300,
+      height: 225,
+      x: 75,
+      y: 37.5,
+      toJSON: () => {},
+    });
+
+    // Create a child element to dispatch from — simulates xterm.js's screen element
+    const child = document.createElement('div');
+    contentArea!.appendChild(child);
+
+    // Click at (225, 150) → offset from content area (150, 112.5)
+    // Adjusted: 75 + 150/0.75 = 275, 37.5 + 112.5/0.75 = 187.5
+    const captured = dispatchAndCapture(child, 'mousedown', 225, 150);
+    expect(captured.clientX).toBe(275);
+    expect(captured.clientY).toBe(187.5);
+
+    contentArea!.removeChild(child);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes text selection (drag-to-highlight) being offset in canvas card widgets — the highlighted area appeared a few lines too high when the canvas was zoomed
- Root cause: xterm.js and Monaco compute cell positions from `clientX/Y` (screen-space) and cached cell dimensions (unscaled space), producing wrong row/col at zoom ≠ 1
- Fix: intercept mouse events in capture phase on the content wrapper and divide relative offset by zoom before child handlers see them

## Changes
- `src/renderer/plugins/builtin/canvas/CanvasView.tsx`
  - Added `contentRef` on the widget content area div
  - Added `useEffect` that registers capture-phase mouse event handlers (`mousedown`, `mouseup`, `mousemove`, `click`, `dblclick`, `contextmenu`) on the content wrapper
  - These handlers adjust `clientX`/`clientY` via `Object.defineProperty` to divide the screen-space offset from the element edge by the current zoom, converting to the unscaled coordinate space that xterm.js and Monaco expect
  - At zoom = 1, the handler is a no-op (early return)
  - Zoom value is read from the existing `zoomRef` so the effect doesn't need to re-register on every zoom change

- `src/renderer/plugins/builtin/canvas/canvas-zoom-mouse-adjust.test.tsx` (new)
  - Tests coordinate adjustment at zoom = 1 (no-op), zoom < 1, and zoom > 1
  - Tests all six mouse event types are adjusted
  - Tests that events on child elements (simulating xterm.js screen element) bubble through the capture handler correctly

## Test Plan
- [x] 5 unit tests covering zoom = 1, 0.5, 0.75, 2.0, all event types, and child element propagation
- [x] Full test suite passes (8476 tests, 354 files)
- [x] TypeScript typecheck passes
- [x] ESLint passes (no new warnings)
- [ ] Manual: open canvas, zoom to ~75%, create an agent terminal widget, drag to select text — highlight should match cursor position
- [ ] Manual: repeat at zoom 50% and 200% — selection should track correctly at all zoom levels

## Manual Validation
1. Open the canvas workspace
2. Add an agent terminal widget (or shell terminal widget)
3. Zoom the canvas to ~75% (Ctrl+scroll or pinch)
4. Click and drag to select text in the terminal
5. Verify the blue highlight matches the mouse cursor position exactly
6. Repeat at 50% and 200% zoom levels
7. Also verify text selection works correctly in file viewer (Monaco editor) canvas widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)