### PR TITLE
fix(assistant): self-gate experimental flag with friendly placeholder (Mission 73)

### DIFF
--- a/e2e/assistant/assistant-disabled.spec.ts
+++ b/e2e/assistant/assistant-disabled.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * E2E tests for the assistant when the experimental flag is DISABLED.
+ *
+ * Mission 73 — Assistant visual crash on view (P1).
+ *
+ * Before the fix, the assistant page was wrapped in `{assistantEnabled && ...}`
+ * in App.tsx. When the flag was off — the default in stable builds — the
+ * assistant tab rendered only the title bar and banners with no main content,
+ * which Mason reported as a "visual crash on view".
+ *
+ * These tests verify the fix end-to-end by reaching the assistant tab from
+ * a stable-build-like state (flag explicitly disabled) via the rail button,
+ * and asserting:
+ *   1. The page resolves to the disabled placeholder, not a blank content area.
+ *   2. The recovery button ("Open Experimental Settings") is present and routes
+ *      back to the settings page.
+ *   3. No JS errors are emitted on navigation.
+ *
+ * Uses an isolated Electron instance with a clean user data dir so no state
+ * leaks from the main `assistant.spec.ts` file (which intentionally enables
+ * the flag in its launch helper).
+ */
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { _electron as electron } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const APP_PATH = path.resolve(__dirname, '../..');
+const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
+
+interface DisabledInstance {
+  electronApp: Awaited<ReturnType<typeof electron.launch>>;
+  window: Page;
+  userDataDir: string;
+  pageErrors: Error[];
+}
+
+async function findRendererWindow(
+  electronApp: Awaited<ReturnType<typeof electron.launch>>,
+): Promise<Page> {
+  const seen = new Set<Page>();
+
+  for (const page of electronApp.windows()) {
+    if (page.url().startsWith('devtools://')) { seen.add(page); continue; }
+    try {
+      await page.waitForLoadState('load');
+      if (await page.evaluate(() => !!document.getElementById('root'))) return page;
+    } catch { /* not ready */ }
+    seen.add(page);
+  }
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const page = await electronApp.waitForEvent('window', {
+      timeout: Math.max(1_000, deadline - Date.now()),
+    });
+    if (seen.has(page)) continue;
+    seen.add(page);
+    if (page.url().startsWith('devtools://')) continue;
+    try {
+      await page.waitForLoadState('load');
+      if (await page.evaluate(() => !!document.getElementById('root'))) return page;
+    } catch { /* not ready */ }
+  }
+
+  throw new Error('Timed out waiting for renderer window (30 s)');
+}
+
+/**
+ * Launch a clean Clubhouse instance with the assistant experimental flag
+ * EXPLICITLY disabled (default for stable builds).
+ */
+async function launchDisabledInstance(): Promise<DisabledInstance> {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clubhouse-e2e-assistant-disabled-'));
+
+  const electronApp = await electron.launch({
+    args: ['--disable-gpu', MAIN_ENTRY],
+    cwd: APP_PATH,
+    env: {
+      ...process.env,
+      CLUBHOUSE_USER_DATA: userDataDir,
+    },
+  });
+
+  const window = await findRendererWindow(electronApp);
+  await window.waitForLoadState('load');
+
+  const pageErrors: Error[] = [];
+  window.on('pageerror', (error) => pageErrors.push(error));
+
+  // Skip onboarding so we can interact with the chrome
+  await window.evaluate(() => {
+    localStorage.setItem('clubhouse_onboarding', JSON.stringify({ completed: true, cohort: null }));
+  });
+
+  const onboardingBackdrop = window.locator('[data-testid="onboarding-backdrop"]');
+  try {
+    await onboardingBackdrop.waitFor({ state: 'visible', timeout: 3_000 });
+    await window.locator('[data-testid="onboarding-skip"]').click();
+    await onboardingBackdrop.waitFor({ state: 'hidden', timeout: 5_000 });
+  } catch {
+    // Onboarding already completed
+  }
+
+  // Explicitly DISABLE the assistant flag to simulate a stable build's default state.
+  await window.evaluate(async () => {
+    const w = window as unknown as {
+      clubhouse?: {
+        app?: {
+          getExperimentalSettings?: () => Promise<Record<string, boolean>>;
+          saveExperimentalSettings?: (s: Record<string, boolean>) => Promise<void>;
+        };
+      };
+    };
+    if (w.clubhouse?.app?.getExperimentalSettings && w.clubhouse?.app?.saveExperimentalSettings) {
+      const expSettings = await w.clubhouse.app.getExperimentalSettings();
+      await w.clubhouse.app.saveExperimentalSettings({ ...expSettings, assistant: false });
+    }
+  });
+
+  return { electronApp, window, userDataDir, pageErrors };
+}
+
+async function cleanupInstance(handle: DisabledInstance): Promise<void> {
+  try { await handle.electronApp.close(); } catch { /* ok */ }
+  try { fs.rmSync(handle.userDataDir, { recursive: true, force: true }); } catch { /* ok */ }
+}
+
+let instance: DisabledInstance;
+
+test.beforeAll(async () => {
+  instance = await launchDisabledInstance();
+});
+
+test.afterAll(async () => {
+  await cleanupInstance(instance);
+});
+
+test.beforeEach(() => {
+  instance.pageErrors.length = 0;
+});
+
+test('clicking nav-assistant when flag is disabled shows placeholder, not blank page', async () => {
+  const { window } = instance;
+
+  // Wait for the rail to mount
+  const assistantBtn = window.locator('[data-testid="nav-assistant"]');
+  await expect(assistantBtn).toBeVisible({ timeout: 10_000 });
+
+  // Click the assistant rail button — same flow as a stable-build user would take
+  await assistantBtn.click();
+
+  // The assistant view should mount and resolve to the disabled state.
+  // Before the Mission 73 fix, this navigation produced an empty content area
+  // (the title bar would render but the assistant view itself was gated out
+  // of the JSX entirely by `{assistantEnabled && ...}`).
+  const assistantView = window.locator('[data-testid="assistant-view"]');
+  await expect(assistantView).toBeVisible({ timeout: 10_000 });
+
+  // The data attribute should resolve away from "loading" to "disabled".
+  await expect(assistantView).toHaveAttribute('data-assistant-state', 'disabled', {
+    timeout: 10_000,
+  });
+
+  // The recovery button should be present.
+  await expect(window.locator('[data-testid="assistant-open-settings-button"]')).toBeVisible();
+
+  // The chat UI elements should NOT be present (the bug they replaced).
+  await expect(window.locator('[data-testid="assistant-feed-empty"]')).toHaveCount(0);
+  await expect(window.locator('[data-testid="assistant-message-input"]')).toHaveCount(0);
+
+  // No JS errors on navigation — the original bug was visual emptiness, but
+  // we want this guard so a future regression that throws is caught here too.
+  expect(instance.pageErrors).toHaveLength(0);
+});
+
+test('clicking "Open Experimental Settings" routes to settings page', async () => {
+  const { window } = instance;
+
+  // The previous test left us on the assistant tab in the disabled state.
+  // Re-open if we got navigated away.
+  const assistantView = window.locator('[data-testid="assistant-view"]');
+  if (!(await assistantView.isVisible().catch(() => false))) {
+    await window.locator('[data-testid="nav-assistant"]').click();
+    await expect(assistantView).toBeVisible({ timeout: 10_000 });
+  }
+  await expect(assistantView).toHaveAttribute('data-assistant-state', 'disabled', {
+    timeout: 10_000,
+  });
+
+  const settingsBtn = window.locator('[data-testid="assistant-open-settings-button"]');
+  await expect(settingsBtn).toBeVisible();
+  await settingsBtn.click();
+
+  // After clicking, the assistant view should no longer be on screen
+  // (we navigated away to the settings page).
+  await expect(assistantView).toHaveCount(0, { timeout: 5_000 });
+
+  expect(instance.pageErrors).toHaveLength(0);
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -101,13 +101,8 @@ export function App() {
 
   // Annex is now a stable feature — no need to clear stale activeHostId based on experimental flag
 
-  // ── Experimental feature flags (for gating assistant) ──────────────────
-  const [assistantEnabled, setAssistantEnabled] = useState(false);
-  useEffect(() => {
-    window.clubhouse.app.getExperimentalSettings().then((flags) => {
-      setAssistantEnabled(!!flags.assistant);
-    }).catch(() => {});
-  }, []);
+  // Note: assistant experimental gating now lives inside AssistantView itself,
+  // so the assistant page is never blank when navigated to. (Mission 73 fix.)
 
   // ── Reactive effects (depend on state already subscribed for routing) ───
 
@@ -392,11 +387,9 @@ export function App() {
           />
           <PluginUpdateBanner />
         </div>
-        {assistantEnabled && (
-          <RailSection>
-            <AssistantView />
-          </RailSection>
-        )}
+        <RailSection>
+          <AssistantView />
+        </RailSection>
         <CommandPalette />
         <QuickAgentDialog />
         <BlueprintGallery />

--- a/src/renderer/features/assistant/AssistantView.tsx
+++ b/src/renderer/features/assistant/AssistantView.tsx
@@ -4,18 +4,46 @@ import { AssistantFeed } from './AssistantFeed';
 import { AssistantInput } from './AssistantInput';
 import { AgentTerminal } from '../agents/AgentTerminal';
 import * as assistantAgent from './assistant-agent';
+import { useUIStore } from '../../stores/uiStore';
 import type { FeedItem } from './types';
 import type { AssistantMode, AssistantStatus } from './assistant-agent';
 
 /**
  * Top-level container for the Clubhouse Assistant.
  *
- * Tri-state rendering:
+ * Self-gates on the `experimental.assistant` feature flag. When the flag is
+ * disabled (or while it is loading), renders a friendly placeholder instead
+ * of the chat UI — never an empty page. The previous gating in App.tsx
+ * (Mission 61, PR #1347) wrapped this view in `{assistantEnabled && ...}`,
+ * which produced a blank assistant page when the flag was off, when the IPC
+ * fetch failed silently, or during the async race before it resolved. That
+ * is the visual "crash on view" Mason reported in Mission 73.
+ *
+ * Tri-state rendering (when enabled):
  * - interactive: AgentTerminal (raw PTY canvas, same as durable agents)
  * - headless:    Chat feed + input (conversational via headless --continue)
  * - structured:  Chat feed + input (experimental typed events)
  */
 export function AssistantView() {
+  // Experimental flag gating (tri-state: null = loading, true = enabled, false = disabled).
+  // Lives inside this component so the assistant page is never empty when navigated to.
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => {
+        if (!cancelled) setEnabled(!!flags.assistant);
+      })
+      .catch((err) => {
+        // Don't leave the user stranded on a blank page if the IPC fails.
+        // Treat fetch failure as "disabled" so the placeholder explains the situation,
+        // and surface the error to the renderer console for diagnosis.
+        console.error('AssistantView: failed to load experimental settings', err);
+        if (!cancelled) setEnabled(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
   const [feedItems, setFeedItems] = useState<FeedItem[]>(() => assistantAgent.getFeedItems());
   const [status, setStatus] = useState<AssistantStatus>(() => assistantAgent.getStatus());
   const [mode, setMode] = useState<AssistantMode>(() => assistantAgent.getMode());
@@ -31,11 +59,95 @@ export function AssistantView() {
     return () => { u1(); u2(); u3(); u4(); u5(); };
   }, []);
 
+  // Restore persisted chat history once the flag resolves to enabled.
+  // loadHistory was previously dead code — exported but never called from
+  // production, which meant users always lost their chat history on view open.
+  useEffect(() => {
+    if (enabled === true) {
+      assistantAgent.loadHistory().catch((err) => {
+        console.error('AssistantView: failed to load chat history', err);
+      });
+    }
+  }, [enabled]);
+
   const handleSend = useCallback((content: string) => { assistantAgent.sendMessage(content); }, []);
   const handleModeChange = useCallback((m: AssistantMode) => { assistantAgent.setMode(m); }, []);
   const handleOrchestratorChange = useCallback((id: string | null) => { assistantAgent.setOrchestrator(id); }, []);
   const handleApproveAction = useCallback((actionId: string) => { assistantAgent.approveAction(actionId); }, []);
   const handleSkipAction = useCallback((actionId: string) => { assistantAgent.skipAction(actionId); }, []);
+
+  const setExplorerTab = useUIStore((s) => s.setExplorerTab);
+  const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
+  const handleOpenSettings = useCallback(() => {
+    setExplorerTab('settings');
+    setSettingsSubPage('experimental');
+  }, [setExplorerTab, setSettingsSubPage]);
+
+  // Loading state — flag fetch is in flight. Render a minimal container so the
+  // page is never blank during the (usually millisecond-scale) IPC round-trip.
+  if (enabled === null) {
+    return (
+      <div
+        className="h-full min-h-0 flex items-center justify-center bg-ctp-base"
+        data-testid="assistant-view"
+        data-assistant-state="loading"
+      >
+        <span className="text-xs text-ctp-subtext0">{'Loading\u2026'}</span>
+      </div>
+    );
+  }
+
+  // Disabled state — flag is off (or fetch failed). Friendly placeholder
+  // explains the situation and provides a recovery path to the settings page.
+  // This is the fix for Mission 73's "visual crash" — previously this same
+  // situation produced an empty page with only the title bar and banners.
+  if (enabled === false) {
+    return (
+      <div
+        className="h-full min-h-0 flex items-center justify-center px-6 bg-ctp-base"
+        data-testid="assistant-view"
+        data-assistant-state="disabled"
+      >
+        <div className="max-w-md text-center">
+          <div className="flex justify-center mb-5">
+            <div className="w-20 h-20 rounded-full bg-ctp-accent/10 flex items-center justify-center">
+              <svg
+                width="40"
+                height="40"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-ctp-accent"
+              >
+                <rect x="3" y="11" width="18" height="10" rx="2" />
+                <circle cx="12" cy="5" r="2" />
+                <line x1="12" y1="7" x2="12" y2="11" />
+                <line x1="8" y1="16" x2="8" y2="16.01" />
+                <line x1="16" y1="16" x2="16" y2="16.01" />
+              </svg>
+            </div>
+          </div>
+          <p className="text-base text-ctp-text mb-1 font-semibold">
+            The Assistant is an experimental feature
+          </p>
+          <p className="text-sm text-ctp-subtext0 mb-6 leading-relaxed">
+            Enable it in <span className="text-ctp-text">Settings &rarr; Experimental</span> to
+            chat with the built-in helper, scaffold projects, and configure agents.
+          </p>
+          <button
+            onClick={handleOpenSettings}
+            className="px-4 py-2 text-sm rounded-lg bg-ctp-accent text-white font-medium hover:opacity-90 cursor-pointer"
+            data-testid="assistant-open-settings-button"
+          >
+            Open Experimental Settings
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   const isDisabled = status === 'starting' || status === 'responding';
 
@@ -43,7 +155,7 @@ export function AssistantView() {
   const showTerminal = mode === 'interactive' && agentId && (status === 'active' || status === 'responding');
 
   return (
-    <div className="h-full min-h-0 flex flex-col bg-ctp-base" data-testid="assistant-view">
+    <div className="h-full min-h-0 flex flex-col bg-ctp-base" data-testid="assistant-view" data-assistant-state="enabled">
       <AssistantHeader
         onReset={assistantAgent.reset}
         mode={mode}

--- a/src/renderer/features/assistant/assistant-view.test.tsx
+++ b/src/renderer/features/assistant/assistant-view.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AssistantView } from './AssistantView';
 import * as assistantAgent from './assistant-agent';
+import { useUIStore } from '../../stores/uiStore';
 
 // Mock assistant-agent module
 vi.mock('./assistant-agent', () => ({
@@ -21,6 +23,7 @@ vi.mock('./assistant-agent', () => ({
   reset: vi.fn(),
   approveAction: vi.fn(),
   skipAction: vi.fn(),
+  loadHistory: vi.fn(async () => {}),
 }));
 
 // Mock AgentTerminal since it depends on PTY
@@ -30,83 +33,203 @@ vi.mock('../agents/AgentTerminal', () => ({
   ),
 }));
 
+/** Helper: render and wait for the experimental flag fetch to settle. */
+async function renderAndSettle(): Promise<void> {
+  render(<AssistantView />);
+  // The flag fetch is async — wait for the loading state to clear before
+  // the test makes assertions about the resolved UI.
+  await waitFor(() => {
+    const view = screen.getByTestId('assistant-view');
+    expect(view.getAttribute('data-assistant-state')).not.toBe('loading');
+  });
+}
+
 describe('AssistantView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset Zustand UI store between tests so the "Open Settings" assertion
+    // doesn't leak into sibling tests.
+    useUIStore.setState({ explorerTab: 'agents', settingsSubPage: 'display' });
+    // Default: experimental.assistant flag is enabled, so existing tests
+    // exercise the chat UI path. Tests that need the disabled state override.
+    vi.spyOn(window.clubhouse.app, 'getExperimentalSettings').mockResolvedValue({
+      assistant: true,
+    } as Record<string, boolean>);
   });
 
-  it('renders assistant-view container', () => {
-    render(<AssistantView />);
+  // ── Mission 73 — gating + recovery ─────────────────────────────────────────
+
+  describe('experimental flag gating (Mission 73)', () => {
+    it('renders loading state synchronously before the flag fetch resolves', () => {
+      // Don't wait for settle — capture the initial render state
+      render(<AssistantView />);
+      const view = screen.getByTestId('assistant-view');
+      expect(view.getAttribute('data-assistant-state')).toBe('loading');
+    });
+
+    it('renders disabled placeholder when experimental flag is false', async () => {
+      vi.spyOn(window.clubhouse.app, 'getExperimentalSettings').mockResolvedValue({
+        assistant: false,
+      } as Record<string, boolean>);
+
+      await renderAndSettle();
+
+      const view = screen.getByTestId('assistant-view');
+      expect(view.getAttribute('data-assistant-state')).toBe('disabled');
+      expect(screen.getByText(/experimental feature/i)).toBeInTheDocument();
+      expect(screen.getByTestId('assistant-open-settings-button')).toBeInTheDocument();
+      // The chat UI should NOT be present
+      expect(screen.queryByTestId('assistant-feed-empty')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('assistant-message-input')).not.toBeInTheDocument();
+    });
+
+    it('renders disabled placeholder when getExperimentalSettings rejects', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(window.clubhouse.app, 'getExperimentalSettings').mockRejectedValue(
+        new Error('IPC failed'),
+      );
+
+      await renderAndSettle();
+
+      const view = screen.getByTestId('assistant-view');
+      expect(view.getAttribute('data-assistant-state')).toBe('disabled');
+      // Error should be logged, not swallowed (the fix's "stop swallowing" guarantee)
+      expect(errorSpy).toHaveBeenCalledWith(
+        'AssistantView: failed to load experimental settings',
+        expect.any(Error),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('renders disabled placeholder when flag key is missing entirely', async () => {
+      // Stable build default: getExperimentalSettings returns {} so flags.assistant is undefined
+      vi.spyOn(window.clubhouse.app, 'getExperimentalSettings').mockResolvedValue(
+        {} as Record<string, boolean>,
+      );
+
+      await renderAndSettle();
+
+      const view = screen.getByTestId('assistant-view');
+      expect(view.getAttribute('data-assistant-state')).toBe('disabled');
+    });
+
+    it('"Open Experimental Settings" button routes to Settings -> Experimental', async () => {
+      vi.spyOn(window.clubhouse.app, 'getExperimentalSettings').mockResolvedValue({
+        assistant: false,
+      } as Record<string, boolean>);
+
+      await renderAndSettle();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('assistant-open-settings-button'));
+
+      const ui = useUIStore.getState();
+      expect(ui.explorerTab).toBe('settings');
+      expect(ui.settingsSubPage).toBe('experimental');
+    });
+
+    it('renders the chat UI when the flag is enabled', async () => {
+      await renderAndSettle();
+
+      const view = screen.getByTestId('assistant-view');
+      expect(view.getAttribute('data-assistant-state')).toBe('enabled');
+      expect(screen.getByTestId('assistant-feed-empty')).toBeInTheDocument();
+      expect(screen.getByTestId('assistant-message-input')).toBeInTheDocument();
+    });
+
+    it('calls loadHistory exactly once on mount when enabled', async () => {
+      await renderAndSettle();
+      // Allow microtasks for the loadHistory effect to fire
+      await act(async () => { await Promise.resolve(); });
+      expect(vi.mocked(assistantAgent.loadHistory)).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call loadHistory when the flag is false', async () => {
+      vi.spyOn(window.clubhouse.app, 'getExperimentalSettings').mockResolvedValue({
+        assistant: false,
+      } as Record<string, boolean>);
+
+      await renderAndSettle();
+      await act(async () => { await Promise.resolve(); });
+
+      expect(vi.mocked(assistantAgent.loadHistory)).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Existing chat-UI tests (now run with the flag pre-enabled) ─────────────
+
+  it('renders assistant-view container', async () => {
+    await renderAndSettle();
     expect(screen.getByTestId('assistant-view')).toBeInTheDocument();
   });
 
-  it('renders feed and input in headless mode', () => {
+  it('renders feed and input in headless mode', async () => {
     vi.mocked(assistantAgent.getMode).mockReturnValue('headless');
     vi.mocked(assistantAgent.getAgentId).mockReturnValue(null);
-    render(<AssistantView />);
+    await renderAndSettle();
 
     expect(screen.getByTestId('assistant-feed-empty')).toBeInTheDocument();
     expect(screen.getByTestId('assistant-input')).toBeInTheDocument();
     expect(screen.queryByTestId('agent-terminal')).not.toBeInTheDocument();
   });
 
-  it('renders feed and input in structured mode', () => {
+  it('renders feed and input in structured mode', async () => {
     vi.mocked(assistantAgent.getMode).mockReturnValue('structured');
     vi.mocked(assistantAgent.getAgentId).mockReturnValue(null);
-    render(<AssistantView />);
+    await renderAndSettle();
 
     expect(screen.getByTestId('assistant-feed-empty')).toBeInTheDocument();
     expect(screen.getByTestId('assistant-input')).toBeInTheDocument();
     expect(screen.queryByTestId('agent-terminal')).not.toBeInTheDocument();
   });
 
-  it('renders terminal in interactive mode with active agent', () => {
+  it('renders terminal in interactive mode with active agent', async () => {
     vi.mocked(assistantAgent.getMode).mockReturnValue('interactive');
     vi.mocked(assistantAgent.getAgentId).mockReturnValue('agent_123');
     vi.mocked(assistantAgent.getStatus).mockReturnValue('active');
-    render(<AssistantView />);
+    await renderAndSettle();
 
     expect(screen.getByTestId('agent-terminal')).toBeInTheDocument();
     expect(screen.queryByTestId('assistant-feed-empty')).not.toBeInTheDocument();
     expect(screen.queryByTestId('assistant-input')).not.toBeInTheDocument();
   });
 
-  it('renders feed (not terminal) in interactive mode without active agent', () => {
+  it('renders feed (not terminal) in interactive mode without active agent', async () => {
     vi.mocked(assistantAgent.getMode).mockReturnValue('interactive');
     vi.mocked(assistantAgent.getAgentId).mockReturnValue(null);
     vi.mocked(assistantAgent.getStatus).mockReturnValue('idle');
-    render(<AssistantView />);
+    await renderAndSettle();
 
     expect(screen.queryByTestId('agent-terminal')).not.toBeInTheDocument();
     expect(screen.getByTestId('assistant-feed-empty')).toBeInTheDocument();
   });
 
-  it('disables input when status is starting', () => {
+  it('disables input when status is starting', async () => {
     vi.mocked(assistantAgent.getStatus).mockReturnValue('starting');
-    render(<AssistantView />);
+    await renderAndSettle();
 
     const input = screen.getByTestId('assistant-message-input');
     expect(input).toBeDisabled();
   });
 
-  it('disables input when status is responding', () => {
+  it('disables input when status is responding', async () => {
     vi.mocked(assistantAgent.getStatus).mockReturnValue('responding');
-    render(<AssistantView />);
+    await renderAndSettle();
 
     const input = screen.getByTestId('assistant-message-input');
     expect(input).toBeDisabled();
   });
 
-  it('enables input when status is idle', () => {
+  it('enables input when status is idle', async () => {
     vi.mocked(assistantAgent.getStatus).mockReturnValue('idle');
-    render(<AssistantView />);
+    await renderAndSettle();
 
     const input = screen.getByTestId('assistant-message-input');
     expect(input).not.toBeDisabled();
   });
 
-  it('subscribes to all agent listeners on mount', () => {
-    render(<AssistantView />);
+  it('subscribes to all agent listeners on mount', async () => {
+    await renderAndSettle();
 
     expect(assistantAgent.onFeedUpdate).toHaveBeenCalledOnce();
     expect(assistantAgent.onStatusChange).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- **Mission 73 — Assistant visual crash on view (P1).** Mason reported that opening the assistant produced a visually broken/empty page in stable builds.
- **Root cause:** PR #1347 (Mission 61, stable build feature flags) wrapped `<AssistantView />` in `App.tsx` with `{assistantEnabled && (...)}` to gate the assistant behind the experimental flag — but provided no fallback. When the flag was off (default in stable), when the IPC fetch failed silently in the `.catch(() => {})` handler, or during the async race before the flag resolved, the assistant page rendered only the title bar and banners with no main content. That empty content area is the "visual crash" Mason reported.
- **Fix:** `AssistantView` now self-gates with a tri-state (loading / enabled / disabled) and renders a friendly placeholder when disabled, with a recovery button that routes to Settings → Experimental. `App.tsx` unconditionally renders the view; the page is never blank.

## Root Cause Walkthrough

The original Mission 61 diff:

```diff
-        <RailSection>
-          <AssistantView />
-        </RailSection>
+        {assistantEnabled && (
+          <RailSection>
+            <AssistantView />
+          </RailSection>
+        )}
```

The companion state lived in `App.tsx`:

\`\`\`ts
const [assistantEnabled, setAssistantEnabled] = useState(false);
useEffect(() => {
  window.clubhouse.app.getExperimentalSettings().then((flags) => {
    setAssistantEnabled(!!flags.assistant);
  }).catch(() => {});  // ← silent swallow
}, []);
\`\`\`

Three failure modes:

1. **Stable default** — In a stable build with no experimental flags toggled, \`flags.assistant\` is \`undefined\` → \`assistantEnabled\` stays \`false\` forever → the assistant page renders empty.
2. **First-render race** — Even with the flag enabled in settings, the IPC fetch is async. The first render uses \`useState(false)\`, so the page is briefly empty before the fetch resolves.
3. **Silent IPC failure** — If \`getExperimentalSettings\` ever rejects, the empty \`.catch(() => {})\` swallows the error and \`assistantEnabled\` is stuck at \`false\` with no diagnostic.

The rail's \`Assistant\` button (\`data-testid=\"nav-assistant\"\`) and HelpView's \"Ask Assistant\" button are both unconditional, so users in stable builds could click either one and land on the empty page.

## Changes

### \`src/renderer/features/assistant/AssistantView.tsx\`
- Add tri-state \`enabled: boolean | null\` (null = loading) sourced from \`getExperimentalSettings\`.
- Render a minimal **loading** state while the flag fetch is in flight (avoids first-render flash).
- Render a friendly **disabled** placeholder when the flag is false or the fetch rejects, with an \"Open Experimental Settings\" button.
- Render the existing chat UI when the flag is enabled.
- Call \`assistantAgent.loadHistory()\` on mount when enabled. **This was previously dead code** — exported but never called from production, so users always lost their persisted chat on view open. Caught by the same investigation.
- Replace silent \`.catch(() => {})\` with \`console.error\` for diagnosability.
- Add \`data-assistant-state\` attribute (\`loading\` / \`disabled\` / \`enabled\`) for E2E visibility.

### \`src/renderer/App.tsx\`
- Remove the local \`assistantEnabled\` state and effect (now lives in \`AssistantView\`).
- Unconditionally render \`<AssistantView />\` when \`isAssistant\` — the page is never blank.

### \`src/renderer/features/assistant/assistant-view.test.tsx\`
- Add 8 new tests under \`experimental flag gating (Mission 73)\` for the loading/disabled/enabled states, error handling, settings navigation, and \`loadHistory\` invocation.
- Update existing chat-UI tests to await the async flag fetch via a \`renderAndSettle\` helper.
- Add \`getExperimentalSettings\` mock with \`{ assistant: true }\` default in \`beforeEach\`; tests for the disabled state override per-test.
- Reset \`useUIStore\` between tests so the \"Open Settings\" navigation assertion doesn't leak.

### \`e2e/assistant/assistant-disabled.spec.ts\` (new)
- Launches a clean Electron instance with \`experimental.assistant\` explicitly disabled (default for stable builds).
- Clicks the rail's \`nav-assistant\` button — the same flow a stable-build user would take.
- Asserts \`data-assistant-state=\"disabled\"\` resolves and the recovery button is visible.
- Asserts the chat UI elements are NOT present (the bug they replaced).
- Asserts no JS errors emitted.
- Verifies \"Open Experimental Settings\" routes away from the view.

## Test Plan

- [x] **Regression coverage verified.** Per the team's \"verify regression tests actually fail on pre-fix code\" rule: I temporarily reverted \`AssistantView.tsx\` to its pre-fix (origin/main) state and ran the new test file. **7 of the 17 tests failed** (loading state, disabled placeholder × 3, settings nav, chat UI marker, loadHistory call), confirming each test guards a real behavior.
- [x] \`npm run typecheck\` — clean.
- [x] \`npm test\` — **11,269 passed, 4 skipped, 0 failed.**
- [x] \`npx eslint\` on all changed files — clean (full-repo \`npm run lint\` shows 19 pre-existing errors in unrelated files, none introduced by this PR).

## Manual Validation

For the QA reviewer or anyone running the dev app:

1. **Stable-default state (the bug):**
   - Launch the dev app fresh (or with \`experimental.assistant\` disabled in Settings → Experimental).
   - Click the **Assistant** button in the project rail.
   - **Expected:** Friendly placeholder with a robot icon, copy explaining the feature is experimental, and an \"Open Experimental Settings\" button.
   - **Before this PR:** Title bar + banners + an empty content area.
2. **Recovery flow:**
   - From the disabled placeholder, click \"Open Experimental Settings\".
   - **Expected:** Lands directly on the Experimental settings page.
   - Toggle the Assistant flag on, then click the **Assistant** rail button again.
   - **Expected:** Chat UI loads normally (existing behavior unchanged).
3. **History persistence:**
   - With the flag enabled, send the assistant a message in headless or structured mode.
   - Switch tabs (e.g., to a project) and back to the Assistant.
   - **Expected:** Previous chat history is restored. (Before this PR, \`loadHistory()\` was dead code so history was always blank on view re-mount.)
4. **No regression in enabled state:**
   - The chat UI, mode toggle, terminal mode, suggestion chips, reset button, and orchestrator selector should all work exactly as before when the flag is enabled.

## What's NOT in this PR

I considered also hiding the rail's \`nav-assistant\` button when the flag is off (so stable users don't see the entry point at all). I implemented and reverted it because:

- The rail subscribes to \`getExperimentalSettings\` once on mount and has no settings-change subscription. With the existing E2E helpers that enable the flag *after* the rail mounts, gating the button would require a settings-change event (which doesn't exist) or every E2E that uses \`nav-assistant\` would need a reload step.
- The disabled placeholder fully fixes the visual crash regardless of how the user reaches the assistant tab.
- A future PR can add a \`useExperimentalSettings\` hook with subscription support and gate the rail button cleanly.

## Mission Reference

Mission 73 brief: posted in \`missions\` topic 2026-04-10T17:35:18Z by @Clubhouse-Assisstant-Driver. Wave 12 bug fix sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)