### PR TITLE
feat: enhance MCP wire activity visuals

### DIFF
--- a/src/renderer/plugins/builtin/canvas/WireFlowDots.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireFlowDots.test.tsx
@@ -36,28 +36,28 @@ describe('WireFlowDots', () => {
     expect(motion?.getAttribute('dur')).toBe('6s');
   });
 
-  it('renders 3 fast forward dots in active-forward mode', () => {
+  it('renders 5 fast forward dots in active-forward mode', () => {
     const { container } = renderWithSvg(
       <WireFlowDots wireKey="test-wire" activity="active-forward" />,
     );
     const fwdDots = container.querySelectorAll('[data-testid^="wire-dot-fwd-test-wire-"]');
-    expect(fwdDots.length).toBe(3);
+    expect(fwdDots.length).toBe(5);
     const revDots = container.querySelectorAll('[data-testid^="wire-dot-rev-test-wire-"]');
     expect(revDots.length).toBe(0);
 
-    // Active uses fast 2s duration
+    // Active uses fast 1.4s duration
     const motion = fwdDots[0].querySelector('animateMotion');
-    expect(motion?.getAttribute('dur')).toBe('2s');
+    expect(motion?.getAttribute('dur')).toBe('1.4s');
   });
 
-  it('renders 3 reverse dots in active-reverse mode', () => {
+  it('renders 5 reverse dots in active-reverse mode', () => {
     const { container } = renderWithSvg(
       <WireFlowDots wireKey="test-wire" activity="active-reverse" />,
     );
     const fwdDots = container.querySelectorAll('[data-testid^="wire-dot-fwd-test-wire-"]');
     expect(fwdDots.length).toBe(0);
     const revDots = container.querySelectorAll('[data-testid^="wire-dot-rev-test-wire-"]');
-    expect(revDots.length).toBe(3);
+    expect(revDots.length).toBe(5);
   });
 
   it('renders both forward and reverse dots in active-both mode', () => {
@@ -65,9 +65,9 @@ describe('WireFlowDots', () => {
       <WireFlowDots wireKey="test-wire" activity="active-both" />,
     );
     const fwdDots = container.querySelectorAll('[data-testid^="wire-dot-fwd-test-wire-"]');
-    expect(fwdDots.length).toBe(3);
+    expect(fwdDots.length).toBe(5);
     const revDots = container.querySelectorAll('[data-testid^="wire-dot-rev-test-wire-"]');
-    expect(revDots.length).toBe(3);
+    expect(revDots.length).toBe(5);
   });
 
   it('reverse dots use keyPoints="1;0" for backward motion', () => {
@@ -95,7 +95,7 @@ describe('WireFlowDots', () => {
     );
     const dot = container.querySelector('[data-testid="wire-dot-fwd-test-wire-0"]');
     const anim = dot?.querySelector('animate[attributeName="opacity"]');
-    expect(anim?.getAttribute('values')).toBe('0;0.9;0.9;0');
+    expect(anim?.getAttribute('values')).toBe('0;1;1;0');
   });
 
   it('renders a glow filter for the wire', () => {
@@ -103,5 +103,37 @@ describe('WireFlowDots', () => {
       <WireFlowDots wireKey="test-wire" activity="ambient" />,
     );
     expect(container.querySelector('#wire-dot-glow-test-wire')).toBeTruthy();
+  });
+
+  it('uses small radius for ambient dots', () => {
+    const { container } = renderWithSvg(
+      <WireFlowDots wireKey="test-wire" activity="ambient" />,
+    );
+    const dot = container.querySelector('[data-testid="wire-dot-fwd-test-wire-0"]');
+    expect(dot?.getAttribute('r')).toBe('2.5');
+  });
+
+  it('uses larger radius for active dots', () => {
+    const { container } = renderWithSvg(
+      <WireFlowDots wireKey="test-wire" activity="active-forward" />,
+    );
+    const dot = container.querySelector('[data-testid="wire-dot-fwd-test-wire-0"]');
+    expect(dot?.getAttribute('r')).toBe('3.5');
+  });
+
+  it('uses stronger glow filter for active dots', () => {
+    const { container } = renderWithSvg(
+      <WireFlowDots wireKey="test-wire" activity="active-forward" />,
+    );
+    const blur = container.querySelector('#wire-dot-glow-test-wire feGaussianBlur');
+    expect(blur?.getAttribute('stdDeviation')).toBe('3.5');
+  });
+
+  it('uses subtle glow filter for ambient dots', () => {
+    const { container } = renderWithSvg(
+      <WireFlowDots wireKey="test-wire" activity="ambient" />,
+    );
+    const blur = container.querySelector('#wire-dot-glow-test-wire feGaussianBlur');
+    expect(blur?.getAttribute('stdDeviation')).toBe('2');
   });
 });

--- a/src/renderer/plugins/builtin/canvas/WireFlowDots.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireFlowDots.tsx
@@ -19,13 +19,15 @@ const AMBIENT_DOT_COUNT = 2;
 const AMBIENT_DOT_DURATION = 6; // slow traversal
 const AMBIENT_DOT_STAGGER = 3;
 const AMBIENT_OPACITY = '0;0.3;0.3;0';
+const AMBIENT_DOT_RADIUS = 2.5;
+const AMBIENT_GLOW_STD_DEV = 2;
 
-const ACTIVE_DOT_COUNT = 3;
-const ACTIVE_DOT_DURATION = 2; // fast traversal
-const ACTIVE_DOT_STAGGER = 0.7;
-const ACTIVE_OPACITY = '0;0.9;0.9;0';
-
-const DOT_RADIUS = 2.5;
+const ACTIVE_DOT_COUNT = 5;
+const ACTIVE_DOT_DURATION = 1.4; // fast burst traversal
+const ACTIVE_DOT_STAGGER = 0.3;
+const ACTIVE_OPACITY = '0;1;1;0';
+const ACTIVE_DOT_RADIUS = 3.5;
+const ACTIVE_GLOW_STD_DEV = 3.5;
 
 interface WireFlowDotsProps {
   wireKey: string;
@@ -45,6 +47,8 @@ export const WireFlowDots = React.memo(function WireFlowDots({
   const duration = isActive ? ACTIVE_DOT_DURATION : AMBIENT_DOT_DURATION;
   const stagger = isActive ? ACTIVE_DOT_STAGGER : AMBIENT_DOT_STAGGER;
   const opacityValues = isActive ? ACTIVE_OPACITY : AMBIENT_OPACITY;
+  const dotRadius = isActive ? ACTIVE_DOT_RADIUS : AMBIENT_DOT_RADIUS;
+  const glowStdDev = isActive ? ACTIVE_GLOW_STD_DEV : AMBIENT_GLOW_STD_DEV;
 
   const showForward = activity === 'ambient' || activity === 'active-forward' || activity === 'active-both';
   const showReverse = activity === 'active-reverse' || activity === 'active-both';
@@ -53,7 +57,7 @@ export const WireFlowDots = React.memo(function WireFlowDots({
     <>
       {/* Glow filter for dots */}
       <filter id={`wire-dot-glow-${wireKey}`}>
-        <feGaussianBlur stdDeviation="2" result="blur" />
+        <feGaussianBlur stdDeviation={glowStdDev} result="blur" />
         <feMerge>
           <feMergeNode in="blur" />
           <feMergeNode in="SourceGraphic" />
@@ -64,7 +68,7 @@ export const WireFlowDots = React.memo(function WireFlowDots({
       {showForward && Array.from({ length: dotCount }, (_, i) => (
         <circle
           key={`fwd-${i}`}
-          r={DOT_RADIUS}
+          r={dotRadius}
           fill="rgb(var(--ctp-accent, 137 180 250))"
           filter={`url(#wire-dot-glow-${wireKey})`}
           data-testid={`wire-dot-fwd-${wireKey}-${i}`}
@@ -91,7 +95,7 @@ export const WireFlowDots = React.memo(function WireFlowDots({
       {showReverse && Array.from({ length: dotCount }, (_, i) => (
         <circle
           key={`rev-${i}`}
-          r={DOT_RADIUS}
+          r={dotRadius}
           fill="rgb(var(--ctp-accent, 137 180 250))"
           filter={`url(#wire-dot-glow-${wireKey})`}
           data-testid={`wire-dot-rev-${wireKey}-${i}`}

--- a/src/renderer/plugins/builtin/canvas/WireOverlay.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireOverlay.tsx
@@ -14,11 +14,15 @@ import { WireFlowDots } from './WireFlowDots';
 import { useWirePhysics } from './useWirePhysics';
 import { useWireActivity } from './useWireActivity';
 
-/** CSS animation for ambient wire glow */
+/** CSS animations for wire glow — ambient is subtle, active is vivid */
 const WIRE_GLOW_KEYFRAMES = `
 @keyframes wire-pulse {
   0%, 100% { filter: drop-shadow(0 0 3px rgb(var(--ctp-accent, 137 180 250) / 0.4)); }
   50% { filter: drop-shadow(0 0 6px rgb(var(--ctp-accent, 137 180 250) / 0.7)); }
+}
+@keyframes wire-pulse-active {
+  0%, 100% { filter: drop-shadow(0 0 6px rgb(var(--ctp-accent, 137 180 250) / 0.8)); }
+  50% { filter: drop-shadow(0 0 12px rgb(var(--ctp-accent, 137 180 250) / 1)); }
 }
 `;
 
@@ -106,6 +110,8 @@ const WireGroup = React.memo(function WireGroup({
     ? sleepingAgentIds.has(binding.agentId) || sleepingAgentIds.has(binding.targetId)
     : false;
 
+  const isActive = activity.startsWith('active');
+
   return (
     <g data-testid={`wire-group-${wireKey}`} data-bidir={bidir ? 'true' : undefined} data-activity={activity} data-dimmed={isDimmed ? 'true' : undefined}>
       {/* Invisible thick hitbox for click interaction */}
@@ -123,15 +129,15 @@ const WireGroup = React.memo(function WireGroup({
         d={path}
         fill="none"
         stroke="rgb(var(--ctp-accent, 137 180 250))"
-        strokeWidth={2}
+        strokeWidth={isActive ? 2.5 : 2}
         strokeLinecap="round"
         markerEnd="url(#wire-arrow-fwd)"
         markerStart={bidir ? 'url(#wire-arrow-rev)' : undefined}
         style={{
           pointerEvents: 'none',
-          animation: isDimmed ? 'none' : 'wire-pulse 3s ease-in-out infinite',
+          animation: isDimmed ? 'none' : isActive ? 'wire-pulse-active 1.5s ease-in-out infinite' : 'wire-pulse 3s ease-in-out infinite',
           opacity: isDimmed ? 0.35 : 1,
-          transition: 'opacity 0.5s ease',
+          transition: 'opacity 0.5s ease, stroke-width 0.3s ease',
         }}
         data-testid={`wire-path-${wireKey}`}
       />


### PR DESCRIPTION
## Summary
- Boost the visual intensity of MCP wires during active communication — more dots, brighter, faster, larger, with stronger glow
- Add a dedicated `wire-pulse-active` CSS animation with vivid drop-shadow and slightly thicker stroke when traffic is flowing
- Wires now feel lively and engaging when agents communicate, addressing the issue of active wires appearing too dim

## Changes
**WireFlowDots.tsx**
- Active dot count: 3 → 5 (denser burst of particles)
- Active dot speed: 2s → 1.4s traversal (faster motion)
- Active dot stagger: 0.7s → 0.3s (tighter packet feel)
- Active dot opacity: 0.9 → 1.0 (full brightness)
- Active dot radius: 2.5px → 3.5px (larger, more visible)
- Active glow blur: stdDeviation 2 → 3.5 (stronger halo)
- Ambient parameters unchanged — subtle idle pulse stays the same

**WireOverlay.tsx**
- New `wire-pulse-active` keyframe: drop-shadow 6px→12px at 0.8–1.0 opacity, 1.5s cycle
- Active wires use thicker stroke (2px → 2.5px) with smooth transition
- Wire automatically selects the vivid animation when activity state is active

**WireFlowDots.test.tsx**
- Updated dot count assertions (3 → 5) for active-forward, active-reverse, active-both
- Updated active opacity assertion to `0;1;1;0`
- Updated active duration assertion to `1.4s`
- Added tests for dynamic dot radius (2.5 ambient, 3.5 active)
- Added tests for dynamic glow filter strength (stdDeviation 2 ambient, 3.5 active)

## Test Plan
- [x] All 232 renderer test files pass (5016 tests)
- [x] Lint passes clean
- [ ] Manual: Open canvas with wired agents, trigger MCP tool call, verify forward dots are bright and plentiful
- [ ] Manual: Verify response phase shows reverse dots flowing back
- [ ] Manual: Verify ambient (idle but alive) wires remain subtle
- [ ] Manual: Verify sleeping/dimmed wires are unaffected

## Manual Validation
1. Open a canvas with two wired agents
2. Send a message that triggers an MCP tool call between them
3. Observe: forward direction should show 5 bright, fast-moving dots with visible glow
4. Observe: response phase should show reverse dots flowing back
5. After activity decays (~4s), wire should return to subtle ambient pulse
6. Compare with previous behavior — active state should be noticeably more vivid and engaging