### PR TITLE
fix: resolve all pre-existing lint errors and warnings

### DIFF
--- a/e2e/annex-v2/error-handling.spec.ts
+++ b/e2e/annex-v2/error-handling.spec.ts
@@ -4,7 +4,6 @@
  * Adversarial/negative tests: wrong PIN, invalid token, rapid connect/disconnect.
  */
 import { test, expect } from '@playwright/test';
-import WebSocket from 'ws';
 import { launchDual, cleanupDual, type DualInstanceHandles } from './dual-launch';
 import {
   enableAnnexViaPreload,

--- a/e2e/annex-v2/helpers.ts
+++ b/e2e/annex-v2/helpers.ts
@@ -7,8 +7,6 @@
 import type { Page } from '@playwright/test';
 import WebSocket from 'ws';
 
-type ElectronApp = Awaited<ReturnType<typeof import('@playwright/test')._electron.launch>>;
-
 // ---------------------------------------------------------------------------
 // UI helpers
 // ---------------------------------------------------------------------------

--- a/e2e/annex-v2/lifecycle.spec.ts
+++ b/e2e/annex-v2/lifecycle.spec.ts
@@ -15,7 +15,6 @@ import {
   connectWsPlain,
   waitForOpen,
   waitForMessage,
-  collectPtyData,
 } from './helpers';
 
 /** Connect with bearer token (tries wss, falls back to ws). */

--- a/e2e/annex-v2/minimal-test.spec.ts
+++ b/e2e/annex-v2/minimal-test.spec.ts
@@ -177,10 +177,6 @@ test('annex experimental flag can be toggled', async () => {
   // The nav button visibility in settings is gated behind isBetaBuild() +
   // an async useEffect, which is already exercised by full-demo.spec.ts.
   // Here we just verify the flag round-trips correctly.
-  const before = await window.evaluate(async () => {
-    return (window as any).clubhouse.app.getExperimentalSettings();
-  });
-
   await window.evaluate(async () => {
     const w = window as any;
     const s = await w.clubhouse.app.getExperimentalSettings();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clubhouse",
-  "version": "0.38.0-beta.16",
+  "version": "0.38.0-beta.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clubhouse",
-      "version": "0.38.0-beta.16",
+      "version": "0.38.0-beta.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, Menu, BrowserWindow } from 'electron';
+import { app, Menu, BrowserWindow } from 'electron';
 import { IPC } from '../shared/ipc-channels';
 
 export function buildMenu(): void {

--- a/src/main/orchestrators/codex-cli-provider.ts
+++ b/src/main/orchestrators/codex-cli-provider.ts
@@ -13,7 +13,6 @@ import {
   StructuredCapable,
 } from './types';
 import type { McpServerDef } from '../../shared/types';
-import { mcpServerToToml } from '../services/toml-utils';
 import { BaseProvider } from './base-provider';
 import { CodexAppServerAdapter } from './adapters';
 import { homePath, parseModelChoicesFromHelp } from './shared';

--- a/src/main/services/annex-client.test.ts
+++ b/src/main/services/annex-client.test.ts
@@ -833,9 +833,7 @@ describe('annex-client', () => {
       });
 
       // Mock WebSocket instance to have OPEN state but throw on send
-      let wsInstance: any = null;
       vi.mocked(WsMock).mockImplementation(function (this: any) {
-        wsInstance = this;
         this.readyState = 1; // WebSocket.OPEN
         this.on = vi.fn().mockImplementation((event: string, cb: any) => {
           if (event === 'open') setTimeout(cb, 0);
@@ -1002,6 +1000,7 @@ describe('annex-client', () => {
       let wsInstance: any = null;
 
       vi.mocked(WsMock).mockImplementation(function (this: any) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
         wsInstance = this;
         this.readyState = 1;
         this.on = vi.fn().mockImplementation((event: string, cb: any) => {

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -1724,7 +1724,7 @@ async function handleSpawnQuickAgentWs(
       parentAgentId, projectId: project.id, headless: true,
     });
     ws.send(JSON.stringify({ type: 'agent:spawn:ack', payload: { id: agentId, name, status: 'starting' } }));
-  } catch (err) {
+  } catch {
     tracked.status = 'failed';
     trackedQuickAgents.delete(agentId);
     ws.send(JSON.stringify({ type: 'error', payload: { message: 'spawn_failed' } }));
@@ -1761,7 +1761,7 @@ async function handleWakeAgentWs(
     broadcastAndBuffer('agent:woken', { agentId: config.id, source: 'annex-v2' });
     broadcastSnapshotRefresh();
     ws.send(JSON.stringify({ type: 'agent:wake:ack', payload: { agentId: config.id, status: 'starting' } }));
-  } catch (err) {
+  } catch {
     ws.send(JSON.stringify({ type: 'error', payload: { message: 'wake_failed' } }));
   }
 }
@@ -2163,7 +2163,7 @@ async function applyCanvasMutationServerSide(
     ? (raw as CanvasInstanceJSON[])
     : [{ id: canvasId, name: 'Canvas', views: [], viewport: { panX: 0, panY: 0, zoom: 1 }, nextZIndex: 0, zoomedViewId: null }];
 
-  let activeIdRaw = await readPluginStorageKey({
+  const activeIdRaw = await readPluginStorageKey({
     pluginId: 'canvas',
     scope: 'project-local',
     key: 'canvas-active-id',

--- a/src/main/services/clubhouse-mcp/bridge-server.test.ts
+++ b/src/main/services/clubhouse-mcp/bridge-server.test.ts
@@ -28,7 +28,6 @@ vi.mock('../log-service', () => ({
 import * as bridgeServer from './bridge-server';
 import { bindingManager } from './binding-manager';
 import { registerToolTemplate, buildToolName, _resetForTesting as resetTools } from './tool-registry';
-import type { McpBinding } from './types';
 
 function makeRequest(port: number, method: string, path: string, body?: unknown, nonce?: string, rawBody?: string): Promise<{ statusCode: number; body: any }> {
   return new Promise((resolve, reject) => {

--- a/src/main/services/clubhouse-mcp/tool-registry.test.ts
+++ b/src/main/services/clubhouse-mcp/tool-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerToolTemplate, getScopedToolList, callTool, buildToolName, buildToolKey, parseToolName, sanitizeId, shortHash, _resetForTesting } from './tool-registry';
+import { registerToolTemplate, getScopedToolList, callTool, buildToolName, buildToolKey, parseToolName, shortHash, _resetForTesting } from './tool-registry';
 import { bindingManager } from './binding-manager';
 import { agentRegistry } from '../agent-registry';
 import type { McpBinding } from './types';

--- a/src/main/services/toml-utils.ts
+++ b/src/main/services/toml-utils.ts
@@ -91,22 +91,6 @@ export function jsonMcpToToml(jsonStr: string): string | null {
 // ── TOML section management ─────────────────────────────────────────────────
 
 /**
- * Pattern that matches a `[mcp_servers.<name>]` section header and all
- * subsequent lines up to the next top-level section header or EOF.
- * Also matches sub-sections like `[mcp_servers.<name>.env]`.
- */
-function mcpServerSectionPattern(name: string): RegExp {
-  // Escape dots and other regex-special chars in the name
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  // Match [mcp_servers.<name>] or [mcp_servers.<name>.<sub>] headers
-  // and all lines until the next top-level section (not a sub-section of this server)
-  return new RegExp(
-    `(?:^|\\n)(\\[mcp_servers\\.${escaped}(?:\\.[^\\]]*)?\\](?:[^\\[]|\\[(?!(?:[a-z_]|mcp_servers\\.(?!${escaped}(?:\\.|\\])))))*?)(?=\\n\\[(?!mcp_servers\\.${escaped})|$)`,
-    'g',
-  );
-}
-
-/**
  * Remove all `[mcp_servers.<name>]` sections (and sub-sections) from a TOML string.
  */
 export function stripMcpServerSection(toml: string, serverName: string): string {

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -14,7 +14,7 @@ import { WireConfigPopover } from './WireConfigPopover';
 import { useWiring } from './useWiring';
 import { useMcpBindingStore, type McpBindingEntry } from '../../../stores/mcpBindingStore';
 import { useMcpSettingsStore } from '../../../stores/mcpSettingsStore';
-import type { AgentCanvasView as AgentCanvasViewType, PluginCanvasView as PluginCanvasViewType } from './canvas-types';
+import type { PluginCanvasView as PluginCanvasViewType } from './canvas-types';
 import type { PluginAPI, CanvasWidgetMetadata } from '../../../../shared/plugin-types';
 import { getRegisteredWidgetType } from '../../canvas-widget-registry';
 

--- a/src/renderer/plugins/builtin/canvas/canvas-zoom-mouse-adjust.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-zoom-mouse-adjust.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { CanvasViewComponent } from './CanvasView';
 import type { CanvasView } from './canvas-types';
 import type { PluginAPI } from '../../../../shared/plugin-types';

--- a/src/renderer/plugins/builtin/canvas/lifecycle-cleanup.test.ts
+++ b/src/renderer/plugins/builtin/canvas/lifecycle-cleanup.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { findBindingsForView } from './main';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
-import type { AgentCanvasView, PluginCanvasView, CanvasView } from './canvas-types';
+import type { AgentCanvasView, PluginCanvasView } from './canvas-types';
 
 function makeAgentView(id: string, agentId: string): AgentCanvasView {
   return {

--- a/src/renderer/plugins/builtin/review/main.ts
+++ b/src/renderer/plugins/builtin/review/main.ts
@@ -314,7 +314,6 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       map.set(a.id, api.agents.getDetailedStatus(a.id));
     }
     return map;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, allAgents, agentTick]);
 
   const agents = useMemo(() => {

--- a/src/renderer/plugins/plugin-api-agents.ts
+++ b/src/renderer/plugins/plugin-api-agents.ts
@@ -14,7 +14,7 @@ import { useAgentStore } from '../stores/agentStore';
 import { useProjectStore } from '../stores/projectStore';
 import { useQuickAgentStore } from '../stores/quickAgentStore';
 import { useOrchestratorStore } from '../stores/orchestratorStore';
-import { useRemoteProjectStore, isRemoteProjectId, parseNamespacedId } from '../stores/remoteProjectStore';
+import { useRemoteProjectStore, parseNamespacedId } from '../stores/remoteProjectStore';
 import { useAnnexClientStore } from '../stores/annexClientStore';
 
 export function createAgentsAPI(ctx: PluginContext, manifest?: PluginManifest): AgentsAPI {

--- a/src/renderer/plugins/plugin-api-badges.ts
+++ b/src/renderer/plugins/plugin-api-badges.ts
@@ -5,7 +5,6 @@ let _badgeStoreCache: any = null;
 function getBadgeStore() {
   if (_badgeStoreCache) return _badgeStoreCache;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     _badgeStoreCache = require('../stores/badgeStore').useBadgeStore;
   } catch {
     // Test environment — return a no-op store

--- a/src/renderer/plugins/plugin-api-terminal.ts
+++ b/src/renderer/plugins/plugin-api-terminal.ts
@@ -49,7 +49,6 @@ export function createTerminalAPI(ctx: PluginContext): TerminalAPI {
   let ShellTerminalComponent: React.ComponentType<any> | null = null;
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     ShellTerminalComponent = require('../features/terminal/ShellTerminal').ShellTerminal;
   } catch {
     // Test environment — return stub

--- a/src/renderer/plugins/plugin-api-theme.ts
+++ b/src/renderer/plugins/plugin-api-theme.ts
@@ -2,7 +2,6 @@ import type { PluginContext, ThemeAPI, ThemeInfo, Disposable } from '../../share
 
 export function buildThemeInfo(): ThemeInfo {
   // Lazy import to avoid circular deps — only needed when a plugin uses the theme API
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { useThemeStore } = require('../stores/themeStore');
   const state = useThemeStore.getState();
   const theme = state.theme;
@@ -28,7 +27,6 @@ export function createThemeAPI(ctx: PluginContext): ThemeAPI {
       return buildThemeInfo();
     },
     onDidChange(callback: (theme: ThemeInfo) => void): Disposable {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { useThemeStore } = require('../stores/themeStore');
       let prevId = useThemeStore.getState().themeId;
       const unsub = useThemeStore.subscribe((state: { themeId: string; experimentalGradients: boolean; theme: { id: string; name: string; type: 'dark' | 'light'; colors: Record<string, string>; hljs: Record<string, string>; terminal: Record<string, string>; fonts?: { ui?: string; mono?: string }; gradients?: { background?: string; surface?: string; accent?: string } } }) => {

--- a/src/renderer/plugins/plugin-api-ui.ts
+++ b/src/renderer/plugins/plugin-api-ui.ts
@@ -125,14 +125,12 @@ export function createNavigationAPI(): NavigationAPI {
     },
     toggleSidebar(): void {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { usePanelStore } = require('../stores/panelStore');
         usePanelStore.getState().toggleExplorerCollapse();
       } catch { /* ignore in test */ }
     },
     toggleAccessoryPanel(): void {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { usePanelStore } = require('../stores/panelStore');
         usePanelStore.getState().toggleAccessoryCollapse();
       } catch { /* ignore in test */ }
@@ -160,15 +158,10 @@ export function createWidgetsAPI(): WidgetsAPI {
   let AgentAvatarWithRingComponent: React.ComponentType<any>;
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     AgentTerminalComponent = require('../features/agents/AgentTerminal').AgentTerminal;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     SleepingAgentComponent = require('../features/agents/SleepingAgent').SleepingAgent;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     AgentAvatarComponent = require('../features/agents/AgentAvatar').AgentAvatar;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     AgentAvatarWithRingComponent = require('../features/agents/AgentAvatar').AgentAvatarWithRing;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     QuickAgentGhostComponent = require('../features/agents/QuickAgentGhost').QuickAgentGhost;
   } catch {
     // In test environments, return stub components

--- a/src/renderer/services/resume-queue.ts
+++ b/src/renderer/services/resume-queue.ts
@@ -4,8 +4,6 @@ import type { Agent } from '../../shared/types';
 import type { RestartSessionEntry, RestartSessionState } from '../../shared/types';
 import type { ResumeStatus } from '../features/app/ResumeBanner';
 
-const RESUME_TIMEOUT_MS = 60_000;
-
 /**
  * Process pending resume entries after an update restart.
  * Sequential per workspace, parallel across workspaces.

--- a/test/annex-v2/protocol-client.test.ts
+++ b/test/annex-v2/protocol-client.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AnnexProtocolClient } from '../../e2e/annex-v2/protocol-client';
 import * as http from 'http';
-import { WebSocketServer, WebSocket } from 'ws';
+import { WebSocketServer } from 'ws';
 import { randomInt, randomUUID } from 'crypto';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove all 21 lint errors and 12 lint warnings that existed on main
- Fixes are minimal: unused imports/variables removed, stale eslint-disable directives cleaned up, prefer-const applied

## Changes
- **Unused imports removed**: `WebSocket`, `ElectronApp`, `collectPtyData`, `ipcMain`, `mcpServerToToml`, `McpBinding`, `sanitizeId`, `AgentCanvasViewType`, `act`, `CanvasView`, `isRemoteProjectId`, `WebSocket` (test)
- **Unused variables removed**: `before` (minimal-test), `wsInstance` (annex-client.test first occurrence), `RESUME_TIMEOUT_MS` (resume-queue)
- **Unused function removed**: `mcpServerSectionPattern` (toml-utils) — superseded by inline approach in `stripMcpServerSection`
- **Unused `err` params**: changed `catch (err)` → `catch` in annex-server.ts (2 occurrences)
- **`prefer-const`**: `let activeIdRaw` → `const activeIdRaw` in annex-server.ts
- **Stale eslint-disable directives**: removed 12 `@typescript-eslint/no-require-imports` disables and 1 `react-hooks/exhaustive-deps` disable (rule not loaded in .ts context)
- **Suppressed unavoidable `no-this-alias`**: added inline disable in annex-client.test.ts where mock constructor requires `this` capture

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 368 files, 8871 tests all passing
- [x] `npm run lint` — 0 errors, 0 warnings

## Manual Validation
No manual validation needed — all changes are mechanical removal of dead code and stale lint directives.