### PR TITLE
feat(copilot-cli): --autopilot in headless + structured spawn args (Mission 72)

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -51,6 +51,10 @@ vi.mock('../util/shell', () => ({
 
 vi.mock('./adapters', () => ({
   AcpAdapter: class MockAcpAdapter {
+    public ctorOpts: any;
+    constructor(opts: any) {
+      this.ctorOpts = opts;
+    }
     start = vi.fn();
     sendMessage = vi.fn();
     respondToPermission = vi.fn();
@@ -133,6 +137,22 @@ describe('CopilotCliProvider', () => {
       expect(typeof adapter.respondToPermission).toBe('function');
       expect(typeof adapter.cancel).toBe('function');
       expect(typeof adapter.dispose).toBe('function');
+    });
+
+    it('passes --acp and --stdio in spawn args', () => {
+      const adapter = provider.createStructuredAdapter!() as any;
+      expect(adapter.ctorOpts.args).toContain('--acp');
+      expect(adapter.ctorOpts.args).toContain('--stdio');
+    });
+
+    it('passes --autopilot in spawn args (Mission 72: structured mode is autonomous)', () => {
+      const adapter = provider.createStructuredAdapter!() as any;
+      expect(adapter.ctorOpts.args).toContain('--autopilot');
+    });
+
+    it('uses the resolved binary path', () => {
+      const adapter = provider.createStructuredAdapter!() as any;
+      expect(adapter.ctorOpts.binary).toBe('/usr/local/bin/copilot');
     });
   });
 
@@ -539,6 +559,23 @@ describe('CopilotCliProvider', () => {
       expect(result!.args).toContain('--allow-all');
       expect(result!.args).toContain('--output-format');
       expect(result!.args).toContain('json');
+    });
+
+    it('passes --autopilot in args (Mission 72: headless mode is autonomous)', async () => {
+      const result = await provider.buildHeadlessCommand({
+        cwd: '/project',
+        mission: 'Fix bug',
+      });
+      expect(result!.args).toContain('--autopilot');
+    });
+
+    it('passes --autopilot regardless of model selection', async () => {
+      const result = await provider.buildHeadlessCommand({
+        cwd: '/project',
+        mission: 'Fix bug',
+        model: 'gpt-5',
+      });
+      expect(result!.args).toContain('--autopilot');
     });
 
     it('adds model flag for non-default model', async () => {

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -199,7 +199,11 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
   createStructuredAdapter(_opts?: { resume?: boolean }): StructuredAdapter {
     return new AcpAdapter({
       binary: this.findBinary(),
-      args: ['--acp', '--stdio'],
+      // --autopilot lets Copilot CLI v1.0.23+ run autonomously without per-step
+      // approval round-trips. Structured (ACP) sessions are non-interactive by
+      // definition, so they always opt in. Interactive PTY sessions only opt in
+      // when freeAgentMode is set (see buildSpawnCommand).
+      args: ['--acp', '--stdio', '--autopilot'],
       toolVerbs: TOOL_VERBS,
     });
   }
@@ -276,7 +280,10 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
     const parts: string[] = [];
     if (opts.systemPrompt) parts.push(opts.systemPrompt);
     parts.push(opts.mission);
-    const args = ['-p', parts.join('\n\n'), '--allow-all', '--output-format', 'json'];
+    // --autopilot lets Copilot CLI v1.0.23+ run autonomously without per-step
+    // approval round-trips. Headless mode is non-interactive by definition, so
+    // we always opt in here.
+    const args = ['-p', parts.join('\n\n'), '--allow-all', '--autopilot', '--output-format', 'json'];
 
     if (opts.model && opts.model !== 'default') {
       args.push('--model', opts.model);

--- a/src/main/orchestrators/provider-integration.test.ts
+++ b/src/main/orchestrators/provider-integration.test.ts
@@ -418,6 +418,7 @@ describe('Provider integration tests', () => {
       expect(args[pIdx + 1]).toContain('Be thorough');
       expect(args[pIdx + 1]).toContain('Fix the bug');
       expect(args).toContain('--allow-all');
+      expect(args).toContain('--autopilot');
       expect(args).toContain('--output-format');
       expect(args).toContain('json');
       expect(args).toContain('--model');


### PR DESCRIPTION
## Summary

Mission 72 — GitHub Copilot CLI v1.0.23+ supports an `--autopilot` flag that lets the agent run autonomously without per-step approval round-trips. Add `--autopilot` to the args list when spawning Copilot in non-interactive modes.

- **Headless** (`buildHeadlessCommand`): always passes `--autopilot`
- **Structured/ACP** (`createStructuredAdapter`): always passes `--autopilot`
- **Interactive PTY** (`buildSpawnCommand`): unchanged — only passes `--autopilot` when `freeAgentMode` is set, preserving existing user-driven UX

Per Mason: v1.0.23+ is a hard floor — no version detection or fallback needed.

Reference: https://docs.github.com/en/copilot/concepts/agents/copilot-cli/autopilot

## Changes

`src/main/orchestrators/copilot-cli-provider.ts`
- `createStructuredAdapter` — adds `--autopilot` to ACP spawn args alongside `--acp --stdio`
- `buildHeadlessCommand` — adds `--autopilot` to args alongside `--allow-all`
- Inline comments document the rationale and the asymmetry vs. interactive PTY

`src/main/orchestrators/copilot-cli-provider.test.ts` (+5 tests)
- Mock `AcpAdapter` constructor now captures `opts` so structured args can be inspected from tests
- `createStructuredAdapter` block: 3 new tests asserting `--acp`, `--stdio`, `--autopilot`, and the binary path
- `buildHeadlessCommand` block: 2 new tests asserting `--autopilot` (default) and `--autopilot` regardless of model selection
- Existing PTY freeAgentMode tests untouched — still assert `--autopilot` only with `freeAgentMode: true`

`src/main/orchestrators/provider-integration.test.ts`
- Augmented existing CopilotCli headless test to assert `--autopilot` is in args

## Test plan

- [x] `npx vitest run src/main/orchestrators/copilot-cli-provider.test.ts` — 96/96 pass (file went from 91 → 96 with +5 new tests)
- [x] `npx vitest run src/main/orchestrators/ src/main/services/headless-integration.test.ts` — 670/670 pass
- [x] `npm test` (full suite) — 11,266 pass / 4 skip / 0 fail across 455 files
- [x] `npm run typecheck` — clean
- [x] `npx eslint src/main/orchestrators/copilot-cli-provider.{ts,test.ts} src/main/orchestrators/provider-integration.test.ts` — clean
- [x] Existing Copilot SessionCapable + structured event stream tests still pass unchanged

## Acceptance criteria

- [x] Copilot CLI agents launched in headless mode pass `--autopilot` in spawn args
- [x] Copilot CLI agents launched in structured mode pass `--autopilot` in spawn args
- [x] Interactive PTY mode does NOT pass `--autopilot` (unless `freeAgentMode` is set, preserving existing behavior)
- [x] Existing Copilot tests pass
- [x] New behavioral tests assert spawn args include `--autopilot` for headless/structured and exclude it for interactive (mock the spawn layer)
- [x] Typecheck clean
- [x] No actual Copilot CLI in CI — all assertions made via mocked spawn layer

## Notes for QA

- **Pre-existing lint state on `origin/main`:** `npm run lint` reports 19 errors / 2 warnings on `origin/main` itself, all in renderer files (`AgentSettingsView.tsx`, `SatelliteDashboard.tsx`, several `assistant/*.test.ts`, `canvas-blueprint.test.ts`). These are NOT introduced by Mission 72 — confirmed by running lint on a clean `origin/main` checkout. My touched files are lint-clean. Other Wave 12 missions may address them.
- The brief mentioned an optional "supports autonomous mode" capability flag — `ProviderCapabilities` (`src/main/orchestrators/types.ts:71`) has no such field today, so no UI-side wiring was added. If you want one exposed, file a follow-up.

## Test commands

```bash
npx vitest run src/main/orchestrators/copilot-cli-provider.test.ts
npx vitest run src/main/orchestrators/provider-integration.test.ts
npm test
npm run typecheck
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)