### PR TITLE
fix(annex/gp): default-enable group-project + replay topic history on connect (Mission 67)

### DIFF
--- a/src/renderer/plugins/builtin/canvas/feature-gating.test.ts
+++ b/src/renderer/plugins/builtin/canvas/feature-gating.test.ts
@@ -32,11 +32,22 @@ describe('canvas feature gating', () => {
     expect(defaults.has('canvas')).toBe(true);
   });
 
-  it('canvas sub-plugins NOT in default enabled IDs', () => {
+  it('stable canvas sub-plugins (group-project, sticky-note) ARE in default enabled IDs', () => {
     const defaults = getDefaultEnabledIds({});
-    for (const id of CANVAS_SUB_PLUGIN_IDS) {
-      expect(defaults.has(id)).toBe(false);
-    }
+    expect(defaults.has('group-project')).toBe(true);
+    expect(defaults.has('sticky-note')).toBe(true);
+  });
+
+  it('agent-queue is NOT in default enabled IDs (correctly experimental-gated)', () => {
+    const defaults = getDefaultEnabledIds({});
+    expect(defaults.has('agent-queue')).toBe(false);
+  });
+
+  it('agent-queue stays out of defaults even when its experimental flag is set', () => {
+    // The experimental flag controls whether agent-queue is *loaded*, not whether
+    // it is auto-enabled. Users still opt in explicitly via the plugin list.
+    const defaults = getDefaultEnabledIds({ agentQueue: true });
+    expect(defaults.has('agent-queue')).toBe(false);
   });
 
   it('CANVAS_SUB_PLUGIN_IDS contains group-project, agent-queue, and sticky-note', () => {
@@ -53,7 +64,7 @@ describe('canvas feature gating', () => {
     }
   });
 
-  it('default enabled IDs include terminal, files, git, browser, review, canvas', () => {
+  it('default enabled IDs include terminal, files, git, browser, review, canvas, group-project, sticky-note', () => {
     const defaults = getDefaultEnabledIds({});
     expect(defaults.has('terminal')).toBe(true);
     expect(defaults.has('files')).toBe(true);
@@ -61,6 +72,8 @@ describe('canvas feature gating', () => {
     expect(defaults.has('browser')).toBe(true);
     expect(defaults.has('review')).toBe(true);
     expect(defaults.has('canvas')).toBe(true);
+    expect(defaults.has('group-project')).toBe(true);
+    expect(defaults.has('sticky-note')).toBe(true);
   });
 
   it('hub is NOT in default enabled IDs', () => {

--- a/src/renderer/plugins/builtin/group-project/useGroupProjectContext.test.ts
+++ b/src/renderer/plugins/builtin/group-project/useGroupProjectContext.test.ts
@@ -196,3 +196,177 @@ describe('useGroupProjectContext — local mode', () => {
     expect(result.current.isRemote).toBe(false);
   });
 });
+
+describe('useGroupProjectContext — remote namespace stripping (Mission 67)', () => {
+  const SAT_ID = 'sat-abc';
+  const BARE_ID = 'gp-123';
+  const NAMESPACED_ID = `remote||${SAT_ID}||${BARE_ID}`;
+
+  function seedRemoteGP() {
+    useRemoteProjectStore.setState({
+      remoteGroupProjects: {
+        [SAT_ID]: [
+          {
+            id: BARE_ID,
+            name: 'Test GP',
+            description: 'desc',
+            instructions: 'instr',
+            metadata: {},
+          },
+        ],
+      },
+    });
+  }
+
+  // Canvas state on a remote canvas re-namespaces metadata.groupProjectId to
+  // `remote||satId||originalId`. The widget passes that to the context's fetch
+  // helpers, which previously forwarded it untouched to the annex client REST
+  // path. The satellite registry only knows the bare ID, so it 404'd and
+  // returned [] — the user saw an empty topic list with no history.
+  // The fix strips the prefix in every read/write helper before crossing the
+  // annex client boundary.
+
+  it('strips namespace from gpId before calling gpBulletinDigest', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.fetchDigest(NAMESPACED_ID);
+    });
+
+    expect(mockGpBulletinDigest).toHaveBeenCalledWith(SAT_ID, BARE_ID, undefined);
+    expect(mockGpBulletinDigest).not.toHaveBeenCalledWith(SAT_ID, NAMESPACED_ID, undefined);
+  });
+
+  it('strips namespace from gpId before calling gpBulletinAll', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.fetchAllMessages(NAMESPACED_ID);
+    });
+
+    expect(mockGpBulletinAll).toHaveBeenCalledWith(SAT_ID, BARE_ID, undefined, undefined);
+    expect(mockGpBulletinAll).not.toHaveBeenCalledWith(SAT_ID, NAMESPACED_ID, undefined, undefined);
+  });
+
+  it('strips namespace from gpId before calling gpBulletinTopic', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.fetchTopicMessages(NAMESPACED_ID, 'general');
+    });
+
+    expect(mockGpBulletinTopic).toHaveBeenCalledWith(SAT_ID, BARE_ID, 'general', undefined, undefined);
+  });
+
+  it('strips namespace from gpId before calling gpUpdate', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.update(NAMESPACED_ID, { description: 'new' });
+    });
+
+    expect(mockGpUpdate).toHaveBeenCalledWith(SAT_ID, BARE_ID, { description: 'new' });
+  });
+
+  it('strips namespace from gpId before calling gpDeleteMessage', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.deleteMessage(NAMESPACED_ID, 'general', 'msg-1');
+    });
+
+    expect(mockGpDeleteMessage).toHaveBeenCalledWith(SAT_ID, BARE_ID, 'general', 'msg-1');
+  });
+
+  it('strips namespace from gpId before calling gpDeleteTopic', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.deleteTopic(NAMESPACED_ID, 'general');
+    });
+
+    expect(mockGpDeleteTopic).toHaveBeenCalledWith(SAT_ID, BARE_ID, 'general');
+  });
+
+  it('strips namespace from gpId before calling gpSetTopicProtection', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.setTopicProtection(NAMESPACED_ID, 'general', true);
+    });
+
+    expect(mockGpSetTopicProtection).toHaveBeenCalledWith(SAT_ID, BARE_ID, 'general', true);
+  });
+
+  it('returns full topic history end-to-end when satellite serves multiple topics with messages', async () => {
+    // Acceptance criterion: 2 topics × 5 messages each, satellite joining via
+    // annex sees full topic history. Stub the satellite responses, drive the
+    // controller-side context, and verify history flows back into the widget.
+    const topic1Messages = Array.from({ length: 5 }, (_, i) => ({
+      id: `msg-t1-${i}`,
+      sender: `agent-${i}`,
+      topic: 'general',
+      body: `general message ${i}`,
+      timestamp: `2026-04-10T00:00:0${i}.000Z`,
+    }));
+    const topic2Messages = Array.from({ length: 5 }, (_, i) => ({
+      id: `msg-t2-${i}`,
+      sender: `agent-${i}`,
+      topic: 'shoulder-tap',
+      body: `shoulder-tap message ${i}`,
+      timestamp: `2026-04-10T00:00:1${i}.000Z`,
+    }));
+    const allMessages = [...topic1Messages, ...topic2Messages];
+
+    mockGpBulletinDigest.mockResolvedValue([
+      { topic: 'general', messageCount: 5, newMessageCount: 0, latestTimestamp: topic1Messages[4].timestamp, isProtected: false },
+      { topic: 'shoulder-tap', messageCount: 5, newMessageCount: 0, latestTimestamp: topic2Messages[4].timestamp, isProtected: false },
+    ]);
+    mockGpBulletinAll.mockResolvedValue(allMessages);
+
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(NAMESPACED_ID, true, SAT_ID));
+
+    let digest: any;
+    let messages: any;
+    await act(async () => {
+      digest = await result.current.fetchDigest(NAMESPACED_ID);
+      messages = await result.current.fetchAllMessages(NAMESPACED_ID);
+    });
+
+    // Both REST calls were made with the bare gpId, not the namespaced one.
+    expect(mockGpBulletinDigest).toHaveBeenCalledWith(SAT_ID, BARE_ID, undefined);
+    expect(mockGpBulletinAll).toHaveBeenCalledWith(SAT_ID, BARE_ID, undefined, undefined);
+
+    // Full history is returned to the widget.
+    expect(digest).toHaveLength(2);
+    expect(digest.find((d: any) => d.topic === 'general').messageCount).toBe(5);
+    expect(digest.find((d: any) => d.topic === 'shoulder-tap').messageCount).toBe(5);
+    expect(messages).toHaveLength(10);
+    expect(messages.filter((m: any) => m.topic === 'general')).toHaveLength(5);
+    expect(messages.filter((m: any) => m.topic === 'shoulder-tap')).toHaveLength(5);
+  });
+
+  it('still passes bare gpId through unchanged when used directly without namespacing', async () => {
+    // Defensive: if a caller already strips the prefix (or there's no prefix
+    // because the canvas hasn't applied the namespace step), the helpers
+    // must not break the bare ID.
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(BARE_ID, true, SAT_ID));
+
+    await act(async () => {
+      await result.current.fetchDigest(BARE_ID);
+      await result.current.fetchAllMessages(BARE_ID);
+    });
+
+    expect(mockGpBulletinDigest).toHaveBeenLastCalledWith(SAT_ID, BARE_ID, undefined);
+    expect(mockGpBulletinAll).toHaveBeenLastCalledWith(SAT_ID, BARE_ID, undefined, undefined);
+  });
+});

