### PR TITLE
fix: sync annex session pause state on controller reconnect

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -1633,6 +1633,57 @@ describe('annex-server', () => {
     });
   });
 
+  describe('session pause state tracking', () => {
+    it('notifySessionPause tracks sessionPaused state (structural)', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const source = fs.readFileSync(
+        path.resolve(__dirname, 'annex-server.ts'),
+        'utf-8',
+      );
+
+      // notifySessionPause must update the tracked sessionPaused state
+      const notifyFn = source.slice(
+        source.indexOf('export function notifySessionPause'),
+        source.indexOf('}', source.indexOf('export function notifySessionPause') + 80) + 1,
+      );
+      expect(notifyFn).toContain('sessionPaused = paused');
+    });
+
+    it('buildSnapshot includes sessionPaused in payload (structural)', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const source = fs.readFileSync(
+        path.resolve(__dirname, 'annex-server.ts'),
+        'utf-8',
+      );
+
+      // The snapshot return object must include sessionPaused
+      const snapshotReturn = source.slice(
+        source.lastIndexOf('return {', source.indexOf('canvasState,')),
+        source.indexOf('};', source.indexOf('canvasState,')) + 2,
+      );
+      expect(snapshotReturn).toContain('sessionPaused');
+    });
+
+    it('resets sessionPaused when last mTLS controller disconnects (structural)', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const source = fs.readFileSync(
+        path.resolve(__dirname, 'annex-server.ts'),
+        'utf-8',
+      );
+
+      // When the last mTLS client disconnects and locked=false is broadcast,
+      // sessionPaused must also be reset
+      const unlockBlock = source.slice(
+        source.indexOf('if (!hasMtlsClient)'),
+        source.indexOf('locked: false,') + 100,
+      );
+      expect(unlockBlock).toContain('sessionPaused = false');
+    });
+  });
+
   describe('canvas mutation error propagation', () => {
     it('canvas:mutation handler sends error back to client on failure (structural)', () => {
       // BUG-09: Verify that server-side canvas mutation failures are not

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -76,6 +76,9 @@ let unsubPermissionRequest: (() => void) | null = null;
 let unsubStructuredEvent: (() => void) | null = null;
 let staleEvictionInterval: ReturnType<typeof setInterval> | null = null;
 
+/** Whether the satellite session is currently paused (tracks across reconnects). */
+let sessionPaused = false;
+
 /** Unsubscribe all event bus listeners to prevent accumulation on restart cycles. */
 function unsubscribeEventBus(): void {
   unsubPtyData?.();
@@ -476,6 +479,7 @@ async function buildSnapshot(): Promise<object> {
     projectIcons,
     agentIcons,
     canvasState,
+    sessionPaused,
   };
 }
 
@@ -1974,6 +1978,7 @@ export function start(): void {
           (client) => client !== ws && client.readyState === WebSocket.OPEN && wsAuthTypes.get(client) === 'mtls',
         );
         if (!hasMtlsClient) {
+          sessionPaused = false;
           broadcastToAllWindows(IPC.ANNEX.LOCK_STATE_CHANGED, {
             locked: false,
             remainingMs: 0,
@@ -2417,6 +2422,7 @@ export function broadcastCanvasStateToClients(projectId: string, state: unknown)
 
 /** Broadcast session pause/resume to all connected WS clients. */
 export function notifySessionPause(paused: boolean): void {
+  sessionPaused = paused;
   broadcastWs({ type: paused ? 'session:paused' : 'session:resumed', payload: { paused } });
 }
 

--- a/src/renderer/stores/annexClientStore.test.ts
+++ b/src/renderer/stores/annexClientStore.test.ts
@@ -315,6 +315,107 @@ describe('annexClientStore', () => {
   });
 
   // -------------------------------------------------------------------------
+  // session:paused / session:resumed events
+  // -------------------------------------------------------------------------
+
+  describe('session pause/resume events', () => {
+    it('sets satellitePaused to true on session:paused', () => {
+      let eventCallback: ((event: any) => void) | undefined;
+      mockAnnexClient.onSatelliteEvent.mockImplementationOnce((cb: any) => {
+        eventCallback = cb;
+        return vi.fn();
+      });
+
+      initAnnexClientListener();
+      eventCallback!({ satelliteId: 'sat-1', type: 'session:paused', payload: { paused: true } });
+
+      expect(getState().satellitePaused['sat-1']).toBe(true);
+    });
+
+    it('sets satellitePaused to false on session:resumed', () => {
+      useAnnexClientStore.setState({ satellitePaused: { 'sat-1': true } });
+
+      let eventCallback: ((event: any) => void) | undefined;
+      mockAnnexClient.onSatelliteEvent.mockImplementationOnce((cb: any) => {
+        eventCallback = cb;
+        return vi.fn();
+      });
+
+      initAnnexClientListener();
+      eventCallback!({ satelliteId: 'sat-1', type: 'session:resumed', payload: { paused: false } });
+
+      expect(getState().satellitePaused['sat-1']).toBe(false);
+    });
+
+    it('clears stale paused state when snapshot arrives with sessionPaused=false', () => {
+      // Simulate stale paused state from a previous connection
+      useAnnexClientStore.setState({
+        satellitePaused: { 'sat-1': true },
+        satellites: [SATELLITE],
+      });
+
+      let eventCallback: ((event: any) => void) | undefined;
+      mockAnnexClient.onSatelliteEvent.mockImplementationOnce((cb: any) => {
+        eventCallback = cb;
+        return vi.fn();
+      });
+
+      initAnnexClientListener();
+      eventCallback!({
+        satelliteId: 'sat-1',
+        type: 'snapshot',
+        payload: { projects: [], agents: {}, quickAgents: {}, theme: {}, orchestrators: {}, pendingPermissions: [], lastSeq: 0, sessionPaused: false },
+      });
+
+      expect(getState().satellitePaused['sat-1']).toBe(false);
+    });
+
+    it('preserves paused state when snapshot arrives with sessionPaused=true', () => {
+      useAnnexClientStore.setState({
+        satellitePaused: {},
+        satellites: [SATELLITE],
+      });
+
+      let eventCallback: ((event: any) => void) | undefined;
+      mockAnnexClient.onSatelliteEvent.mockImplementationOnce((cb: any) => {
+        eventCallback = cb;
+        return vi.fn();
+      });
+
+      initAnnexClientListener();
+      eventCallback!({
+        satelliteId: 'sat-1',
+        type: 'snapshot',
+        payload: { projects: [], agents: {}, quickAgents: {}, theme: {}, orchestrators: {}, pendingPermissions: [], lastSeq: 0, sessionPaused: true },
+      });
+
+      expect(getState().satellitePaused['sat-1']).toBe(true);
+    });
+
+    it('defaults to unpaused when snapshot has no sessionPaused field', () => {
+      useAnnexClientStore.setState({
+        satellitePaused: { 'sat-1': true },
+        satellites: [SATELLITE],
+      });
+
+      let eventCallback: ((event: any) => void) | undefined;
+      mockAnnexClient.onSatelliteEvent.mockImplementationOnce((cb: any) => {
+        eventCallback = cb;
+        return vi.fn();
+      });
+
+      initAnnexClientListener();
+      eventCallback!({
+        satelliteId: 'sat-1',
+        type: 'snapshot',
+        payload: { projects: [], agents: {}, quickAgents: {}, theme: {}, orchestrators: {}, pendingPermissions: [], lastSeq: 0 },
+      });
+
+      expect(getState().satellitePaused['sat-1']).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // sendAgentWake
   // -------------------------------------------------------------------------
 

--- a/src/renderer/stores/annexClientStore.ts
+++ b/src/renderer/stores/annexClientStore.ts
@@ -292,11 +292,16 @@ export function initAnnexClientListener(): () => void {
       // Find satellite name from current satellites list
       const satellite = useAnnexClientStore.getState().satellites.find((s) => s.id === satelliteId);
       const satelliteName = satellite?.alias || satelliteId;
+      const snap = payload as SatelliteSnapshot;
       useRemoteProjectStore.getState().applySatelliteSnapshot(
         satelliteId,
         satelliteName,
-        payload as SatelliteSnapshot,
+        snap,
       );
+      // Sync pause state from snapshot so reconnects clear stale paused flags
+      useAnnexClientStore.setState((state) => ({
+        satellitePaused: { ...state.satellitePaused, [satelliteId]: !!snap.sessionPaused },
+      }));
     } else if (type === 'pty:data') {
       const p = payload as { agentId: string; data: string };
       satellitePtyDataBus.emit(satelliteId, p.agentId, p.data);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -563,6 +563,8 @@ export interface SatelliteSnapshot {
   agentIcons?: Record<string, string>;
   /** Per-project canvas state keyed by satellite project ID. */
   canvasState?: Record<string, { canvases: unknown[]; activeCanvasId: string }>;
+  /** Whether the satellite session is currently paused. */
+  sessionPaused?: boolean;
 }
 
 // --- Auto-update types ---


### PR DESCRIPTION
## Summary
- Fixes a bug where the controller host would stay stuck showing "paused" after an annex session auto-resumed (e.g. due to WebSocket reconnect from inactivity)
- The snapshot sent on reconnect now includes `sessionPaused` state, and the controller resets its `satellitePaused` flag accordingly

## Changes
- **annex-server.ts**: Track `sessionPaused` as module-level state; update it in `notifySessionPause()`, reset on last mTLS controller disconnect, and include it in the `buildSnapshot()` payload
- **types.ts**: Add optional `sessionPaused` field to `SatelliteSnapshot` interface
- **annexClientStore.ts**: When processing a `snapshot` event, sync `satellitePaused` from the snapshot's `sessionPaused` field (defaults to `false` if absent, clearing stale pause state)
- **annex-server.test.ts**: Structural tests verifying `notifySessionPause` tracks state, snapshot includes `sessionPaused`, and disconnect resets it
- **annexClientStore.test.ts**: Tests for `session:paused`/`session:resumed` events and snapshot-based pause state sync (including stale state clearing and missing field handling)

## Test Plan
- [x] `session:paused` event sets `satellitePaused[id]` to `true`
- [x] `session:resumed` event sets `satellitePaused[id]` to `false`
- [x] Snapshot with `sessionPaused: false` clears stale paused state on controller
- [x] Snapshot with `sessionPaused: true` preserves paused state
- [x] Snapshot without `sessionPaused` field defaults to unpaused (clears stale state)
- [x] Server `notifySessionPause` updates tracked `sessionPaused` state
- [x] Server `buildSnapshot` includes `sessionPaused` in payload
- [x] Server resets `sessionPaused` when last mTLS controller disconnects
- [x] All 8805 tests pass; lint clean on changed files

## Manual Validation
1. Connect a controller to a satellite via Annex
2. On the satellite, click "Pause" — controller should show the paused overlay
3. Disconnect the controller's network briefly (or kill and restart the controller app)
4. On reconnect, the controller should no longer show the paused overlay (satellite unlocked during disconnect, so sessionPaused=false in snapshot)
5. Alternatively: pause on satellite, then on satellite click "Resume" — controller should immediately clear the paused overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)