### PR TITLE
docs: rewrite README, expand PRINCIPLES to 5, update CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,11 @@
 
 Thanks for your interest in contributing! This guide covers the essentials for getting started.
 
+Before diving in, read [PRINCIPLES.md](PRINCIPLES.md) — it describes the values that guide what goes where and how contributions are evaluated.
+
 ## Development Setup
 
-**Prerequisites:** Node.js 20+, npm, Git
+**Prerequisites:** Node.js 22+, npm, Git
 
 ```bash
 git clone https://github.com/Agent-Clubhouse/Clubhouse.git
@@ -15,9 +17,9 @@ npm start  # Launches dev mode with hot reload
 
 ### Platform Notes
 
-- **macOS:** Full support including code signing and notarization (requires Apple Developer credentials for distribution builds)
-- **Windows:** Full support. The `postinstall` script handles native module setup automatically.
-- **Linux:** Builds via deb/rpm makers. Not actively tested but should work.
+- **macOS:** Xcode Command Line Tools required (`xcode-select --install`). Full support including code signing and notarization (requires Apple Developer credentials for distribution builds).
+- **Windows:** Visual Studio Build Tools with the "Desktop development with C++" workload (for `node-pty` and other native modules). The `postinstall` script handles native module setup automatically.
+- **Linux:** Install `build-essential`, `python3` for native compilation. For packaging: `dpkg`, `fakeroot`, `rpm`. For E2E tests: `xvfb` (virtual display).
 
 ## Project Structure
 
@@ -55,16 +57,27 @@ Use conventional-ish messages — the prefix matters, the format is flexible:
 
 ## Testing
 
+Every PR must include tests. See [Principle 2](PRINCIPLES.md#principle-2-extreme-bias-for-test-coverage) for the full rationale.
+
 ```bash
-npm test                 # All tests (Vitest)
+npm test                 # All unit + component tests (Vitest)
 npm run test:unit        # Main + shared unit tests
-npm run test:components  # React component tests
-npm run test:e2e         # Playwright E2E tests
+npm run test:components  # React component tests (jsdom)
+npm run test:e2e         # Playwright E2E tests (requires packaged app)
 npm run typecheck        # TypeScript type checking
