### PR TITLE
fix: minimap auto-hide timing and rename pin to auto-hide

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasMinimap.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasMinimap.tsx
@@ -8,7 +8,8 @@ import {
   centerViewportOn,
   MINIMAP_WIDTH,
   MINIMAP_HEIGHT,
-  MINIMAP_AUTO_HIDE_DELAY,
+  MINIMAP_INITIAL_HIDE_DELAY,
+  MINIMAP_INTERACTION_HIDE_DELAY,
 } from './canvas-minimap';
 import type { PluginCanvasView } from './canvas-types';
 
@@ -119,30 +120,54 @@ export function CanvasMinimap({
   attentionMap,
   onViewportChange,
 }: CanvasMinimapProps) {
-  const [pinned, setPinned] = useState(false);
+  const [autoHide, setAutoHide] = useState(true);
   const [visible, setVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const minimapRef = useRef<HTMLDivElement>(null);
+  const mountTimeRef = useRef(Date.now());
 
-  // Reset auto-hide timer on viewport or view changes
+  const scheduleHide = useCallback((delay: number) => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => setVisible(false), delay);
+  }, []);
+
+  const cancelHide = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  // Compute hide delay: during the initial window use remaining time, then 1s
+  const getHideDelay = useCallback(() => {
+    const elapsed = Date.now() - mountTimeRef.current;
+    if (elapsed < MINIMAP_INITIAL_HIDE_DELAY) {
+      return MINIMAP_INITIAL_HIDE_DELAY - elapsed;
+    }
+    return MINIMAP_INTERACTION_HIDE_DELAY;
+  }, []);
+
+  // Auto-hide on viewport or view changes
   const changeFingerprint = `${viewport.panX},${viewport.panY},${viewport.zoom},${views.length}`;
   useEffect(() => {
     setVisible(true);
-    if (pinned) return;
-    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-    hideTimerRef.current = setTimeout(() => setVisible(false), MINIMAP_AUTO_HIDE_DELAY);
-    return () => {
-      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-    };
-  }, [changeFingerprint, pinned]);
+    if (!autoHide) {
+      cancelHide();
+      return;
+    }
+    scheduleHide(getHideDelay());
+    return cancelHide;
+  }, [changeFingerprint, autoHide, scheduleHide, cancelHide, getHideDelay]);
 
   // Show on hover even if auto-hidden
