### PR TITLE
test: add tests for high-risk plugin API modules

### DIFF
--- a/src/renderer/plugins/plugin-api-process.test.ts
+++ b/src/renderer/plugins/plugin-api-process.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createProcessAPI } from './plugin-api-process';
+import type { PluginContext } from '../../shared/plugin-types';
+
+const mockExec = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as any).clubhouse = {
+    process: { exec: mockExec },
+  };
+});
+
+describe('createProcessAPI', () => {
+  const ctx: PluginContext = {
+    pluginId: 'my-plugin',
+    projectPath: '/project/path',
+    projectId: 'proj_1',
+    scope: 'project',
+  };
+
+  it('exec delegates to window.clubhouse.process.exec with pluginId', async () => {
+    mockExec.mockResolvedValue({ stdout: 'output', stderr: '', exitCode: 0 });
+
+    const api = createProcessAPI(ctx);
+    const result = await api.exec('ls', ['-la']);
+
+    expect(mockExec).toHaveBeenCalledWith({
+      pluginId: 'my-plugin',
+      command: 'ls',
+      args: ['-la'],
+      projectPath: '/project/path',
+      options: undefined,
+    });
+    expect(result).toEqual({ stdout: 'output', stderr: '', exitCode: 0 });
+  });
+
+  it('exec passes options when provided', async () => {
+    mockExec.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+    const api = createProcessAPI(ctx);
+    await api.exec('node', ['script.js'], { cwd: '/other/path', timeout: 5000 });
+
+    expect(mockExec).toHaveBeenCalledWith({
+      pluginId: 'my-plugin',
+      command: 'node',
+      args: ['script.js'],
+      projectPath: '/project/path',
+      options: { cwd: '/other/path', timeout: 5000 },
+    });
+  });
+
+  it('exec propagates errors from IPC', async () => {
+    mockExec.mockRejectedValue(new Error('Permission denied'));
+
+    const api = createProcessAPI(ctx);
+    await expect(api.exec('rm', ['-rf', '/'])).rejects.toThrow('Permission denied');
+  });
+
+  it('uses the pluginId from context', async () => {
+    mockExec.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+    const otherCtx: PluginContext = { ...ctx, pluginId: 'other-plugin' };
+    const api = createProcessAPI(otherCtx);
+    await api.exec('echo', ['hello']);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginId: 'other-plugin' }),
+    );
+  });
+});

