### PR TITLE
feat(agents): custom instructions file path per durable agent

### DIFF
--- a/src/main/orchestrators/adapters/stream-json-adapter.ts
+++ b/src/main/orchestrators/adapters/stream-json-adapter.ts
@@ -86,6 +86,10 @@ export class StreamJsonAdapter implements StructuredAdapter {
       args.push('--append-system-prompt', sessionOpts.systemPrompt);
     }
 
+    if (sessionOpts.customInstructionsPath) {
+      args.push('--append-system-prompt-file', sessionOpts.customInstructionsPath);
+    }
+
     if (sessionOpts.freeAgentMode) {
       // Permission handling already applied above via permissionMode
     }

--- a/src/main/orchestrators/claude-code-provider.test.ts
+++ b/src/main/orchestrators/claude-code-provider.test.ts
@@ -238,6 +238,31 @@ describe('ClaudeCodeProvider', () => {
       expect(args).toContain('--model');
       expect(args[args.length - 1]).toBe('Fix bug');
     });
+
+    it('adds --append-system-prompt-file when customInstructionsPath is set', async () => {
+      const { args } = await provider.buildSpawnCommand({
+        cwd: '/p',
+        customInstructionsPath: '/path/to/persona.md',
+      });
+      expect(args).toContain('--append-system-prompt-file');
+      expect(args[args.indexOf('--append-system-prompt-file') + 1]).toBe('/path/to/persona.md');
+    });
+
+    it('does not add --append-system-prompt-file when customInstructionsPath is undefined', async () => {
+      const { args } = await provider.buildSpawnCommand({ cwd: '/p' });
+      expect(args).not.toContain('--append-system-prompt-file');
+    });
+
+    it('places --append-system-prompt-file before mission', async () => {
+      const { args } = await provider.buildSpawnCommand({
+        cwd: '/p',
+        customInstructionsPath: '/persona.md',
+        mission: 'Do the thing',
+      });
+      const fileIdx = args.indexOf('--append-system-prompt-file');
+      expect(fileIdx).toBeGreaterThan(-1);
+      expect(args[args.length - 1]).toBe('Do the thing');
+    });
   });
 
   describe('getExitCommand', () => {

--- a/src/main/orchestrators/claude-code-provider.ts
+++ b/src/main/orchestrators/claude-code-provider.ts
@@ -160,6 +160,10 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
       args.push('--append-system-prompt', opts.systemPrompt);
     }
 
+    if (opts.customInstructionsPath) {
+      args.push('--append-system-prompt-file', opts.customInstructionsPath);
+    }
+
     if (opts.mission) {
       args.push(opts.mission);
     }
@@ -263,6 +267,10 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
 
     if (opts.systemPrompt) {
       args.push('--append-system-prompt', opts.systemPrompt);
+    }
+
+    if (opts.customInstructionsPath) {
+      args.push('--append-system-prompt-file', opts.customInstructionsPath);
     }
 
     if (opts.noSessionPersistence) {

--- a/src/main/orchestrators/codex-cli-provider.test.ts
+++ b/src/main/orchestrators/codex-cli-provider.test.ts
@@ -325,6 +325,30 @@ describe('CodexCliProvider', () => {
       expect(args).not.toContain('--yolo');
     });
 
+    it('reads customInstructionsPath file and injects contents into prompt', async () => {
+      const fsp = await import('fs/promises');
+      vi.mocked(fsp.readFile).mockResolvedValueOnce('You are a frontend expert');
+      const { args } = await provider.buildSpawnCommand({
+        cwd: '/p',
+        customInstructionsPath: '/personas/frontend.md',
+        mission: 'Style the button',
+      });
+      const lastArg = args[args.length - 1];
+      expect(lastArg).toContain('You are a frontend expert');
+      expect(lastArg).toContain('Style the button');
+    });
+
+    it('gracefully handles missing customInstructionsPath file', async () => {
+      const fsp = await import('fs/promises');
+      vi.mocked(fsp.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+      const { args } = await provider.buildSpawnCommand({
+        cwd: '/p',
+        customInstructionsPath: '/missing.md',
+        mission: 'Fix it',
+      });
+      expect(args[args.length - 1]).toBe('Fix it');
+    });
+
     it('does not add --allowedTools or --allow-tool (Codex uses sandbox, not per-tool)', async () => {
       const { args } = await provider.buildSpawnCommand({
         cwd: '/p',

--- a/src/main/orchestrators/codex-cli-provider.ts
+++ b/src/main/orchestrators/codex-cli-provider.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fsp from 'fs/promises';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import {
@@ -189,8 +190,11 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable, S
       args.push('--model', opts.model);
     }
 
-    if (opts.mission || opts.systemPrompt) {
+    if (opts.mission || opts.systemPrompt || opts.customInstructionsPath) {
       const parts: string[] = [];
+      if (opts.customInstructionsPath) {
+        try { parts.push(await fsp.readFile(opts.customInstructionsPath, 'utf-8')); } catch { /* file not found — skip */ }
+      }
       if (opts.systemPrompt) parts.push(opts.systemPrompt);
       if (opts.mission) parts.push(opts.mission);
       args.push(parts.join('\n\n'));
@@ -252,6 +256,9 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable, S
 
     const binary = this.findBinary();
     const parts: string[] = [];
+    if (opts.customInstructionsPath) {
+      try { parts.push(await fsp.readFile(opts.customInstructionsPath, 'utf-8')); } catch { /* file not found — skip */ }
+    }
     if (opts.systemPrompt) parts.push(opts.systemPrompt);
     parts.push(opts.mission);
     const prompt = parts.join('\n\n');

--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -232,6 +232,31 @@ describe('CopilotCliProvider', () => {
       expect(result.args).toContain('--allow-tool');
       expect(result.args.filter(a => a === '--allow-tool')).toHaveLength(2);
     });
+
+    it('reads customInstructionsPath file and injects contents into prompt', async () => {
+      const fsp = await import('fs/promises');
+      vi.mocked(fsp.readFile).mockResolvedValueOnce('You are a backend specialist');
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        customInstructionsPath: '/personas/backend.md',
+        mission: 'Fix the API',
+      });
+      const promptIdx = result.args.indexOf('-p');
+      expect(result.args[promptIdx + 1]).toContain('You are a backend specialist');
+      expect(result.args[promptIdx + 1]).toContain('Fix the API');
+    });
+
+    it('gracefully handles missing customInstructionsPath file', async () => {
+      const fsp = await import('fs/promises');
+      vi.mocked(fsp.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        customInstructionsPath: '/nonexistent.md',
+        mission: 'Fix it',
+      });
+      const promptIdx = result.args.indexOf('-p');
+      expect(result.args[promptIdx + 1]).toBe('Fix it');
+    });
   });
 
   describe('getExitCommand', () => {

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -166,8 +166,11 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
       }
     }
 
-    if (opts.mission || opts.systemPrompt) {
+    if (opts.mission || opts.systemPrompt || opts.customInstructionsPath) {
       const parts: string[] = [];
+      if (opts.customInstructionsPath) {
+        try { parts.push(await fsp.readFile(opts.customInstructionsPath, 'utf-8')); } catch { /* file not found — skip */ }
+      }
       if (opts.systemPrompt) parts.push(opts.systemPrompt);
       if (opts.mission) parts.push(opts.mission);
       args.push('-p', parts.join('\n\n'));
@@ -264,6 +267,9 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
 
     const binary = this.findBinary();
     const parts: string[] = [];
+    if (opts.customInstructionsPath) {
+      try { parts.push(await fsp.readFile(opts.customInstructionsPath, 'utf-8')); } catch { /* file not found — skip */ }
+    }
     if (opts.systemPrompt) parts.push(opts.systemPrompt);
     parts.push(opts.mission);
     const args = ['-p', parts.join('\n\n'), '--allow-all', '--silent'];

--- a/src/main/orchestrators/types.ts
+++ b/src/main/orchestrators/types.ts
@@ -19,6 +19,8 @@ export interface SpawnOpts {
   freeAgentMode?: boolean;
   /** Permission mode for autonomous execution: 'auto' uses Claude's auto-approve classifier, 'skip-all' bypasses all permissions */
   permissionMode?: 'auto' | 'skip-all';
+  /** Path to a custom instructions file appended to the system prompt */
+  customInstructionsPath?: string;
 }
 
 export interface HeadlessOpts extends SpawnOpts {
@@ -232,6 +234,8 @@ export interface StructuredSessionOpts {
   freeAgentMode?: boolean;
   /** Permission mode for autonomous execution: 'auto' uses Claude's auto-approve classifier, 'skip-all' bypasses all permissions */
   permissionMode?: 'auto' | 'skip-all';
+  /** Path to a custom instructions file appended to the system prompt */
+  customInstructionsPath?: string;
   /** Shell command prefix prepended before the CLI binary */
   commandPrefix?: string;
   /** Extra CLI args appended after generated args (e.g. MCP server config flags). */

--- a/src/main/services/agent-config.test.ts
+++ b/src/main/services/agent-config.test.ts
@@ -1169,7 +1169,6 @@ describe('updateDurableConfig', () => {
     expect(result).not.toBeNull();
     expect(result!.lastSessionId).toBeUndefined();
   });
-});
 
   it('persists customInstructionsPath and round-trips', async () => {
     const agents = [

--- a/src/main/services/agent-config.test.ts
+++ b/src/main/services/agent-config.test.ts
@@ -1171,6 +1171,69 @@ describe('updateDurableConfig', () => {
   });
 });
 
+  it('persists customInstructionsPath and round-trips', async () => {
+    const agents = [
+      { id: 'durable_cip', name: 'cip-agent', color: 'indigo', createdAt: '2024-01-01' },
+    ];
+    const writtenData: Record<string, string> = {};
+    const agentsJsonPath = path.join(PROJECT_PATH, '.clubhouse', 'agents.json');
+    writtenData[agentsJsonPath] = JSON.stringify(agents);
+
+    vi.mocked(pathExists).mockImplementation(async (p: any) => {
+      if (String(p).endsWith('agents.json')) return true;
+      return false;
+    });
+    vi.mocked(fsp.readFile).mockImplementation(async (p: any) => {
+      return writtenData[String(p)] || '[]';
+    });
+    vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => {
+      writtenData[String(p)] = String(data);
+    });
+    vi.mocked(fsp.rename).mockImplementation(async (src: any, dest: any) => {
+      writtenData[String(dest)] = writtenData[String(src)] || '';
+      delete writtenData[String(src)];
+    });
+    vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
+
+    await updateDurableConfig(PROJECT_PATH, 'durable_cip', { customInstructionsPath: '/path/to/persona.md' });
+
+    const result = await getDurableConfig(PROJECT_PATH, 'durable_cip');
+    expect(result).not.toBeNull();
+    expect(result!.customInstructionsPath).toBe('/path/to/persona.md');
+  });
+
+  it('clears customInstructionsPath when set to null', async () => {
+    const agents = [
+      { id: 'durable_cip_clear', name: 'cip-clear', color: 'indigo', createdAt: '2024-01-01', customInstructionsPath: '/old.md' },
+    ];
+    const writtenData: Record<string, string> = {};
+    const agentsJsonPath = path.join(PROJECT_PATH, '.clubhouse', 'agents.json');
+    writtenData[agentsJsonPath] = JSON.stringify(agents);
+
+    vi.mocked(pathExists).mockImplementation(async (p: any) => {
+      if (String(p).endsWith('agents.json')) return true;
+      return false;
+    });
+    vi.mocked(fsp.readFile).mockImplementation(async (p: any) => {
+      return writtenData[String(p)] || '[]';
+    });
+    vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => {
+      writtenData[String(p)] = String(data);
+    });
+    vi.mocked(fsp.rename).mockImplementation(async (src: any, dest: any) => {
+      writtenData[String(dest)] = writtenData[String(src)] || '';
+      delete writtenData[String(src)];
+    });
+    vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
+
+    await updateDurableConfig(PROJECT_PATH, 'durable_cip_clear', { customInstructionsPath: null });
+
+    const result = await getDurableConfig(PROJECT_PATH, 'durable_cip_clear');
+    expect(result).not.toBeNull();
+    expect(result!.customInstructionsPath).toBeUndefined();
+  });
+});
+
 describe('updateSessionId', () => {
   it('persists a session ID via updateSessionId helper', async () => {
     const agents = [

--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -473,7 +473,7 @@ export async function getDurableConfig(projectPath: string, agentId: string): Pr
 export async function updateDurableConfig(
   projectPath: string,
   agentId: string,
-  updates: { quickAgentDefaults?: QuickAgentDefaults; orchestrator?: OrchestratorId; model?: string; freeAgentMode?: boolean; clubhouseModeOverride?: boolean; lastSessionId?: string | null },
+  updates: { quickAgentDefaults?: QuickAgentDefaults; orchestrator?: OrchestratorId; model?: string; freeAgentMode?: boolean; clubhouseModeOverride?: boolean; lastSessionId?: string | null; customInstructionsPath?: string | null },
 ): Promise<void> {
   const agents = await readAgents(projectPath);
   const agent = agents.find((a) => a.id === agentId);
@@ -510,6 +510,13 @@ export async function updateDurableConfig(
       agent.lastSessionId = updates.lastSessionId;
     } else {
       delete agent.lastSessionId;
+    }
+  }
+  if (updates.customInstructionsPath !== undefined) {
+    if (updates.customInstructionsPath) {
+      agent.customInstructionsPath = updates.customInstructionsPath;
+    } else {
+      delete agent.customInstructionsPath;
     }
   }
   await writeAgents(projectPath, agents);

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -50,6 +50,8 @@ export interface SpawnAgentParams {
   companionWorkspace?: string;
   /** Permission mode override for resume (preserves pre-restart mode) */
   permissionMode?: FreeAgentPermissionMode;
+  /** Path to a custom instructions file appended to the system prompt */
+  customInstructionsPath?: string;
 }
 
 export function isHeadlessAgent(agentId: string): boolean {
@@ -148,6 +150,7 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
           if (params.freeAgentMode === undefined) params = { ...params, freeAgentMode: durableConfig.freeAgentMode };
           if (params.structuredMode === undefined && durableConfig.structuredMode) params = { ...params, structuredMode: durableConfig.structuredMode };
           if (params.model === undefined && durableConfig.model) params = { ...params, model: durableConfig.model };
+          if (params.customInstructionsPath === undefined && durableConfig.customInstructionsPath) params = { ...params, customInstructionsPath: durableConfig.customInstructionsPath };
         }
       } catch { /* config not available — use caller-provided values */ }
     }
@@ -196,6 +199,7 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
         freeAgentMode: params.freeAgentMode,
         permissionMode,
         commandPrefix,
+        customInstructionsPath: params.customInstructionsPath,
       }, (exitAgentId) => {
         if (params.kind !== 'durable') bindingManager.unbindAgent(exitAgentId);
         untrackAgent(exitAgentId);
@@ -215,6 +219,7 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
         noSessionPersistence: true,
         freeAgentMode: params.freeAgentMode,
         permissionMode,
+        customInstructionsPath: params.customInstructionsPath,
       });
 
       if (headlessResult) {
@@ -318,6 +323,7 @@ async function spawnPtyAgent(
       permissionMode,
       resume: params.resume,
       sessionId: params.sessionId,
+      customInstructionsPath: params.customInstructionsPath,
     }),
   ]);
 

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -154,6 +154,14 @@ export function AgentSettingsView({ agent }: Props) {
     });
   };
 
