### PR TITLE
fix: add --autopilot flag for GHCP CLI free agent mode

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -155,9 +155,22 @@ describe('CopilotCliProvider', () => {
       expect(result.args).toEqual([]);
     });
 
-    it('adds --yolo flag for freeAgentMode', async () => {
+    it('adds --yolo and --autopilot flags for freeAgentMode', async () => {
       const result = await provider.buildSpawnCommand({ cwd: '/project', freeAgentMode: true });
       expect(result.args).toContain('--yolo');
+      expect(result.args).toContain('--autopilot');
+    });
+
+    it('does not add --yolo or --autopilot when freeAgentMode is false', async () => {
+      const result = await provider.buildSpawnCommand({ cwd: '/project', freeAgentMode: false });
+      expect(result.args).not.toContain('--yolo');
+      expect(result.args).not.toContain('--autopilot');
+    });
+
+    it('does not add --yolo or --autopilot when freeAgentMode is undefined', async () => {
+      const result = await provider.buildSpawnCommand({ cwd: '/project' });
+      expect(result.args).not.toContain('--yolo');
+      expect(result.args).not.toContain('--autopilot');
     });
 
     it('adds --model flag for non-default model', async () => {

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -146,7 +146,7 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
     }
 
     if (opts.freeAgentMode) {
-      args.push('--yolo');
+      args.push('--yolo', '--autopilot');
     }
 
     if (opts.model && opts.model !== 'default') {

--- a/src/main/orchestrators/provider-integration.test.ts
+++ b/src/main/orchestrators/provider-integration.test.ts
@@ -243,22 +243,24 @@ describe('Provider integration tests', () => {
       expect(args).not.toContain('--dangerously-skip-permissions');
     });
 
-    it('CopilotCli: adds --yolo when freeAgentMode is true', async () => {
+    it('CopilotCli: adds --yolo and --autopilot when freeAgentMode is true', async () => {
       const provider = new CopilotCliProvider();
       const { args } = await provider.buildSpawnCommand({
         cwd: '/p',
         freeAgentMode: true,
       });
       expect(args).toContain('--yolo');
+      expect(args).toContain('--autopilot');
     });
 
-    it('CopilotCli: no --yolo when freeAgentMode is false', async () => {
+    it('CopilotCli: no --yolo or --autopilot when freeAgentMode is false', async () => {
       const provider = new CopilotCliProvider();
       const { args } = await provider.buildSpawnCommand({
         cwd: '/p',
         freeAgentMode: false,
       });
       expect(args).not.toContain('--yolo');
+      expect(args).not.toContain('--autopilot');
     });
 
     it('CodexCli: adds --full-auto when freeAgentMode is true', async () => {


### PR DESCRIPTION
## Summary
- The free agent mode setting was only passing `--yolo` to GitHub Copilot CLI, which grants tool permissions but does not enable multi-step autonomous continuation
- GHCP CLI requires both `--yolo` (auto-approve permissions) and `--autopilot` (autonomous multi-step continuation) for full free agent operation
- This is analogous to how Claude Code uses `--dangerously-skip-permissions` and Codex uses `--full-auto` as single flags that cover both concerns

## Changes
- **`copilot-cli-provider.ts`**: `buildSpawnCommand` now pushes both `--yolo` and `--autopilot` when `freeAgentMode` is true
- **`copilot-cli-provider.test.ts`**: Updated existing test and added coverage for `false` and `undefined` freeAgentMode cases
- **`provider-integration.test.ts`**: Updated cross-provider freeAgentMode assertions to verify both flags

## Test Plan
- [x] Existing test updated: verifies `--yolo` AND `--autopilot` both present when `freeAgentMode: true`
- [x] New test: `freeAgentMode: false` produces neither `--yolo` nor `--autopilot`
- [x] New test: `freeAgentMode: undefined` produces neither flag
- [x] Integration test: cross-provider freeAgentMode assertions updated
- [x] All 8661 tests pass, typecheck clean

## Manual Validation
1. Create/open a GHCP CLI agent with free agent mode enabled
2. Verify the spawned CLI process receives both `--yolo` and `--autopilot` flags (visible in spawn log)
3. Confirm the agent runs autonomously without pausing for permission or continuation prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)