-  const handleMouseEnter = useCallback(() => setVisible(true), []);
+  const handleMouseEnter = useCallback(() => {
+    cancelHide();
+    setVisible(true);
+  }, [cancelHide]);
   const handleMouseLeave = useCallback(() => {
-    if (pinned) return;
-    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-    hideTimerRef.current = setTimeout(() => setVisible(false), MINIMAP_AUTO_HIDE_DELAY);
-  }, [pinned]);
+    if (!autoHide) return;
+    scheduleHide(MINIMAP_INTERACTION_HIDE_DELAY);
+  }, [autoHide, scheduleHide]);
 
   const minimapSize: Size = { width: MINIMAP_WIDTH, height: MINIMAP_HEIGHT };
   const worldBounds = useMemo(
@@ -324,24 +349,24 @@ export function CanvasMinimap({
         data-testid="minimap-viewport"
       />
 
-      {/* Pin checkbox */}
+      {/* Auto-hide checkbox */}
       <label
         className="absolute bottom-1 left-1.5 flex items-center gap-1 cursor-pointer"
         style={{ pointerEvents: 'auto' }}
         onClick={(e) => e.stopPropagation()}
-        data-testid="minimap-pin-label"
+        data-testid="minimap-autohide-label"
       >
         <input
           type="checkbox"
-          checked={pinned}
+          checked={autoHide}
           onChange={(e) => {
-            setPinned(e.target.checked);
-            if (e.target.checked) setVisible(true);
+            setAutoHide(e.target.checked);
+            if (!e.target.checked) setVisible(true);
           }}
           className="w-2.5 h-2.5 accent-ctp-blue cursor-pointer"
-          data-testid="minimap-pin-checkbox"
+          data-testid="minimap-autohide-checkbox"
         />
-        <span className="text-[8px] text-ctp-overlay0 leading-none select-none">Pin</span>
+        <span className="text-[8px] text-ctp-overlay0 leading-none select-none">Auto hide</span>
       </label>
     </div>
   );

--- a/src/renderer/plugins/builtin/canvas/canvas-minimap.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-minimap.test.ts
@@ -9,7 +9,8 @@ import {
   MINIMAP_WORLD_PADDING_FACTOR,
   MINIMAP_WIDTH,
   MINIMAP_HEIGHT,
-  MINIMAP_AUTO_HIDE_DELAY,
+  MINIMAP_INITIAL_HIDE_DELAY,
+  MINIMAP_INTERACTION_HIDE_DELAY,
 } from './canvas-minimap';
 
 // ── Factories ────────────────────────────────────────────────────────
@@ -248,8 +249,13 @@ describe('constants', () => {
     expect(MINIMAP_HEIGHT).toBe(140);
   });
 
-  it('has a positive auto-hide delay', () => {
-    expect(MINIMAP_AUTO_HIDE_DELAY).toBeGreaterThan(0);
+  it('has a positive initial hide delay', () => {
+    expect(MINIMAP_INITIAL_HIDE_DELAY).toBe(3000);
+  });
+
+  it('has a shorter interaction hide delay', () => {
+    expect(MINIMAP_INTERACTION_HIDE_DELAY).toBe(1000);
+    expect(MINIMAP_INTERACTION_HIDE_DELAY).toBeLessThan(MINIMAP_INITIAL_HIDE_DELAY);
   });
 
   it('has padding factor > 1', () => {

--- a/src/renderer/plugins/builtin/canvas/canvas-minimap.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-minimap.ts
@@ -30,8 +30,11 @@ export const MINIMAP_WORLD_PADDING_FACTOR = 1.5;
 export const MINIMAP_WIDTH = 200;
 export const MINIMAP_HEIGHT = 140;
 
-/** Milliseconds of viewport inactivity before the minimap auto-hides. */
-export const MINIMAP_AUTO_HIDE_DELAY = 3000;
+/** Milliseconds before the minimap auto-hides on initial canvas load. */
+export const MINIMAP_INITIAL_HIDE_DELAY = 3000;
+
+/** Milliseconds before the minimap auto-hides after a pan/zoom interaction. */
+export const MINIMAP_INTERACTION_HIDE_DELAY = 1000;
 
 // ── Viewport in canvas-space ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fix minimap not auto-dismissing on initial canvas load
- Reduce post-interaction hide delay from 3s to 1s for snappier feel
- Replace "Pin" checkbox with "Auto hide" (checked by default)

## Changes
- **canvas-minimap.ts**: Split `MINIMAP_AUTO_HIDE_DELAY` (3s) into `MINIMAP_INITIAL_HIDE_DELAY` (3s for first load) and `MINIMAP_INTERACTION_HIDE_DELAY` (1s for post-pan/zoom)
- **CanvasMinimap.tsx**: 
  - Replace `pinned` state with `autoHide` (default `true`, inverted semantics)
  - Use mount-time approach for hide delay: during the first 3s window, viewport changes schedule remaining time instead of resetting the full delay — fixes the bug where rapid viewport changes during init prevented dismissal
  - After initial window, use 1s delay for pan/zoom interactions
  - On mouse enter: cancel hide timer; on mouse leave: use 1s delay
  - Checkbox label changed from "Pin" to "Auto hide", test IDs updated
- **canvas-minimap.test.ts**: Updated constant assertions to cover both delay values

## Test Plan
- [x] Unit tests pass (8932/8932, 0 new failures)
- [x] Lint passes on changed files
- [ ] Manual: open canvas → minimap shows for ~3s then fades out (no interaction needed)
- [ ] Manual: pan canvas → minimap reappears → fades after ~1s of inactivity
- [ ] Manual: hover minimap → stays visible; move mouse away → fades after ~1s
- [ ] Manual: uncheck "Auto hide" → minimap stays pinned permanently
- [ ] Manual: re-check "Auto hide" → minimap resumes auto-hide behavior

## Manual Validation
1. Open a canvas with views — minimap should appear and auto-dismiss after ~3 seconds without any interaction
2. Pan or zoom the canvas — minimap should reappear and dismiss ~1 second after the last pan/zoom
3. Hover the minimap — it should stay visible; moving the mouse away starts a ~1s hide timer
4. Uncheck "Auto hide" — minimap stays permanently visible
5. Re-check "Auto hide" — auto-hide behavior resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)