-npm run validate         # Full pipeline: typecheck + test + make + e2e
+npm run lint             # ESLint
+npm run validate         # Full pipeline: typecheck → test → make → e2e
 ```
 
-All PRs must pass `npm run typecheck` and `npm test`. The CI workflow runs these automatically.
+**E2E tests** run Playwright against the packaged Electron app. You need to `npm run package` first, or use `npm run validate` which handles the full sequence.
+
+**On Linux**, E2E tests require a virtual display:
+
+```bash
+xvfb-run --auto-servernum npx playwright test
+```
+
+All PRs must pass `npm run typecheck` and `npm test`. The CI workflow runs these on macOS, Windows, and Linux automatically.
 
 ## Pull Requests
 
@@ -84,11 +97,11 @@ Open an issue with:
 
 ## Feature Requests
 
-Open an issue describing the use case. Explain the problem you're solving, not just the solution you want.
+Open an issue describing the use case. Explain the problem you're solving, not just the solution you want. Consider whether the feature belongs in core or in a plugin — see [Principle 3](PRINCIPLES.md#principle-3-opinions-are-opt-in) and [Principle 4](PRINCIPLES.md#principle-4-change-at-the-least-obtrusive-layer).
 
 ## Plugin Development
 
-Clubhouse has a plugin API (v0.5) for extending functionality. See the [Plugin System](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Plugin-System) wiki page for the full API reference, manifest format, and permissions model.
+Clubhouse has a plugin API for extending functionality. Current supported API versions: `0.5`, `0.6`, `0.7`, `0.8`. See the [Plugin System](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Plugin-System) wiki page for the full API reference, manifest format, and permissions model.
 
 ## License
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,12 +1,47 @@
-# Extensibility Principles
+# Principles
 
-## Principle 1: Opinions Are Opt-In
+Five principles guide how Clubhouse is built, how contributions are evaluated, and what goes where.
+
+---
+
+## Principle 1: Agents Are First-Class Contributors
+
+The codebase is built for agents and humans to contribute equally. An agent working in a worktree follows the same workflow as a human in a clone: branch, implement, test, validate, open a PR. The tooling, documentation, and conventions must support both without special-casing either.
+
+- **Isolation by default.** Each durable agent gets its own git worktree, standby branch, and configuration. Agents cannot interfere with each other or with the main working tree. This isolation is structural, not policy — it is enforced by the worktree model and scoped permissions.
+- **The same bar applies.** Agent contributions go through the same validation pipeline as human contributions: typecheck, unit tests, component tests, e2e tests, and code review. An agent PR that skips tests is treated the same as a human PR that skips tests.
+- **Documentation is for everyone.** READMEs, inline comments, and architectural docs should be clear enough for an agent to act on and detailed enough for a human to understand. If a doc is only useful to one audience, it is incomplete.
+- **Automation is the default.** Repeatable tasks — branching, validating, pushing, creating PRs — should be automatable. Skills, hooks, and CI exist so that neither agents nor humans need to remember multi-step rituals.
+
+### Why this matters
+
+Agent-first is not about replacing human contributors. It is about building a codebase where the feedback loop is fast, the conventions are explicit, and the guardrails are structural. These properties make the project better for everyone — agents just make the gaps more visible.
+
+---
+
+## Principle 2: Extreme Bias for Test Coverage
+
+If it ships, it has tests. If it is hard to test, that is a design problem. The test suite is not a safety net that catches some things — it is the primary mechanism by which we know the software works.
+
+- **Every PR includes tests.** New features ship with unit tests. Bug fixes ship with regression tests. Refactors prove they changed nothing with the existing suite. PRs without tests require an explicit justification, not a promise to add them later.
+- **Tests run on all platforms.** Unit and component tests run on macOS, Windows, and Linux in CI. Platform-specific behavior that only works on one OS is a bug, not a feature.
+- **E2E tests run against the real app.** Playwright tests package the Electron app and exercise it as a user would — launching windows, clicking UI, navigating between views. The Annex E2E suite goes further: it launches two Clubhouse instances and tests real-time pairing, remote terminal control, and agent lifecycle over loopback. These are not optional — they run in CI on every PR.
+- **A failing test is a release blocker.** If a test fails, the code does not merge. If a test is flaky, the test is fixed — not skipped, not retried into submission, not marked as known-failure.
+- **API version contracts are tested.** Each supported plugin API version has contract tests covering its full surface. A failing contract test means a breaking change was introduced — rev the version instead of changing the test.
+
+### Why this matters
+
+Test coverage is not about process compliance. It is about confidence. A well-tested codebase can be changed aggressively — refactored, extended, simplified — because the test suite proves the change is safe. A poorly-tested codebase becomes fragile: every change is risky, every refactor is deferred, and the code slowly calcifies. We choose the first path.
+
+---
+
+## Principle 3: Opinions Are Opt-In
 
 The way one person uses AI agents is not the way another will. Highly opinionated workflows are valuable — but only to the people who share those opinions. Baking them into the core turns a preference into an imposition.
 
 - **The core host is unopinionated.** It provides capabilities, not workflows. It does not assume how you organize agents, what models you prefer, how you review output, or what a "good" session looks like.
-- **Opinions belong in plugins.** A plugin can be as opinionated as it wants — that's the point. It can enforce a strict review flow, auto-organize agents by branch, require approval gates, or do nothing at all. Users install the opinions they agree with.
-- **No default workflow is "correct."** If a feature assumes a specific way of working, it should be a plugin that users enable, not a core behavior that users endure. The test: would a reasonable user want to turn this off? If yes, it doesn't belong in core.
+- **Opinions belong in plugins.** A plugin can be as opinionated as it wants — that is the point. It can enforce a strict review flow, auto-organize agents by branch, require approval gates, or do nothing at all. Users install the opinions they agree with.
+- **No default workflow is "correct."** If a feature assumes a specific way of working, it should be a plugin that users enable, not a core behavior that users endure. The test: would a reasonable user want to turn this off? If yes, it does not belong in core.
 - **Diversity of use is a strength.** The goal is a platform where ten people can use Clubhouse in ten different ways and none of them are fighting the tool. The extensibility model exists to make this possible.
 
 ### The line between capability and opinion
@@ -17,9 +52,11 @@ An opinion is: "agents should be organized by git branch."
 A capability is: "plugins can react to agent status changes."
 An opinion is: "idle agents should be automatically paused after 5 minutes."
 
-Capabilities go in the host. Opinions go in plugins. When in doubt, ask: does this help everyone, or does it help people who work like me? If the latter, it's a plugin.
+Capabilities go in the host. Opinions go in plugins. When in doubt, ask: does this help everyone, or does it help people who work like me? If the latter, it is a plugin.
 
-## Principle 2: Change at the Least Obtrusive Layer
+---
+
+## Principle 4: Change at the Least Obtrusive Layer
 
 Make changes at the outermost layer that can support them. Each layer inward affects more users and is harder to reverse.
 
@@ -42,21 +79,23 @@ Clubhouse supports many diverse work patterns. A change that improves one workfl
 
 Defaulting to the outermost viable layer keeps the blast radius small, keeps options open, and lets the ecosystem grow without centralizing every decision.
 
-## Principle 3: Explicit Support, No Silent Regression
+---
+
+## Principle 5: Explicit Support, No Silent Regression
 
 Be explicit about which API versions we support. Fully support the ones we claim. Never quietly break them.
 
-- **Declare support explicitly.** The set of supported API versions is a source-of-truth list in code, not something implied by which tests happen to pass. If a version is in the list, we support it. If it's not, we don't.
+- **Declare support explicitly.** The set of supported API versions is a source-of-truth list in code, not something implied by which tests happen to pass. If a version is in the list, we support it. If it is not, we do not.
 - **Supported means fully working.** Every method, type, and behavior documented for a supported version must work correctly. No stubs, no silent no-ops, no "mostly works." If we say we support v1, a v1 plugin runs exactly as v1 promises.
 - **Tests prove the commitment.** Each supported version has tests covering its full surface. A failing test for a supported version is a release blocker. If you need to change an existing test to make your code work, you are making a breaking change — rev the version instead.
-- **Reject what we don't support.** A plugin targeting an unsupported version is rejected at load time with a clear message. We don't load it and hope for the best.
+- **Reject what we don't support.** A plugin targeting an unsupported version is rejected at load time with a clear message. We do not load it and hope for the best.
 
 ### Corollary: Know when to let go
 
 Supporting old versions has a real cost. When that cost begins to constrain the evolution of the platform — blocking new capabilities, requiring complex compatibility shims, or creating maintenance burden that slows everything else down — it is time to drop the old version.
 
-Dropping a version is not a failure. Carrying a version we can't properly maintain is. A clean, announced drop is better than slow erosion where the version technically loads but subtly breaks.
+Dropping a version is not a failure. Carrying a version we cannot properly maintain is. A clean, announced drop is better than slow erosion where the version technically loads but subtly breaks.
 
-### Relationship to Principle 2
+### Relationship to Principle 4
 
-This principle serves Principle 2. The layer model only works if plugin authors can trust the API layer beneath them. If we silently regress a supported version, plugins break through no fault of their own — and authors are forced to work around host instability instead of building on a stable platform. Explicit support and no-regression are what make the outer layers viable.
+This principle serves Principle 4. The layer model only works if plugin authors can trust the API layer beneath them. If we silently regress a supported version, plugins break through no fault of their own — and authors are forced to work around host instability instead of building on a stable platform. Explicit support and no-regression are what make the outer layers viable.

--- a/README.md
+++ b/README.md
@@ -1,81 +1,125 @@
 # Clubhouse
 
-A desktop app for managing AI coding agents across your projects. Run multiple agents side-by-side with a split-pane workspace, integrated terminals, file browsing, and a plugin system that makes it all extensible.
+A desktop app for managing AI coding agents across your projects. Clubhouse wraps CLI-based coding agents — Claude Code, GitHub Copilot CLI, OpenCode — in a native Electron shell with a unified interface to spawn, monitor, and orchestrate them across all your projects simultaneously.
 
-Clubhouse wraps CLI-based coding agents (Claude Code, GitHub Copilot CLI, Codex CLI) in a native Electron shell, giving you a unified interface to spawn, monitor, and manage them across all your projects simultaneously.
+## Philosophy
 
-## Key Features
+Three ideas shape how Clubhouse is built and how contributions are evaluated:
 
-- **Multi-agent workspace** — Run durable (long-lived) and quick (one-shot) agents per project, view them in a split-pane Hub
-- **Orchestrator abstraction** — Swap between Claude Code, GitHub Copilot CLI, and Codex CLI with a unified provider interface
-- **Headless mode** — Run quick agents without a terminal, parsing structured JSON output for cost, duration, and transcript data
-- **Live agent status** — Hook events from running agents surface real-time tool usage, permission requests, and errors
-- **Built-in plugins** — Hub (split-pane workspace), Files (Monaco editor + file browser), Terminal (project shell), Issues (GitHub integration)
-- **Plugin API (v0.5)** — Build community plugins with access to files, git, agents, terminals, storage, and UI widgets
-- **Git integration** — Branch management, staging, diffs, and per-agent git worktrees for isolated development
-- **Theming** — 8 built-in themes (Catppuccin Mocha, Nord, Dracula, Tokyo Night, and more)
-- **Notifications** — Configurable desktop alerts for agent idle, completion, permission requests, and errors
+**Agent-first development.** Agents are first-class contributors. Each durable agent gets its own git worktree, standby branch, and isolated configuration. Agents branch, implement, validate, and open PRs — the same workflow a human follows. The codebase, tooling, and documentation should be equally useful to both human and agent contributors. See the [full principles](PRINCIPLES.md) for details.
 
-## Quick Start
+**Extreme bias for test coverage.** Every PR must include tests. Unit and component tests run on all three platforms (macOS, Windows, Linux) in CI. End-to-end tests run Playwright against the packaged Electron app on every platform. The Annex dual-instance E2E suite launches two Clubhouse instances and tests real-time remote control over the local network. If a feature is hard to test, that is a design problem, not an excuse to skip tests.
+
+**Opinions belong in plugins, not core.** The core host provides capabilities without assuming how you use them. Opinionated workflows — review flows, auto-organization, approval gates — are plugins that users choose to enable. The plugin API is versioned: new features land in the latest version, older versions are fully supported or cleanly dropped, never quietly broken. See [PRINCIPLES.md](PRINCIPLES.md) for the full extensibility contract.
+
+## Building and Testing Locally
+
+### Prerequisites
+
+- **Node.js 22+** and **npm**
+- **Git**
+- **Platform-specific:**
+  - **macOS:** Xcode Command Line Tools (`xcode-select --install`)
+  - **Windows:** Visual Studio Build Tools with the "Desktop development with C++" workload (for native module compilation). The `postinstall` script handles `node-pty` setup automatically.
+  - **Linux:** `build-essential`, `python3`, `dpkg`, `fakeroot`, `rpm` (for packaging). E2E tests require `xvfb` for headless display.
+
+### Setup
 
 ```bash
