### PR TITLE
fix: sanitize plugin icon SVGs with DOMPurify (SEC-07)

### DIFF
--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -7,6 +7,7 @@ import { useBadgeStore, aggregateBadges } from '../stores/badgeStore';
 import { useBadgeSettingsStore } from '../stores/badgeSettingsStore';
 import { Badge } from '../components/Badge';
 import { AGENT_COLORS } from '../../shared/name-generator';
+import { sanitizeSvg } from '../utils/sanitize-svg';
 
 const EMPTY_STRING_ARRAY: string[] = [];
 
@@ -228,7 +229,7 @@ export function ExplorerRail() {
             id: `plugin:${p.id}`,
             label: contributes.tab.label,
             icon: contributes.tab.icon
-              ? <span className={isAvailable ? '' : 'opacity-60'} dangerouslySetInnerHTML={{ __html: contributes.tab.icon }} />
+              ? <span className={isAvailable ? '' : 'opacity-60'} dangerouslySetInnerHTML={{ __html: sanitizeSvg(contributes.tab.icon) }} />
               : <span className={isAvailable ? '' : 'opacity-60'}>{PLUGIN_FALLBACK_ICON}</span>,
             disabled: isMissing,
             disabledReason: p.status === 'missing'
@@ -248,7 +249,7 @@ export function ExplorerRail() {
         id: `plugin:${entry.manifest.id}`,
         label: entry.manifest.contributes!.tab!.label,
         icon: entry.manifest.contributes!.tab!.icon
-          ? <span dangerouslySetInnerHTML={{ __html: entry.manifest.contributes!.tab!.icon }} />
+          ? <span dangerouslySetInnerHTML={{ __html: sanitizeSvg(entry.manifest.contributes!.tab!.icon) }} />
           : PLUGIN_FALLBACK_ICON,
       }));
   }, [pluginTabKey]);

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -12,6 +12,7 @@ import { Badge } from '../components/Badge';
 import { Project } from '../../shared/types';
 import { PluginRegistryEntry } from '../../shared/plugin-types';
 import { AGENT_COLORS } from '../../shared/name-generator';
