### PR TITLE
fix: gate dev-only IPC channel behind NODE_ENV check (SEC-14)

### DIFF
--- a/src/main/dev-ipc-guard.test.ts
+++ b/src/main/dev-ipc-guard.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * These tests validate the dev-only IPC guard pattern used in the preload.
+ * The actual preload code gates devSimulateUpdateRestart behind NODE_ENV === 'development'.
+ * We test the guard logic in isolation since the preload module requires Electron runtime.
+ */
+
+function isDevOnlyAllowed(): boolean {
+  return process.env.NODE_ENV === 'development';
+}
+
+describe('dev-only IPC guard', () => {
+  it('allows dev-only APIs in development mode', () => {
+    const originalEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = 'development';
+      expect(isDevOnlyAllowed()).toBe(true);
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it('blocks dev-only APIs in production mode', () => {
+    const originalEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = 'production';
+      expect(isDevOnlyAllowed()).toBe(false);
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it('blocks dev-only APIs when NODE_ENV is undefined', () => {
+    const originalEnv = process.env.NODE_ENV;
+    try {
+      delete process.env.NODE_ENV;
+      expect(isDevOnlyAllowed()).toBe(false);
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+});

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -661,9 +661,12 @@ const api = {
       ipcRenderer.invoke(IPC.APP.RESOLVE_WORKING_AGENT, agentId, action),
     confirmUpdateRestart: (data: { agentNames: Record<string, string>; agentMeta?: Record<string, unknown> }) =>
       ipcRenderer.invoke(IPC.APP.CONFIRM_UPDATE_RESTART, data),
-    devSimulateUpdateRestart: (data: { agentNames: Record<string, string>; agentMeta?: Record<string, unknown> }) =>
-      ipcRenderer.invoke(IPC.APP.DEV_SIMULATE_UPDATE_RESTART, data),
+    devSimulateUpdateRestart: (data: { agentNames: Record<string, string>; agentMeta?: Record<string, unknown> }) => {
+      if (process.env.NODE_ENV !== 'development') return Promise.reject(new Error('dev-only API'));
+      return ipcRenderer.invoke(IPC.APP.DEV_SIMULATE_UPDATE_RESTART, data);
+    },
     onDevSimulateUpdateRestart: (callback: () => void) => {
+      if (process.env.NODE_ENV !== 'development') return () => {};
       const listener = () => callback();
       ipcRenderer.on(IPC.APP.DEV_SIMULATE_UPDATE_RESTART, listener);
       return () => { ipcRenderer.removeListener(IPC.APP.DEV_SIMULATE_UPDATE_RESTART, listener); };


### PR DESCRIPTION
## Summary
- Fix `DEV_SIMULATE_UPDATE_RESTART` IPC channel exposed to renderer in production builds
- The main process handler was already guarded (`!app.isPackaged`), but the preload API surface was not
- Reported by 1/8 code review agents — P0 HIGH priority

## Changes
- **`src/preload/index.ts`**: Gate `devSimulateUpdateRestart` and `onDevSimulateUpdateRestart` behind `process.env.NODE_ENV === 'development'`
  - In production: invoke rejects with `Error('dev-only API')`, listener returns no-op cleanup
- **`src/main/dev-ipc-guard.test.ts`**: 3 test cases validating the guard pattern across development, production, and undefined NODE_ENV

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 369 files, 8874 tests all passing (3 new)
- [x] `npm run lint` — clean

## Manual Validation
- In dev: `window.clubhouse.app.devSimulateUpdateRestart({agentNames: {}})` should work as before
- In production build: the same call should reject with "dev-only API" error