### PR TITLE
fix(visual): replace inline hex/rgba colors with CSS variable references

### DIFF
--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -419,7 +419,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
               const modelLabel = formatModelLabel(agent.model);
               const c = agent.model && agent.model !== 'default'
                 ? getModelColor(agent.model)
-                : { bg: 'rgba(148,163,184,0.15)', text: '#94a3b8' };
+                : { bg: 'rgb(var(--ctp-overlay1) / 0.15)', text: 'rgb(var(--ctp-overlay1))' };
               return (
                 <span className="text-[10px] px-1.5 py-0.5 rounded truncate font-mono"
                   style={{ backgroundColor: c.bg, color: c.text }}>
@@ -429,13 +429,13 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
             })()}
             {agent.freeAgentMode && (
               <span className="text-[10px] px-1.5 py-0.5 rounded truncate"
-                style={{ backgroundColor: 'rgba(239,68,68,0.15)', color: '#f87171' }}>
+                style={{ backgroundColor: 'rgb(var(--ctp-error) / 0.15)', color: 'rgb(var(--ctp-error))' }}>
                 Free
               </span>
             )}
             {agent.mcpIds && agent.mcpIds.length > 0 && (
               <span className="text-[10px] px-1.5 py-0.5 rounded truncate"
-                style={{ backgroundColor: 'rgba(168,85,247,0.15)', color: '#d8b4fe' }}
+                style={{ backgroundColor: 'rgb(var(--ctp-accent2) / 0.15)', color: 'rgb(var(--ctp-accent2))' }}
                 title={agent.mcpIds.join(', ')}>
                 {agent.mcpIds.length} MCP{agent.mcpIds.length !== 1 ? 's' : ''}
               </span>

--- a/src/renderer/features/annex/SatelliteDashboard.tsx
+++ b/src/renderer/features/annex/SatelliteDashboard.tsx
@@ -259,7 +259,7 @@ function SatelliteStats({ projects, agents, detailedStatuses }: {
   return (
     <div className="grid grid-cols-4 gap-3 mb-6">
       <div className="bg-ctp-mantle border border-surface-0 rounded-xl p-4 flex items-center gap-3">
-        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#a78bfa15', color: '#a78bfa' }}>
+        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: 'rgb(var(--ctp-accent2) / 0.08)', color: 'rgb(var(--ctp-accent2))' }}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
           </svg>
@@ -270,7 +270,7 @@ function SatelliteStats({ projects, agents, detailedStatuses }: {
         </div>
       </div>
       <div className="bg-ctp-mantle border border-surface-0 rounded-xl p-4 flex items-center gap-3">
-        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#34d39915', color: '#34d399' }}>
+        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: 'rgb(var(--ctp-success) / 0.08)', color: 'rgb(var(--ctp-success))' }}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="10" />
             <polyline points="12 6 12 12 16 14" />
@@ -282,7 +282,7 @@ function SatelliteStats({ projects, agents, detailedStatuses }: {
         </div>
       </div>
       <div className="bg-ctp-mantle border border-surface-0 rounded-xl p-4 flex items-center gap-3">
-        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: stats.attention > 0 ? '#fb923c15' : '#6c708615', color: stats.attention > 0 ? '#fb923c' : '#6c7086' }}>
+        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: stats.attention > 0 ? 'rgb(var(--ctp-warning) / 0.08)' : 'rgb(var(--ctp-overlay0) / 0.08)', color: stats.attention > 0 ? 'rgb(var(--ctp-warning))' : 'rgb(var(--ctp-overlay0))' }}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
             <line x1="12" y1="9" x2="12" y2="13" />
@@ -295,7 +295,7 @@ function SatelliteStats({ projects, agents, detailedStatuses }: {
         </div>
       </div>
       <div className="bg-ctp-mantle border border-surface-0 rounded-xl p-4 flex items-center gap-3">
-        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#6c708615', color: '#6c7086' }}>
+        <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: 'rgb(var(--ctp-overlay0) / 0.08)', color: 'rgb(var(--ctp-overlay0))' }}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="10" />
             <line x1="12" y1="8" x2="12" y2="12" />

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -586,22 +586,22 @@ function MiniLayoutPreview({ views }: { views: { x: number; y: number; w: number
 
 function rectFill(type: string): string {
   switch (type) {
-    case 'agent': return '#89b4fa20';
-    case 'anchor': return '#f5a62320';
-    case 'plugin': return '#22c55e20';
-    case 'sticky-note': return '#f9e2af30';
-    case 'zone': return '#cba6f720';
+    case 'agent': return 'rgb(var(--ctp-accent) / 0.12)';
+    case 'anchor': return 'rgb(var(--ctp-warning) / 0.12)';
+    case 'plugin': return 'rgb(var(--ctp-success) / 0.12)';
+    case 'sticky-note': return 'rgb(var(--ctp-warning) / 0.19)';
+    case 'zone': return 'rgb(var(--ctp-accent2) / 0.12)';
     default: return '#31324440';
   }
 }
 
 function rectStroke(type: string): string {
   switch (type) {
-    case 'agent': return '#89b4fa';
-    case 'anchor': return '#f5a623';
-    case 'plugin': return '#22c55e';
-    case 'sticky-note': return '#f9e2af';
-    case 'zone': return '#cba6f7';
+    case 'agent': return 'rgb(var(--ctp-accent))';
+    case 'anchor': return 'rgb(var(--ctp-warning))';
+    case 'plugin': return 'rgb(var(--ctp-success))';
+    case 'sticky-note': return 'rgb(var(--ctp-warning))';
+    case 'zone': return 'rgb(var(--ctp-accent2))';
     default: return '#45475a';
   }
 }

--- a/src/renderer/features/projects/Dashboard.tsx
+++ b/src/renderer/features/projects/Dashboard.tsx
@@ -89,17 +89,18 @@ function AgentAvatar({ agent, size = 'sm' }: { agent: Agent; size?: 'sm' | 'md' 
 
 /* ─── Stat Card ─── */
 
-function StatCard({ label, value, icon, color }: {
+function StatCard({ label, value, icon, color, bgColor }: {
   label: string;
   value: number;
   icon: React.ReactNode;
   color?: string;
+  bgColor?: string;
 }) {
   return (
     <div className="flex-1 min-w-0 bg-ctp-mantle border border-surface-0 rounded-xl p-4 flex items-center gap-3">
       <div
         className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
-        style={{ backgroundColor: color ? `${color}15` : undefined, color: color || undefined }}
+        style={{ backgroundColor: bgColor || (color ? `${color}15` : undefined), color: color || undefined }}
       >
         {icon}
       </div>
@@ -150,7 +151,8 @@ function StatsOverview() {
       <StatCard
         label="Projects"
         value={stats.projects}
-        color="#a78bfa"
+        color="rgb(var(--ctp-accent2))"
+        bgColor="rgb(var(--ctp-accent2) / 0.08)"
         icon={
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
@@ -160,7 +162,8 @@ function StatsOverview() {
       <StatCard
         label="Working"
         value={stats.working}
-        color="#34d399"
+        color="rgb(var(--ctp-success))"
+        bgColor="rgb(var(--ctp-success) / 0.08)"
         icon={
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="10" />
@@ -171,7 +174,8 @@ function StatsOverview() {
       <StatCard
         label="Attention"
         value={stats.attention}
-        color={stats.attention > 0 ? '#fb923c' : '#6c7086'}
+        color={stats.attention > 0 ? 'rgb(var(--ctp-warning))' : 'rgb(var(--ctp-overlay0))'}
+        bgColor={stats.attention > 0 ? 'rgb(var(--ctp-warning) / 0.08)' : 'rgb(var(--ctp-overlay0) / 0.08)'}
         icon={
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
@@ -183,7 +187,8 @@ function StatsOverview() {
       <StatCard
         label="Done today"
         value={stats.completedToday}
-        color="#60a5fa"
+        color="rgb(var(--ctp-accent))"
+        bgColor="rgb(var(--ctp-accent) / 0.08)"
         icon={
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="20 6 9 17 4 12" />
@@ -223,7 +228,7 @@ function NeedsAttentionBox() {
   return (
     <div className="border border-orange-400/30 bg-orange-400/5 rounded-xl overflow-hidden mb-6">
       <div className="px-4 py-3 flex items-center gap-2 border-b border-orange-400/15">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fb923c" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="rgb(var(--ctp-warning))" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
           <line x1="12" y1="9" x2="12" y2="13" />
           <line x1="12" y1="17" x2="12.01" y2="17" />

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -265,10 +265,10 @@
     from 0deg,
     transparent 0%,
     transparent 70%,
-    rgba(137, 180, 250, 0.3) 82%,
-    rgba(137, 180, 250, 0.7) 90%,
-    rgba(205, 214, 244, 0.8) 95%,
-    rgba(137, 180, 250, 0.7) 98%,
+    rgb(var(--ctp-accent) / 0.3) 82%,
+    rgb(var(--ctp-accent) / 0.7) 90%,
+    rgb(var(--ctp-text) / 0.8) 95%,
+    rgb(var(--ctp-accent) / 0.7) 98%,
     transparent 100%
   );
   -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), black calc(100% - 3px));
@@ -291,13 +291,13 @@
 }
 
 .attention-border-orange {
-  --attention-color: #f97316;
-  border: 1.5px solid #f97316;
+  --attention-color: rgb(var(--ctp-warning));
+  border: 1.5px solid rgb(var(--ctp-warning));
 }
 
 .attention-border-yellow {
-  --attention-color: #facc15;
-  border: 1.5px solid #facc15;
+  --attention-color: rgb(var(--ctp-warning));
+  border: 1.5px solid rgb(var(--ctp-warning));
 }
 
 .animate-attention-border {
@@ -307,34 +307,34 @@
 /* Canvas: attention flash border — outside the card, never clips inner content */
 @keyframes canvas-attention-flash {
   0%, 100% {
-    outline-color: rgba(250, 204, 21, 0.9);
-    box-shadow: 0 0 12px 3px rgba(250, 204, 21, 0.35), 0 4px 24px rgba(0, 0, 0, 0.5);
+    outline-color: rgb(var(--ctp-warning) / 0.9);
+    box-shadow: 0 0 12px 3px rgb(var(--ctp-warning) / 0.35), 0 4px 24px rgba(0, 0, 0, 0.5);
   }
   50% {
-    outline-color: rgba(250, 204, 21, 0.35);
-    box-shadow: 0 0 4px 1px rgba(250, 204, 21, 0.1), 0 4px 24px rgba(0, 0, 0, 0.5);
+    outline-color: rgb(var(--ctp-warning) / 0.35);
+    box-shadow: 0 0 4px 1px rgb(var(--ctp-warning) / 0.1), 0 4px 24px rgba(0, 0, 0, 0.5);
   }
 }
 
 @keyframes canvas-error-flash {
   0%, 100% {
-    outline-color: rgba(248, 113, 113, 0.9);
-    box-shadow: 0 0 12px 3px rgba(248, 113, 113, 0.35), 0 4px 24px rgba(0, 0, 0, 0.5);
+    outline-color: rgb(var(--ctp-error) / 0.9);
+    box-shadow: 0 0 12px 3px rgb(var(--ctp-error) / 0.35), 0 4px 24px rgba(0, 0, 0, 0.5);
   }
   50% {
-    outline-color: rgba(248, 113, 113, 0.35);
-    box-shadow: 0 0 4px 1px rgba(248, 113, 113, 0.1), 0 4px 24px rgba(0, 0, 0, 0.5);
+    outline-color: rgb(var(--ctp-error) / 0.35);
+    box-shadow: 0 0 4px 1px rgb(var(--ctp-error) / 0.1), 0 4px 24px rgba(0, 0, 0, 0.5);
   }
 }
 
 .canvas-attention-warning {
-  outline: 2.5px solid rgba(250, 204, 21, 0.9);
+  outline: 2.5px solid rgb(var(--ctp-warning) / 0.9);
   outline-offset: 2px;
   animation: canvas-attention-flash 1.5s ease-in-out infinite;
 }
 
 .canvas-attention-error {
-  outline: 2.5px solid rgba(248, 113, 113, 0.9);
+  outline: 2.5px solid rgb(var(--ctp-error) / 0.9);
   outline-offset: 2px;
   animation: canvas-error-flash 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary

- **VQ-MED (Dashboard):** Replace 5 hardcoded hex colors (`#a78bfa`, `#34d399`, `#fb923c`, `#60a5fa`, `#6c7086`) with `rgb(var(--ctp-*))` semantic token references in StatCard components.
- **VQ-MED (SatelliteDashboard):** Replace 4 inline hex colors with CSS variable references for stat card icons.
- **VQ-MED (AgentListItem):** Replace 3 inline rgba badge colors with theme-aware `rgb(var(--ctp-*) / alpha)` patterns.
- **VQ-HIGH (BlueprintGallery):** Replace 10 hardcoded Mocha hex values in `rectFill()`/`rectStroke()` with CSS variable references.
- **VQ-HIGH (CSS animations):** Replace hardcoded rgba in pulse-ring conic gradient, attention-border classes, canvas-attention-flash, and canvas-error-flash keyframes with `rgb(var(--ctp-warning/error) / alpha)`.

## Test plan

- [x] TypeScript typecheck passes
- [x] All 11,210 tests pass (454 test files, 0 failures)
- [ ] Visual verification that stat cards, badges, blueprint previews, and attention animations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)