### PR TITLE
design: add 3 animated concept illustrations for assistant teaching aids

### DIFF
--- a/docs/assistant-ui/BACKLOG.md
+++ b/docs/assistant-ui/BACKLOG.md
@@ -1,0 +1,34 @@
+# Assistant UI — Design Backlog
+
+Priority order: top = highest impact.
+
+## In Progress
+
+- **Animated concept illustrations** — Canvas/zones, agent communication, plugin
+  architecture — visual teaching aids the assistant can embed inline
+
+## Done
+
+- **Mascot character design** — Pip selected (Comp C). 3 comps + rationale.
+- **Mascot expression sheet** — All 8 emotional states + animation specs + guide.
+- **Mascot size variants** — 32px avatar, 18px icon.
+- **Chat layout proposal** — Full spec in `chat-layout/proposal.md`.
+- **Rich content rendering spec** — Mode-specific rendering, ContentFrame, SVG conventions.
+- **Drill-in card designs** — 6 card types, interaction patterns, consent/undo system.
+- **Visual explanation templates** — Flow diagram, architecture block, before/after, tree/hierarchy + guide.
+- **Sleeping mascot component** — TSX reference impl ready for SleepingMascots.tsx integration.
+- **Animation keyframes** — Full CSS spec for all 8 mascot states + UI animations.
+- **Headless mode indicator** — Badges, toasts, status bar for background activity.
+- **Structured view layout** — Wizards, config grids, comparisons.
+- **PTY sidebar visual spec** — Rich content sidebar for terminal mode.
+- **Consistency audit** — 2 minor issues found, 10 patterns documented.
+- **PR reviews** — Phase 1 & 2 mission design compliance reviews.
+- **Step-sequence template** — Numbered card reveal for wizard/scaffolding flows.
+- **Annotated UI wireframe template** — Screenshot + callouts for UI explanations.
+- **Concept illustrations** — Canvas/zones, agent communication, plugin architecture.
+
+## Up Next
+
+1. **Comparison grid template** — Feature table with checks/crosses for A|B decisions
+2. **Timeline template** — Horizontal event sequence for project history
+3. **Onboarding flow mockup** — First-run experience with Pip guiding setup

--- a/docs/assistant-ui/templates/README.md
+++ b/docs/assistant-ui/templates/README.md
@@ -1,0 +1,38 @@
+# Visual Explanation Templates
+
+Reusable SVG templates the assistant can embed inline to explain concepts visually.
+Each template uses Catppuccin Mocha CSS variables with hardcoded fallbacks, animated
+draw-on effects, and `prefers-reduced-motion` fallbacks.
+
+## Templates
+
+### Structural Templates
+
+| Template | File | Use When |
+|---|---|---|
+| Step Sequence | `step-sequence.svg` | Multi-step wizard flows (setup, scaffolding) |
+| Annotated Wireframe | `annotated-wireframe.svg` | Explaining UI areas with numbered callouts |
+
+### Concept Illustrations
+
+| Illustration | File | Teaches |
+|---|---|---|
+| Canvas & Zones | `concept-canvas-zones.svg` | Workspace layout: zones group agents, wires connect, cross-zone collaboration |
+| Agent Communication | `concept-agent-communication.svg` | How MCP wires expose tools bidirectionally between agents |
+| Plugin Architecture | `concept-plugin-architecture.svg` | How plugins contribute widgets, tools, themes to core app |
+
+## Design Conventions
+
+All templates follow these rules:
+
+- **ViewBox**: Width 480px, height varies (200–320px)
+- **Colors**: CSS variables with Catppuccin Mocha fallbacks
+  - Background: `var(--ctp-base, #1e1e2e)`
+  - Surfaces: `var(--ctp-surface0, #313244)`
+  - Text: `var(--ctp-text, #cdd6f4)`
+  - Accent: `var(--ctp-accent, #89b4fa)`
+- **Semantic colors**: Blue=primary, Green=success/spoke, Amber=warning/remote, Pink=highlight, Violet=special
+- **Typography**: `monospace`, 14px titles, 11px labels, 8-9px sublabels
+- **Animations**: Staggered fade-in (0.2s intervals), draw-on for connectors (`stroke-dasharray`/`stroke-dashoffset`), pulse for active elements
+- **Reduced motion**: All animations disabled via `@media (prefers-reduced-motion: reduce)` — elements show at full opacity, static
+- **Rounded corners**: `rx: 6-10` for boxes, `rx: 3-4` for small elements

