### PR TITLE
fix(blueprint-handlers): Windows path separator hot-fix (Mission 74, P0)

### DIFF
--- a/src/main/ipc/blueprint-handlers.test.ts
+++ b/src/main/ipc/blueprint-handlers.test.ts
@@ -260,5 +260,53 @@ describe('blueprint-handlers', () => {
       expect(result).toBe(false);
       expect(fsp.unlink).not.toHaveBeenCalled();
     });
+
+    // ── Mission 74: cross-platform path handling ────────────────────────────
+    // The suffix check must work whether realpath returns forward-slash
+    // (POSIX) or backslash (Windows) paths. Tests below assert both styles
+    // succeed for in-bounds paths and both styles still reject out-of-bounds.
+
+    it('accepts a Windows-style backslash path inside blueprints dir', async () => {
+      const bp = 'C:\\Users\\foo\\proj\\.clubhouse\\blueprints\\old.json';
+      vi.mocked(fsp.realpath).mockResolvedValueOnce(bp);
+      vi.mocked(fsp.unlink).mockResolvedValue(undefined);
+
+      const handler = getHandler('blueprint:delete');
+      const result = await handler({}, bp);
+      expect(result).toBe(true);
+      expect(fsp.unlink).toHaveBeenCalledWith(bp);
+    });
+
+    it('accepts a mixed-separator path inside blueprints dir', async () => {
+      // Some Windows APIs return paths with mixed separators
+      const bp = 'C:\\Users\\foo/proj/.clubhouse/blueprints\\old.json';
+      vi.mocked(fsp.realpath).mockResolvedValueOnce(bp);
+      vi.mocked(fsp.unlink).mockResolvedValue(undefined);
+
+      const handler = getHandler('blueprint:delete');
+      const result = await handler({}, bp);
+      expect(result).toBe(true);
+    });
+
+    it('rejects a Windows backslash path OUTSIDE blueprints dir', async () => {
+      // Security: backslash paths must still be rejected when not in
+      // .clubhouse\blueprints\
+      vi.mocked(fsp.realpath).mockResolvedValueOnce('C:\\Users\\foo\\Documents\\important.json');
+
+      const handler = getHandler('blueprint:delete');
+      const result = await handler({}, 'C:\\Users\\foo\\Documents\\important.json');
+      expect(result).toBe(false);
+      expect(fsp.unlink).not.toHaveBeenCalled();
+    });
+
+    it('rejects a Windows backslash path with non-.json extension', async () => {
+      const bp = 'C:\\Users\\foo\\proj\\.clubhouse\\blueprints\\file.txt';
+      vi.mocked(fsp.realpath).mockResolvedValueOnce(bp);
+
+      const handler = getHandler('blueprint:delete');
+      const result = await handler({}, bp);
+      expect(result).toBe(false);
+      expect(fsp.unlink).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/main/ipc/blueprint-handlers.ts
+++ b/src/main/ipc/blueprint-handlers.ts
@@ -168,8 +168,14 @@ export function registerBlueprintHandlers(): void {
       // File doesn't exist
       return false;
     }
-    const blueprintsSuffix = path.join(CLUBHOUSE_DIR, BLUEPRINTS_DIR) + path.sep;
-    if (!resolved.includes(blueprintsSuffix) || !resolved.endsWith('.json')) {
+    // Mission 74: normalize separators to forward slashes before the suffix
+    // check. Native realpath returns backslashes on Windows and forward slashes
+    // elsewhere, but the security invariant ("must be inside .clubhouse/blueprints/")
+    // is platform-independent. Comparing in a single canonical form avoids
+    // false rejections on Windows.
+    const resolvedFwd = resolved.replace(/\\/g, '/');
+    const blueprintsSuffix = `${CLUBHOUSE_DIR}/${BLUEPRINTS_DIR}/`;
+    if (!resolvedFwd.includes(blueprintsSuffix) || !resolvedFwd.endsWith('.json')) {
       appLog('core:blueprint', 'warn', 'Refusing to delete file outside blueprints directory', {
         meta: { filePath, resolved },
       });


### PR DESCRIPTION
## Summary

**Mission 74 — P0 hot-fix.** Repairs the pre-existing Windows-only failure in `blueprint-handlers.test.ts > BLUEPRINT.DELETE > calls assertAllowedPath before deleting` that has been on `main` since PR #1353 and through which 10 PRs (#1358–#1367) merged. Per Driver decision D10, this gates Wave 12: PRs #1368, #1369, #1370, #1371 must rebase on this fix before they can merge.

## Root cause

`src/main/ipc/blueprint-handlers.ts:171` (pre-fix):
```ts
const blueprintsSuffix = path.join(CLUBHOUSE_DIR, BLUEPRINTS_DIR) + path.sep;
if (!resolved.includes(blueprintsSuffix) || !resolved.endsWith('.json')) {
```

On Windows, `path.sep === '\\'` so `blueprintsSuffix` becomes `.clubhouse\blueprints\`. Tests pass forward-slash paths via the mocked `realpath`, so `.includes('.clubhouse\blueprints\')` returns false → handler returns false → assertion fails. macOS/Linux passed because their `path.sep === '/'` matches the test fixtures.

## Fix

Normalize `resolved` to forward slashes before the suffix check; build `blueprintsSuffix` with a literal `/` instead of `path.sep`:

```ts
const resolvedFwd = resolved.replace(/\\/g, '/');
const blueprintsSuffix = `${CLUBHOUSE_DIR}/${BLUEPRINTS_DIR}/`;
if (!resolvedFwd.includes(blueprintsSuffix) || !resolvedFwd.endsWith('.json')) {
```

The security invariant is platform-independent — comparing in a single canonical form removes the platform coupling without changing what the check accepts or rejects. The `realpath` callsite, the `path.sep` in `endsWith('.json')` (which doesn't contain a separator), and the `appLog` meta (still uses native `resolved`) are all unaffected.

## Test plan

- [x] `npx vitest run src/main/ipc/blueprint-handlers.test.ts` — 20/20 pass (file went 16 → 20 with +4 new tests)
- [x] `npm test` — 11,265 pass / 4 skip / 0 fail across 455 files
- [x] `npm run typecheck` — clean
- [x] `npx eslint src/main/ipc/blueprint-handlers.{ts,test.ts}` — clean
- [x] 2 of the 4 new tests verified RED on pre-fix code (`accepts a Windows-style backslash path`, `accepts a mixed-separator path`), then GREEN after the fix
- [x] All 6 pre-existing BLUEPRINT.DELETE tests still pass: positive case, traversal reject, non-json reject, ENOENT, symlink-out-of-bounds reject, allowed-path reject

## New test coverage (Mission 74 block)

`blueprint-handlers.test.ts` — 4 new behavioral tests in BLUEPRINT.DELETE:

1. **`accepts a Windows-style backslash path inside blueprints dir`** — `C:\Users\foo\proj\.clubhouse\blueprints\old.json` → must succeed (was failing on Windows before fix)
2. **`accepts a mixed-separator path inside blueprints dir`** — `C:\Users\foo/proj/.clubhouse/blueprints\old.json` → must succeed (defensive, since some Windows APIs return mixed paths)
3. **`rejects a Windows backslash path OUTSIDE blueprints dir`** — `C:\Users\foo\Documents\important.json` → must reject (security invariant preserved)
4. **`rejects a Windows backslash path with non-.json extension`** — `C:\Users\foo\proj\.clubhouse\blueprints\file.txt` → must reject (security invariant preserved)

## Acceptance criteria (from Mission 74 brief)

- [x] Windows CI will pass for `blueprint-handlers.test.ts > BLUEPRINT.DELETE` (verified by red→green on the new Windows tests)
- [x] macOS/Ubuntu CI still passes (full suite green; existing forward-slash test still passes)
- [x] Security invariant preserved: paths outside `.clubhouse/blueprints/` still rejected (test #3); non-`.json` paths still rejected (test #4)
- [x] Behavioral tests for both Windows-style and mixed-separator paths
- [x] No unrelated files touched (diff is 2 files: `blueprint-handlers.ts` + `blueprint-handlers.test.ts`)
- [x] Typecheck + lint clean on touched files

## Wave 12 unblock plan

Once this PR lands:
- @zesty-lynx — rebase PR #1368 (Mission 72, Copilot `--autopilot`) on new main and re-trigger CI
- @perky-moth — rebase PR #1369 (Mission 70, git diff flash)
- @ancient-zebra — rebase PR #1370 (Mission 66, review nav clamp)
- @mighty-rabbit — rebase PR #1371 (Mission 67, GP default + annex replay)

Each PR's own CI failure will go away once they're branched on top of this fix.

## Notes

- Pre-existing repo-wide lint state (19 errors / 2 warnings) is unchanged — not touched by this PR. Confirmed identical on `origin/main` by 4+ Wave 12 agents.
- Driver decision D10 explicitly rejected the PR #1367 waiver precedent; this hot-fix is the corrective action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)