### PR TITLE
fix: persist hub-to-canvas conversion across plugin boundaries

### DIFF
--- a/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
@@ -107,6 +107,112 @@ describe('canvas-store', () => {
     expect(store.getState().viewport).toEqual({ panX: 10, panY: 20, zoom: 0.8 });
   });
 
+  // ── loadAndInsertCanvas ──────────────────────────────────────
+
+  it('loadAndInsertCanvas loads existing data then inserts', async () => {
+    // Pre-populate storage with an existing canvas
+    const existingCanvas = {
+      id: 'existing-1',
+      name: 'Existing',
+      views: [],
+      viewport: { panX: 0, panY: 0, zoom: 1 },
+      nextZIndex: 0,
+    };
+    const storage = createMockStorage({
+      'canvas-instances': [existingCanvas],
+      'canvas-active-id': 'existing-1',
+    });
+
+    const newCanvas = {
+      id: 'new-from-hub',
+      name: 'From Hub',
+      views: [],
+      viewport: { panX: 0, panY: 0, zoom: 1 },
+      nextZIndex: 0,
+      zoomedViewId: null,
+      selectedViewId: null,
+    };
+
+    await store.getState().loadAndInsertCanvas(newCanvas, storage);
+
+    // Should have both the existing canvas and the new one
+    expect(store.getState().canvases).toHaveLength(2);
+    expect(store.getState().canvases.map((c) => c.id)).toContain('existing-1');
+    expect(store.getState().canvases.map((c) => c.id)).toContain('new-from-hub');
+    // New canvas should be active
+    expect(store.getState().activeCanvasId).toBe('new-from-hub');
+    expect(store.getState().loaded).toBe(true);
+  });
+
+  it('loadAndInsertCanvas persists to storage immediately', async () => {
+    const storage = createMockStorage();
+    await store.getState().loadCanvas(storage);
+
+    const newCanvas = {
+      id: 'persisted-canvas',
+      name: 'Persisted',
+      views: [],
+      viewport: { panX: 5, panY: 10, zoom: 0.8 },
+      nextZIndex: 0,
+      zoomedViewId: null,
+      selectedViewId: null,
+    };
+
+    await store.getState().loadAndInsertCanvas(newCanvas, storage);
+
+    // Verify data was written to storage
+    const saved = await storage.read('canvas-instances') as any[];
+    expect(saved.map((c: any) => c.id)).toContain('persisted-canvas');
+    const savedActive = await storage.read('canvas-active-id');
+    expect(savedActive).toBe('persisted-canvas');
+  });
+
+  it('loadAndInsertCanvas skips load if already loaded', async () => {
+    const storage = createMockStorage();
+    await store.getState().loadCanvas(storage);
+    const initialCount = store.getState().canvases.length;
+
+    const newCanvas = {
+      id: 'after-load',
+      name: 'After Load',
+      views: [],
+      viewport: { panX: 0, panY: 0, zoom: 1 },
+      nextZIndex: 0,
+      zoomedViewId: null,
+      selectedViewId: null,
+    };
+
+    await store.getState().loadAndInsertCanvas(newCanvas, storage);
+
+    // Should have initial canvas + new one (didn't double-load)
+    expect(store.getState().canvases).toHaveLength(initialCount + 1);
+    expect(store.getState().activeCanvasId).toBe('after-load');
+  });
+
+  it('loadAndInsertCanvas survives re-load from storage', async () => {
+    const storage = createMockStorage();
+
+    const newCanvas = {
+      id: 'survive-reload',
+      name: 'Survives',
+      views: [],
+      viewport: { panX: 0, panY: 0, zoom: 1 },
+      nextZIndex: 0,
+      zoomedViewId: null,
+      selectedViewId: null,
+    };
+
+    // Insert (which also saves)
+    await store.getState().loadAndInsertCanvas(newCanvas, storage);
+
+    // Simulate canvas plugin re-mounting: create new store and load from same storage
+    const store2 = createCanvasStore();
+    await store2.getState().loadCanvas(storage);
+
+    // The new canvas should still be there
+    expect(store2.getState().canvases.map((c) => c.id)).toContain('survive-reload');
+  });
+
   it('removes a canvas', () => {
     const id = store.getState().addCanvas();
     expect(store.getState().canvases).toHaveLength(2);

--- a/src/renderer/plugins/builtin/canvas/canvas-store.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.ts
@@ -37,6 +37,8 @@ export interface CanvasState {
   // Canvas tab management
   addCanvas: () => string;
   insertCanvas: (canvas: CanvasInstance) => void;
+  /** Load existing canvases from storage (if not loaded), insert a new canvas, and persist immediately. */
+  loadAndInsertCanvas: (canvas: CanvasInstance, storage: ScopedStorage) => Promise<void>;
   removeCanvas: (canvasId: string) => void;
   renameCanvas: (canvasId: string, name: string) => void;
   setActiveCanvas: (canvasId: string) => void;
@@ -321,6 +323,18 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
     insertCanvas: (canvas) => {
       const canvases = [...get().canvases, canvas];
       set({ canvases, activeCanvasId: canvas.id, ...syncDerivedState(canvases, canvas.id) });
+    },
+
+    loadAndInsertCanvas: async (canvas, storage) => {
+      // Ensure existing canvases are loaded from disk first
+      if (!get().loaded) {
+        await get().loadCanvas(storage);
+      }
+      // Insert the new canvas
+      const canvases = [...get().canvases, canvas];
+      set({ canvases, activeCanvasId: canvas.id, loaded: true, ...syncDerivedState(canvases, canvas.id) });
+      // Persist immediately so the canvas survives re-mounts
+      await get().saveCanvas(storage);
     },
 
     removeCanvas: (canvasId) => {

--- a/src/renderer/plugins/builtin/hub/main.ts
+++ b/src/renderer/plugins/builtin/hub/main.ts
@@ -15,6 +15,7 @@ import { isRemoteAgentId } from '../../../stores/remoteProjectStore';
 import { UpgradeToCanvasDialog } from './UpgradeToCanvasDialog';
 import { convertHubToCanvas } from './hub-to-canvas';
 import { useAppCanvasStore, getProjectCanvasStore } from '../canvas/main';
+import { createScopedStorage } from '../../plugin-api-storage';
 
 const PANE_PREFIX = 'hub';
 
@@ -223,8 +224,15 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   const upgradeHub = upgradeHubId ? hubs.find((h) => h.id === upgradeHubId) : null;
 
   const canvasStore = isAppMode ? useAppCanvasStore : getProjectCanvasStore(api.context.projectId ?? null);
+  // Build a canvas-scoped storage handle so we can persist across plugin boundaries
+  const canvasStorage = useMemo(() =>
+    isAppMode
+      ? createScopedStorage('canvas', 'global')
+      : createScopedStorage('canvas', 'project-local', api.context.projectPath),
+    [isAppMode, api.context.projectPath],
+  );
 
-  const performUpgrade = useCallback((deleteOriginal: boolean) => {
+  const performUpgrade = useCallback(async (deleteOriginal: boolean) => {
     if (!upgradeHub) return;
 
     const canvasInstance = convertHubToCanvas({
@@ -237,14 +245,14 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       containerHeight: window.innerHeight,
     });
 
-    canvasStore.getState().insertCanvas(canvasInstance);
+    await canvasStore.getState().loadAndInsertCanvas(canvasInstance, canvasStorage);
 
     if (deleteOriginal) {
       store.getState().removeHub(upgradeHub.id, PANE_PREFIX);
     }
 
     setUpgradeHubId(null);
-  }, [upgradeHub, canvasStore, store]);
+  }, [upgradeHub, canvasStore, canvasStorage, store]);
 
   const handleUpgradeToCanvas = useCallback((hubId: string) => {
     setUpgradeHubId(hubId);


### PR DESCRIPTION
## Summary
- Fix hub-to-canvas upgrade not producing a visible canvas tab
- Root cause: canvas was inserted into zustand store but never persisted to disk; when canvas MainPanel mounted it loaded stale data from storage, overwriting the inserted canvas

## Changes
- **`canvas-store.ts`** — Added `loadAndInsertCanvas(canvas, storage)` method that: loads existing canvases from disk if not already loaded, inserts the new canvas, and saves immediately
- **`hub/main.ts`** — Creates a canvas-scoped storage handle via `createScopedStorage('canvas', ...)` and calls `loadAndInsertCanvas` instead of `insertCanvas`
- **`canvas-store.test.ts`** — 4 new tests: loads existing data then inserts, persists to storage immediately, skips load if already loaded, survives re-load from storage

## Root Cause
The hub and canvas are separate plugins with independent lifecycles. When the user upgrades a hub:
1. Hub calls `canvasStore.insertCanvas()` — updates in-memory zustand store
2. Canvas MainPanel is NOT mounted (user is viewing hub), so no auto-save effect fires
3. When user switches to canvas tab, MainPanel mounts and calls `loadCanvas(storage)` which reads from **disk** and **overwrites** the in-memory state
4. The inserted canvas was never saved to disk, so it's lost

## Test Plan
- [x] `loadAndInsertCanvas` loads existing data from storage before inserting (preserves existing canvases)
- [x] `loadAndInsertCanvas` persists to storage immediately (survives re-mount)
- [x] `loadAndInsertCanvas` skips redundant load if store already loaded
- [x] Inserted canvas survives a fresh store re-loading from same storage
- [x] All 8866 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)