### PR TITLE
fix: prevent interval leak in wire activity decay timer (CQ-01)

### DIFF
--- a/src/renderer/plugins/builtin/canvas/useWireActivity.ts
+++ b/src/renderer/plugins/builtin/canvas/useWireActivity.ts
@@ -12,7 +12,7 @@
  * - 'active-both'    — recent traffic in both directions
  */
 
-import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 
 /** How long activity persists after the last tool call (ms). */
 export const ACTIVITY_DECAY_MS = 4000;
@@ -138,14 +138,14 @@ export function _resetForTesting(): void {
  * @param alive - Whether both endpoints are alive/connected
  */
 export function useWireActivity(wireKey: string, alive: boolean = true): WireActivityState {
-  const decayTimerRef = useRef<ReturnType<typeof setInterval>>(undefined);
-
   // Subscribe to the singleton store
   useSyncExternalStore(subscribe, getSnapshot);
 
-  // Set up decay timer to re-render when activity expires
+  // Set up decay timer to re-render when activity expires.
+  // Capture the interval ID directly in the cleanup closure so that rapid
+  // wireKey changes always clear the correct (old) interval.
   useEffect(() => {
-    decayTimerRef.current = setInterval(() => {
+    const timer = setInterval(() => {
       const ts = activityMap.get(wireKey);
       if (ts) {
         const now = Date.now();
@@ -158,7 +158,7 @@ export function useWireActivity(wireKey: string, alive: boolean = true): WireAct
     }, DECAY_CHECK_INTERVAL);
 
     return () => {
-      if (decayTimerRef.current) clearInterval(decayTimerRef.current);
+      clearInterval(timer);
     };
   }, [wireKey]);
 


### PR DESCRIPTION
## Summary
- Fix stale closures causing setInterval leak in `useWireActivity` hook
- Rapidly re-created wires accumulated intervals that were never cleared
- Reported by 2/8 code review agents — P2 CRITICAL priority

## Changes
- **`src/renderer/plugins/builtin/canvas/useWireActivity.ts`**:
  - Replace shared `useRef` for interval ID with direct closure capture in the cleanup function
  - Each `useEffect` cleanup now captures and clears its own specific interval, regardless of re-render timing
  - Remove unused `useRef` import

## Root Cause
The `setInterval` ID was stored in a shared ref (`decayTimerRef.current`). When `wireKey` changed rapidly:
1. Effect A creates interval, writes to ref
2. Effect B creates new interval, overwrites ref
3. Cleanup A runs, reads ref → clears B's interval (wrong!)
4. Interval A leaks forever

## Fix
Capture the interval ID directly in a local variable. The closure-based cleanup always refers to the correct interval:
```ts
const timer = setInterval(...);
return () => clearInterval(timer); // always clears the right one
```

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 368 files, 8871 tests all passing
- [x] `npm run lint` — clean