### PR TITLE
fix: prevent terminal PTY buffer from resetting scroll to top

### DIFF
--- a/src/renderer/features/agents/AgentTerminal.tsx
+++ b/src/renderer/features/agents/AgentTerminal.tsx
@@ -36,6 +36,13 @@ export function AgentTerminal({ agentId, focused }: Props) {
   const sendClipboardImage = useAnnexClientStore((s) => s.sendClipboardImage);
   const requestPtyBuffer = useAnnexClientStore((s) => s.requestPtyBuffer);
 
+  // Refs for Zustand store methods — prevents terminal destruction/recreation
+  // if the store ever returns a new function reference during state updates.
+  const sendPtyInputRef = useRef(sendPtyInput);
+  sendPtyInputRef.current = sendPtyInput;
+  const requestPtyBufferRef = useRef(requestPtyBuffer);
+  requestPtyBufferRef.current = requestPtyBuffer;
+
   const resuming = useAgentStore((s) => s.agents[agentId]?.resuming);
   const clearResuming = useAgentStore((s) => s.clearResuming);
 
@@ -89,7 +96,7 @@ export function AgentTerminal({ agentId, focused }: Props) {
         });
       } else if (remoteParts) {
         // Remote agents: fetch buffer from satellite via HTTPS REST
-        requestPtyBuffer(remoteParts.satelliteId, remoteParts.agentId).then((buf: string) => {
+        requestPtyBufferRef.current(remoteParts.satelliteId, remoteParts.agentId).then((buf: string) => {
           if (terminalRef.current !== term) return;
           if (buf) term.write(buf);
           bufferReplayed = true;
@@ -105,7 +112,7 @@ export function AgentTerminal({ agentId, focused }: Props) {
       if (!isRemote) {
         window.clubhouse.pty.write(agentId, data);
       } else if (remoteParts) {
-        sendPtyInput(remoteParts.satelliteId, remoteParts.agentId, data);
+        sendPtyInputRef.current(remoteParts.satelliteId, remoteParts.agentId, data);
       }
     });
 
@@ -158,7 +165,7 @@ export function AgentTerminal({ agentId, focused }: Props) {
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [agentId, isRemote, remoteParts, sendPtyInput, requestPtyBuffer]);
+  }, [agentId, isRemote, remoteParts]);
 
   // Focus-aware resize: ResizeObserver, visibilitychange, window focus, pane focus
   // Pass ptyResize so remote agents route resize through the Annex client, not local IPC
@@ -203,7 +210,7 @@ export function AgentTerminal({ agentId, focused }: Props) {
       if (!isRemote) {
         window.clubhouse.pty.write(agentId, data);
       } else if (remoteParts) {
-        sendPtyInput(remoteParts.satelliteId, remoteParts.agentId, data);
+        sendPtyInputRef.current(remoteParts.satelliteId, remoteParts.agentId, data);
       }
     };
     const handleImagePaste = (isRemote && remoteParts)
@@ -213,7 +220,7 @@ export function AgentTerminal({ agentId, focused }: Props) {
       : undefined;
     const cleanup = attachClipboardHandlers(terminalRef.current, containerRef.current, writeData, handleImagePaste);
     return cleanup;
-  }, [clipboardCompat, agentId, isRemote, remoteParts, sendPtyInput, sendClipboardImage]);
+  }, [clipboardCompat, agentId, isRemote, remoteParts, sendClipboardImage]);
 
   // Live-update theme on existing terminal instances
   useEffect(() => {

--- a/src/renderer/features/terminal/ShellTerminal.test.tsx
+++ b/src/renderer/features/terminal/ShellTerminal.test.tsx
@@ -321,6 +321,86 @@ describe('ShellTerminal', () => {
     });
   });
 