--- a/docs/assistant-ui/templates/concept-agent-communication.svg
+++ b/docs/assistant-ui/templates/concept-agent-communication.svg
@@ -1,0 +1,253 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300" width="480" height="300">
+  <!-- Concept Illustration: Agent Communication via MCP -->
+  <!-- Shows: Two agents sharing tools through a bidirectional wire, with tool list -->
+  <style>
+    .ac-label {
+      font-family: monospace;
+      font-size: 11px;
+      fill: var(--ctp-text, #cdd6f4);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .ac-sublabel {
+      font-family: monospace;
+      font-size: 8px;
+      fill: var(--ctp-subtext0, #a6adc8);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .ac-title {
+      font-family: monospace;
+      font-size: 14px;
+      font-weight: bold;
+      fill: var(--ctp-text, #cdd6f4);
+      text-anchor: middle;
+    }
+    .ac-code {
+      font-family: monospace;
+      font-size: 8px;
+      fill: #a6e3a1;
+      dominant-baseline: central;
+    }
+    .ac-agent-box {
+      fill: var(--ctp-surface0, #313244);
+      stroke-width: 2;
+      rx: 8;
+    }
+    .ac-tool-row {
+      fill: var(--ctp-mantle, #181825);
+      rx: 4;
+    }
+    .ac-bridge {
+      fill: var(--ctp-surface0, #313244);
+      stroke: var(--ctp-surface1, #45475a);
+      stroke-width: 1;
+      rx: 6;
+    }
+
+    /* Wire with flowing dots */
+    .ac-wire {
+      stroke-width: 2;
+      fill: none;
+      stroke-linecap: round;
+    }
+    .ac-wire-draw {
+      stroke-dasharray: 200;
+      stroke-dashoffset: 200;
+    }
+
+    /* Flowing data particles */
+    .ac-particle {
+      r: 2.5;
+      opacity: 0;
+    }
+
+    /* Staggered animations */
+    .fade-a1 { opacity: 0; animation: acFade 0.4s ease-out 0.2s forwards; }
+    .fade-a2 { opacity: 0; animation: acFade 0.4s ease-out 0.4s forwards; }
+    .fade-bridge { opacity: 0; animation: acFade 0.4s ease-out 0.6s forwards; }
+    .fade-tools { opacity: 0; animation: acFade 0.3s ease-out 0.8s forwards; }
+    .fade-tools-2 { opacity: 0; animation: acFade 0.3s ease-out 0.9s forwards; }
+    .fade-tools-3 { opacity: 0; animation: acFade 0.3s ease-out 1.0s forwards; }
+
+    .draw-wire-top { animation: acDraw 0.7s ease-out 1.1s forwards; }
+    .draw-wire-bot { animation: acDraw 0.7s ease-out 1.3s forwards; }
+
+    /* Particle flow — right to left (tools exposed TO agent A) */
+    .particle-r2l-1 { animation: acFade 0.1s ease-out 1.8s forwards, flowR2L 2s linear 1.8s infinite; }
+    .particle-r2l-2 { animation: acFade 0.1s ease-out 2.4s forwards, flowR2L 2s linear 2.4s infinite; }
+
+    /* Particle flow — left to right (tools exposed TO agent B) */
+    .particle-l2r-1 { animation: acFade 0.1s ease-out 2.0s forwards, flowL2R 2s linear 2.0s infinite; }
+    .particle-l2r-2 { animation: acFade 0.1s ease-out 2.6s forwards, flowL2R 2s linear 2.6s infinite; }
+
+    /* Arrow indicators */
+    .fade-arrows { opacity: 0; animation: acFade 0.3s ease-out 1.8s forwards; }
+
+    @keyframes acFade { to { opacity: 1; } }
+    @keyframes acDraw { to { stroke-dashoffset: 0; } }
+
+    @keyframes flowR2L {
+      0% { cx: 330; opacity: 0; }
+      10% { opacity: 0.9; }
+      90% { opacity: 0.9; }
+      100% { cx: 150; opacity: 0; }
+    }
+    @keyframes flowL2R {
+      0% { cx: 150; opacity: 0; }
+      10% { opacity: 0.9; }
+      90% { opacity: 0.9; }
+      100% { cx: 330; opacity: 0; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .fade-a1, .fade-a2, .fade-bridge, .fade-tools,
+      .fade-tools-2, .fade-tools-3, .fade-arrows,
+      .draw-wire-top, .draw-wire-bot,
+      .particle-r2l-1, .particle-r2l-2,
+      .particle-l2r-1, .particle-l2r-2 {
+        animation: none !important;
+        opacity: 1 !important;
+        stroke-dashoffset: 0 !important;
+      }
+      .particle-r2l-1, .particle-r2l-2,
+      .particle-l2r-1, .particle-l2r-2 { opacity: 0 !important; }
+    }
+  </style>
+
+  <!-- Background -->
+  <rect width="480" height="300" fill="var(--ctp-base, #1e1e2e)" rx="8"/>
+
+  <!-- Title -->
+  <text x="240" y="24" class="ac-title">Agent Communication</text>
+  <text x="240" y="40" class="ac-sublabel" font-size="10">Wires expose MCP tools bidirectionally between agents</text>
+
+  <!-- Agent A (left) -->
+  <g class="fade-a1">
+    <rect x="20" y="60" width="130" height="190" class="ac-agent-box" stroke="#fb923c"/>
+    <!-- Agent header -->
+    <ellipse cx="50" cy="80" rx="10" ry="9" fill="#fb923c" opacity="0.4"/>
+    <circle cx="47" cy="79" r="2" fill="var(--ctp-base, #1e1e2e)"/>
+    <circle cx="53" cy="79" r="2" fill="var(--ctp-base, #1e1e2e)"/>
+    <rect x="49" y="69" width="2" height="4" rx="1" fill="#fb923c" opacity="0.4"/>
+    <circle cx="50" cy="68" r="1.5" fill="#fb923c" opacity="0.4"/>
+    <text x="95" y="77" class="ac-label" font-size="10">Agent A</text>
+    <text x="95" y="90" class="ac-sublabel">Claude Code</text>
+
+    <!-- Separator -->
+    <line x1="30" y1="100" x2="140" y2="100" stroke="var(--ctp-surface1, #45475a)" stroke-width="0.5"/>
+
+    <!-- Own tools -->
+    <text x="85" y="113" class="ac-sublabel" font-size="7" fill="var(--ctp-subtext0, #a6adc8)">OWN TOOLS</text>
+  </g>
+
+  <g class="fade-tools">
+    <rect x="30" y="120" width="110" height="18" class="ac-tool-row"/>
+    <text x="38" y="130" class="ac-code">read_file()</text>
+  </g>
+  <g class="fade-tools-2">
+    <rect x="30" y="142" width="110" height="18" class="ac-tool-row"/>
+    <text x="38" y="152" class="ac-code">write_file()</text>
+  </g>
+  <g class="fade-tools-3">
+    <rect x="30" y="164" width="110" height="18" class="ac-tool-row"/>
+    <text x="38" y="174" class="ac-code">run_tests()</text>
+  </g>
+
+  <!-- Received tools indicator -->
+  <g class="fade-arrows">
+    <text x="85" y="196" class="ac-sublabel" font-size="7" fill="#60a5fa">RECEIVED VIA WIRE</text>
+    <rect x="30" y="203" width="110" height="18" class="ac-tool-row" style="stroke: #60a5fa; stroke-width: 0.5;"/>
+    <text x="38" y="213" class="ac-code" fill="#60a5fa">review_code()</text>
+    <rect x="30" y="225" width="110" height="18" class="ac-tool-row" style="stroke: #60a5fa; stroke-width: 0.5;"/>
+    <text x="38" y="235" class="ac-code" fill="#60a5fa">lint_check()</text>
+  </g>
+
+  <!-- Agent B (right) -->
+  <g class="fade-a2">
+    <rect x="330" y="60" width="130" height="190" class="ac-agent-box" stroke="#60a5fa"/>
+    <!-- Agent header -->
+    <ellipse cx="360" cy="80" rx="10" ry="9" fill="#60a5fa" opacity="0.4"/>
+    <!-- Copilot visor -->
+    <rect x="352" y="76" width="16" height="6" rx="3" fill="var(--ctp-base, #1e1e2e)"/>
+    <line x1="354" y1="79" x2="358" y2="79" stroke="#60a5fa" stroke-width="0.8" opacity="0.6"/>
+    <line x1="362" y1="79" x2="366" y2="79" stroke="#60a5fa" stroke-width="0.8" opacity="0.6"/>
+    <text x="405" y="77" class="ac-label" font-size="10">Agent B</text>
+    <text x="405" y="90" class="ac-sublabel">Copilot</text>
+
+    <line x1="340" y1="100" x2="450" y2="100" stroke="var(--ctp-surface1, #45475a)" stroke-width="0.5"/>
+
+    <text x="395" y="113" class="ac-sublabel" font-size="7" fill="var(--ctp-subtext0, #a6adc8)">OWN TOOLS</text>
+  </g>
+
+  <g class="fade-tools">
+    <rect x="340" y="120" width="110" height="18" class="ac-tool-row"/>
+    <text x="348" y="130" class="ac-code">review_code()</text>
+  </g>
+  <g class="fade-tools-2">
+    <rect x="340" y="142" width="110" height="18" class="ac-tool-row"/>
+    <text x="348" y="152" class="ac-code">lint_check()</text>
+  </g>
+  <g class="fade-tools-3">
+    <rect x="340" y="164" width="110" height="18" class="ac-tool-row"/>
+    <text x="348" y="174" class="ac-code">suggest_fix()</text>
+  </g>
+
+  <!-- Received tools indicator -->
+  <g class="fade-arrows">
+    <text x="395" y="196" class="ac-sublabel" font-size="7" fill="#fb923c">RECEIVED VIA WIRE</text>
+    <rect x="340" y="203" width="110" height="18" class="ac-tool-row" style="stroke: #fb923c; stroke-width: 0.5;"/>
+    <text x="348" y="213" class="ac-code" fill="#fb923c">read_file()</text>
+    <rect x="340" y="225" width="110" height="18" class="ac-tool-row" style="stroke: #fb923c; stroke-width: 0.5;"/>
+    <text x="348" y="235" class="ac-code" fill="#fb923c">write_file()</text>
+  </g>
+
+  <!-- MCP Bridge (center) -->
+  <g class="fade-bridge">
+    <rect x="195" y="105" width="90" height="50" class="ac-bridge"/>
+    <text x="240" y="125" class="ac-label" font-size="10">MCP Wire</text>
+    <text x="240" y="140" class="ac-sublabel">Bidirectional</text>
+  </g>
+
+  <!-- Wire: Agent A → Bridge (top) -->
+  <line x1="150" y1="120" x2="195" y2="120" stroke="#a6e3a1" class="ac-wire ac-wire-draw draw-wire-top"/>
+
+  <!-- Wire: Bridge → Agent B (top) -->
+  <line x1="285" y1="120" x2="330" y2="120" stroke="#a6e3a1" class="ac-wire ac-wire-draw draw-wire-top"/>
+
+  <!-- Wire: Agent A → Bridge (bottom) -->
+  <line x1="150" y1="140" x2="195" y2="140" stroke="#a6e3a1" class="ac-wire ac-wire-draw draw-wire-bot"/>
+
+  <!-- Wire: Bridge → Agent B (bottom) -->
+  <line x1="285" y1="140" x2="330" y2="140" stroke="#a6e3a1" class="ac-wire ac-wire-draw draw-wire-bot"/>
+
+  <!-- Direction arrows -->
+  <g class="fade-arrows">
+    <!-- → on top wire -->
+    <polygon points="328,116 334,120 328,124" fill="#a6e3a1" opacity="0.7"/>
+    <text x="240" y="114" class="ac-sublabel" font-size="7" fill="#a6e3a1">tools A → B</text>
+
+    <!-- ← on bottom wire -->
+    <polygon points="152,136 146,140 152,144" fill="#a6e3a1" opacity="0.7"/>
+    <text x="240" y="149" class="ac-sublabel" font-size="7" fill="#a6e3a1">tools B → A</text>
+  </g>
+
+  <!-- Flowing particles (top wire: L→R = A's tools going to B) -->
+  <circle cy="120" fill="#fb923c" class="ac-particle particle-l2r-1"/>
+  <circle cy="120" fill="#fb923c" class="ac-particle particle-l2r-2"/>
+
+  <!-- Flowing particles (bottom wire: R→L = B's tools going to A) -->
+  <circle cy="140" fill="#60a5fa" class="ac-particle particle-r2l-1"/>
+  <circle cy="140" fill="#60a5fa" class="ac-particle particle-r2l-2"/>
+
+  <!-- Bottom explanation -->
+  <g transform="translate(20, 265)">
+    <rect x="0" y="-4" width="440" height="30" rx="6" fill="var(--ctp-surface0, #313244)" opacity="0.5"/>
+    <text x="220" y="7" class="ac-sublabel" text-anchor="middle" font-size="8">
+      When agents are wired, each gains access to the other's tools via MCP protocol.
+    </text>
+    <text x="220" y="19" class="ac-sublabel" text-anchor="middle" font-size="7" fill="var(--ctp-subtext0, #a6adc8)">
+      Tool permissions are configurable per wire · Unidirectional wires restrict to one direction
+    </text>
+  </g>
+</svg>

--- a/docs/assistant-ui/templates/concept-canvas-zones.svg
+++ b/docs/assistant-ui/templates/concept-canvas-zones.svg
@@ -1,0 +1,258 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 320" width="480" height="320">
+  <!-- Concept Illustration: Canvas & Zones -->
+  <!-- Shows: Canvas workspace with colored zones containing agent cards, wires connecting them -->
+  <style>
+    .cz-label {
+      font-family: monospace;
+      font-size: 11px;
+      fill: var(--ctp-text, #cdd6f4);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .cz-sublabel {
+      font-family: monospace;
+      font-size: 8px;
+      fill: var(--ctp-subtext0, #a6adc8);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .cz-title {
+      font-family: monospace;
+      font-size: 14px;
+      font-weight: bold;
+      fill: var(--ctp-text, #cdd6f4);
+      text-anchor: middle;
+    }
+    .cz-zone-label {
+      font-family: monospace;
+      font-size: 9px;
+      font-weight: bold;
+      text-anchor: start;
+      dominant-baseline: central;
+    }
+    .cz-card {
+      fill: var(--ctp-surface0, #313244);
+      stroke-width: 1.5;
+      rx: 6;
+    }
+    .cz-wire {
+      stroke-width: 1.5;
+      fill: none;
+      stroke-linecap: round;
+      stroke-dasharray: 120;
+      stroke-dashoffset: 120;
+    }
+    .cz-wire-dot {
+      r: 3;
+    }
+
+    /* Zone backgrounds */
+    .zone-cyan {
+      fill: rgba(137, 220, 235, 0.06);
+      stroke: #89dceb;
+      stroke-width: 1.5;
+      stroke-dasharray: 6 3;
+      rx: 10;
+    }
+    .zone-rose {
+      fill: rgba(244, 114, 182, 0.06);
+      stroke: #f472b6;
+      stroke-width: 1.5;
+      stroke-dasharray: 6 3;
+      rx: 10;
+    }
+    .zone-violet {
+      fill: rgba(203, 166, 247, 0.06);
+      stroke: #cba6f7;
+      stroke-width: 1.5;
+      stroke-dasharray: 6 3;
+      rx: 10;
+    }
+
+    /* Card accents by orchestrator */
+    .card-claude { stroke: #fb923c; }
+    .card-copilot { stroke: #60a5fa; }
+    .card-gp { stroke: var(--ctp-accent, #89b4fa); }
+
+    /* Staggered fade-in */
+    .fade-z1 { opacity: 0; animation: czFade 0.5s ease-out 0.2s forwards; }
+    .fade-z2 { opacity: 0; animation: czFade 0.5s ease-out 0.4s forwards; }
+    .fade-z3 { opacity: 0; animation: czFade 0.5s ease-out 0.6s forwards; }
+    .fade-c1 { opacity: 0; animation: czFade 0.3s ease-out 0.5s forwards; }
+    .fade-c2 { opacity: 0; animation: czFade 0.3s ease-out 0.7s forwards; }
+    .fade-c3 { opacity: 0; animation: czFade 0.3s ease-out 0.8s forwards; }
+    .fade-c4 { opacity: 0; animation: czFade 0.3s ease-out 0.9s forwards; }
+    .fade-c5 { opacity: 0; animation: czFade 0.3s ease-out 1.0s forwards; }
+    .fade-c6 { opacity: 0; animation: czFade 0.3s ease-out 1.1s forwards; }
+
+    /* Wire draw-on */
+    .wire-1 { animation: czDraw 0.8s ease-out 1.2s forwards; }
+    .wire-2 { animation: czDraw 0.8s ease-out 1.4s forwards; }
+    .wire-3 { animation: czDraw 0.8s ease-out 1.6s forwards; }
+    .wire-4 { animation: czDraw 0.8s ease-out 1.8s forwards; }
+
+    /* Wire dot pulse */
+    .wire-dot-1 { opacity: 0; animation: czFade 0.2s ease-out 2.0s forwards, czPulse 2s ease-in-out 2.2s infinite; }
+    .wire-dot-2 { opacity: 0; animation: czFade 0.2s ease-out 2.2s forwards, czPulse 2s ease-in-out 2.6s infinite; }
+
+    @keyframes czFade { to { opacity: 1; } }
+    @keyframes czDraw { to { stroke-dashoffset: 0; } }
+    @keyframes czPulse {
+      0%, 100% { opacity: 0.4; }
+      50% { opacity: 1; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .fade-z1, .fade-z2, .fade-z3,
+      .fade-c1, .fade-c2, .fade-c3, .fade-c4, .fade-c5, .fade-c6,
+      .wire-1, .wire-2, .wire-3, .wire-4,
+      .wire-dot-1, .wire-dot-2 {
+        animation: none !important;
+        opacity: 1 !important;
+        stroke-dashoffset: 0 !important;
+      }
+      .wire-dot-1, .wire-dot-2 { opacity: 0.7 !important; }
+    }
+  </style>
+
+  <!-- Background -->
+  <rect width="480" height="320" fill="var(--ctp-base, #1e1e2e)" rx="8"/>
+
+  <!-- Title -->
+  <text x="240" y="24" class="cz-title">Canvas &amp; Zones</text>
+  <text x="240" y="40" class="cz-sublabel" font-size="10">Zones group agents · Wires share tools · Layout arranges everything</text>
+
+  <!-- Zone 1: Alpha (cyan, left) -->
+  <g class="fade-z1">
+    <rect x="20" y="55" width="195" height="200" class="zone-cyan"/>
+    <text x="32" y="70" class="cz-zone-label" fill="#89dceb">Alpha Team</text>
+  </g>
+
+  <!-- Zone 2: Beta (rose, right) -->
+  <g class="fade-z2">
+    <rect x="230" y="55" width="195" height="130" class="zone-rose"/>
+    <text x="242" y="70" class="cz-zone-label" fill="#f472b6">Beta Team</text>
+  </g>
+
+  <!-- Zone 3: Judging (violet, bottom-right) -->
+  <g class="fade-z3">
+    <rect x="230" y="200" width="195" height="55" class="zone-violet"/>
+    <text x="242" y="215" class="cz-zone-label" fill="#cba6f7">Judging</text>
+  </g>
+
+  <!-- Cards in Alpha zone -->
+  <!-- Lead agent -->
+  <g class="fade-c1">
+    <rect x="35" y="82" width="80" height="50" class="cz-card card-claude"/>
+    <!-- Mini robot icon -->
+    <ellipse cx="52" cy="100" rx="6" ry="5" fill="#fb923c" opacity="0.5"/>
+    <circle cx="50" cy="99" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <circle cx="54" cy="99" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="82" y="102" class="cz-label" font-size="9" text-anchor="start">Lead</text>
+    <text x="82" y="115" class="cz-sublabel" text-anchor="start">Claude</text>
+  </g>
+
+  <!-- Worker A -->
+  <g class="fade-c2">
+    <rect x="35" y="145" width="80" height="50" class="cz-card card-claude"/>
+    <ellipse cx="52" cy="163" rx="6" ry="5" fill="#fb923c" opacity="0.5"/>
+    <circle cx="50" cy="162" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <circle cx="54" cy="162" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="82" y="165" class="cz-label" font-size="9" text-anchor="start">Worker</text>
+    <text x="82" y="178" class="cz-sublabel" text-anchor="start">Claude</text>
+  </g>
+
+  <!-- QA agent -->
+  <g class="fade-c3">
+    <rect x="125" y="145" width="80" height="50" class="cz-card card-copilot"/>
+    <ellipse cx="142" cy="163" rx="6" ry="5" fill="#60a5fa" opacity="0.5"/>
+    <circle cx="140" cy="162" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <circle cx="144" cy="162" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="172" y="165" class="cz-label" font-size="9" text-anchor="start">QA</text>
+    <text x="172" y="178" class="cz-sublabel" text-anchor="start">Copilot</text>
+  </g>
+
+  <!-- Group Project hub (Alpha zone) -->
+  <g class="fade-c4">
+    <rect x="125" y="82" width="80" height="50" class="cz-card card-gp"/>
+    <!-- GP icon: small bulletin board -->
+    <rect x="142" y="94" width="12" height="10" rx="1" fill="var(--ctp-accent, #89b4fa)" opacity="0.5"/>
+    <rect x="145" y="97" width="6" height="2" rx="0.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <rect x="145" y="100" width="4" height="2" rx="0.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="175" y="102" class="cz-label" font-size="9" text-anchor="start">GP</text>
+    <text x="175" y="115" class="cz-sublabel" text-anchor="start">Hub</text>
+  </g>
+
+  <!-- Cards in Beta zone -->
+  <g class="fade-c5">
+    <rect x="245" y="82" width="80" height="50" class="cz-card card-claude"/>
+    <ellipse cx="262" cy="100" rx="6" ry="5" fill="#fb923c" opacity="0.5"/>
+    <circle cx="260" cy="99" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <circle cx="264" cy="99" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="292" y="102" class="cz-label" font-size="9" text-anchor="start">Lead</text>
+    <text x="292" y="115" class="cz-sublabel" text-anchor="start">Claude</text>
+  </g>
+
+  <g class="fade-c5">
+    <rect x="340" y="82" width="75" height="50" class="cz-card card-copilot"/>
+    <ellipse cx="357" cy="100" rx="6" ry="5" fill="#60a5fa" opacity="0.5"/>
+    <circle cx="355" cy="99" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <circle cx="359" cy="99" r="1.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="382" y="102" class="cz-label" font-size="9" text-anchor="start">QA</text>
+    <text x="382" y="115" class="cz-sublabel" text-anchor="start">Copilot</text>
+  </g>
+
+  <!-- Beta Worker -->
+  <g class="fade-c5">
+    <rect x="290" y="140" width="80" height="35" class="cz-card card-claude"/>
+    <text x="330" y="160" class="cz-label" font-size="9">Worker</text>
+  </g>
+
+  <!-- Judge card in Judging zone -->
+  <g class="fade-c6">
+    <rect x="290" y="210" width="80" height="35" class="cz-card" style="stroke: #cba6f7;">
+    </rect>
+    <text x="330" y="225" class="cz-label" font-size="9">Judge</text>
+    <text x="330" y="237" class="cz-sublabel">Evaluates</text>
+  </g>
+
+  <!-- Wires -->
+  <!-- Lead → GP in Alpha zone -->
+  <line x1="115" y1="107" x2="125" y2="107" stroke="var(--ctp-accent, #89b4fa)" class="cz-wire wire-1"/>
+
+  <!-- Worker → GP -->
+  <path d="M115 170 Q120 170 120 140 Q120 132 125 132" stroke="#a6e3a1" class="cz-wire wire-2" fill="none"/>
+
+  <!-- QA → GP -->
+  <path d="M165 145 Q165 137 165 132" stroke="#a6e3a1" class="cz-wire wire-2" fill="none"/>
+
+  <!-- Cross-zone: Alpha GP → Beta Lead -->
+  <line x1="205" y1="107" x2="245" y2="107" stroke="#f5a623" class="cz-wire wire-3" stroke-dasharray="4 3"/>
+  <circle cx="225" cy="107" fill="#f5a623" class="cz-wire-dot wire-dot-1"/>
+
+  <!-- Cross-zone: Beta Lead → Judge -->
+  <path d="M285 132 Q290 180 330 210" stroke="#cba6f7" class="cz-wire wire-4" fill="none" stroke-dasharray="4 3"/>
+  <circle cx="310" cy="180" fill="#cba6f7" class="cz-wire-dot wire-dot-2"/>
+
+  <!-- Legend -->
+  <g transform="translate(20, 272)">
+    <rect x="0" y="-4" width="440" height="38" rx="6" fill="var(--ctp-surface0, #313244)" opacity="0.5"/>
+
+    <rect x="10" y="2" width="12" height="8" rx="2" fill="none" stroke="#89dceb" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="28" y="7" class="cz-sublabel" text-anchor="start">Zone</text>
+
+    <rect x="65" y="2" width="12" height="8" rx="2" fill="var(--ctp-surface0, #313244)" stroke="#fb923c" stroke-width="1"/>
+    <text x="83" y="7" class="cz-sublabel" text-anchor="start">Agent</text>
+
+    <rect x="125" y="2" width="12" height="8" rx="2" fill="var(--ctp-surface0, #313244)" stroke="var(--ctp-accent, #89b4fa)" stroke-width="1"/>
+    <text x="143" y="7" class="cz-sublabel" text-anchor="start">Group Project</text>
+
+    <line x1="225" y1="6" x2="245" y2="6" stroke="#a6e3a1" stroke-width="1.5"/>
+    <text x="252" y="7" class="cz-sublabel" text-anchor="start">Wire (in-zone)</text>
+
+    <line x1="330" y1="6" x2="350" y2="6" stroke="#f5a623" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="357" y="7" class="cz-sublabel" text-anchor="start">Wire (cross-zone)</text>
+
+    <text x="220" y="23" class="cz-sublabel" font-size="7" text-anchor="middle">Zones group related agents · Wires expose MCP tools between cards · Cross-zone wires connect teams</text>
+  </g>
+</svg>

--- a/docs/assistant-ui/templates/concept-plugin-architecture.svg
+++ b/docs/assistant-ui/templates/concept-plugin-architecture.svg
@@ -1,0 +1,231 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300" width="480" height="300">
+  <!-- Concept Illustration: Plugin Architecture -->
+  <!-- Shows: Core app with plugin registry, plugins contributing widgets, tools, and themes -->
+  <style>
+    .pa-label {
+      font-family: monospace;
+      font-size: 11px;
+      fill: var(--ctp-text, #cdd6f4);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .pa-sublabel {
+      font-family: monospace;
+      font-size: 8px;
+      fill: var(--ctp-subtext0, #a6adc8);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .pa-title {
+      font-family: monospace;
+      font-size: 14px;
+      font-weight: bold;
+      fill: var(--ctp-text, #cdd6f4);
+      text-anchor: middle;
+    }
+    .pa-code {
+      font-family: monospace;
+      font-size: 8px;
+      dominant-baseline: central;
+    }
+    .pa-core {
+      fill: var(--ctp-surface0, #313244);
+      stroke: var(--ctp-accent, #89b4fa);
+      stroke-width: 2;
+      rx: 10;
+    }
+    .pa-core-glow {
+      fill: var(--ctp-accent, #89b4fa);
+      opacity: 0;
+    }
+    .pa-registry {
+      fill: var(--ctp-mantle, #181825);
+      stroke: var(--ctp-surface1, #45475a);
+      stroke-width: 1;
+      rx: 6;
+    }
+    .pa-plugin {
+      fill: var(--ctp-surface0, #313244);
+      stroke-width: 1.5;
+      rx: 6;
+    }
+    .pa-contrib {
+      fill: var(--ctp-mantle, #181825);
+      rx: 3;
+    }
+    .pa-connector {
+      stroke-width: 1.5;
+      fill: none;
+      stroke-linecap: round;
+      stroke-dasharray: 100;
+      stroke-dashoffset: 100;
+    }
+
+    /* Plugin colors */
+    .plugin-canvas { stroke: #a6e3a1; }
+    .plugin-git { stroke: #fab387; }
+    .plugin-gp { stroke: #89b4fa; }
+    .plugin-custom { stroke: #f472b6; }
+
+    /* Animations */
+    .fade-core { opacity: 0; animation: paFade 0.5s ease-out 0.2s forwards; }
+    .fade-reg { opacity: 0; animation: paFade 0.4s ease-out 0.5s forwards; }
+    .fade-p1 { opacity: 0; animation: paFade 0.3s ease-out 0.8s forwards; }
+    .fade-p2 { opacity: 0; animation: paFade 0.3s ease-out 1.0s forwards; }
+    .fade-p3 { opacity: 0; animation: paFade 0.3s ease-out 1.2s forwards; }
+    .fade-p4 { opacity: 0; animation: paFade 0.3s ease-out 1.4s forwards; }
+
+    .conn-1 { animation: paDraw 0.5s ease-out 1.1s forwards; }
+    .conn-2 { animation: paDraw 0.5s ease-out 1.3s forwards; }
+    .conn-3 { animation: paDraw 0.5s ease-out 1.5s forwards; }
+    .conn-4 { animation: paDraw 0.5s ease-out 1.7s forwards; }
+
+    .core-pulse {
+      animation: paFade 0.5s ease-out 0.2s forwards, paPulse 3s ease-in-out 1.5s infinite;
+    }
+
+    /* Contribution type badges with stagger */
+    .badge-1 { opacity: 0; animation: paFade 0.2s ease-out 1.6s forwards; }
+    .badge-2 { opacity: 0; animation: paFade 0.2s ease-out 1.8s forwards; }
+    .badge-3 { opacity: 0; animation: paFade 0.2s ease-out 2.0s forwards; }
+    .badge-4 { opacity: 0; animation: paFade 0.2s ease-out 2.2s forwards; }
+
+    @keyframes paFade { to { opacity: 1; } }
+    @keyframes paDraw { to { stroke-dashoffset: 0; } }
+    @keyframes paPulse {
+      0%, 100% { opacity: 0.06; }
+      50% { opacity: 0.15; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .fade-core, .fade-reg, .fade-p1, .fade-p2, .fade-p3, .fade-p4,
+      .conn-1, .conn-2, .conn-3, .conn-4, .core-pulse,
+      .badge-1, .badge-2, .badge-3, .badge-4 {
+        animation: none !important;
+        opacity: 1 !important;
+        stroke-dashoffset: 0 !important;
+      }
+      .core-pulse { opacity: 0.08 !important; }
+    }
+  </style>
+
+  <!-- Background -->
+  <rect width="480" height="300" fill="var(--ctp-base, #1e1e2e)" rx="8"/>
+
+  <!-- Title -->
+  <text x="240" y="24" class="pa-title">Plugin Architecture</text>
+  <text x="240" y="40" class="pa-sublabel" font-size="10">Plugins contribute widgets, tools, and themes to the core app</text>
+
+  <!-- Core app (center) -->
+  <ellipse cx="240" cy="155" rx="70" ry="55" class="pa-core-glow core-pulse"/>
+  <g class="fade-core">
+    <rect x="185" y="105" width="110" height="100" class="pa-core"/>
+    <!-- Core icon: Clubhouse logo simplified -->
+    <rect x="220" y="120" width="20" height="16" rx="3" fill="var(--ctp-accent, #89b4fa)" opacity="0.5"/>
+    <rect x="224" y="124" width="12" height="3" rx="1" fill="var(--ctp-base, #1e1e2e)"/>
+    <rect x="224" y="129" width="8" height="3" rx="1" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="240" y="152" class="pa-label">Clubhouse</text>
+    <text x="240" y="165" class="pa-sublabel">Core App</text>
+
+    <!-- Registry rows -->
+    <rect x="195" y="175" width="90" height="14" class="pa-registry"/>
+    <text x="240" y="183" class="pa-sublabel" font-size="7">Plugin Registry</text>
+    <rect x="195" y="191" width="90" height="8" rx="2" fill="var(--ctp-mantle, #181825)"/>
+    <rect x="195" y="191" width="60" height="8" rx="2" fill="var(--ctp-accent, #89b4fa)" opacity="0.2"/>
+    <text x="240" y="196" class="pa-sublabel" font-size="6">4 plugins loaded</text>
+  </g>
+
+  <!-- Plugin 1: Canvas (top-left) -->
+  <g class="fade-p1">
+    <rect x="15" y="55" width="120" height="70" class="pa-plugin plugin-canvas"/>
+    <!-- Canvas icon -->
+    <rect x="28" y="66" width="14" height="10" rx="2" fill="#a6e3a1" opacity="0.4"/>
+    <rect x="30" y="68" width="4" height="3" rx="0.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <rect x="36" y="68" width="4" height="3" rx="0.5" fill="var(--ctp-base, #1e1e2e)"/>
+    <text x="68" y="73" class="pa-label" font-size="10" text-anchor="start">Canvas</text>
+    <text x="28" y="88" class="pa-sublabel" text-anchor="start">Builtin</text>
+  </g>
+  <!-- Canvas contributions -->
+  <g class="badge-1">
+    <rect x="25" y="100" width="50" height="14" class="pa-contrib"/>
+    <text x="50" y="108" class="pa-code" fill="#a6e3a1" text-anchor="middle">widget</text>
+    <rect x="80" y="100" width="44" height="14" class="pa-contrib"/>
+    <text x="102" y="108" class="pa-code" fill="#a6e3a1" text-anchor="middle">views</text>
+  </g>
+
+  <!-- Plugin 2: Git (top-right) -->
+  <g class="fade-p2">
+    <rect x="345" y="55" width="120" height="70" class="pa-plugin plugin-git"/>
+    <!-- Git icon -->
+    <circle cx="362" cy="73" r="6" fill="none" stroke="#fab387" stroke-width="1.5" opacity="0.5"/>
+    <circle cx="362" cy="73" r="2" fill="#fab387" opacity="0.5"/>
+    <text x="382" y="73" class="pa-label" font-size="10" text-anchor="start">Git</text>
+    <text x="355" y="88" class="pa-sublabel" text-anchor="start">Builtin</text>
+  </g>
+  <g class="badge-2">
+    <rect x="355" y="100" width="50" height="14" class="pa-contrib"/>
+    <text x="380" y="108" class="pa-code" fill="#fab387" text-anchor="middle">widget</text>
+    <rect x="410" y="100" width="44" height="14" class="pa-contrib"/>
+    <text x="432" y="108" class="pa-code" fill="#fab387" text-anchor="middle">diff</text>
+  </g>
+
+  <!-- Plugin 3: Group Project (bottom-left) -->
+  <g class="fade-p3">
+    <rect x="15" y="195" width="120" height="70" class="pa-plugin plugin-gp"/>
+    <rect x="28" y="208" width="14" height="10" rx="2" fill="#89b4fa" opacity="0.4"/>
+    <line x1="31" y1="212" x2="39" y2="212" stroke="var(--ctp-base, #1e1e2e)" stroke-width="1"/>
+    <line x1="31" y1="215" x2="36" y2="215" stroke="var(--ctp-base, #1e1e2e)" stroke-width="1"/>
+    <text x="50" y="215" class="pa-label" font-size="10" text-anchor="start">Group</text>
+    <text x="50" y="228" class="pa-label" font-size="10" text-anchor="start">Project</text>
+    <text x="28" y="245" class="pa-sublabel" text-anchor="start">Builtin</text>
+  </g>
+  <g class="badge-3">
+    <rect x="25" y="250" width="50" height="14" class="pa-contrib"/>
+    <text x="50" y="258" class="pa-code" fill="#89b4fa" text-anchor="middle">widget</text>
+    <rect x="80" y="250" width="44" height="14" class="pa-contrib"/>
+    <text x="102" y="258" class="pa-code" fill="#89b4fa" text-anchor="middle">tools</text>
+  </g>
+
+  <!-- Plugin 4: Custom/Community (bottom-right) -->
+  <g class="fade-p4">
+    <rect x="345" y="195" width="120" height="70" class="pa-plugin plugin-custom"/>
+    <!-- Custom puzzle piece icon -->
+    <rect x="358" y="210" width="10" height="10" rx="1" fill="#f472b6" opacity="0.4"/>
+    <rect x="362" y="206" width="3" height="4" rx="1" fill="#f472b6" opacity="0.4"/>
+    <rect x="368" y="213" width="4" height="3" rx="1" fill="#f472b6" opacity="0.4"/>
+    <text x="380" y="215" class="pa-label" font-size="10" text-anchor="start">Custom</text>
+    <text x="380" y="228" class="pa-label" font-size="10" text-anchor="start">Plugin</text>
+    <text x="358" y="245" class="pa-sublabel" text-anchor="start">Community</text>
+  </g>
+  <g class="badge-4">
+    <rect x="355" y="250" width="50" height="14" class="pa-contrib"/>
+    <text x="380" y="258" class="pa-code" fill="#f472b6" text-anchor="middle">theme</text>
+    <rect x="410" y="250" width="44" height="14" class="pa-contrib"/>
+    <text x="432" y="258" class="pa-code" fill="#f472b6" text-anchor="middle">tools</text>
+  </g>
+
+  <!-- Connectors -->
+  <!-- Canvas → Core -->
+  <path d="M135 90 Q160 90 172 105 Q184 120 185 130" stroke="#a6e3a1" class="pa-connector conn-1"/>
+  <circle cx="185" cy="130" r="3" fill="#a6e3a1" class="badge-1"/>
+
+  <!-- Git → Core -->
+  <path d="M345 90 Q320 90 308 105 Q296 120 295 130" stroke="#fab387" class="pa-connector conn-2"/>
+  <circle cx="295" cy="130" r="3" fill="#fab387" class="badge-2"/>
+
+  <!-- Group Project → Core -->
+  <path d="M135 230 Q160 230 172 215 Q184 200 185 190" stroke="#89b4fa" class="pa-connector conn-3"/>
+  <circle cx="185" cy="190" r="3" fill="#89b4fa" class="badge-3"/>
+
+  <!-- Custom → Core -->
+  <path d="M345 230 Q320 230 308 215 Q296 200 295 190" stroke="#f472b6" class="pa-connector conn-4"/>
+  <circle cx="295" cy="190" r="3" fill="#f472b6" class="badge-4"/>
+
+  <!-- Bottom legend -->
+  <g transform="translate(20, 280)">
+    <rect x="0" y="-4" width="440" height="18" rx="4" fill="var(--ctp-surface0, #313244)" opacity="0.5"/>
+    <text x="220" y="5" class="pa-sublabel" text-anchor="middle" font-size="7">
+      Plugins register widgets (canvas cards), tools (MCP capabilities), themes (color palettes), and views (UI panels)
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- **3 animated SVG concept illustrations** for assistant teaching aids, covering core Clubhouse concepts:
  - `concept-canvas-zones.svg` — Workspace layout with colored zones, agent cards, MCP wires, and cross-zone collaboration
  - `concept-agent-communication.svg` — Two agents with MCP wire bridge showing bidirectional tool sharing
  - `concept-plugin-architecture.svg` — Core app with plugin registry and 4 plugin cards connected via wires
- All follow established design system conventions: 480px width, Catppuccin Mocha CSS vars with hardcoded fallbacks, `prefers-reduced-motion: reduce` media query
- Animations: staggered fade-in, draw-on for wires, pulsing active elements
- Added `docs/assistant-ui/BACKLOG.md` with prioritized design work queue
- Added `docs/assistant-ui/templates/README.md` documenting the illustration template system

## Design decisions
- Used existing animation vocabulary (stagger, draw-on, pulse) from SleepingMascots and download page patterns
- All illustrations are self-contained SVGs with embedded CSS — no external dependencies
- Reduced-motion support: all animations disabled, static opacity forced to 1

## Test plan
- [ ] Open each SVG in a browser — animations play correctly
- [ ] Verify `prefers-reduced-motion` disables all animations
- [ ] No visual regressions in existing components

🤖 Generated with [Claude Code](https://claude.com/claude-code)