--- a/src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts
+++ b/src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts
@@ -69,6 +69,16 @@ function dedupeMembers(members: GroupProjectMember[]): GroupProjectMember[] {
 }
 
 /**
+ * Strip the `remote||satelliteId||` prefix from a group project ID. Canvas
+ * metadata stores remote IDs in the namespaced form for resolution against the
+ * controller's stores, but the satellite's REST API only knows the bare ID.
+ * Always call this before sending a gpId across an annex client request.
+ */
+function stripRemotePrefix(gpId: string): string {
+  return gpId.startsWith('remote||') ? gpId.split('||').pop()! : gpId;
+}
+
+/**
  * Provides a unified API for accessing group project data regardless of
  * whether the widget is rendering in a local or remote (satellite) context.
  */
@@ -130,11 +140,11 @@ export function useGroupProjectContext(
   // --- Mutations ---
   const update = useCallback(async (gpId: string, fields: { name?: string; description?: string; instructions?: string; metadata?: Record<string, unknown> }) => {
     if (isRemote && satelliteId) {
-      await window.clubhouse.annexClient.gpUpdate(satelliteId, gpId, fields);
+      const bareId = stripRemotePrefix(gpId);
+      await window.clubhouse.annexClient.gpUpdate(satelliteId, bareId, fields);
       // Optimistically update local remote GP state so the UI reflects the change
       // immediately rather than waiting for the next snapshot sync.
       const satProjects = useRemoteProjectStore.getState().remoteGroupProjects[satelliteId] as GroupProject[] | undefined;
-      const bareId = gpId.startsWith('remote||') ? gpId.split('||').pop()! : gpId;
       const existing = satProjects?.find((p) => p.id === bareId || p.id === gpId);
       if (existing) {
         const merged = {
@@ -154,21 +164,21 @@ export function useGroupProjectContext(
   // --- Bulletin reads ---
   const fetchDigest = useCallback(async (gpId: string, since?: string): Promise<TopicDigest[]> => {
     if (isRemote && satelliteId) {
-      return await window.clubhouse.annexClient.gpBulletinDigest(satelliteId, gpId, since) as TopicDigest[];
+      return await window.clubhouse.annexClient.gpBulletinDigest(satelliteId, stripRemotePrefix(gpId), since) as TopicDigest[];
     }
     return await window.clubhouse.groupProject.getBulletinDigest(gpId, since) as TopicDigest[];
   }, [isRemote, satelliteId]);
 
   const fetchTopicMessages = useCallback(async (gpId: string, topic: string, since?: string, limit?: number): Promise<BulletinMessage[]> => {
     if (isRemote && satelliteId) {
-      return await window.clubhouse.annexClient.gpBulletinTopic(satelliteId, gpId, topic, since, limit) as BulletinMessage[];
+      return await window.clubhouse.annexClient.gpBulletinTopic(satelliteId, stripRemotePrefix(gpId), topic, since, limit) as BulletinMessage[];
     }
     return await window.clubhouse.groupProject.getTopicMessages(gpId, topic, since, limit) as BulletinMessage[];
   }, [isRemote, satelliteId]);
 
   const fetchAllMessages = useCallback(async (gpId: string, since?: string, limit?: number): Promise<BulletinMessage[]> => {
     if (isRemote && satelliteId) {
-      return await window.clubhouse.annexClient.gpBulletinAll(satelliteId, gpId, since, limit) as BulletinMessage[];
+      return await window.clubhouse.annexClient.gpBulletinAll(satelliteId, stripRemotePrefix(gpId), since, limit) as BulletinMessage[];
     }
     return await window.clubhouse.groupProject.getAllMessages(gpId, since, limit) as BulletinMessage[];
   }, [isRemote, satelliteId]);
@@ -185,7 +195,7 @@ export function useGroupProjectContext(
   // --- Delete operations ---
   const deleteMessage = useCallback(async (gpId: string, topic: string, messageId: string): Promise<boolean> => {
     if (isRemote && satelliteId) {
-      const result = await window.clubhouse.annexClient.gpDeleteMessage(satelliteId, gpId, topic, messageId) as unknown;
+      const result = await window.clubhouse.annexClient.gpDeleteMessage(satelliteId, stripRemotePrefix(gpId), topic, messageId) as unknown;
       return (result as { deleted: boolean })?.deleted ?? false;
     }
     return window.clubhouse.groupProject.deleteMessage(gpId, topic, messageId);
@@ -193,7 +203,7 @@ export function useGroupProjectContext(
 
   const deleteTopic = useCallback(async (gpId: string, topic: string): Promise<boolean> => {
     if (isRemote && satelliteId) {
-      const result = await window.clubhouse.annexClient.gpDeleteTopic(satelliteId, gpId, topic) as unknown;
+      const result = await window.clubhouse.annexClient.gpDeleteTopic(satelliteId, stripRemotePrefix(gpId), topic) as unknown;
       return (result as { deleted: boolean })?.deleted ?? false;
     }
     return window.clubhouse.groupProject.deleteTopic(gpId, topic);
@@ -201,7 +211,7 @@ export function useGroupProjectContext(
 
   const setTopicProtection = useCallback(async (gpId: string, topic: string, isProtected: boolean): Promise<boolean> => {
     if (isRemote && satelliteId) {
-      await window.clubhouse.annexClient.gpSetTopicProtection(satelliteId, gpId, topic, isProtected);
+      await window.clubhouse.annexClient.gpSetTopicProtection(satelliteId, stripRemotePrefix(gpId), topic, isProtected);
       return true;
     }
     return window.clubhouse.groupProject.setTopicProtection(gpId, topic, isProtected);

--- a/src/renderer/plugins/builtin/index.ts
+++ b/src/renderer/plugins/builtin/index.ts
@@ -35,7 +35,7 @@ export interface ExperimentalFlags {
 }
 
 /** Plugin IDs that are always enabled by default in a fresh install. */
-const BASE_DEFAULT_IDS = ['terminal', 'files', 'git', 'browser', 'review', 'canvas'];
+const BASE_DEFAULT_IDS = ['terminal', 'files', 'git', 'browser', 'review', 'canvas', 'group-project', 'sticky-note'];
 
 /** Canvas sub-plugin IDs — hidden from the plugin list unless canvas is enabled. */
 export const CANVAS_SUB_PLUGIN_IDS: ReadonlySet<string> = new Set(['group-project', 'agent-queue', 'sticky-note']);

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -608,8 +608,10 @@ describe('plugin-loader', () => {
 
       const { appEnabled } = usePluginStore.getState();
       expect(appEnabled).toContain('canvas');
-      // Sub-plugins (group-project, agent-queue) depend on MCP (still
-      // experimental) — they must be enabled manually by the user.
+      // The canvas-flag migration only enables canvas. Sub-plugin defaults are
+      // owned by BASE_DEFAULT_IDS in builtin/index.ts (group-project + sticky-note
+      // are now default-enabled there for fresh installs); the migration path
+      // itself does not add them.
       expect(appEnabled).not.toContain('group-project');
       expect(appEnabled).not.toContain('agent-queue');
     });


### PR DESCRIPTION
## Mission 67 — Group Project default enable + Annex GP history replay (P1)

Two fixes from Wave 12 bug-fix sprint.

### Part A — Default-enable group-project + sticky-note

Mission 61 verified GP loads in stable without an experimental flag, but missed that it isn't *default-enabled*. Fresh installs ended up with GP installed but unchecked, requiring users to manually toggle it on. Mason expects GP enabled out-of-the-box.

- `src/renderer/plugins/builtin/index.ts` — added `'group-project'` and `'sticky-note'` to `BASE_DEFAULT_IDS`. Did **NOT** add `'agent-queue'` — it stays correctly experimental-gated.
- `feature-gating.test.ts` — replaced "sub-plugins NOT in defaults" with positive assertions for the stable two; added a separate guardrail that `agent-queue` stays out even when its experimental load flag is set; extended the default-IDs roster test.
- `plugin-loader.test.ts` — refreshed the stale "GP depends on MCP (still experimental)" comment in the canvas-flag migration test (untrue since Mission 61).

The plugin-loader's existing app-enabled merge logic (plugin-loader.ts:191-196) propagates new defaults to existing users on next startup, so this lands cleanly for both fresh installs and upgrades.

### Part B — Annex GP history replay

**Root cause:** When canvas state arrives from a satellite, `annexClientStore.ts:458-460` and `remoteProjectStore.ts:231-233` re-namespace `metadata.groupProjectId` from the bare satellite id (e.g. `gp-123`) to `remote||satId||gp-123` so it resolves against the controller's stores. The GP widget then handed that namespaced id straight to `fetchDigest` / `fetchAllMessages` / `fetchTopicMessages` / `delete*` / `setTopicProtection` in `useGroupProjectContext.ts`, which forwarded it unchanged to `window.clubhouse.annexClient.gp*`. Those IPCs hit the satellite's REST endpoints (`annex-server.ts:1832-1883`), which look the project up by id in `groupProjectRegistry`. The registry only knows the bare id, so every read 404'd and the client's `request*` helpers converted that to `[]`. Result: opening a remote canvas with a GP card showed an empty topic list with no history — exactly the symptom in the brief.

The optimistic `update()` callback already stripped the prefix inline (PR #1325 follow-up). Hoisted that into a `stripRemotePrefix()` helper and applied it consistently across **every** annex-client crossing — `fetchDigest`, `fetchTopicMessages`, `fetchAllMessages`, `gpUpdate`, `gpDeleteMessage`, `gpDeleteTopic`, `gpSetTopicProtection`.

The widget's existing on-mount poll (`GroupProjectCanvasWidget.tsx:422`, `refresh()` called synchronously inside the polling `useEffect`) then returns the satellite's full topic history immediately — within the first ~hundred ms after subscription — instead of staying empty until something new is posted.

### Tests

- **Part A:** existing feature-gating tests updated with positive assertions; existing canvas-flag migration test still asserts the migration path doesn't double-add sub-plugins (defaults are now owned by `BASE_DEFAULT_IDS`, not the migration).
- **Part B:** one behavioral test per crossing asserting the bare id is forwarded *and* the namespaced id is **not**, plus a round-trip test that stubs the satellite returning **2 topics × 5 messages each** and asserts the controller-side context delivers all 10 messages plus the digest counts back to the widget — directly mirrors the mission acceptance criterion. Plus a defensive bare-id passthrough test.

### Validation

- ✅ Typecheck: clean
- ✅ Tests: 11,272 pass / 4 skipped / 0 fail (455 files, full suite)
- ⚠️ Lint: same 19 pre-existing errors / 1 warning that zesty-lynx, perky-moth, and ancient-zebra all flagged in their Wave 12 PRs. None in files I touched. Per Driver's explicit direction in #1368/#1369/#1370 ack messages, not blocking — to be addressed in a separate Wave 12 follow-up.

### Files

- `src/renderer/plugins/builtin/index.ts` — `BASE_DEFAULT_IDS`
- `src/renderer/plugins/builtin/canvas/feature-gating.test.ts` — Part A test updates
- `src/renderer/plugins/plugin-loader.test.ts` — stale comment refresh
- `src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts` — `stripRemotePrefix()` + 7 call sites
- `src/renderer/plugins/builtin/group-project/useGroupProjectContext.test.ts` — 9 new behavioral tests

### Acceptance criteria

- [x] Fresh install (no settings) → GP plugin enabled and visible without manual toggle
- [x] Stable build retains GP behavior (Mission 61 invariant intact — `experimental.assistant`/`experimental.agentQueue` unchanged)
- [x] Satellite joining via annex sees full topic history on connect (round-trip test with 2 topics × 5 messages each)
- [x] Behavioral tests for both fixes; existing GP + annex tests pass
- [x] Typecheck + lint clean (in touched files)
- [N/A] E2E: no existing group-project annex E2E test to extend (per the brief's "if there's an existing test")