### PR TITLE
feat: gate group project on MCP enabled in canvas

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
@@ -8,6 +8,7 @@ import {
 import { MenuPortal } from './MenuPortal';
 import { useDismissibleLayer } from './useDismissibleLayer';
 import { sanitizeSvg } from '../../../utils/sanitize-svg';
+import { useMcpSettingsStore } from '../../../stores/mcpSettingsStore';
 
 /** A menu item can either be a built-in view type or a qualified plugin widget type string. */
 export type ContextMenuSelection =
@@ -31,8 +32,12 @@ const BUILTIN_ITEMS: Array<{ type: CanvasViewType; label: string; icon: string }
   { type: 'anchor', label: 'Add Anchor', icon: ANCHOR_ICON },
 ];
 
+/** Widget plugin IDs that require MCP to be enabled in order to function. */
+const MCP_REQUIRED_PLUGIN_IDS = new Set(['group-project']);
+
 export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const mcpEnabled = !!useMcpSettingsStore((s) => s.enabled);
   const [pluginWidgets, setPluginWidgets] = useState<RegisteredCanvasWidget[]>(() => getRegisteredWidgetTypes());
 
   useEffect(() => {
@@ -41,6 +46,10 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
     });
     return () => disposable.dispose();
   }, []);
+
+  const visibleWidgets = mcpEnabled
+    ? pluginWidgets
+    : pluginWidgets.filter((w) => !MCP_REQUIRED_PLUGIN_IDS.has(w.pluginId));
   useDismissibleLayer({ layerRef: menuRef, onDismiss });
 
   const handleBuiltinSelect = useCallback((type: CanvasViewType) => {
@@ -79,10 +88,10 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
         ))}
 
         {/* Plugin-provided widgets */}
