### PR TITLE
fix: gate Upgrade to Canvas behind canvas experimental flag

### DIFF
--- a/src/renderer/plugins/builtin/hub/HubTabBar.test.tsx
+++ b/src/renderer/plugins/builtin/hub/HubTabBar.test.tsx
@@ -297,4 +297,25 @@ describe('HubTabBar', () => {
     fireEvent.click(screen.getByTestId('hub-ctx-duplicate'));
     expect(onDuplicateHub).toHaveBeenCalledWith('h1');
   });
+
+  it('shows context menu with only Duplicate when canvas is not enabled', () => {
+    const onDuplicateHub = vi.fn();
+    const hubs = [makeHub('h1', 'test-hub')];
+    render(
+      <HubTabBar
+        hubs={hubs}
+        activeHubId="h1"
+        onSelectHub={noop}
+        onAddHub={noop}
+        onRemoveHub={noop}
+        onRenameHub={noop}
+        onPopOutHub={noop}
+        onDuplicateHub={onDuplicateHub}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByTestId('hub-tab-h1'));
+    expect(screen.getByTestId('hub-tab-context-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('hub-ctx-duplicate')).toBeInTheDocument();
+    expect(screen.queryByTestId('hub-ctx-upgrade-to-canvas')).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/plugins/builtin/hub/HubTabBar.tsx
+++ b/src/renderer/plugins/builtin/hub/HubTabBar.tsx
@@ -55,7 +55,7 @@ export function HubTabBar({
       >
         +
       </button>
-      {contextMenu && onUpgradeToCanvas && onDuplicateHub && (
+      {contextMenu && onDuplicateHub && (
         <HubTabContextMenu
           x={contextMenu.x}
           y={contextMenu.y}

--- a/src/renderer/plugins/builtin/hub/HubTabContextMenu.test.tsx
+++ b/src/renderer/plugins/builtin/hub/HubTabContextMenu.test.tsx
@@ -78,4 +78,32 @@ describe('HubTabContextMenu', () => {
     expect(menu.style.left).toBe('150px');
     expect(menu.style.top).toBe('250px');
   });
+
+  it('hides Upgrade to Canvas when onUpgradeToCanvas is not provided', () => {
+    render(
+      <HubTabContextMenu
+        x={100}
+        y={200}
+        hubId="hub-1"
+        onDuplicate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('hub-ctx-upgrade-to-canvas')).not.toBeInTheDocument();
+    expect(screen.getByTestId('hub-ctx-duplicate')).toBeInTheDocument();
+  });
+
+  it('shows only Duplicate when canvas is not enabled', () => {
+    render(
+      <HubTabContextMenu
+        x={100}
+        y={200}
+        hubId="hub-1"
+        onDuplicate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('Upgrade to Canvas')).not.toBeInTheDocument();
+    expect(screen.getByText('Duplicate')).toBeInTheDocument();
+  });
 });

--- a/src/renderer/plugins/builtin/hub/HubTabContextMenu.tsx
+++ b/src/renderer/plugins/builtin/hub/HubTabContextMenu.tsx
@@ -4,7 +4,7 @@ export interface HubTabContextMenuProps {
   x: number;
   y: number;
   hubId: string;
-  onUpgradeToCanvas: (hubId: string) => void;
+  onUpgradeToCanvas?: (hubId: string) => void;
   onDuplicate: (hubId: string) => void;
   onClose: () => void;
 }
@@ -55,19 +55,23 @@ export function HubTabContextMenu({
       style={{ left: x, top: y }}
       data-testid="hub-tab-context-menu"
     >
-      <button
-        className="w-full text-left px-3 py-1.5 hover:bg-surface-1 text-ctp-text transition-colors flex items-center gap-2"
-        onClick={() => { onUpgradeToCanvas(hubId); onClose(); }}
-        data-testid="hub-ctx-upgrade-to-canvas"
-      >
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="5" y1="1" x2="5" y2="15" />
-          <line x1="1" y1="5" x2="15" y2="5" />
-        </svg>
-        Upgrade to Canvas
-      </button>
-      <div className="border-t border-surface-0 my-1" />
+      {onUpgradeToCanvas && (
+        <>
+          <button
+            className="w-full text-left px-3 py-1.5 hover:bg-surface-1 text-ctp-text transition-colors flex items-center gap-2"
+            onClick={() => { onUpgradeToCanvas(hubId); onClose(); }}
+            data-testid="hub-ctx-upgrade-to-canvas"
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2" />
+              <line x1="5" y1="1" x2="5" y2="15" />
+              <line x1="1" y1="5" x2="15" y2="5" />
+            </svg>
+            Upgrade to Canvas
+          </button>
+          <div className="border-t border-surface-0 my-1" />
+        </>
+      )}
       <button
         className="w-full text-left px-3 py-1.5 hover:bg-surface-1 text-ctp-text transition-colors flex items-center gap-2"
         onClick={() => { onDuplicate(hubId); onClose(); }}

--- a/src/renderer/plugins/builtin/hub/main.ts
+++ b/src/renderer/plugins/builtin/hub/main.ts
@@ -64,6 +64,14 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   const focusedPaneId = store((s) => s.focusedPaneId);
   const loaded = store((s) => s.loaded);
 
+  // Check if canvas experimental feature is enabled
+  const [canvasEnabled, setCanvasEnabled] = useState(false);
+  useEffect(() => {
+    window.clubhouse.app.getExperimentalSettings().then((s) => {
+      setCanvasEnabled(!!s.canvas);
+    }).catch(() => {});
+  }, []);
+
   // Dynamic title: show active hub name
   const activeHub = hubs.find((h) => h.id === activeHubId);
   useEffect(() => {
@@ -298,7 +306,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       onRemoveHub: handleRemoveHub,
       onRenameHub: handleRenameHub,
       onPopOutHub: handlePopOutHub,
-      onUpgradeToCanvas: handleUpgradeToCanvas,
+      onUpgradeToCanvas: canvasEnabled ? handleUpgradeToCanvas : undefined,
       onDuplicateHub: handleDuplicateHub,
     }),
     hubPopout


### PR DESCRIPTION
## Summary
- "Upgrade to Canvas" in the hub tab context menu now only appears when the canvas experimental feature is enabled
- "Duplicate" always appears regardless of canvas feature flag

## Changes
- **`HubTabContextMenu.tsx`** — `onUpgradeToCanvas` is now optional; the menu item and separator only render when provided
- **`HubTabBar.tsx`** — Context menu renders when `onDuplicateHub` is provided (no longer requires `onUpgradeToCanvas`)
- **`main.ts`** (hub) — Fetches `window.clubhouse.app.getExperimentalSettings()` on mount; only passes `onUpgradeToCanvas` when `canvas` flag is true

## Test Plan
- [x] Context menu shows only Duplicate when canvas is disabled (new test)
- [x] Context menu shows both options when canvas is enabled (existing tests)
- [x] HubTabContextMenu hides upgrade option when `onUpgradeToCanvas` not provided (2 new tests)
- [x] All 8880 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)