### PR TITLE
feat: include group project name in system messages

### DIFF
--- a/src/main/services/group-project-lifecycle.test.ts
+++ b/src/main/services/group-project-lifecycle.test.ts
@@ -93,6 +93,8 @@ describe('GroupProjectLifecycle', () => {
     expect(messages[0].sender).toBe('system');
     expect(messages[0].body).toContain('robin');
     expect(messages[0].body).toContain('joined');
+    // Should include project identifier (falls back to ID when project not in registry)
+    expect(messages[0].body).toContain('gp_123');
   });
 
   it('posts leave event when agent unbinds from group project', async () => {
@@ -116,6 +118,8 @@ describe('GroupProjectLifecycle', () => {
     expect(messages).toHaveLength(2);
     expect(messages[1].body).toContain('robin');
     expect(messages[1].body).toContain('left');
+    // Should include project identifier
+    expect(messages[1].body).toContain('gp_123');
   });
 
   it('is idempotent — does not double-post on repeated calls', async () => {
@@ -226,6 +230,60 @@ describe('GroupProjectLifecycle', () => {
       (c: unknown[]) => c[1] === '\r',
     );
     expect(lateEnter).toBeDefined();
+  });
+
+  it('includes project name in welcome message when project exists', async () => {
+    const project = await groupProjectRegistry.create('Alpha Squad');
+
+    initGroupProjectLifecycle();
+
+    bindingManager.bind('agent-1', {
+      targetId: project.id,
+      targetKind: 'group-project',
+      label: 'GP',
+      agentName: 'robin',
+    });
+
+    await new Promise(r => setTimeout(r, 250));
+
+    // Welcome PTY message should include the project name
+    const calls = mockPtyWrite.mock.calls;
+    const welcomeCall = calls.find(
+      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('GROUP_PROJECT_JOINED'),
+    );
+    expect(welcomeCall).toBeDefined();
+    expect(welcomeCall![1]).toContain('[GROUP:Alpha Squad]');
+    expect(welcomeCall![1]).toContain('"Alpha Squad"');
+
+    // Join bulletin message should include project name
+    const board = getBulletinBoard(project.id);
+    const messages = await board.getTopicMessages('system');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].body).toContain('Alpha Squad');
+  });
+
+  it('includes project name in polling start message', async () => {
+    const project = await groupProjectRegistry.create('Beta Team');
+    await groupProjectRegistry.update(project.id, { metadata: { pollingEnabled: true } });
+
+    initGroupProjectLifecycle();
+
+    bindingManager.bind('agent-1', {
+      targetId: project.id,
+      targetKind: 'group-project',
+      label: 'GP',
+      agentName: 'robin',
+    });
+
+    await new Promise(r => setTimeout(r, 800));
+
+    const calls = mockPtyWrite.mock.calls;
+    const pollingCall = calls.find(
+      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('POLLING_START'),
+    );
+    expect(pollingCall).toBeDefined();
+    expect(pollingCall![1]).toContain('[GROUP:Beta Team]');
+    expect(pollingCall![1]).toContain('"Beta Team"');
   });
 
   it('does not inject polling instruction when polling is disabled', async () => {

--- a/src/main/services/group-project-lifecycle.ts
+++ b/src/main/services/group-project-lifecycle.ts
@@ -16,14 +16,20 @@ import { getProvider } from '../orchestrators/registry';
 /** Debounce window (ms) — suppress rejoins within this period after a leave unless agent is verified running. */
 const REJOIN_DEBOUNCE_MS = 30_000;
 
-const WELCOME_MSG =
-  '[SYSTEM:GROUP_PROJECT_JOINED] You have been connected to a group project. ' +
-  'Use your group project MCP tools to collaborate: read_bulletin to check messages, ' +
-  'post_bulletin to share updates, and list_members to see who is connected.';
+function welcomeMsg(projectName: string): string {
+  return (
+    `[SYSTEM:GROUP_PROJECT_JOINED] [GROUP:${projectName}] You have been connected to group project "${projectName}". ` +
+    'Use your group project MCP tools to collaborate: read_bulletin to check messages, ' +
+    'post_bulletin to share updates, and list_members to see who is connected.'
+  );
+}
 
-const POLLING_START_MSG =
-  '[SYSTEM:POLLING_START] Poll the bulletin board every 60 seconds when idle or between turns. ' +
-  'Use read_bulletin to check for updates.';
+function pollingStartMsg(projectName: string): string {
+  return (
+    `[SYSTEM:POLLING_START] [GROUP:${projectName}] Poll the bulletin board for "${projectName}" every 60 seconds when idle or between turns. ` +
+    'Use read_bulletin to check for updates.'
+  );
+}
 
 /** Default delay (ms) before sending Enter after bracketed paste. */
 const DEFAULT_PASTE_DELAY_MS = 200;
@@ -100,7 +106,9 @@ async function syncMemberships(agentId: string): Promise<void> {
       const agentName = agentNames.get(agentId) || resolveAgentName(agentId);
       try {
         const board = getBulletinBoard(projectId);
-        await board.postMessage('system', 'system', `${agentName} left the project`);
+        const proj = await groupProjectRegistry.get(projectId);
+        const projName = proj?.name || projectId;
+        await board.postMessage('system', 'system', `${agentName} left project "${projName}"`);
       } catch (err) {
         appLog('core:group-project', 'warn', 'Failed to post leave event', {
           meta: { agentId, projectId, error: err instanceof Error ? err.message : String(err) },
@@ -140,9 +148,19 @@ async function syncMemberships(agentId: string): Promise<void> {
 
       const agentName = resolveAgentName(agentId);
       agentNames.set(agentId, agentName);
+
+      // Fetch project info for name inclusion in messages
+      let project: Awaited<ReturnType<typeof groupProjectRegistry.get>> | undefined;
+      try {
+        project = await groupProjectRegistry.get(projectId);
+      } catch {
+        // proceed with fallback name
+      }
+      const projectName = project?.name || projectId;
+
       try {
         const board = getBulletinBoard(projectId);
-        await board.postMessage('system', 'system', `${agentName} joined the project`);
+        await board.postMessage('system', 'system', `${agentName} joined project "${projectName}"`);
       } catch (err) {
         appLog('core:group-project', 'warn', 'Failed to post join event', {
           meta: { agentId, projectId, error: err instanceof Error ? err.message : String(err) },
@@ -150,19 +168,12 @@ async function syncMemberships(agentId: string): Promise<void> {
       }
 
       // Inject welcome message into the new agent's PTY
-      injectPtyMessage(agentId, WELCOME_MSG);
+      injectPtyMessage(agentId, welcomeMsg(projectName));
 
       // Auto-send polling instruction if polling is enabled
-      try {
-        const project = await groupProjectRegistry.get(projectId);
-        if (project?.metadata?.pollingEnabled) {
-          // Small delay so the welcome message is processed first
-          setTimeout(() => injectPtyMessage(agentId, POLLING_START_MSG), 500);
-        }
-      } catch (err) {
-        appLog('core:group-project', 'warn', 'Failed to send polling instruction to new agent', {
-          meta: { agentId, projectId, error: err instanceof Error ? err.message : String(err) },
-        });
+      if (project?.metadata?.pollingEnabled) {
+        // Small delay so the welcome message is processed first
+        setTimeout(() => injectPtyMessage(agentId, pollingStartMsg(projectName)), 500);
       }
     }
   }

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -12,10 +12,12 @@ const EXPANDED_WIDTH_THRESHOLD = 500;
 const POLL_INTERVAL_MS = 5000;
 const ALL_TOPICS_KEY = '__all__';
 
-const POLLING_START_MSG =
-  '[SYSTEM:POLLING_START] Poll the bulletin board every 60 seconds when idle or between turns. Use read_bulletin to check for updates.';
-const POLLING_STOP_MSG =
-  '[SYSTEM:POLLING_STOP] Stop periodic bulletin board polling.';
+function pollingStartMsg(projectName: string): string {
+  return `[SYSTEM:POLLING_START] [GROUP:${projectName}] Poll the bulletin board for "${projectName}" every 60 seconds when idle or between turns. Use read_bulletin to check for updates.`;
+}
+function pollingStopMsg(projectName: string): string {
+  return `[SYSTEM:POLLING_STOP] [GROUP:${projectName}] Stop periodic bulletin board polling for "${projectName}".`;
+}
 
 /** Inject a message into an agent's PTY using bracketed paste + Enter. */
 function injectPtyMessage(agentId: string, message: string): void {
@@ -209,11 +211,12 @@ function ProjectCard({
     const newVal = !pollingEnabled;
     await update(groupProjectId, { metadata: { pollingEnabled: newVal } } as any);
     onUpdateMetadata({ pollingEnabled: newVal });
-    const msg = newVal ? POLLING_START_MSG : POLLING_STOP_MSG;
+    const name = project?.name || groupProjectId;
+    const msg = newVal ? pollingStartMsg(name) : pollingStopMsg(name);
     for (const agent of connectedAgents) {
       injectPtyMessage(agent.agentId, msg);
     }
-  }, [pollingEnabled, update, groupProjectId, onUpdateMetadata, connectedAgents]);
+  }, [pollingEnabled, update, groupProjectId, onUpdateMetadata, connectedAgents, project]);
 
   return (
     <div className="flex flex-col h-full p-4 gap-3">
@@ -366,11 +369,12 @@ function ExpandedProjectView({
     const newVal = !pollingEnabled;
     await update(groupProjectId, { metadata: { pollingEnabled: newVal } } as any);
     onUpdateMetadata({ pollingEnabled: newVal });
-    const msg = newVal ? POLLING_START_MSG : POLLING_STOP_MSG;
+    const name = project?.name || groupProjectId;
+    const msg = newVal ? pollingStartMsg(name) : pollingStopMsg(name);
     for (const agent of connectedAgents) {
       injectPtyMessage(agent.agentId, msg);
     }
-  }, [pollingEnabled, update, groupProjectId, onUpdateMetadata, connectedAgents]);
+  }, [pollingEnabled, update, groupProjectId, onUpdateMetadata, connectedAgents, project]);
 
   return (
     <div className="flex flex-col h-full text-ctp-text">


### PR DESCRIPTION
## Summary
- Add group project name/identifier to all system messages (welcome, polling toggle, join/leave) so agents can distinguish which project a message belongs to when connected to multiple group projects
- Aligns these messages with the shoulder tap format which already included `[GROUP:name]` tags

## Changes
- **`group-project-lifecycle.ts`**: Convert `WELCOME_MSG` and `POLLING_START_MSG` from static constants to functions that accept a project name. Fetch project info earlier in the join flow to include the name in all messages. Update join/leave bulletin board messages to include project name (e.g., `robin joined project "Alpha Squad"`)
- **`GroupProjectCanvasWidget.tsx`**: Convert `POLLING_START_MSG` and `POLLING_STOP_MSG` from static constants to functions that accept a project name. Both compact and expanded view polling toggle callbacks now pass the project name
- **Message format**: All system PTY messages now include `[GROUP:projectName]` tags consistent with shoulder taps, plus human-readable project name in quotes

### Before
```
[SYSTEM:GROUP_PROJECT_JOINED] You have been connected to a group project.
[SYSTEM:POLLING_START] Poll the bulletin board every 60 seconds...
robin joined the project
```

### After
```
[SYSTEM:GROUP_PROJECT_JOINED] [GROUP:Alpha Squad] You have been connected to group project "Alpha Squad".
[SYSTEM:POLLING_START] [GROUP:Alpha Squad] Poll the bulletin board for "Alpha Squad" every 60 seconds...
robin joined project "Alpha Squad"
```

## Test Plan
- [x] Typecheck passes
- [x] All 8758 tests pass (366 test files)
- [x] Lint clean (no new warnings)
- [x] New test: verifies project name appears in welcome PTY message when project exists in registry
- [x] New test: verifies project name appears in polling start PTY message
- [x] Updated test: join bulletin message includes project identifier
- [x] Updated test: leave bulletin message includes project identifier
- [x] Existing tests continue to pass (fallback to project ID when project not in registry)

## Manual Validation
1. Create two group projects with different names
2. Connect an agent to both projects
3. Verify the welcome message for each identifies which project it belongs to
4. Toggle polling on each project — verify the polling messages name the correct project
5. Disconnect an agent — verify the leave message names the correct project

🤖 Generated with [Claude Code](https://claude.com/claude-code)