+  const handleCustomInstructionsPathBlur = async () => {
+    if (!projectPath) return;
+    const trimmed = customInstructionsPath.trim();
+    await window.clubhouse.agent.updateDurableConfig(projectPath, agent.id, {
+      customInstructionsPath: trimmed || null,
+    });
+  };
+
   const handleOrchestratorChange = async (value: string) => {
     if (!projectPath) return;
     await window.clubhouse.agent.updateDurableConfig(projectPath, agent.id, { orchestrator: value });
@@ -222,6 +230,9 @@ export function AgentSettingsView({ agent }: Props) {
 
   // Structured Mode state (main agent)
   const [structuredMode, setStructuredMode] = useState(agent.structuredMode ?? false);
+
+  // Custom instructions file path
+  const [customInstructionsPath, setCustomInstructionsPath] = useState('');
 
   // Quick Agent Defaults state
   const projectPath = projects.find((p) => p.id === agent.projectId)?.path;
@@ -321,6 +332,7 @@ export function AgentSettingsView({ agent }: Props) {
         }
         setFreeAgentMode(config?.freeAgentMode ?? false);
         setStructuredMode(config?.structuredMode ?? false);
+        setCustomInstructionsPath(config?.customInstructionsPath ?? '');
         setQadLoaded(true);
       } catch {
         setQadLoaded(true);
@@ -713,6 +725,26 @@ export function AgentSettingsView({ agent }: Props) {
                     Not supported by {orchestratorInfo?.displayName || 'this orchestrator'}.
                   </p>
                 )}
+              </div>
+
+              {/* Custom Instructions Path */}
+              <div>
+                <label className="block text-xs text-ctp-subtext0 uppercase tracking-wider mb-1">
+                  Custom instructions file
+                </label>
+                <input
+                  type="text"
+                  value={customInstructionsPath}
+                  onChange={(e) => setCustomInstructionsPath(e.target.value)}
+                  onBlur={handleCustomInstructionsPathBlur}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleCustomInstructionsPathBlur(); }}
+                  disabled={isRunning}
+                  placeholder="e.g. /path/to/persona.md"
+                  className={`w-full bg-surface-0 border border-surface-2 rounded px-2 py-1 text-sm text-ctp-text font-mono placeholder:text-ctp-overlay0 focus:outline-none focus:border-ctp-blue disabled:opacity-50 disabled:cursor-not-allowed`}
+                />
+                <p className="mt-1 text-[10px] text-ctp-subtext0/60">
+                  Path to a file appended to this agent's system prompt at launch. Useful for giving agents in the same folder unique personas.
+                </p>
               </div>
             </div>
           </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -211,6 +211,8 @@ export interface DurableAgentConfig {
   mcpOverride?: boolean;
   /** Persona template ID applied at creation. Used to re-inject instructions on materialization. */
   persona?: string;
+  /** Path to a custom instructions file appended to the agent's system prompt at launch */
+  customInstructionsPath?: string;
 }
 
 /** Maps an orchestrator ID to its wrapper subcommand */


