### PR TITLE
feat: show newest messages first in group project expanded view

### DIFF
--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
@@ -126,6 +126,23 @@ describe('GroupProjectCanvasWidget — broadcast modal', () => {
   });
 });
 
+// ── Message ordering (newest-first feed) ────────────────────────────
+
+describe('GroupProjectCanvasWidget — message ordering', () => {
+  it('sorts messages newest-first in expanded view using sortedMessages', () => {
+    // The expanded view should sort messages by timestamp descending
+    expect(source).toContain('sortedMessages');
+    expect(source).toMatch(/\[\.\.\.messages\]\.sort\(/);
+    expect(source).toMatch(/b\.timestamp\.localeCompare\(a\.timestamp\)/);
+  });
+
+  it('renders sortedMessages instead of raw messages in the list', () => {
+    // The message list pane should iterate over sortedMessages, not messages
+    expect(source).toContain('sortedMessages.map((m)');
+    expect(source).toContain('sortedMessages.length === 0');
+  });
+});
+
 // ── Polling toggle uses PTY injection ───────────────────────────────
 
 describe('GroupProjectCanvasWidget — polling toggle', () => {

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -379,6 +379,12 @@ function ExpandedProjectView({
     return () => { cancelled = true; clearInterval(interval); };
   }, [groupProjectId, selectedTopic]);
 
+  // Sort messages newest-first so the feed shows latest on top
+  const sortedMessages = useMemo(
+    () => [...messages].sort((a, b) => b.timestamp.localeCompare(a.timestamp)),
+    [messages],
+  );
+
   const selectedMessage = useMemo(
     () => messages.find((m) => m.id === selectedMessageId) ?? null,
     [messages, selectedMessageId],
@@ -463,12 +469,12 @@ function ExpandedProjectView({
 
         {/* Message List (compact preview pane) */}
         <div className="w-48 flex-shrink-0 border-r border-surface-1 overflow-y-auto">
-          {messages.length === 0 ? (
+          {sortedMessages.length === 0 ? (
             <div className="p-3 text-xs text-ctp-overlay0 italic">
               {selectedTopic === ALL_TOPICS_KEY ? 'No messages yet' : `No messages in "${selectedTopic}"`}
             </div>
           ) : (
-            messages.map((m) => (
+            sortedMessages.map((m) => (
               <button
                 key={m.id}
                 onClick={() => setSelectedMessageId(m.id)}


### PR DESCRIPTION
## Summary
- Reverse message order in the expanded group project card so the latest bulletin messages appear at the top, like a feed
- Most relevant/recent content is now immediately visible without scrolling

## Changes
- Added `sortedMessages` memo in `ExpandedProjectView` that sorts messages by timestamp descending (newest first)
- Updated message list pane to render `sortedMessages` instead of raw `messages`
- Added tests verifying the reverse chronological sort and that the sorted array is used for rendering

## Test Plan
- [x] Typecheck passes
- [x] All 8777 tests pass (366 files)
- [x] Lint clean (no new warnings)
- [ ] Open an expanded group project card with multiple bulletin messages and verify newest appear at the top

## Manual Validation
1. Open a group project widget on the canvas at expanded size
2. Ensure there are multiple bulletin messages with different timestamps
3. Verify the message list (middle pane) shows the most recent message at the top
4. Verify clicking a message still shows its detail in the right pane correctly