### PR TITLE
fix: propagate canvas mutation errors to WebSocket client

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -1561,4 +1561,32 @@ describe('annex-server', () => {
       }, 10_000);
     });
   });
+
+  describe('canvas mutation error propagation', () => {
+    it('canvas:mutation handler sends error back to client on failure (structural)', () => {
+      // BUG-09: Verify that server-side canvas mutation failures are not
+      // silently swallowed but propagated back to the WebSocket client.
+      // This structural test reads the source to confirm the fix is in place.
+      const fs = require('fs');
+      const path = require('path');
+      const source = fs.readFileSync(
+        path.resolve(__dirname, 'annex-server.ts'),
+        'utf-8',
+      );
+
+      // Find the canvas:mutation case and verify it sends an error message
+      const mutationBlock = source.slice(
+        source.indexOf("case 'canvas:mutation':"),
+        source.indexOf("case 'agent:reorder':"),
+      );
+
+      // Must send error back via ws.send with canvas:mutation:error type
+      expect(mutationBlock).toContain('canvas:mutation:error');
+      expect(mutationBlock).toContain('ws.send');
+      // Must log the error
+      expect(mutationBlock).toContain('appLog');
+      // Must NOT silently swallow — no empty catch body
+      expect(mutationBlock).not.toMatch(/\.catch\(\s*\(\s*\)\s*=>\s*\{\s*\}\s*\)/);
+    });
+  });
 });

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -1659,8 +1659,15 @@ function handleWsMessage(ws: WebSocket, data: string): void {
       broadcastToAllWindows(IPC.WINDOW.REQUEST_CANVAS_MUTATION, canvasId, scope, mutation, projectId);
 
       // Server-side: read → apply → write → broadcast
-      applyCanvasMutationServerSide(projectId, canvasId, mutation).catch(() => {
-        // Mutation failed server-side — renderer path is the fallback
+      applyCanvasMutationServerSide(projectId, canvasId, mutation).catch((err) => {
+        const message = err instanceof Error ? err.message : 'canvas_mutation_failed';
+        appLog('core:annex', 'error', 'Canvas mutation failed server-side', {
+          meta: { projectId, canvasId, mutationType: mutation.type, error: message },
+        });
+        ws.send(JSON.stringify({
+          type: 'canvas:mutation:error',
+          payload: { projectId, canvasId, mutationType: mutation.type, message },
+        }));
       });
       break;
     }


### PR DESCRIPTION
## Summary
- **BUG-09 (P1 HIGH):** Server-side canvas mutation failures were silently swallowed via an empty `.catch()` handler. The renderer applies mutations optimistically, so when persistence fails the client never learns about it — causing state divergence and data loss on restart.
- Now sends a `canvas:mutation:error` message back through the WebSocket with `projectId`, `canvasId`, `mutationType`, and error `message`.
- Logs failures via `appLog` for observability.
- Added structural regression test verifying the error propagation pattern is in place.

## Test plan
- [x] All 73 annex-server tests pass including new structural test
- [x] Structural test verifies: error is sent via `ws.send`, `canvas:mutation:error` type used, `appLog` called, no empty `.catch()` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)