### PR TITLE
fix: await killAll and flushAllAgentConfigs during app shutdown (BUG-05)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -226,7 +226,11 @@ app.on('activate', () => {
   }
 });
 
-app.on('before-quit', () => {
+let isQuitting = false;
+app.on('before-quit', (event) => {
+  if (isQuitting) return; // Re-entrance guard — already shutting down
+  isQuitting = true;
+
   appLog('core:shutdown', 'info', 'App shutting down, restoring configs and killing all PTY sessions');
   stopUpdateChecks();
   stopPeriodicPluginUpdateChecks();
@@ -242,16 +246,25 @@ app.on('before-quit', () => {
   // Flush any pending throttled IPC broadcasts before tearing down
   flushPendingBroadcasts();
 
-  // Flush any pending agent config writes to disk (best-effort async)
-  void flushAllAgentConfigs().catch((err) => {
-    appLog('core:shutdown', 'error', `Failed to flush agent configs: ${err instanceof Error ? err.message : String(err)}`);
-  });
-
   stopPtyStaleSweep();
   stopHeadlessStaleSweep();
   annexServer.stop();
   mcpBridgeServer.stop();
   restoreAll();
-  killAll();
   stopAllWatches();
+
+  // Delay quit to await async cleanup (killAll, flushAllAgentConfigs).
+  // Without this, Electron may exit before PTY processes are terminated,
+  // leaving orphaned processes.
+  event.preventDefault();
+  Promise.all([
+    killAll().catch((err) => {
+      appLog('core:shutdown', 'error', `Failed to kill PTY sessions: ${err instanceof Error ? err.message : String(err)}`);
+    }),
+    flushAllAgentConfigs().catch((err) => {
+      appLog('core:shutdown', 'error', `Failed to flush agent configs: ${err instanceof Error ? err.message : String(err)}`);
+    }),
+  ]).finally(() => {
+    app.quit();
+  });
 });

--- a/src/main/shutdown-guard.test.ts
+++ b/src/main/shutdown-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Structural tests verifying the before-quit handler properly awaits async cleanup.
+ * The actual Electron event handling can't be unit-tested without mocking the full
+ * Electron runtime, so we verify the source structure instead.
+ */
+
+const indexSource = fs.readFileSync(
+  path.resolve(__dirname, 'index.ts'),
+  'utf-8',
+);
+
+describe('before-quit handler', () => {
+  it('should use event.preventDefault() to delay quit', () => {
+    expect(indexSource).toContain('event.preventDefault()');
+  });
+
+  it('should have a re-entrance guard', () => {
+    expect(indexSource).toContain('isQuitting');
+  });
+
+  it('should await killAll via Promise', () => {
+    // killAll should be inside a Promise.all or awaited
+    expect(indexSource).toMatch(/Promise\.all\(\s*\[[\s\S]*?killAll\(\)/);
+  });
+
+  it('should await flushAllAgentConfigs via Promise', () => {
+    expect(indexSource).toMatch(/Promise\.all\(\s*\[[\s\S]*?flushAllAgentConfigs\(\)/);
+  });
+
+  it('should call app.quit() in the finally block', () => {
+    expect(indexSource).toMatch(/\.finally\(\s*\(\)\s*=>\s*\{[\s\S]*?app\.quit\(\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `killAll()` not being awaited in the `before-quit` handler, which could leave orphaned PTY processes
- Also properly await `flushAllAgentConfigs()` which was fire-and-forget
- Reported by 2/8 code review agents — P1 HIGH priority

## Changes
- **`src/main/index.ts`**:
  - Use `event.preventDefault()` to delay Electron quit
  - Await both `killAll()` and `flushAllAgentConfigs()` via `Promise.all`
  - Call `app.quit()` in the `.finally()` block after async cleanup completes
  - Add `isQuitting` re-entrance guard to prevent infinite quit loop
- **`src/main/shutdown-guard.test.ts`**: 5 structural tests verifying the shutdown pattern

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 369 files, 8876 tests all passing (5 new)
- [x] `npm run lint` — clean

## Manual Validation
- Quit the app while agents are running — PTY processes should be fully terminated before exit
- No orphaned node/shell processes should remain after quit