-        {pluginWidgets.length > 0 && (
+        {visibleWidgets.length > 0 && (
           <>
             <div className="border-t border-surface-0 my-1" />
-            {pluginWidgets.map((widget) => (
+            {visibleWidgets.map((widget) => (
               <button
                 key={widget.qualifiedType}
                 className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-ctp-text hover:bg-surface-1 transition-colors text-left"

--- a/src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-context-menu-icons.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CanvasContextMenu } from './CanvasContextMenu';
 import * as widgetRegistry from '../../canvas-widget-registry';
 import type { RegisteredCanvasWidget } from '../../canvas-widget-registry';
+import { useMcpSettingsStore } from '../../../stores/mcpSettingsStore';
 
 // ── Mock the canvas-widget-registry ──────────────────────────────────
 
@@ -122,5 +123,47 @@ describe('CanvasContextMenu plugin widget icons', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CanvasContextMenu MCP gating', () => {
+  const onSelect = vi.fn();
+  const onDismiss = vi.fn();
+
+  const groupProjectWidget = makeWidget({
+    qualifiedType: 'plugin:group-project:group-project',
+    pluginId: 'group-project',
+    declaration: { id: 'group-project', label: 'Group Project', icon: TEST_SVG_ICON },
+  });
+
+  const terminalWidget = makeWidget({
+    qualifiedType: 'plugin:terminal:shell',
+    pluginId: 'terminal',
+    declaration: { id: 'shell', label: 'Terminal', icon: TEST_SVG_ICON },
+  });
+
+  beforeEach(() => {
+    onSelect.mockReset();
+    onDismiss.mockReset();
+  });
+
+  it('hides group-project widget when MCP is disabled', () => {
+    useMcpSettingsStore.setState({ enabled: false, loaded: true });
+    vi.mocked(widgetRegistry.getRegisteredWidgetTypes).mockReturnValue([groupProjectWidget, terminalWidget]);
+
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    expect(screen.queryByTestId('canvas-context-menu-plugin:group-project:group-project')).toBeNull();
+    expect(screen.getByTestId('canvas-context-menu-plugin:terminal:shell')).toBeTruthy();
+  });
+
+  it('shows group-project widget when MCP is enabled', () => {
+    useMcpSettingsStore.setState({ enabled: true, loaded: true });
+    vi.mocked(widgetRegistry.getRegisteredWidgetTypes).mockReturnValue([groupProjectWidget, terminalWidget]);
+
+    render(<CanvasContextMenu x={100} y={100} onSelect={onSelect} onDismiss={onDismiss} />);
+
+    expect(screen.getByTestId('canvas-context-menu-plugin:group-project:group-project')).toBeTruthy();
+    expect(screen.getByTestId('canvas-context-menu-plugin:terminal:shell')).toBeTruthy();
   });
 });

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
@@ -152,6 +152,30 @@ describe('GroupProjectCanvasWidget — polling toggle', () => {
   });
 });
 
+// ── MCP gating ──────────────────────────────────────────────────────
+
+describe('GroupProjectCanvasWidget — MCP required gate', () => {
+  it('imports useMcpSettingsStore for MCP check', () => {
+    expect(source).toContain("from '../../../stores/mcpSettingsStore'");
+    expect(source).toContain('useMcpSettingsStore');
+  });
+
+  it('reads mcpEnabled from the store', () => {
+    expect(source).toContain('useMcpSettingsStore((s) => s.enabled)');
+  });
+
+  it('renders an MCP-required placeholder when MCP is disabled', () => {
+    expect(source).toContain('!mcpEnabled');
+    expect(source).toContain('group-project-mcp-disabled');
+    expect(source).toContain('MCP Required');
+  });
+
+  it('directs user to enable MCP in settings', () => {
+    expect(source).toContain('Settings');
+    expect(source).toContain('MCP');
+  });
+});
+
 // ── Orchestrator-aware polling messages ─────────────────────────────
 
 describe('GroupProjectCanvasWidget — orchestrator-aware polling', () => {

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -9,6 +9,7 @@ import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { AnnexUnsupportedPlaceholder } from '../../../features/annex/AnnexUnsupportedPlaceholder';
 import { useAgentStore } from '../../../stores/agentStore';
 import { pollingStartMsg, pollingStopMsg } from '../../../../shared/polling-messages';
+import { useMcpSettingsStore } from '../../../stores/mcpSettingsStore';
 
 const EXPANDED_WIDTH_THRESHOLD = 500;
 const POLL_INTERVAL_MS = 5000;
@@ -37,6 +38,8 @@ export function GroupProjectCanvasWidget({
   const projectId = (metadata.projectId as string) || (isAppMode ? undefined : api.context.projectId);
   const remote = useRemoteProject(projectId);
 
+  const mcpEnabled = !!useMcpSettingsStore((s) => s.enabled);
+
   // Group project bulletin board is not yet proxied over annex
   if (remote.isRemote) {
     const name = metadata.name as string | undefined;
@@ -45,6 +48,26 @@ export function GroupProjectCanvasWidget({
         widgetType="Group Project"
         reason={name ? `"${name}" is running on the satellite.` : 'Group project data is not yet available over Annex.'}
       />
+    );
+  }
+
+  if (!mcpEnabled) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 p-4 text-center" data-testid="group-project-mcp-disabled">
+        <div className="w-10 h-10 rounded-lg bg-surface-1 flex items-center justify-center">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-ctp-overlay1">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+        </div>
+        <div className="space-y-1">
+          <div className="text-xs font-medium text-ctp-subtext1">MCP Required</div>
+          <div className="text-[10px] text-ctp-overlay0 max-w-[200px]">
+            Group Project requires MCP to be enabled. Enable it in Settings &gt; MCP.
+          </div>
+        </div>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- Group project widgets in the canvas now require MCP to be enabled, since they don't function without it
- When MCP is disabled, the group-project option is hidden from the canvas context menu
- Existing group project widgets on the canvas show an "MCP Required" placeholder with instructions to enable MCP in settings

## Changes
- **CanvasContextMenu.tsx**: Import `useMcpSettingsStore`, define `MCP_REQUIRED_PLUGIN_IDS` set, filter out group-project widget from the context menu when MCP is disabled
- **GroupProjectCanvasWidget.tsx**: Import `useMcpSettingsStore`, add early return with an "MCP Required" placeholder (warning icon + message) when MCP is not enabled
- **canvas-context-menu-icons.test.tsx**: Add RTL tests verifying group-project is hidden when MCP disabled and shown when enabled
- **GroupProjectCanvasWidget.test.ts**: Add source-level tests verifying MCP gating code is present (import, store read, conditional render, test ID)

## Test Plan
- [x] Context menu hides group-project widget when MCP is disabled
- [x] Context menu shows group-project widget when MCP is enabled
- [x] Non-MCP-dependent widgets (e.g. terminal) remain visible regardless of MCP state
- [x] GroupProjectCanvasWidget shows MCP Required placeholder when MCP disabled
- [x] All 8769 tests pass; lint clean

## Manual Validation
1. Disable MCP in Settings > MCP
2. Right-click on canvas — "Group Project" should not appear in the context menu
3. If a group project widget already exists on the canvas, it should show "MCP Required" placeholder
4. Enable MCP — group project should reappear in context menu and existing widgets should render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)