+import { sanitizeSvg } from '../utils/sanitize-svg';
 
 /** Renders satellite sections (connected first, then offline, both alphabetical). */
 function SatelliteSections({ activeProjectId, expanded, onSelectProject }: {
@@ -241,7 +242,7 @@ function PluginRailButton({ entry, isActive, onClick, expanded }: {
           `}
         >
           {customIcon ? (
-            <span dangerouslySetInnerHTML={{ __html: customIcon }} />
+            <span dangerouslySetInnerHTML={{ __html: sanitizeSvg(customIcon) }} />
           ) : (
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />

--- a/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../canvas-widget-registry';
 import { MenuPortal } from './MenuPortal';
 import { useDismissibleLayer } from './useDismissibleLayer';
+import { sanitizeSvg } from '../../../utils/sanitize-svg';
 
 /** A menu item can either be a built-in view type or a qualified plugin widget type string. */
 export type ContextMenuSelection =
@@ -72,7 +73,7 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
             onClick={(e) => { e.stopPropagation(); handleBuiltinSelect(type); }}
             data-testid={`canvas-context-menu-${type}`}
           >
-            <span className="w-4 text-center text-ctp-overlay0" dangerouslySetInnerHTML={{ __html: icon }} />
+            <span className="w-4 text-center text-ctp-overlay0" dangerouslySetInnerHTML={{ __html: sanitizeSvg(icon) }} />
             {label}
           </button>
         ))}
@@ -90,7 +91,7 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
               >
                 <span className="w-4 text-center text-ctp-overlay0">
                   {widget.declaration.icon
-                    ? <span dangerouslySetInnerHTML={{ __html: widget.declaration.icon }} />
+                    ? <span dangerouslySetInnerHTML={{ __html: sanitizeSvg(widget.declaration.icon) }} />
                     : '+'}
                 </span>
                 Add {widget.declaration.label}

--- a/src/renderer/utils/sanitize-svg.test.ts
+++ b/src/renderer/utils/sanitize-svg.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeSvg } from './sanitize-svg';
+
+describe('sanitizeSvg', () => {
+  it('passes through safe SVG markup', () => {
+    const svg = '<svg width="16" height="16" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>';
+    const result = sanitizeSvg(svg);
+    expect(result).toContain('<svg');
+    expect(result).toContain('circle');
+    expect(result).toContain('viewBox="0 0 24 24"');
+  });
+
+  it('strips script tags from SVG', () => {
+    const malicious = '<svg><script>alert("xss")</script><circle cx="12" cy="12" r="10"/></svg>';
+    const result = sanitizeSvg(malicious);
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('alert');
+    expect(result).toContain('<circle');
+  });
+
+  it('strips onload event handler attributes', () => {
+    const malicious = '<svg onload="alert(1)"><circle cx="12" cy="12" r="10"/></svg>';
+    const result = sanitizeSvg(malicious);
+    expect(result).not.toContain('onload');
+    expect(result).not.toContain('alert');
+  });
+
+  it('strips onerror event handler attributes', () => {
+    const malicious = '<svg><image href="x" onerror="alert(1)"/></svg>';
+    const result = sanitizeSvg(malicious);
+    expect(result).not.toContain('onerror');
+    expect(result).not.toContain('alert');
+  });
+
+  it('strips onclick event handler attributes', () => {
+    const malicious = '<svg onclick="alert(1)"><rect width="10" height="10"/></svg>';
+    const result = sanitizeSvg(malicious);
+    expect(result).not.toContain('onclick');
+  });
+
+  it('strips style tags', () => {
+    const malicious = '<svg><style>body{background:red}</style><circle cx="12" cy="12" r="10"/></svg>';
+    const result = sanitizeSvg(malicious);
+    expect(result).not.toContain('<style');
+    expect(result).toContain('<circle');
+  });
+
+  it('preserves SVG attributes like fill, stroke, viewBox', () => {
+    const svg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 22h20z"/></svg>';
+    const result = sanitizeSvg(svg);
+    expect(result).toContain('viewBox');
+    expect(result).toContain('fill');
+    expect(result).toContain('stroke');
+  });
+
+  it('strips javascript: URLs in href', () => {
+    const malicious = '<svg><a href="javascript:alert(1)"><circle cx="12" cy="12" r="10"/></a></svg>';
+    const result = sanitizeSvg(malicious);
+    expect(result).not.toContain('javascript:');
+  });
+});

--- a/src/renderer/utils/sanitize-svg.ts
+++ b/src/renderer/utils/sanitize-svg.ts
@@ -1,0 +1,13 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitize an SVG string for safe use with dangerouslySetInnerHTML.
+ * Strips script-bearing elements and event handler attributes (onload, onerror, etc.).
+ */
+export function sanitizeSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    FORBID_TAGS: ['script', 'style'],
+    FORBID_ATTR: ['onload', 'onerror', 'onclick', 'onmouseover', 'onfocus', 'onblur', 'onanimationend'],
+  });
+}


### PR DESCRIPTION
## Summary
- Fix XSS vulnerability where plugin manifest `icon` fields were rendered via `dangerouslySetInnerHTML` without sanitization
- Malicious community plugins could inject JavaScript via SVG event handlers (`onload`, `onerror`, etc.)
- Corroborated by 4/8 independent code review agents — P0 HIGH priority

## Changes
- **New utility**: `src/renderer/utils/sanitize-svg.ts` — wraps `DOMPurify.sanitize()` with SVG-specific config (allows SVG tags/filters, forbids script/style tags and event handler attributes)
- **ProjectRail.tsx**: sanitize `customIcon` before rendering (line 245)
- **ExplorerRail.tsx**: sanitize `contributes.tab.icon` at both rendering sites (lines 232, 252)
- **CanvasContextMenu.tsx**: sanitize built-in icon and plugin widget icon (lines 76, 94)
- **New tests**: `sanitize-svg.test.ts` — 8 test cases covering script injection, event handlers, style tags, javascript: URLs, and safe SVG passthrough

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 369 files, 8879 tests all passing (8 new)
- [x] `npm run lint` — clean

## Manual Validation
- Install a plugin with an icon containing `<svg onload="alert(1)">` — should render SVG without executing script
- Existing plugin icons should render normally (sanitizer preserves safe SVG attributes)