--- a/src/renderer/plugins/plugin-api-project.test.ts
+++ b/src/renderer/plugins/plugin-api-project.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createProjectAPI } from './plugin-api-project';
+import type { PluginContext } from '../../shared/plugin-types';
+
+const mockRead = vi.fn();
+const mockWrite = vi.fn();
+const mockDelete = vi.fn();
+const mockReadTree = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as any).clubhouse = {
+    file: {
+      read: mockRead,
+      write: mockWrite,
+      delete: mockDelete,
+      readTree: mockReadTree,
+    },
+  };
+});
+
+describe('createProjectAPI', () => {
+  const ctx: PluginContext = {
+    pluginId: 'test-plugin',
+    projectPath: '/project/root',
+    projectId: 'proj_1',
+    scope: 'project',
+  };
+
+  it('throws if projectPath is missing', () => {
+    const badCtx: PluginContext = { pluginId: 'p', scope: 'app' };
+    expect(() => createProjectAPI(badCtx)).toThrow('requires projectPath');
+  });
+
+  it('throws if projectId is missing', () => {
+    const badCtx: PluginContext = { pluginId: 'p', projectPath: '/path', scope: 'project' };
+    expect(() => createProjectAPI(badCtx)).toThrow('requires projectPath');
+  });
+
+  it('exposes projectPath and projectId', () => {
+    const api = createProjectAPI(ctx);
+    expect(api.projectPath).toBe('/project/root');
+    expect(api.projectId).toBe('proj_1');
+  });
+
+  describe('readFile', () => {
+    it('constructs full path from projectPath + relativePath', async () => {
+      mockRead.mockResolvedValue('file content');
+      const api = createProjectAPI(ctx);
+
+      const result = await api.readFile('src/index.ts');
+      expect(mockRead).toHaveBeenCalledWith('/project/root/src/index.ts');
+      expect(result).toBe('file content');
+    });
+
+    it('propagates read errors', async () => {
+      mockRead.mockRejectedValue(new Error('ENOENT'));
+      const api = createProjectAPI(ctx);
+      await expect(api.readFile('missing.ts')).rejects.toThrow('ENOENT');
+    });
+  });
+
+  describe('writeFile', () => {
+    it('constructs full path and delegates to file.write', async () => {
+      mockWrite.mockResolvedValue(undefined);
+      const api = createProjectAPI(ctx);
+
+      await api.writeFile('output.txt', 'hello');
+      expect(mockWrite).toHaveBeenCalledWith('/project/root/output.txt', 'hello');
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('constructs full path and delegates to file.delete', async () => {
+      mockDelete.mockResolvedValue(undefined);
+      const api = createProjectAPI(ctx);
+
+      await api.deleteFile('temp.txt');
+      expect(mockDelete).toHaveBeenCalledWith('/project/root/temp.txt');
+    });
+  });
+
+  describe('fileExists', () => {
+    it('returns true when file can be read', async () => {
+      mockRead.mockResolvedValue('content');
+      const api = createProjectAPI(ctx);
+
+      const result = await api.fileExists('exists.ts');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when read throws', async () => {
+      mockRead.mockRejectedValue(new Error('ENOENT'));
+      const api = createProjectAPI(ctx);
+
+      const result = await api.fileExists('missing.ts');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('listDirectory', () => {
+    it('maps readTree results to DirectoryEntry format', async () => {
+      mockReadTree.mockResolvedValue([
+        { name: 'src', path: '/project/root/src', isDirectory: true },
+        { name: 'index.ts', path: '/project/root/index.ts', isDirectory: false },
+      ]);
+      const api = createProjectAPI(ctx);
+
+      const entries = await api.listDirectory('.');
+      expect(mockReadTree).toHaveBeenCalledWith('/project/root/.');
+      expect(entries).toEqual([
+        { name: 'src', path: '/project/root/src', isDirectory: true },
+        { name: 'index.ts', path: '/project/root/index.ts', isDirectory: false },
+      ]);
+    });
+
+    it('defaults to current directory when no path provided', async () => {
+      mockReadTree.mockResolvedValue([]);
+      const api = createProjectAPI(ctx);
+
+      await api.listDirectory();
+      expect(mockReadTree).toHaveBeenCalledWith('/project/root/.');
+    });
+  });
+});

--- a/src/renderer/plugins/plugin-api-shared.test.ts
+++ b/src/renderer/plugins/plugin-api-shared.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./plugin-store', () => ({
+  usePluginStore: {
+    getState: vi.fn(() => ({
+      plugins: { 'test-plugin': { manifest: { name: 'Test Plugin' } } },
+      recordPermissionViolation: vi.fn(),
+      disableApp: vi.fn(),
+      setPluginStatus: vi.fn(),
+      appEnabled: {},
+    })),
+  },
+}));
+
+vi.mock('./renderer-logger', () => ({
+  rendererLog: vi.fn(),
+}));
+
+import {
+  hasPermission,
+  permissionDeniedProxy,
+  handlePermissionViolation,
+  gated,
+  _resetEnforcedViolations,
+} from './plugin-api-shared';
+import { usePluginStore } from './plugin-store';
+import type { PluginManifest } from '../../shared/plugin-types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetEnforcedViolations();
+  (window as any).clubhouse = {
+    plugin: { storageWrite: vi.fn() },
+  };
+});
+
+describe('hasPermission', () => {
+  it('returns true when manifest includes the permission', () => {
+    const manifest = { permissions: ['files', 'storage'] } as unknown as PluginManifest;
+    expect(hasPermission(manifest, 'files')).toBe(true);
+  });
+
+  it('returns false when manifest does not include the permission', () => {
+    const manifest = { permissions: ['storage'] } as unknown as PluginManifest;
+    expect(hasPermission(manifest, 'files')).toBe(false);
+  });
+
+  it('returns false when manifest is undefined', () => {
+    expect(hasPermission(undefined, 'files')).toBe(false);
+  });
+
+  it('returns false when permissions array is missing', () => {
+    const manifest = {} as unknown as PluginManifest;
+    expect(hasPermission(manifest, 'files')).toBe(false);
+  });
+});
+
+describe('permissionDeniedProxy', () => {
+  it('returns a proxy that throws on method invocation', () => {
+    const proxy = permissionDeniedProxy<{ doSomething: () => void }>('bad-plugin', 'files', 'project');
+    expect(() => proxy.doSomething()).toThrow("requires 'files' permission");
+  });
+
+  it('throws with plugin id in error message', () => {
+    const proxy = permissionDeniedProxy<{ run: () => void }>('evil-plugin', 'process', 'process');
+    expect(() => proxy.run()).toThrow('evil-plugin');
+  });
+
+  it('does not throw on symbol property access (React dev-mode safety)', () => {
+    const proxy = permissionDeniedProxy<Record<string | symbol, unknown>>('p', 'files', 'project');
+    expect(proxy[Symbol.toPrimitive]).toBeUndefined();
+  });
+});
+
+describe('handlePermissionViolation', () => {
+  it('records violation in plugin store', () => {
+    const mockRecord = vi.fn();
+    vi.mocked(usePluginStore.getState).mockReturnValue({
+      plugins: { 'test-plugin': { manifest: { name: 'Test Plugin' } } },
+      recordPermissionViolation: mockRecord,
+      disableApp: vi.fn(),
+      setPluginStatus: vi.fn(),
+      appEnabled: {},
+    } as any);
+
+    handlePermissionViolation('test-plugin', 'files', 'project.readFile');
+
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: 'test-plugin',
+        pluginName: 'Test Plugin',
+        permission: 'files',
+        apiName: 'project.readFile',
+      }),
+    );
+  });
+
+  it('only fires once per pluginId:permission pair', () => {
+    const mockRecord = vi.fn();
+    vi.mocked(usePluginStore.getState).mockReturnValue({
+      plugins: { 'test-plugin': { manifest: { name: 'Test Plugin' } } },
+      recordPermissionViolation: mockRecord,
+      disableApp: vi.fn(),
+      setPluginStatus: vi.fn(),
+      appEnabled: {},
+    } as any);
+
+    handlePermissionViolation('test-plugin', 'files', 'project.readFile');
+    handlePermissionViolation('test-plugin', 'files', 'project.writeFile');
+
+    // Second call with same pluginId:permission should be skipped
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires for different permissions on same plugin', () => {
+    const mockRecord = vi.fn();
+    vi.mocked(usePluginStore.getState).mockReturnValue({
+      plugins: { 'test-plugin': { manifest: { name: 'Test Plugin' } } },
+      recordPermissionViolation: mockRecord,
+      disableApp: vi.fn(),
+      setPluginStatus: vi.fn(),
+      appEnabled: {},
+    } as any);
+
+    handlePermissionViolation('test-plugin', 'files', 'project');
+    handlePermissionViolation('test-plugin', 'process', 'process');
+
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('gated', () => {
+  const manifest = { permissions: ['files'] } as unknown as PluginManifest;
+  const noPermManifest = { permissions: [] } as unknown as PluginManifest;
+
+  it('returns constructed API when scope available and permission granted', () => {
+    const api = gated(true, 'project', 'project', 'files', 'p', manifest, () => ({ read: () => 'data' }));
+    expect(api.read()).toBe('data');
+  });
+
+  it('returns permission denied proxy when permission missing', () => {
+    const api = gated<{ read: () => string }>(true, 'project', 'project', 'files', 'p', noPermManifest, () => ({ read: () => 'data' }));
+    expect(() => api.read()).toThrow("requires 'files' permission");
+  });
+
+  it('returns unavailable proxy when scope not available', () => {
+    const api = gated<{ read: () => string }>(false, 'project', 'project', 'files', 'p', manifest, () => ({ read: () => 'data' }));
+    expect(() => api.read()).toThrow();
+  });
+});

--- a/src/renderer/plugins/plugin-api-storage.test.ts
+++ b/src/renderer/plugins/plugin-api-storage.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createScopedStorage, createStorageAPI } from './plugin-api-storage';
+import type { PluginContext } from '../../shared/plugin-types';
+
+const mockStorageRead = vi.fn();
+const mockStorageWrite = vi.fn();
+const mockStorageDelete = vi.fn();
+const mockStorageList = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as any).clubhouse = {
+    plugin: {
+      storageRead: mockStorageRead,
+      storageWrite: mockStorageWrite,
+      storageDelete: mockStorageDelete,
+      storageList: mockStorageList,
+    },
+  };
+});
+
+describe('createScopedStorage', () => {
+  it('read delegates to storageRead with correct scope', async () => {
+    mockStorageRead.mockResolvedValue({ key: 'value' });
+    const storage = createScopedStorage('my-plugin', 'project', '/project/path');
+
+    const result = await storage.read('settings');
+    expect(mockStorageRead).toHaveBeenCalledWith({
+      pluginId: 'my-plugin',
+      scope: 'project',
+      key: 'settings',
+      projectPath: '/project/path',
+    });
+    expect(result).toEqual({ key: 'value' });
+  });
+
+  it('write delegates to storageWrite with correct scope', async () => {
+    mockStorageWrite.mockResolvedValue(undefined);
+    const storage = createScopedStorage('my-plugin', 'global');
+
+    await storage.write('config', { enabled: true });
+    expect(mockStorageWrite).toHaveBeenCalledWith({
+      pluginId: 'my-plugin',
+      scope: 'global',
+      key: 'config',
+      value: { enabled: true },
+      projectPath: undefined,
+    });
+  });
+
+  it('delete delegates to storageDelete with correct scope', async () => {
+    mockStorageDelete.mockResolvedValue(undefined);
+    const storage = createScopedStorage('my-plugin', 'project-local', '/path');
+
+    await storage.delete('cache');
+    expect(mockStorageDelete).toHaveBeenCalledWith({
+      pluginId: 'my-plugin',
+      scope: 'project-local',
+      key: 'cache',
+      projectPath: '/path',
+    });
+  });
+
+  it('list delegates to storageList with correct scope', async () => {
+    mockStorageList.mockResolvedValue(['key1', 'key2']);
+    const storage = createScopedStorage('my-plugin', 'global');
+
+    const result = await storage.list();
+    expect(mockStorageList).toHaveBeenCalledWith({
+      pluginId: 'my-plugin',
+      scope: 'global',
+      projectPath: undefined,
+    });
+    expect(result).toEqual(['key1', 'key2']);
+  });
+});
+
+describe('createStorageAPI', () => {
+  it('creates project, projectLocal, and global scoped storage', () => {
+    const ctx: PluginContext = {
+      pluginId: 'test-plugin',
+      projectPath: '/test/project',
+      projectId: 'proj_1',
+      scope: 'project',
+    };
+
+    const api = createStorageAPI(ctx);
+    expect(api.project).toBeDefined();
+    expect(api.projectLocal).toBeDefined();
+    expect(api.global).toBeDefined();
+  });
+
+  it('project storage uses project scope', async () => {
+    mockStorageRead.mockResolvedValue(null);
+    const ctx: PluginContext = {
+      pluginId: 'test-plugin',
+      projectPath: '/test/project',
+      projectId: 'proj_1',
+      scope: 'project',
+    };
+
+    const api = createStorageAPI(ctx);
+    await api.project.read('key');
+    expect(mockStorageRead).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'project', projectPath: '/test/project' }),
+    );
+  });
+
+  it('global storage uses global scope without projectPath', async () => {
+    mockStorageRead.mockResolvedValue(null);
+    const ctx: PluginContext = {
+      pluginId: 'test-plugin',
+      projectPath: '/test/project',
+      projectId: 'proj_1',
+      scope: 'project',
+    };
+
+    const api = createStorageAPI(ctx);
+    await api.global.read('key');
+    expect(mockStorageRead).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'global', projectPath: undefined }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **TEST-06 (P2 HIGH):** 13 plugin API modules had zero tests. The runtime APIs exposed to community plugins had no test coverage for permission enforcement, parameter validation, or error paths.
- Added 35 tests across 4 new test files covering the three highest-risk modules plus the shared permission layer:
  - `plugin-api-storage.test.ts` (7 tests) — scoped storage delegation
  - `plugin-api-process.test.ts` (4 tests) — process exec with pluginId, error propagation
  - `plugin-api-project.test.ts` (11 tests) — file ops, path construction, error handling, context validation
  - `plugin-api-shared.test.ts` (13 tests) — `hasPermission`, `permissionDeniedProxy`, `handlePermissionViolation` dedup, `gated()` blocking

## Test plan
- [x] All 35 new tests pass
- [x] Full test suite passes (8931 tests, +60 from baseline)
- [x] Permission denied proxy throws on invocation, not construction (React dev-mode safe)
- [x] Violation handler deduplicates by pluginId:permission pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)