### PR TITLE
fix: properly await async initialization to prevent race conditions (BUG-01)

### DIFF
--- a/src/renderer/App.structural.test.ts
+++ b/src/renderer/App.structural.test.ts
@@ -434,7 +434,6 @@ describe('app-initializer.ts – initialization order', () => {
       'loadProjects',
       'loadSettings', // notification, orchestrator, logging, headless, badge, update stores
       'loadTheme',
-      'initBadgeSideEffects',
     ];
 
     const pluginInitPos = findFirstCallPosition(initializerAst, 'initializePluginSystem');
@@ -450,23 +449,19 @@ describe('app-initializer.ts – initialization order', () => {
     }
   });
 
-  it('should handle initializePluginSystem failure gracefully (catch handler)', () => {
-    // Verify the AST has a .catch() call chained to initializePluginSystem()
-    let found = false;
-    function visit(node: ts.Node) {
-      if (found) return;
-      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-        const prop = node.expression;
-        if (prop.name.text === 'catch' && ts.isCallExpression(prop.expression)
-            && containsIdentifier(prop.expression, 'initializePluginSystem')) {
-          found = true;
-          return;
-        }
-      }
-      ts.forEachChild(node, visit);
-    }
-    ts.forEachChild(initializerAst, visit);
-    expect(found, 'initializePluginSystem() should have a .catch() handler').toBe(true);
+  it('should call badge side effects after plugin system init', () => {
+    const pluginInitPos = findFirstCallPosition(initializerAst, 'initializePluginSystem');
+    const badgePos = findFirstCallPosition(initializerAst, 'initBadgeSideEffects');
+    expect(pluginInitPos, 'initializePluginSystem() not found').toBeGreaterThan(-1);
+    expect(badgePos, 'initBadgeSideEffects() not found').toBeGreaterThan(-1);
+    expect(badgePos, 'initBadgeSideEffects should be called AFTER initializePluginSystem').toBeGreaterThan(pluginInitPos);
+  });
+
+  it('should handle initializePluginSystem failure gracefully (try/catch)', () => {
+    // Verify the source contains a try/catch around initializePluginSystem
+    expect(initializerSource).toContain('initializePluginSystem');
+    // The error handling logs and shows a toast — verify those are present
+    expect(initializerSource).toContain('Failed to initialize plugin system');
   });
 
   // Simple presence checks — these identifier names are formatting-resilient

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -76,10 +76,19 @@ export function App() {
 
   // ── One-time initialization & event bridge ──────────────────────────────
   useEffect(() => {
-    const cleanupInit = initApp();
+    let cleanupInit: (() => void) | undefined;
+    let cancelled = false;
+    initApp().then((cleanup) => {
+      if (cancelled) {
+        cleanup();
+      } else {
+        cleanupInit = cleanup;
+      }
+    });
     const cleanupBridge = initAppEventBridge();
     return () => {
-      cleanupInit();
+      cancelled = true;
+      cleanupInit?.();
       cleanupBridge();
     };
   }, []);

--- a/src/renderer/app-initializer.test.ts
+++ b/src/renderer/app-initializer.test.ts
@@ -10,20 +10,22 @@ const {
   mockLoadLoggingSettings,
   mockLoadHeadlessSettings,
   mockLoadBadgeSettings,
+  mockLoadSessionSettings,
   mockLoadUpdateSettings,
   mockCheckWhatsNew,
   mockStartOnboarding,
   mockInitBadgeSideEffects,
   mockInitializePluginSystem,
 } = vi.hoisted(() => ({
-  mockLoadProjects: vi.fn(),
-  mockLoadNotificationSettings: vi.fn(),
-  mockLoadTheme: vi.fn(),
-  mockLoadOrchestratorSettings: vi.fn(),
-  mockLoadLoggingSettings: vi.fn(),
-  mockLoadHeadlessSettings: vi.fn(),
-  mockLoadBadgeSettings: vi.fn(),
-  mockLoadUpdateSettings: vi.fn(),
+  mockLoadProjects: vi.fn().mockResolvedValue(undefined),
+  mockLoadNotificationSettings: vi.fn().mockResolvedValue(undefined),
+  mockLoadTheme: vi.fn().mockResolvedValue(undefined),
+  mockLoadOrchestratorSettings: vi.fn().mockResolvedValue(undefined),
+  mockLoadLoggingSettings: vi.fn().mockResolvedValue(undefined),
+  mockLoadHeadlessSettings: vi.fn().mockResolvedValue(undefined),
+  mockLoadBadgeSettings: vi.fn().mockResolvedValue(undefined),
+  mockLoadSessionSettings: vi.fn().mockResolvedValue(undefined),
+  mockLoadUpdateSettings: vi.fn().mockResolvedValue(undefined),
   mockCheckWhatsNew: vi.fn(),
   mockStartOnboarding: vi.fn(),
   mockInitBadgeSideEffects: vi.fn(),
@@ -69,6 +71,12 @@ vi.mock('./stores/headlessStore', () => ({
 vi.mock('./stores/badgeSettingsStore', () => ({
   useBadgeSettingsStore: Object.assign(vi.fn(), {
     getState: vi.fn(() => ({ loadSettings: mockLoadBadgeSettings })),
+  }),
+}));
+
+vi.mock('./stores/sessionSettingsStore', () => ({
+  useSessionSettingsStore: Object.assign(vi.fn(), {
+    getState: vi.fn(() => ({ loadSettings: mockLoadSessionSettings })),
   }),
 }));
 
@@ -118,16 +126,15 @@ import { initPluginUpdateListener } from './stores/pluginUpdateStore';
 describe('initApp', () => {
   let cleanup: () => void;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
     mockOnboardingCompleted = true;
-    // mockReset:true clears implementations — restore them each test
     mockInitializePluginSystem.mockResolvedValue(undefined);
     (initUpdateListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
     (initAnnexListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
     (initPluginUpdateListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
     (window.clubhouse.app.getPendingResumes as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    cleanup = initApp();
+    cleanup = await initApp();
   });
 
   afterEach(() => {
@@ -143,10 +150,11 @@ describe('initApp', () => {
     expect(mockLoadLoggingSettings).toHaveBeenCalled();
     expect(mockLoadHeadlessSettings).toHaveBeenCalled();
     expect(mockLoadBadgeSettings).toHaveBeenCalled();
+    expect(mockLoadSessionSettings).toHaveBeenCalled();
     expect(mockLoadUpdateSettings).toHaveBeenCalled();
   });
 
-  it('should initialize badge side effects', () => {
+  it('should initialize badge side effects after settings load', () => {
     expect(mockInitBadgeSideEffects).toHaveBeenCalled();
   });
 
@@ -176,10 +184,59 @@ describe('initApp', () => {
   });
 });
 
+describe('initApp – ordering', () => {
+  it('should await settings before plugin system and badge side effects', async () => {
+    vi.useFakeTimers();
+    const callOrder: string[] = [];
+
+    // Make settings load take time via a delayed promise
+    mockLoadProjects.mockImplementation(() => {
+      callOrder.push('loadProjects:start');
+      return new Promise<void>((resolve) => {
+        setTimeout(() => { callOrder.push('loadProjects:done'); resolve(); }, 100);
+      });
+    });
+    mockInitializePluginSystem.mockImplementation(() => {
+      callOrder.push('pluginSystem');
+      return Promise.resolve();
+    });
+    mockInitBadgeSideEffects.mockImplementation(() => {
+      callOrder.push('badgeSideEffects');
+    });
+
+    (initUpdateListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
+    (initAnnexListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
+    (initPluginUpdateListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
+    (window.clubhouse.app.getPendingResumes as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const initPromise = initApp();
+
+    // Settings haven't resolved yet — plugin system should NOT have been called
+    expect(callOrder).toContain('loadProjects:start');
+    expect(callOrder).not.toContain('pluginSystem');
+    expect(callOrder).not.toContain('badgeSideEffects');
+
+    // Advance timers to let the delayed settings resolve
+    await vi.advanceTimersByTimeAsync(100);
+    await initPromise;
+
+    // Now plugin system and badge side effects should have been called, in order
+    const pluginIdx = callOrder.indexOf('pluginSystem');
+    const badgeIdx = callOrder.indexOf('badgeSideEffects');
+    const settingsDoneIdx = callOrder.indexOf('loadProjects:done');
+
+    expect(settingsDoneIdx).toBeLessThan(pluginIdx);
+    expect(pluginIdx).toBeLessThan(badgeIdx);
+
+    (await initPromise)?.();
+    vi.useRealTimers();
+  });
+});
+
 describe('initApp – onboarding', () => {
   let cleanup: () => void;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
     mockOnboardingCompleted = false;
     mockInitializePluginSystem.mockResolvedValue(undefined);
@@ -187,7 +244,7 @@ describe('initApp – onboarding', () => {
     (initAnnexListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
     (initPluginUpdateListener as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
     (window.clubhouse.app.getPendingResumes as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    cleanup = initApp();
+    cleanup = await initApp();
   });
 
   afterEach(() => {

--- a/src/renderer/app-initializer.ts
+++ b/src/renderer/app-initializer.ts
@@ -33,17 +33,19 @@ import type { RestartSessionState } from '../shared/types';
 
 // ─── Settings Loading ───────────────────────────────────────────────────────
 
-function loadAllSettings(): void {
-  useProjectStore.getState().loadProjects();
-  useNotificationStore.getState().loadSettings();
-  useThemeStore.getState().loadTheme();
-  useOrchestratorStore.getState().loadSettings();
-  useLoggingStore.getState().loadSettings();
-  useHeadlessStore.getState().loadSettings();
-  useBadgeSettingsStore.getState().loadSettings();
-  useSessionSettingsStore.getState().loadSettings();
-  useUpdateStore.getState().loadSettings();
-  initBadgeSideEffects();
+async function loadAllSettings(): Promise<void> {
+  // All store loads are independent — run them in parallel.
+  await Promise.all([
+    useProjectStore.getState().loadProjects(),
+    useNotificationStore.getState().loadSettings(),
+    useThemeStore.getState().loadTheme(),
+    useOrchestratorStore.getState().loadSettings(),
+    useLoggingStore.getState().loadSettings(),
+    useHeadlessStore.getState().loadSettings(),
+    useBadgeSettingsStore.getState().loadSettings(),
+    useSessionSettingsStore.getState().loadSettings(),
+    useUpdateStore.getState().loadSettings(),
+  ]);
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -52,14 +54,17 @@ function loadAllSettings(): void {
  * Initialize the application: load settings, start listeners, init plugins.
  * Returns a cleanup function that tears down listeners and timers.
  */
-export function initApp(): () => void {
+export async function initApp(): Promise<() => void> {
   const cleanups: (() => void)[] = [];
 
-  // 1. Load all settings BEFORE plugin system init (order matters)
-  loadAllSettings();
+  // 1. Load all settings first — stores must be populated before anything
+  //    that reads from them.
+  await loadAllSettings();
 
-  // 2. Initialize plugin system (must be after settings)
-  initializePluginSystem().catch((err) => {
+  // 2. Initialize plugin system (must be after settings are loaded)
+  try {
+    await initializePluginSystem();
+  } catch (err) {
     rendererLog('core:plugins', 'error', 'Failed to initialize plugin system', {
       meta: { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined },
     });
@@ -67,20 +72,24 @@ export function initApp(): () => void {
       'Failed to initialize plugin system. Some features may be unavailable.',
       'error',
     );
-  });
+  }
 
-  // 3. Start IPC listeners for updates, annex, and plugin updates
+  // 3. Set up badge side effects AFTER settings are loaded, so subscriptions
+  //    see the correct initial state.
+  initBadgeSideEffects();
+
+  // 4. Start IPC listeners for updates, annex, and plugin updates
   cleanups.push(initUpdateListener());
   cleanups.push(initAnnexListener());
   cleanups.push(initPluginUpdateListener());
 
-  // 4. Check for What's New dialog after startup (delayed)
+  // 5. Check for What's New dialog after startup (delayed)
   const whatsNewTimer = setTimeout(() => {
     useUpdateStore.getState().checkWhatsNew();
   }, 1000);
   cleanups.push(() => clearTimeout(whatsNewTimer));
 
-  // 5. Show onboarding on first launch (delayed)
+  // 6. Show onboarding on first launch (delayed)
   if (!useOnboardingStore.getState().completed) {
     const onboardingTimer = setTimeout(() => {
       useOnboardingStore.getState().startOnboarding();
@@ -88,7 +97,7 @@ export function initApp(): () => void {
     cleanups.push(() => clearTimeout(onboardingTimer));
   }
 
-  // 6. Check for pending session resumes after an update restart
+  // 7. Check for pending session resumes after an update restart
   window.clubhouse.app.getPendingResumes().then((state: unknown) => {
     if (state && typeof state === 'object' && 'sessions' in state) {
       const typed = state as RestartSessionState;


### PR DESCRIPTION
## Summary
- Fix critical race conditions in app initialization where 9 async store loads ran as fire-and-forget
- Plugin system and badge side effects could run before settings were ready
- Last remaining P0 item — corroborated by 3/8 code review agents

## Changes
- **`src/renderer/app-initializer.ts`**:
  - `loadAllSettings()` → `async`, uses `Promise.all()` to load all 9 stores in parallel and await completion
  - `initializePluginSystem()` → properly awaited (was fire-and-forget with `.catch()`)
  - `initBadgeSideEffects()` → called AFTER settings and plugins are ready (was called before stores finished loading)
  - `initApp()` → returns `Promise<() => void>` instead of `() => void`
- **`src/renderer/App.tsx`**: Updated `useEffect` to handle async `initApp()` with proper cleanup/cancellation pattern
- **`src/renderer/App.structural.test.ts`**: Updated AST-based ordering checks to match new init sequence
- **`src/renderer/app-initializer.test.ts`**: All mocks return promises, tests await `initApp()`, new ordering test verifies settings → plugins → badge sequence

## Initialization Order (before → after)
**Before:** All 9 loads fire-and-forget → badge subscribes → plugins fire-and-forget
**After:** All 9 loads (parallel, awaited) → plugins (awaited) → badge subscribes

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 368 files, 8873 tests all passing
- [x] `npm run lint` — clean
- [x] New ordering test verifies settings complete before plugin init and badge side effects

## Manual Validation
- App should start normally — no visible change in behavior, but initialization is now deterministic
- Plugin system should always see loaded settings on init
- Badge subscriptions should see correct initial store state