### PR TITLE
fix: handle floating promises in App.tsx and AddAgentDialog

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -90,7 +90,12 @@ export function App() {
   useEffect(() => {
     const loadDurableAgents = useAgentStore.getState().loadDurableAgents;
     for (const p of projects) {
-      loadDurableAgents(p.id, p.path);
+      loadDurableAgents(p.id, p.path).catch((err) => {
+        rendererLog('core:agents', 'error', 'Failed to load durable agents', {
+          projectId: p.id,
+          meta: { error: err instanceof Error ? err.message : String(err) },
+        });
+      });
     }
   }, [projects]);
 

--- a/src/renderer/features/agents/AddAgentDialog.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.tsx
@@ -37,6 +37,8 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
     ]).then(([catalog, defaults]) => {
       setMcpCatalog(catalog || []);
       setSelectedMcps(defaults || []);
+    }).catch(() => {
+      // MCP catalog load failed — leave defaults (empty catalog, no selected MCPs)
     });
   }, [projectPath]);
 


### PR DESCRIPTION
## Summary
- **BUG-02 (P2 CRITICAL):** Two floating promise issues:
  1. `loadDurableAgents` (async) called in a loop in App.tsx without `.catch()` — unhandled rejections could leave the dashboard uninitialized.
  2. `Promise.all` for MCP catalog loading in AddAgentDialog had no `.catch()` — IPC failures caused unhandled rejections.
- App.tsx now logs failures via `rendererLog`. AddAgentDialog falls back to empty defaults on failure.

## Test plan
- [x] AddAgentDialog tests pass (13 tests)
- [x] No unhandled promise rejection scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)