### PR TITLE
feat: add coverage thresholds to vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,14 @@ export default defineConfig({
   plugins: [rawMarkdown()],
   test: {
     ...sharedTestConfig,
+    coverage: {
+      thresholds: {
+        lines: 60,
+        branches: 50,
+        functions: 60,
+        statements: 60,
+      },
+    },
     projects: [
       {
         plugins: [rawMarkdown()],


### PR DESCRIPTION
## Summary
- **TEST-03 (P2 CRITICAL):** No minimum coverage enforcement existed — coverage could regress silently.
- Added conservative coverage thresholds to `vitest.config.ts`: lines 60%, branches 50%, functions 60%, statements 60%.
- Current coverage (~71% stmts, ~62% branches, ~69% funcs, ~73% lines) clears these comfortably. These establish a floor that can be raised over time.

## Test plan
- [x] Full test suite passes (8871 tests)
- [x] Coverage thresholds pass with current codebase
- [x] Build and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)