### PR DESCRIPTION
## Summary
- Add a per-agent custom instructions file path setting that lets users point each durable agent at a unique persona/instructions file
- Enables running multiple agents in the same folder with distinct personas (e.g. 3 agents, 1 folder, each with a unique `.md` file)
- Claude Code uses the native `--append-system-prompt-file` flag; Copilot/Codex read file contents inline

## Changes
- **`src/shared/types.ts`** — Add `customInstructionsPath` to `DurableAgentConfig`
- **`src/main/orchestrators/types.ts`** — Add `customInstructionsPath` to `SpawnOpts` and `StructuredSessionOpts`
- **`src/main/services/agent-config.ts`** — Wire persistence in `updateDurableConfig`
- **`src/main/services/agent-system.ts`** — Read from durable config and pass through all spawn paths (PTY, headless, structured)
- **`src/main/orchestrators/claude-code-provider.ts`** — Use `--append-system-prompt-file` for PTY and headless
- **`src/main/orchestrators/copilot-cli-provider.ts`** — Read file and inject inline via `-p` flag
- **`src/main/orchestrators/codex-cli-provider.ts`** — Read file and inject inline as prompt arg
- **`src/main/orchestrators/adapters/stream-json-adapter.ts`** — Use `--append-system-prompt-file` for structured mode
- **`src/renderer/features/agents/AgentSettingsView.tsx`** — Add input field in Configuration section with save-on-blur

## Test Plan
- [x] Claude Code provider: `--append-system-prompt-file` flag added when path set, omitted when undefined, placed before mission
- [x] Copilot CLI provider: file contents read and injected into prompt; graceful handling of missing files
- [x] Codex CLI provider: file contents read and injected into prompt; graceful handling of missing files
- [x] agent-config: `customInstructionsPath` persists via `updateDurableConfig` and round-trips; clears when set to null
- [x] Typecheck passes
- [x] All 427 test suites pass (10551 tests)
- [x] Lint clean (no new errors)

## Manual Validation
- Open agent settings for a durable agent
- Verify "Custom instructions file" input appears in the Configuration section below Free Agent Mode
- Enter a path to a `.md` file and blur — confirm it persists (check `.clubhouse/agents.json`)
- Start the agent and verify the file contents are appended to the system prompt
- Clear the field and blur — confirm the key is removed from config