+  describe('IO stability', () => {
+    it('does not recreate terminal when io prop changes', () => {
+      const io1 = {
+        write: vi.fn(),
+        resize: vi.fn(),
+        getBuffer: vi.fn().mockResolvedValue(''),
+        onData: vi.fn().mockReturnValue(vi.fn()),
+        onExit: vi.fn().mockReturnValue(vi.fn()),
+      };
+      const io2 = {
+        write: vi.fn(),
+        resize: vi.fn(),
+        getBuffer: vi.fn().mockResolvedValue(''),
+        onData: vi.fn().mockReturnValue(vi.fn()),
+        onExit: vi.fn().mockReturnValue(vi.fn()),
+      };
+
+      const { rerender } = render(<ShellTerminal sessionId="shell-1" io={io1} />);
+      const firstTerm = term();
+      expect(firstTerm).toBeDefined();
+      firstTerm.dispose.mockClear();
+
+      // Changing io should NOT recreate the terminal
+      rerender(<ShellTerminal sessionId="shell-1" io={io2} />);
+      expect(firstTerm.dispose).not.toHaveBeenCalled();
+    });
+
+    it('re-subscribes IO listeners when io prop changes', () => {
+      const unsub1 = vi.fn();
+      const io1 = {
+        write: vi.fn(),
+        resize: vi.fn(),
+        getBuffer: vi.fn().mockResolvedValue(''),
+        onData: vi.fn().mockReturnValue(unsub1),
+        onExit: vi.fn().mockReturnValue(vi.fn()),
+      };
+      const io2 = {
+        write: vi.fn(),
+        resize: vi.fn(),
+        getBuffer: vi.fn().mockResolvedValue(''),
+        onData: vi.fn().mockReturnValue(vi.fn()),
+        onExit: vi.fn().mockReturnValue(vi.fn()),
+      };
+
+      const { rerender } = render(<ShellTerminal sessionId="shell-1" io={io1} />);
+      expect(io1.onData).toHaveBeenCalled();
+
+      rerender(<ShellTerminal sessionId="shell-1" io={io2} />);
+      // Old listener cleaned up, new one registered
+      expect(unsub1).toHaveBeenCalled();
+      expect(io2.onData).toHaveBeenCalled();
+    });
+
+    it('uses the latest io ref for write operations after io change', () => {
+      const io1 = {
+        write: vi.fn(),
+        resize: vi.fn(),
+        getBuffer: vi.fn().mockResolvedValue(''),
+        onData: vi.fn().mockReturnValue(vi.fn()),
+        onExit: vi.fn().mockReturnValue(vi.fn()),
+      };
+      const io2 = {
+        write: vi.fn(),
+        resize: vi.fn(),
+        getBuffer: vi.fn().mockResolvedValue(''),
+        onData: vi.fn().mockReturnValue(vi.fn()),
+        onExit: vi.fn().mockReturnValue(vi.fn()),
+      };
+
+      const { rerender } = render(<ShellTerminal sessionId="shell-1" io={io1} />);
+      rerender(<ShellTerminal sessionId="shell-1" io={io2} />);
+
+      // Simulate user typing — should route through io2
+      const onDataCb = term().onData.mock.calls[0][0];
+      onDataCb('test input');
+      expect(io2.write).toHaveBeenCalledWith('shell-1', 'test input');
+      expect(io1.write).not.toHaveBeenCalled();
+    });
+  });
+
   describe('container rendering', () => {
     it('renders a container div with padding', () => {
       const { getByTestId } = render(<ShellTerminal sessionId="shell-1" />);

--- a/src/renderer/features/terminal/ShellTerminal.tsx
+++ b/src/renderer/features/terminal/ShellTerminal.tsx
@@ -26,10 +26,17 @@ interface Props {
 }
 
 export function ShellTerminal({ sessionId, focused, io }: Props) {
-  const pty = io ?? window.clubhouse.pty;
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+
+  // Use a ref for the IO layer so that changes to `io` don't trigger a full
+  // terminal destruction/recreation cycle.  The terminal instance is expensive
+  // to rebuild — it replays the entire buffer, resets scroll position, and
+  // causes a visible flash.  All IO call-sites read through the ref instead.
+  const ptyRef = useRef<TerminalIO>(io ?? window.clubhouse.pty);
+  ptyRef.current = io ?? window.clubhouse.pty;
+
   const terminalColors = useThemeStore((s) => s.theme.terminal);
   const experimentalMonoFont = useThemeStore(
     (s) => s.experimentalGradients ? (s.theme.fonts?.mono ?? s.theme.fontOverride) : undefined,
@@ -39,6 +46,7 @@ export function ShellTerminal({ sessionId, focused, io }: Props) {
 
   useEffect(() => { loadClipboard(); }, [loadClipboard]);
 
+  // ── Terminal creation — only depends on sessionId ────────────────
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -58,9 +66,9 @@ export function ShellTerminal({ sessionId, focused, io }: Props) {
 
     requestAnimationFrame(() => {
       fitAddon.fit();
-      pty.resize(sessionId, term.cols, term.rows);
+      ptyRef.current.resize(sessionId, term.cols, term.rows);
       term.focus();
-      pty.getBuffer(sessionId).then((buf: string) => {
+      ptyRef.current.getBuffer(sessionId).then((buf: string) => {
         if (buf && terminalRef.current === term) {
           term.write(buf);
         }
@@ -76,15 +84,32 @@ export function ShellTerminal({ sessionId, focused, io }: Props) {
     // the input is incomplete, and PSReadLine on Windows handles it natively.
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type === 'keydown' && ev.key === 'Enter' && (ev.shiftKey || ev.ctrlKey)) {
-        pty.write(sessionId, '\n');
+        ptyRef.current.write(sessionId, '\n');
         return false; // prevent xterm from emitting \r
       }
       return true;
     });
 
     const inputDisposable = term.onData((data) => {
-      pty.write(sessionId, data);
+      ptyRef.current.write(sessionId, data);
     });
+
+    return () => {
+      inputDisposable.dispose();
+      term.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+    };
+  }, [sessionId]);
+
+  // ── IO event listeners — re-registered when io changes ───────────
+  // Separated from terminal creation so that an IO change (e.g. satellite
+  // reconnect) only re-subscribes listeners without destroying the terminal.
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term) return;
+
+    const pty = ptyRef.current;
 
     // Batch PTY data writes using rAF to avoid 100+ DOM renders/sec.
     // Data arriving between frames is concatenated and flushed once per paint.
@@ -124,19 +149,15 @@ export function ShellTerminal({ sessionId, focused, io }: Props) {
 
     return () => {
       if (flushId) cancelAnimationFrame(flushId);
-      inputDisposable.dispose();
       removeDataListener();
       removeExitListener();
-      term.dispose();
-      terminalRef.current = null;
-      fitAddonRef.current = null;
     };
-  }, [sessionId, pty]);
+  }, [sessionId, io]);
 
   // Focus-aware resize: ResizeObserver, visibilitychange, window focus, pane focus
   const resizeCallback = useCallback(
-    (sid: string, cols: number, rows: number) => pty.resize(sid, cols, rows),
-    [pty],
+    (sid: string, cols: number, rows: number) => ptyRef.current.resize(sid, cols, rows),
+    [],
   );
   useTerminalFit(sessionId, terminalRef, fitAddonRef, containerRef, focused, resizeCallback);
 
@@ -146,10 +167,10 @@ export function ShellTerminal({ sessionId, focused, io }: Props) {
     const cleanup = attachClipboardHandlers(
       terminalRef.current,
       containerRef.current,
-      (data) => pty.write(sessionId, data)
+      (data) => ptyRef.current.write(sessionId, data)
     );
     return cleanup;
-  }, [clipboardCompat, sessionId, pty]);
+  }, [clipboardCompat, sessionId]);
 
   useEffect(() => {
     if (terminalRef.current) {
@@ -168,9 +189,9 @@ export function ShellTerminal({ sessionId, focused, io }: Props) {
 
   const { isDragOver, handleDragOver, handleDragLeave, handleDrop } = useFileDrop(
     useCallback((data: string) => {
-      pty.write(sessionId, data);
+      ptyRef.current.write(sessionId, data);
       terminalRef.current?.focus();
-    }, [sessionId, pty])
+    }, [sessionId])
   );
 
   return (

--- a/src/renderer/features/terminal/useTerminalFit.test.ts
+++ b/src/renderer/features/terminal/useTerminalFit.test.ts
@@ -396,6 +396,87 @@ describe('useTerminalFit', () => {
     });
   });
 
+  describe('viewport scroll preservation', () => {
+    let viewportEl: HTMLDivElement;
+
+    function addViewport(scrollTop: number, scrollHeight: number, clientHeight: number) {
+      viewportEl = document.createElement('div');
+      viewportEl.classList.add('xterm-viewport');
+      Object.defineProperty(viewportEl, 'scrollHeight', { value: scrollHeight, configurable: true });
+      Object.defineProperty(viewportEl, 'clientHeight', { value: clientHeight, configurable: true });
+      viewportEl.scrollTop = scrollTop;
+      containerEl.appendChild(viewportEl);
+    }
+
+    it('restores scrollTop when user is scrolled up from bottom', () => {
+      // scrollHeight=1000, clientHeight=200, scrollTop=300 → user is scrolled up
+      addViewport(300, 1000, 200);
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      renderHook(() => useTerminalFit('s1', terminalRef, fitAddonRef, containerRef));
+
+      // Simulate fit() resetting scrollTop to 0 (the bug)
+      mockFit.mockImplementation(() => {
+        viewportEl.scrollTop = 0;
+      });
+
+      mockFit.mockClear();
+      resizeObserverCallbacks[0]();
+
+      expect(mockFit).toHaveBeenCalledTimes(1);
+      expect(viewportEl.scrollTop).toBe(300);
+    });
+
+    it('keeps viewport at bottom when user was already at bottom', () => {
+      // scrollHeight=1000, clientHeight=200, scrollTop=800 → at bottom
+      addViewport(800, 1000, 200);
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      renderHook(() => useTerminalFit('s1', terminalRef, fitAddonRef, containerRef));
+
+      // Simulate fit() changing scrollHeight (reflow) and scrollTop
+      mockFit.mockImplementation(() => {
+        Object.defineProperty(viewportEl, 'scrollHeight', { value: 1200, configurable: true });
+        viewportEl.scrollTop = 500;
+      });
+
+      mockFit.mockClear();
+      resizeObserverCallbacks[0]();
+
+      expect(mockFit).toHaveBeenCalledTimes(1);
+      // Should scroll to the new bottom: 1200 - 200 = 1000
+      expect(viewportEl.scrollTop).toBe(1000);
+    });
+
+    it('preserves scroll position during pane focus fit', () => {
+      addViewport(400, 1000, 200);
+      mockFit.mockImplementation(() => {
+        viewportEl.scrollTop = 0;
+      });
+
+      const { rerender } = renderHook(
+        ({ focused }) => useTerminalFit('s1', terminalRef, fitAddonRef, containerRef, focused),
+        { initialProps: { focused: false } },
+      );
+
+      mockFit.mockClear();
+      rerender({ focused: true });
+
+      expect(mockFit).toHaveBeenCalledTimes(1);
+      expect(viewportEl.scrollTop).toBe(400);
+    });
+
+    it('works gracefully when no .xterm-viewport element exists', () => {
+      // No viewport element — save/restore should be no-ops
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      renderHook(() => useTerminalFit('s1', terminalRef, fitAddonRef, containerRef));
+
+      mockFit.mockClear();
+      resizeObserverCallbacks[0]();
+
+      // Should still call fit without errors
+      expect(mockFit).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('null-safety', () => {
     it('does nothing when container ref is null', () => {
       const nullContainer = { current: null };

--- a/src/renderer/features/terminal/useTerminalFit.ts
+++ b/src/renderer/features/terminal/useTerminalFit.ts
@@ -9,6 +9,36 @@ import type { FitAddon } from '@xterm/addon-fit';
 const WAKE_SETTLE_MS = 150;
 
 /**
+ * Save the terminal viewport's scroll position so it can be restored
+ * after a `fit()` call that may trigger a buffer reflow.
+ *
+ * xterm.js reflows the buffer when the column count changes during
+ * `terminal.resize()`.  This can shift the viewport — particularly
+ * when there is significant scrollback — causing the user's view to
+ * jump to the top.  We record the viewport state before `fit()` and
+ * restore it immediately after.
+ */
+function saveViewportScroll(container: HTMLElement): { scrollTop: number; atBottom: boolean } | null {
+  const viewport = container.querySelector('.xterm-viewport') as HTMLElement | null;
+  if (!viewport) return null;
+  const atBottom = viewport.scrollTop >= viewport.scrollHeight - viewport.clientHeight - 5;
+  return { scrollTop: viewport.scrollTop, atBottom };
+}
+
+function restoreViewportScroll(container: HTMLElement, saved: { scrollTop: number; atBottom: boolean } | null): void {
+  if (!saved) return;
+  const viewport = container.querySelector('.xterm-viewport') as HTMLElement | null;
+  if (!viewport) return;
+  if (saved.atBottom) {
+    // User was at the bottom — make sure we stay there after reflow
+    viewport.scrollTop = viewport.scrollHeight - viewport.clientHeight;
+  } else {
+    // User was scrolled up — restore the previous position
+    viewport.scrollTop = saved.scrollTop;
+  }
+}
+
+/**
  * Manages terminal fit/resize with focus-awareness for multi-window correctness.
  *
  * Triggers a fit + resize on:
@@ -48,7 +78,9 @@ export function useTerminalFit(
         if (!fitAddonRef.current || !terminalRef.current) return;
         const el = containerRef.current;
         if (!el || el.clientWidth === 0 || el.clientHeight === 0) return;
+        const saved = saveViewportScroll(el);
         fitAddonRef.current.fit();
+        restoreViewportScroll(el, saved);
         if (sendResize) {
           doResize(
             sessionId,
@@ -96,7 +128,14 @@ export function useTerminalFit(
     const doResize = onResize ?? window.clubhouse.pty.resize;
     requestAnimationFrame(() => {
       if (fitAddonRef.current && terminalRef.current) {
-        fitAddonRef.current.fit();
+        const el = containerRef.current;
+        if (el) {
+          const saved = saveViewportScroll(el);
+          fitAddonRef.current.fit();
+          restoreViewportScroll(el, saved);
+        } else {
+          fitAddonRef.current.fit();
+        }
         doResize(
           sessionId,
           terminalRef.current.cols,

--- a/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
@@ -25,26 +25,38 @@ function projectColor(name: string): string {
 /**
  * Create a TerminalIO adapter that routes PTY operations through the
  * annex client to a satellite machine.
+ *
+ * Accepts a ref for the satellite ID so the adapter methods always use
+ * the latest connection info without creating a new object reference.
+ * This prevents the downstream ShellTerminal from recreating its xterm
+ * instance (and resetting scroll position) on satellite reconnection.
  */
-function createRemoteTerminalIO(satelliteId: string): TerminalIO {
+function createRemoteTerminalIO(satelliteIdRef: React.RefObject<string | null>): TerminalIO {
   return {
     write(sessionId: string, data: string) {
-      window.clubhouse.annexClient.ptyInput(satelliteId, sessionId, data);
+      if (satelliteIdRef.current) {
+        window.clubhouse.annexClient.ptyInput(satelliteIdRef.current, sessionId, data);
+      }
     },
     resize(sessionId: string, cols: number, rows: number) {
-      window.clubhouse.annexClient.ptyResize(satelliteId, sessionId, cols, rows);
+      if (satelliteIdRef.current) {
+        window.clubhouse.annexClient.ptyResize(satelliteIdRef.current, sessionId, cols, rows);
+      }
     },
     getBuffer(sessionId: string): Promise<string> {
-      return window.clubhouse.annexClient.ptyGetBuffer(satelliteId, sessionId);
+      if (satelliteIdRef.current) {
+        return window.clubhouse.annexClient.ptyGetBuffer(satelliteIdRef.current, sessionId);
+      }
+      return Promise.resolve('');
     },
     onData(callback: (id: string, data: string) => void): () => void {
       return satellitePtyDataBus.on((sid, agentId, data) => {
-        if (sid === satelliteId) callback(agentId, data);
+        if (sid === satelliteIdRef.current) callback(agentId, data);
       });
     },
     onExit(callback: (id: string, exitCode: number) => void): () => void {
       return satellitePtyExitBus.on((sid, agentId, exitCode) => {
-        if (sid === satelliteId) callback(agentId, exitCode);
+        if (sid === satelliteIdRef.current) callback(agentId, exitCode);
       });
     },
   };
@@ -72,11 +84,19 @@ export function TerminalCanvasWidget({ widgetId, api, metadata, onUpdateMetadata
 
   const sessionId = `canvas-widget-terminal:${widgetId}`;
 
-  // Create remote TerminalIO if rendering in a remote context
+  // Stable ref for the satellite ID — the remote IO adapter reads through
+  // this ref so its methods always target the current satellite without
+  // changing the object identity (which would cascade into terminal recreation).
+  const satelliteIdRef = useRef<string | null>(remote.isRemote ? remote.satelliteId : null);
+  satelliteIdRef.current = remote.isRemote ? remote.satelliteId : null;
+
+  // Create remote TerminalIO if rendering in a remote context.
+  // Only recreated when isRemote flips (local <-> remote); satellite ID
+  // changes are picked up through the ref without a new object.
   const remoteIO = useMemo(() => {
-    if (!remote.isRemote || !remote.satelliteId) return undefined;
-    return createRemoteTerminalIO(remote.satelliteId);
-  }, [remote.isRemote, remote.satelliteId]);
+    if (!remote.isRemote) return undefined;
+    return createRemoteTerminalIO(satelliteIdRef);
+  }, [remote.isRemote]);
 
   // Fetch worktrees when project is selected (skip for remote — no worktree listing over annex)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix terminal viewport occasionally jumping to the top of scrollback, particularly in the canvas agent view
- Preserve viewport scroll position across `fit()` calls that trigger xterm.js buffer reflow
- Stabilize IO/PTY references to prevent unnecessary terminal destruction and recreation

## Changes
- **`useTerminalFit.ts`**: Added `saveViewportScroll` / `restoreViewportScroll` helpers that bracket every `fit()` call. When the user is scrolled up, their position is preserved; when at the bottom, they stay at the bottom after reflow.
- **`ShellTerminal.tsx`**: Decoupled the terminal creation lifecycle from the IO layer. Terminal creation now only depends on `sessionId` (not `pty`/`io`). IO event listeners (`onData`, `onExit`) are managed in a separate effect that re-subscribes when `io` changes without destroying the xterm instance. All IO call-sites read through a `ptyRef`.
- **`TerminalCanvasWidget.tsx`**: `createRemoteTerminalIO` now accepts a ref for `satelliteId` instead of a direct value. The IO adapter's object identity stays stable across satellite reconnections — only `remote.isRemote` flipping creates a new adapter.
- **`AgentTerminal.tsx`**: Zustand store selectors (`sendPtyInput`, `requestPtyBuffer`) are accessed through refs, removing them from the main `useEffect` dependency array to prevent terminal recreation if the store returns new function references.

## Test Plan
- [x] `useTerminalFit.test.ts` — 4 new tests: scroll preservation when user scrolled up, stays at bottom when already at bottom, preserves during pane focus fit, graceful when no `.xterm-viewport` exists
- [x] `ShellTerminal.test.tsx` — 3 new tests: IO prop change doesn't recreate terminal, IO listeners re-subscribe on IO change, latest IO ref used for write operations
- [x] Typecheck passes
- [x] Lint clean on changed files
- [x] All 100 tests pass across the 3 relevant test files

## Manual Validation
- Open canvas with an agent terminal card; generate scrollback; scroll up; resize the card — viewport should stay in place
- Open canvas terminal widget for a remote project; trigger satellite reconnection — terminal should not flash/reset
- Wake from sleep with a terminal open — scroll position should be preserved
- Switch between hub panes with a terminal open — scroll position should be preserved