+git clone https://github.com/Agent-Clubhouse/Clubhouse.git
+cd Clubhouse
 npm install
-npm start        # Development mode with hot reload
+npm start          # Dev mode with hot reload
 ```
 
-## Building
+### Building
 
 ```bash
-npm run make     # Build distributable installer
-npm run package  # Package only (creates .app without installer)
+npm run package    # Package the app (no installer)
+npm run make       # Build distributable installers
 ```
 
-The packaged `.app` will be in `out/Clubhouse-darwin-arm64/` (or `x64`). The `make` output goes to `out/make/`.
+| Platform | Output | Location |
+|----------|--------|----------|
+| macOS | `.app`, `.zip`, `.dmg` | `out/make/` |
+| Windows | Squirrel installer (`.exe`, `.nupkg`) | `out/make/squirrel.windows/` |
+| Linux | `.deb`, `.rpm` | `out/make/deb/` and `out/make/rpm/` |
 
-## Testing
+### Testing
 
 ```bash
-npm test              # All tests (Vitest)
-npm run test:unit     # Main + shared unit tests
-npm run test:components  # React component tests
-npm run test:e2e      # Playwright E2E tests
-npm run typecheck     # TypeScript type checking
-npm run validate      # Full pipeline: typecheck + test + make + e2e
+npm test                 # All unit + component tests (Vitest)
+npm run test:unit        # Main process + shared module tests
+npm run test:components  # React component tests (jsdom)
+npm run test:e2e         # E2E tests (Playwright, requires packaged app)
+npm run typecheck        # TypeScript strict-mode type checking
+npm run lint             # ESLint
+npm run validate         # Full pipeline: typecheck → test → make → e2e
 ```
 
-## Extensibility Principles
+**Test projects in Vitest:**
 
-Clubhouse is designed around the idea that opinionated workflows belong in plugins, not in the core. Three principles guide what goes where:
+| Project | Scope | Environment |
+|---------|-------|-------------|
+| `main` | `src/main/**/*.test.ts` | Node |
+| `renderer` | `src/renderer/**/*.test.{ts,tsx}` | jsdom |
+| `shared` | `src/shared/**/*.test.ts` | Node |
+| `integration` | `test/**/*.test.ts` | Node |
 
-1. **Opinions are opt-in.** The core host provides capabilities (run agents, manage files, access git) without assuming how you use them. Opinionated workflows — review flows, auto-organization, approval gates — are plugins that users choose to enable.
+**E2E notes:**
+- E2E tests use Playwright against the packaged Electron app — run `npm run package` first, or use `npm run validate` which does it all.
+- On Linux, E2E tests need a virtual display: `xvfb-run --auto-servernum npx playwright test`
+- Annex dual-instance tests (in `e2e/annex-v2/`) launch two Clubhouse instances and test pairing, remote PTY, and lifecycle over loopback.
 
-2. **Change at the least obtrusive layer.** Default to the outermost layer that can support a change: community plugin > core plugin > plugin API > core feature > app host. The further inward, the higher the burden of proof.
+### CI
 
-3. **Explicit support, no silent regression.** Supported plugin API versions are fully tested and guaranteed. Unsupported versions are rejected at load time. No quiet breakage.
+The `validate.yml` workflow runs on every PR to `main`:
 
-The test for any feature: *would a reasonable user want to turn this off?* If yes, it's a plugin. See the [full principles](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Extensibility-Principles) in the wiki.
+- **Typecheck** — all three platforms
+- **Unit + component tests** — all three platforms
+- **E2E tests** — all three platforms (Linux uses `xvfb-run`)
+- **Annex E2E tests** — all three platforms (separate job for dual-instance tests)
+- **Linux package smoke test** — builds `.deb` and `.rpm`, verifies they exist
+- **API surface check** — runs plugin API version contract tests; flags any PR that modifies `src/shared/plugin-types.ts`
 
 ## Architecture
 
-Clubhouse is an Electron app with a clean separation between processes:
-
 ```
 src/
