### PR TITLE
Fix stuck wire canvas menu dismissal after instructions editing

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
@@ -6,6 +6,7 @@ import {
   type RegisteredCanvasWidget,
 } from '../../canvas-widget-registry';
 import { MenuPortal } from './MenuPortal';
+import { useDismissibleLayer } from './useDismissibleLayer';
 
 /** A menu item can either be a built-in view type or a qualified plugin widget type string. */
 export type ContextMenuSelection =
@@ -39,24 +40,7 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
     });
     return () => disposable.dispose();
   }, []);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onDismiss();
-      }
-    };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onDismiss();
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEscape);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [onDismiss]);
+  useDismissibleLayer({ layerRef: menuRef, onDismiss });
 
   const handleBuiltinSelect = useCallback((type: CanvasViewType) => {
     onSelect({ kind: 'builtin', type });

--- a/src/renderer/plugins/builtin/canvas/WireConfigPopover.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireConfigPopover.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { WireConfigPopover } from './WireConfigPopover';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
@@ -22,6 +22,10 @@ describe('WireConfigPopover', () => {
   beforeEach(() => {
     useMcpBindingStore.setState({ bindings: [browserBinding, agentBinding] });
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders binding info', () => {
@@ -86,6 +90,49 @@ describe('WireConfigPopover', () => {
     expect(queryByTestId('wire-instructions-dialog')).toBeNull();
     fireEvent.click(getByTestId('wire-instructions-button'));
     expect(getByTestId('wire-instructions-dialog')).toBeTruthy();
+  });
+
+  it('dismisses immediately on outside click after closing the instructions dialog', () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const { getByTestId, queryByTestId } = render(
+      <WireConfigPopover binding={browserBinding} x={100} y={200} onClose={onClose} />,
+    );
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    fireEvent.click(getByTestId('wire-instructions-button'));
+    fireEvent.click(getByTestId('wire-instructions-cancel'));
+
+    expect(queryByTestId('wire-instructions-dialog')).toBeNull();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the popover on Escape when the instructions dialog is not open', () => {
+    const onClose = vi.fn();
+    render(<WireConfigPopover binding={browserBinding} x={100} y={200} onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes only the instructions dialog on Escape when editing instructions', () => {
+    const onClose = vi.fn();
+    const { getByTestId, queryByTestId } = render(
+      <WireConfigPopover binding={browserBinding} x={100} y={200} onClose={onClose} />,
+    );
+
+    fireEvent.click(getByTestId('wire-instructions-button'));
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(queryByTestId('wire-instructions-dialog')).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('sets instructions on both bindings for bidirectional agent-to-agent wires', async () => {

--- a/src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx
@@ -8,6 +8,7 @@ import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
 import { Toggle } from '../../../components/Toggle';
 import { WireInstructionsDialog } from './WireInstructionsDialog';
+import { useDismissibleLayer } from './useDismissibleLayer';
 
 interface WireConfigPopoverProps {
   binding: McpBindingEntry;
@@ -42,21 +43,11 @@ export function WireConfigPopover({ binding, x, y, onClose }: WireConfigPopoverP
     }
   }, [bindings, binding, isAgentToAgent]);
 
-  // Close on click outside (skip when instructions dialog is open)
-  useEffect(() => {
-    if (showInstructions) return;
-    const handler = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    // Delay to avoid immediate close from the same click
-    const id = setTimeout(() => document.addEventListener('mousedown', handler), 0);
-    return () => {
-      clearTimeout(id);
-      document.removeEventListener('mousedown', handler);
-    };
-  }, [onClose, showInstructions]);
+  useDismissibleLayer({
+    layerRef: popoverRef,
+    onDismiss: onClose,
+    enabled: !showInstructions,
+  });
 
   const handleDisconnect = async () => {
     await unbind(binding.agentId, binding.targetId);

--- a/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.test.tsx
@@ -104,6 +104,15 @@ describe('WireInstructionsDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(<WireInstructionsDialog binding={agentBinding} onSave={vi.fn()} onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('switches between tools and preserves per-tool drafts', () => {
     const { getByTestId } = render(
       <WireInstructionsDialog binding={agentBinding} onSave={vi.fn()} onClose={vi.fn()} />,

--- a/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
@@ -43,6 +43,18 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
     textareaRef.current?.focus();
   }, [selectedTool]);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
   const currentValue = drafts[selectedTool] || '';
 
   const handleTextChange = (value: string) => {
@@ -60,9 +72,14 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
   };
 
   const handleBackdropClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     if (e.target === backdropRef.current) {
       onClose();
     }
+  };
+
+  const handleBackdropMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation();
   };
 
   // Count how many tools have instructions set
@@ -75,6 +92,7 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
       style={{ zIndex: 100000 }}
+      onMouseDown={handleBackdropMouseDown}
       onClick={handleBackdropClick}
       data-testid="wire-instructions-dialog"
     >

--- a/src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { CanvasContextMenu } from './CanvasContextMenu';
 import * as widgetRegistry from '../../canvas-widget-registry';
 import type { RegisteredCanvasWidget } from '../../canvas-widget-registry';
@@ -106,5 +106,21 @@ describe('CanvasContextMenu plugin widget icons', () => {
     const button = screen.getByTestId('canvas-context-menu-plugin:my-plugin:no-icon');
     expect(button.textContent).toContain('+');
     expect(button.querySelector('svg')).toBeNull();
+  });
+
+  it('dismisses on outside mouse down', () => {
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses on Escape', () => {
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/renderer/plugins/builtin/canvas/useDismissibleLayer.ts
+++ b/src/renderer/plugins/builtin/canvas/useDismissibleLayer.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from 'react';
+import type React from 'react';
+
+interface UseDismissibleLayerOptions {
+  layerRef: React.RefObject<HTMLElement | null>;
+  onDismiss: () => void;
+  enabled?: boolean;
+  closeOnEscape?: boolean;
+  closeOnFocusOutside?: boolean;
+  closeOnWindowBlur?: boolean;
+}
+
+export function useDismissibleLayer({
+  layerRef,
+  onDismiss,
+  enabled = true,
+  closeOnEscape = true,
+  closeOnFocusOutside = true,
+  closeOnWindowBlur = true,
+}: UseDismissibleLayerOptions) {
+  const onDismissRef = useRef(onDismiss);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const isInsideLayer = (target: EventTarget | null) => {
+      if (!layerRef.current || !(target instanceof Node)) {
+        return false;
+      }
+      return layerRef.current.contains(target);
+    };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!isInsideLayer(event.target)) {
+        onDismissRef.current();
+      }
+    };
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (!closeOnFocusOutside || isInsideLayer(event.target)) {
+        return;
+      }
+      onDismissRef.current();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (closeOnEscape && event.key === 'Escape') {
+        onDismissRef.current();
+      }
+    };
+
+    const handleWindowBlur = () => {
+      if (closeOnWindowBlur) {
+        onDismissRef.current();
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('blur', handleWindowBlur);
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('blur', handleWindowBlur);
+    };
+  }, [closeOnEscape, closeOnFocusOutside, closeOnWindowBlur, enabled, layerRef]);
+}


### PR DESCRIPTION
## Summary
- fix the wire configuration popover getting stuck after opening and closing the wire instructions dialog
- centralize canvas-layer dismissal behavior so outside clicks, focus changes, window blur, and `Escape` all dismiss reliably
- add regression coverage for the instruction-edit flow and canvas context menu dismissal

## Changes
- added `useDismissibleLayer` in `src/renderer/plugins/builtin/canvas/useDismissibleLayer.ts` to provide stable dismissal listeners without the prior `setTimeout` race
- updated `WireConfigPopover.tsx` to use the shared dismissal hook and suspend popover dismissal only while the instructions dialog is open
- updated `WireInstructionsDialog.tsx` to close on `Escape` and stop dialog/backdrop events from leaking into surrounding canvas listeners
- updated `CanvasContextMenu.tsx` to use the same stable dismissal behavior as the wire popover
- added regression tests in `WireConfigPopover.test.tsx`, `WireInstructionsDialog.test.tsx`, and `canvas-context-menu-icons.test.tsx`

## Test Plan
- [x] `npx vitest run --project renderer src/renderer/plugins/builtin/canvas/WireConfigPopover.test.tsx src/renderer/plugins/builtin/canvas/WireInstructionsDialog.test.tsx src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx`
- [x] `npm run make`
- [x] `npm test`
- [x] `npx eslint src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx src/renderer/plugins/builtin/canvas/useDismissibleLayer.ts src/renderer/plugins/builtin/canvas/WireConfigPopover.test.tsx src/renderer/plugins/builtin/canvas/WireInstructionsDialog.test.tsx src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx`
- [ ] `npm run lint` (currently fails on unrelated pre-existing issues in other files, including `e2e/annex-v2/*`, `src/main/menu.ts`, `src/renderer/plugins/builtin/review/main.ts`, and others outside this change)

## Manual Validation
- Open the canvas and select a wire connection to open the wire configuration popover.
- Open the instructions dialog, then close it with Cancel, Save, backdrop click, and `Escape`.
- After each close path, click outside the popover and confirm it dismisses immediately.
- Open the canvas context menu and confirm outside click or `Escape` dismisses it reliably.
