### PR TITLE
feat: hash lockfile + CI enforcement for plugin-types.ts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -161,6 +161,9 @@ jobs:
       - run: npx tsc --noEmit
       # API version contract tests only
       - run: npx vitest run --project shared -- plugin-api-versions
+      # Verify plugin-types.ts hash lockfile
+      - name: Verify plugin-types.ts integrity
+        run: bash scripts/check-plugin-types-hash.sh
       # Annotate PR if plugin-types.ts was modified
       - name: Check plugin-types changes
         if: github.event_name == 'pull_request'

--- a/scripts/check-plugin-types-hash.sh
+++ b/scripts/check-plugin-types-hash.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verifies that src/shared/plugin-types.ts matches its committed hash lockfile.
+# If the file was intentionally modified, update the hash with:
+#   shasum -a 256 src/shared/plugin-types.ts > src/shared/plugin-types.ts.sha256
+
+set -euo pipefail
+
+LOCKFILE="src/shared/plugin-types.ts.sha256"
+TARGET="src/shared/plugin-types.ts"
+
+if [ ! -f "$LOCKFILE" ]; then
+  echo "::error::Hash lockfile not found: $LOCKFILE"
+  echo "Generate it with: shasum -a 256 $TARGET > $LOCKFILE"
+  exit 1
+fi
+
+EXPECTED=$(awk '{print $1}' "$LOCKFILE")
+ACTUAL=$(shasum -a 256 "$TARGET" | awk '{print $1}')
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "::error file=$TARGET::plugin-types.ts hash mismatch!"
+  echo ""
+  echo "The plugin API surface has changed without updating the hash lockfile."
+  echo ""
+  echo "  Expected: $EXPECTED"
+  echo "  Actual:   $ACTUAL"
+  echo ""
+  echo "If this change is intentional:"
+  echo "  1. Verify backward compatibility for stable API versions"
+  echo "  2. Update the lockfile: shasum -a 256 $TARGET > $LOCKFILE"
+  echo "  3. Commit both files together"
+  echo ""
+  echo "If this change is NOT intentional, revert your modifications to $TARGET."
+  exit 1
+fi
+
+echo "plugin-types.ts hash verified: $ACTUAL"

--- a/src/shared/plugin-types.ts.sha256
+++ b/src/shared/plugin-types.ts.sha256
@@ -1,0 +1,1 @@
+e379ca5acfcfb8b3ed460f21492eefa959ffa381d5166912f41358353934e5de  src/shared/plugin-types.ts


### PR DESCRIPTION
## Summary
- Adds SHA-256 hash lockfile for `src/shared/plugin-types.ts` to prevent accidental API surface changes
- Adds `scripts/check-plugin-types-hash.sh` verification script with clear error messages and remediation instructions
- Integrates hash check into the `api-surface` CI job in `validate.yml`

Any PR that modifies `plugin-types.ts` without updating the hash lockfile will fail CI with a clear message explaining how to proceed.

## How to update intentionally
```bash
shasum -a 256 src/shared/plugin-types.ts > src/shared/plugin-types.ts.sha256
```
Commit both files together.

## Test plan
- [x] Verified hash check script passes with current `plugin-types.ts`
- [x] Typecheck passes (387 files)
- [x] All 9264 tests pass
- [x] No new lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)