-  main/           # Electron main process — services, IPC handlers, orchestrator providers
+  main/           # Electron main process — services, IPC, orchestrators, MCP bridge
   renderer/       # React UI — features, stores, plugins, panels
   preload/        # Context-isolated IPC bridge (window.clubhouse API)
   shared/         # Types and utilities shared across processes
 ```
 
-The **orchestrator system** abstracts CLI-specific logic behind a provider interface, so adding support for a new coding agent CLI requires implementing a single `OrchestratorProvider`. The **plugin system** exposes a rich API for building custom tabs, commands, and integrations.
+### Orchestrator system
 
-See the [Wiki](https://github.com/Agent-Clubhouse/Clubhouse/wiki) for detailed developer documentation:
+The orchestrator layer abstracts CLI-specific logic behind a provider interface. Adding support for a new coding agent CLI means implementing a single `OrchestratorProvider`. Built-in providers: Claude Code, GitHub Copilot CLI, OpenCode.
 
-- [Architecture](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Architecture) — Process model, IPC, services, and data flow
-- [Orchestrator System](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Orchestrator-System) — Provider interface, registry, and built-in providers
-- [Plugin System](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Plugin-System) — API reference, manifest format, permissions, and built-in plugins
-- [Agent Lifecycle](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Agent-Lifecycle) — Durable vs quick agents, spawn modes, hooks, and deletion
-- [Development Guide](https://github.com/Agent-Clubhouse/Clubhouse/wiki/Development-Guide) — Setup, build, test, and project conventions
+Providers declare capabilities (headless mode, hooks, session resume, structured output) and Clubhouse adapts its spawn, monitoring, and communication behavior accordingly.
+
+### Clubhouse MCP
+
+The Clubhouse MCP system gives agents scoped access to interact with other parts of the app via the Model Context Protocol. When an agent is connected to a target — a browser widget, another agent, a terminal, or a group project — Clubhouse injects an MCP server that exposes context-appropriate tools.
+
+Tool categories:
+- **Browser tools** — navigate, screenshot, click, evaluate JavaScript in a Canvas browser widget
+- **Agent tools** — send messages, read output, check status of other agents
+- **Group project tools** — broadcast messages and coordinate across multi-agent project groups
+
+Bindings are managed dynamically: connect a wire on the Canvas and the agent immediately gains MCP tools scoped to that target.
+
+### Desktop remote control
+
+Clubhouse instances on the same local network can pair for remote control. One instance runs as a **satellite** (being controlled), the other as a **controller**. Communication uses mutual TLS with Ed25519 identity and PIN-based pairing. The controller sees the satellite's projects and agents, can type in remote terminals, spawn and kill agents, and handle permission prompts — all peer-to-peer with no cloud dependency.
+
+### Plugin system
+
+Plugins extend Clubhouse with custom tabs, commands, themes, sounds, and agent configuration. The plugin API is permission-gated — plugins declare what they need (files, git, agents, terminal, etc.) and users approve at install time.
+
+Current supported API versions: `0.5`, `0.6`, `0.7`, `0.8`. See [PRINCIPLES.md](PRINCIPLES.md) for the versioning contract.
+
+Built-in plugins: Hub (split-pane agent workspace), Files (Monaco editor + file browser), Terminal, Canvas (visual wiring workspace), Sessions, Git, Browser, Review, Group Project.
 
 ## Tech Stack
 
@@ -88,7 +132,14 @@ See the [Wiki](https://github.com/Agent-Clubhouse/Clubhouse/wiki) for detailed d
 | Terminal | xterm.js 6 + node-pty |
 | Build tooling | Electron Forge, Webpack, TypeScript 5.9 |
 | Testing | Vitest, Playwright |
-| Markdown | marked + highlight.js |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup details, code style, and PR guidelines.
+
+## Principles
+
+See [PRINCIPLES.md](PRINCIPLES.md) for the full set of principles that guide development — agent-first workflows, test coverage expectations, and the extensibility contract.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **README.md** — Full rewrite. Adds project philosophy section covering agent-first development, test coverage bias, and plugin extensibility. Adds platform-specific build/test instructions for macOS, Windows, and Linux. Documents CI pipeline, Clubhouse MCP, desktop remote control, and architecture overview. Replaces stale feature list with accurate current state.
- **PRINCIPLES.md** — Expanded from 3 extensibility principles to 5 core principles. Added "Agents Are First-Class Contributors" (Principle 1) and "Extreme Bias for Test Coverage" (Principle 2). Existing extensibility principles renumbered 3–5 and lightly edited for consistency.
- **CONTRIBUTING.md** — Updated Node.js version to 22, added platform-specific prerequisites (Windows build tools, Linux xvfb), added cross-references to PRINCIPLES.md, improved E2E test instructions.

## Motivation

The previous README was stale (referenced Node 20, outdated feature list, no platform-specific build instructions, no mention of MCP or Annex remote control). PRINCIPLES.md only covered extensibility but not the agent-first and test-first values that actually drive development decisions. These docs are the entry point for new contributors — human and agent alike — and needed to accurately reflect how the project works.

## Test plan

- [x] `npm run typecheck` — pre-existing failures only (unrelated `@xterm/headless` types)
- [x] `npm test` — 8508 passing, 6 pre-existing failures in unrelated files
- [x] `npm run lint` — pre-existing lint errors only (unused vars in e2e tests)
- [x] Only documentation files changed (README.md, PRINCIPLES.md, CONTRIBUTING.md)
- [ ] Review rendered markdown on GitHub for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)