### PR TITLE
chore: bump version to 0.38.0-beta.21 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.38.0-beta.20",
+  "version": "0.38.0-beta.21",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Canvas Agent Queue & Group Project Editing

# New Features
- Added Agent Queue canvas widget with MCP task spawning
- Create durable agents directly from the canvas agent picker
- Inline description and instructions editor for group projects
- Broadcast project instructions is now opt-in via checkbox
- Non-annex-enabled plugins are blocked from rendering on remote projects

# Bug Fixes
- Fixed canvas zone connection, containment, theme propagation, and drag behavior
- Fixed PTY scroll reset during polling/MCP and added scroll-to-bottom button
- Fixed minimap auto-hide timing
- Synced annex remote canvas selection state and sleeping agent view

# Improvements
- Deprecated v0.5 and v0.6 plugin API versions