### PR TITLE
fix: invisible Delete button in plugin confirm dialog

### DIFF
--- a/src/renderer/plugins/PluginDialog.test.tsx
+++ b/src/renderer/plugins/PluginDialog.test.tsx
@@ -241,7 +241,7 @@ describe('showConfirmDialog', () => {
     });
 
     const confirmBtn = screen.getByTestId('plugin-dialog-confirm');
-    expect(confirmBtn.className).toContain('bg-ctp-red');
+    expect(confirmBtn.className).toContain('bg-ctp-error');
     expect(confirmBtn.textContent).toBe('Delete');
   });
 

--- a/src/renderer/plugins/PluginDialog.tsx
+++ b/src/renderer/plugins/PluginDialog.tsx
@@ -149,7 +149,7 @@ function ConfirmDialog({ message, onResolve }: ConfirmDialogProps) {
             data-testid="plugin-dialog-confirm"
             className={`px-4 py-1.5 text-xs rounded-lg cursor-pointer transition-colors font-medium ${
               isDestructive
-                ? 'bg-ctp-red text-ctp-base hover:opacity-90'
+                ? 'bg-ctp-error text-ctp-base hover:opacity-90'
                 : 'bg-ctp-accent text-ctp-base hover:opacity-90'
             }`}
           >


### PR DESCRIPTION
## Summary

- The Delete button in the plugin confirm dialog (`PluginDialog.tsx`) was invisible across all themes — the button was present in the DOM but rendered with no background color
- Root cause: the button used `bg-ctp-red`, which has no `--color-ctp-red` registration in the Tailwind `@theme inline` block in `index.css`. Without a registration, Tailwind generates no CSS for the class, so the button renders with a transparent background
- Fixed by switching to `bg-ctp-error`, which is a registered theme token (`--color-ctp-error`) that resolves correctly across all themes
- Updated the corresponding test assertion to match

## Test plan

- [x] Verified `bg-ctp-error` is registered in `index.css` `@theme inline` block
- [x] All 20 existing `PluginDialog` tests pass
- [x] Manually tested in local dev build — Delete button now renders with visible red background
- [ ] Verify in Tokyo Dark, Catppuccin Light, and default Mocha themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)