### PR TITLE
fix(canvas): + button no-op when projectId is null (Mission 71, P1)

### DIFF
--- a/e2e/canvas-create.spec.ts
+++ b/e2e/canvas-create.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Mission 71 — Canvas "+" button create-flow E2E coverage.
+ *
+ * Mason reported that the "+" button to create a new canvas was broken,
+ * and asked: how was this missed in test coverage?
+ *
+ * The unit-level CanvasTabBar tests use mocked onAddCanvas handlers, so
+ * they verify the click → handler wiring at the component layer but never
+ * exercise the real store action behind it. The integration test added in
+ * the same PR (CanvasTabBar.test.tsx) closes the unit-level seam, but the
+ * canonical "missed" coverage is an end-to-end test that:
+ *   1. Launches the real Electron app
+ *   2. Navigates to a project's Canvas explorer tab
+ *   3. Clicks the canvas "+" add button
+ *   4. Clicks "New Canvas" in the dropdown
+ *   5. Verifies a brand-new canvas tab appears
+ *
+ * This is the test that should have existed before the regression was
+ * possible.
+ */
+import { test, expect, _electron as electron, Page } from '@playwright/test';
+import * as path from 'path';
+import { launchApp } from './launch';
+
+let electronApp: Awaited<ReturnType<typeof electron.launch>>;
+let window: Page;
+
+const FIXTURE_PROJECT = path.resolve(__dirname, 'fixtures/project-a');
+
+/** Stub Electron's dialog so the next pickAndAddProject resolves to `dirPath`. */
+async function stubDialogForPath(dirPath: string) {
+  await electronApp.evaluate(
+    async ({ dialog, BrowserWindow }, fixturePath) => {
+      const win =
+        BrowserWindow.getAllWindows().find(
+          (w) => !w.webContents.getURL().startsWith('devtools://'),
+        ) ?? BrowserWindow.getAllWindows()[0] ?? null;
+      BrowserWindow.getFocusedWindow = () => win;
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [fixturePath],
+      });
+    },
+    dirPath,
+  );
+}
+
+test.beforeAll(async () => {
+  ({ electronApp, window } = await launchApp());
+});
+
+test.afterAll(async () => {
+  await electronApp?.close();
+});
+
+test('clicking the canvas + button → New Canvas creates a new canvas tab', async () => {
+  // 1. Add a project fixture (canvas is per-project)
+  await stubDialogForPath(FIXTURE_PROJECT);
+  await window.locator('[data-testid="nav-add-project"]').click();
+  await expect(window.locator(`text=${path.basename(FIXTURE_PROJECT)}`).first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // 2. Navigate to the project's canvas explorer tab. The canvas tab is
+  //    keyed as "plugin:canvas" in the UI store (see canvas-command-handler.ts).
+  await window.evaluate(() => {
+    // Reach into the renderer's UI store via the global window.clubhouse
+    // bridge — fall back to dispatching a click on the canvas nav button
+    // if the store handle isn't directly available.
+    const w = window as unknown as {
+      __zustand_uiStore?: { getState: () => { setExplorerTab: (tab: string, projectId?: string) => void } };
+    };
+    if (w.__zustand_uiStore) {
+      w.__zustand_uiStore.getState().setExplorerTab('plugin:canvas');
+    }
+  });
+
+  // If the programmatic store call didn't work, fall back to clicking the
+  // canvas tab in the explorer (the explorer renders one tab per builtin).
+  // The canvas tab title is "Canvas" or shows the canvas icon.
+  const canvasPanel = window.locator('[data-testid="canvas-panel"]');
+  const panelVisible = await canvasPanel.isVisible({ timeout: 3_000 }).catch(() => false);
+  if (!panelVisible) {
+    // Try clicking a canvas tab/button in the explorer
+    const canvasNavBtn = window
+      .locator('button, [role="tab"]')
+      .filter({ hasText: /canvas/i })
+      .first();
+    if (await canvasNavBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await canvasNavBtn.click();
+    }
+  }
+
+  await expect(canvasPanel).toBeVisible({ timeout: 10_000 });
+
+  // 3. Capture the initial canvas tab count (real canvas IDs are
+  //    "canvas_xxxxxxxx" so the testid prefix below excludes the tab bar
+  //    wrapper, the close button, the popout button, and the rename input).
+  const tabsLocator = window.locator('[data-testid^="canvas-tab-canvas_"]');
+  const initialCount = await tabsLocator.count();
+  expect(initialCount).toBeGreaterThanOrEqual(1);
+
+  // 4. Click the + button. In production main.ts always provides
+  //    onAddFromBlueprint, so the + button opens a dropdown.
+  const addBtn = window.locator('[data-testid="canvas-add-button"]');
+  await expect(addBtn).toBeVisible();
+  await addBtn.click();
+
+  // 5. The dropdown should appear and contain "New Canvas".
+  const addMenu = window.locator('[data-testid="canvas-add-menu"]');
+  await expect(addMenu).toBeVisible({ timeout: 2_000 });
+  await window.locator('[data-testid="canvas-add-new"]').click();
+
+  // 6. A new canvas tab must now exist (count increased by exactly 1).
+  await expect(tabsLocator).toHaveCount(initialCount + 1, { timeout: 5_000 });
+});

--- a/src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx
@@ -1,6 +1,8 @@
+import React, { useState, useCallback } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CanvasTabBar } from './CanvasTabBar';
+import { createCanvasStore } from './canvas-store';
 import type { CanvasInstance } from './canvas-types';
 
 function makeCanvas(id: string, name: string): CanvasInstance {
@@ -93,5 +95,97 @@ describe('CanvasTabBar', () => {
     fireEvent.click(screen.getByTestId('canvas-tab-export-blueprint'));
 
     expect(onExportBlueprint).toHaveBeenCalledWith('c1');
+  });
+});
+
+// ── Integration: + button → real store → DOM update ────────────────────
+//
+// Mission 71 — Coverage gap: the tests above mock onAddCanvas with vi.fn(),
+// so they verify the wiring from button to handler but never exercise the
+// real store action behind it. A regression that broke handleAddCanvas or
+// store.addCanvas() would not surface here.
+//
+// These tests render CanvasTabBar wired to a real canvas store via a thin
+// wrapper that mirrors what main.ts MainPanel does, then assert the store
+// state actually changed and the new tab is rendered to the DOM.
+
+describe('CanvasTabBar — + button integration with real store', () => {
+  // Real canvas IDs from createCanvasInstance() are formatted as
+  // "canvas_xxxxxxxx" (see canvas-operations.ts:585), so the matching tab
+  // testid is "canvas-tab-canvas_xxxxxxxx". This selector is specific to
+  // actual tabs and excludes the wrapper ("canvas-tab-bar"), the close
+  // button ("canvas-tab-close"), the popout button ("canvas-tab-popout"),
+  // the rename input ("canvas-tab-rename-input"), and the context menu.
+  function getRenderedTabs(container: HTMLElement): NodeListOf<Element> {
+    return container.querySelectorAll('[data-testid^="canvas-tab-canvas_"]');
+  }
+
+  it('clicking + → New Canvas adds a canvas via the real store action', () => {
+    // Hoist the store outside React so re-renders don't recreate it and
+    // strict-mode double-effects can't influence the count we're asserting.
+    const store = createCanvasStore();
+    expect(store.getState().canvases).toHaveLength(1);
+
+    function Host() {
+      const [, force] = useState(0);
+      // Subscribe ONCE; strict-mode-safe via cleanup.
+      React.useEffect(() => store.subscribe(() => force((n) => n + 1)), []);
+      const state = store.getState();
+      return (
+        <CanvasTabBar
+          canvases={state.canvases}
+          activeCanvasId={state.activeCanvasId}
+          onSelectCanvas={() => undefined}
+          onAddCanvas={() => store.getState().addCanvas()}
+          onAddFromBlueprint={() => undefined}
+          onRemoveCanvas={() => undefined}
+          onRenameCanvas={() => undefined}
+        />
+      );
+    }
+
+    const { container } = render(<Host />);
+    expect(getRenderedTabs(container).length).toBe(1);
+
+    // Click + to open the dropdown (matches production: main.ts always
+    // wires both onAddCanvas and onAddFromBlueprint, so users always see
+    // the dropdown variant of the + button).
+    fireEvent.click(screen.getByTestId('canvas-add-button'));
+    expect(screen.getByTestId('canvas-add-menu')).toBeDefined();
+
+    // Click "New Canvas" — this is what real users click
+    fireEvent.click(screen.getByTestId('canvas-add-new'));
+
+    // The store action must have fired exactly once and added one canvas
+    expect(store.getState().canvases).toHaveLength(2);
+    // And the DOM must reflect the new canvas tab
+    expect(getRenderedTabs(container).length).toBe(2);
+  });
+
+  it('clicking + (no dropdown variant) adds a canvas via the real store action', () => {
+    const store = createCanvasStore();
+    expect(store.getState().canvases).toHaveLength(1);
+
+    function Host() {
+      const [, force] = useState(0);
+      React.useEffect(() => store.subscribe(() => force((n) => n + 1)), []);
+      const state = store.getState();
+      return (
+        <CanvasTabBar
+          canvases={state.canvases}
+          activeCanvasId={state.activeCanvasId}
+          onSelectCanvas={() => undefined}
+          onAddCanvas={() => store.getState().addCanvas()}
+          onRemoveCanvas={() => undefined}
+          onRenameCanvas={() => undefined}
+        />
+      );
+    }
+
+    const { container } = render(<Host />);
+    expect(getRenderedTabs(container).length).toBe(1);
+    fireEvent.click(screen.getByTestId('canvas-add-button'));
+    expect(store.getState().canvases).toHaveLength(2);
+    expect(getRenderedTabs(container).length).toBe(2);
   });
 });

--- a/src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CanvasTabBar } from './CanvasTabBar';

--- a/src/renderer/plugins/builtin/canvas/main.test.ts
+++ b/src/renderer/plugins/builtin/canvas/main.test.ts
@@ -84,6 +84,44 @@ describe('canvas main', () => {
     expect(storeA).not.toBe(storeB);
   });
 
+  // Mission 71 — Regression test for the new-canvas + button.
+  //
+  // MainPanel reads its store on every render via:
+  //   const store = isAppMode ? useAppCanvasStore
+  //                           : getProjectCanvasStore(api.context.projectId ?? null);
+  //
+  // If the projectId is ever null/undefined while mode is NOT 'app', the
+  // pre-fix `getProjectCanvasStore(null)` returned a brand-new transient
+  // store on every call (`return createCanvasStore()`). That made every
+  // re-render of MainPanel observe a fresh store with the initial canvas,
+  // so any addCanvas() the user triggered on the previous render's store
+  // was discarded — the "+ button does nothing" symptom Mason reported.
+  //
+  // The contract should be: same input → same store. Repeated calls with
+  // null must return the same instance, just like repeated calls with the
+  // same project id do.
+  it('getProjectCanvasStore returns a stable store for null projectId across calls', () => {
+    const store1 = canvasModule.getProjectCanvasStore(null);
+    const store2 = canvasModule.getProjectCanvasStore(null);
+    expect(store1).toBe(store2);
+  });
+
+  it('getProjectCanvasStore null fallback preserves state across calls (addCanvas survives re-resolution)', () => {
+    // Reproduces the + button bug at the store layer: if the fallback
+    // store is fresh on every call, an addCanvas mutation on the first
+    // resolution is invisible to the second resolution.
+    const storeA = canvasModule.getProjectCanvasStore(null);
+    const initialCount = storeA.getState().canvases.length;
+
+    storeA.getState().addCanvas();
+    expect(storeA.getState().canvases.length).toBe(initialCount + 1);
+
+    // Re-resolve as MainPanel does on its next render — this MUST observe
+    // the same canvases array, otherwise the click-add was visually a no-op.
+    const storeB = canvasModule.getProjectCanvasStore(null);
+    expect(storeB.getState().canvases.length).toBe(initialCount + 1);
+  });
+
   it('loadCanvas is awaited before loadWires in MainPanel (structural)', () => {
     // The loadCanvas/loadWires race condition caused auto-save to overwrite
     // persisted wire data with incomplete bindings. Verify the fix:

--- a/src/renderer/plugins/builtin/canvas/main.ts
+++ b/src/renderer/plugins/builtin/canvas/main.ts
@@ -50,12 +50,25 @@ export const useAppCanvasStore = createCanvasStore();
 // Project-mode canvas stores: one per project, keyed by projectId
 const projectCanvasStores = new Map<string, ReturnType<typeof createCanvasStore>>();
 
+// Stable singleton fallback for callers that resolve a project store with a
+// null/undefined projectId (e.g. transient states during project switching,
+// command palette lookups when no project is active, or pop-out windows that
+// haven't received their context yet). Mission 71: prior to this fix the
+// fallback was `return createCanvasStore()` per call, which made every
+// re-render observe a fresh store with the initial canvas — addCanvas() on
+// the previous resolution was discarded, surfacing as the "+ button does
+// nothing" bug Mason reported.
+let nullProjectFallbackStore: ReturnType<typeof createCanvasStore> | null = null;
+
 export function hasProjectCanvasStore(projectId: string | null): boolean {
   return projectId !== null && projectCanvasStores.has(projectId);
 }
 
 export function getProjectCanvasStore(projectId: string | null): ReturnType<typeof createCanvasStore> {
-  if (!projectId) return createCanvasStore(); // transient fallback
+  if (!projectId) {
+    if (!nullProjectFallbackStore) nullProjectFallbackStore = createCanvasStore();
+    return nullProjectFallbackStore;
+  }
   let store = projectCanvasStores.get(projectId);
   if (!store) {
     store = createCanvasStore();


### PR DESCRIPTION
## Summary

Mission 71 (P1) — Mason reported that the canvas "+" button to create a new canvas does not work, and asked: how was this missed in test coverage?

**Root cause:** In `MainPanel`, the canvas store is resolved on every render via:

```ts
const store = isAppMode
  ? useAppCanvasStore
  : getProjectCanvasStore(api.context.projectId ?? null);
```

When `isAppMode` is false and `projectId` is null/undefined, the pre-fix `getProjectCanvasStore(null)` returned a brand-new transient store on every call (`return createCanvasStore(); // transient fallback`). That made every re-render observe a fresh store with the initial canvas — any `addCanvas()` mutation the user triggered on the previous render's store was instantly discarded. From the user's seat, the + button did nothing.

The null-projectId path is hit during transient states (project switching, command palette lookups when no project is active, pop-out windows that haven't received their context yet) and by direct callers like `BlueprintGallery.tsx:96`, `command-palette/use-command-source.ts:68/573`, and `app-event-bridge.ts:149`.

**Fix:** Cache the null-projectId fallback as a stable module-level singleton so repeated `getProjectCanvasStore(null)` calls return the same instance — same input → same store, matching the contract the named-projectId path already follows. Three lines of behavior change in `src/renderer/plugins/builtin/canvas/main.ts`.

## Coverage gap — why no test caught this

| Layer | Existing coverage | Why it didn't catch the bug |
|---|---|---|
| `CanvasTabBar.test.tsx` | Mocks `onAddCanvas` with `vi.fn()` | Verifies click → handler wiring but never exercises the real store action |
| `canvas-store.test.ts` | Tests `addCanvas()` in isolation | Never re-resolves the store across calls |
| `main.test.ts` | Tests `getProjectCanvasStore('id-1')` stability | Had no test for the null-projectId case — that's the seam where the bug lived |
| E2E | None for canvas create | No Playwright spec exercised "click + → New Canvas → assert tab appeared" |

## Tests added

**1. `main.test.ts` — direct red→green regression tests for the bug**

- `getProjectCanvasStore returns a stable store for null projectId across calls` — asserts `store1 === store2` for two consecutive null-projectId calls. **Verified red on pre-fix code** (different instances), green after the fix.
- `getProjectCanvasStore null fallback preserves state across calls (addCanvas survives re-resolution)` — directly reproduces the visible symptom. Adds a canvas via the first resolution, asserts the count on a fresh resolution. **Verified red on pre-fix code** (count stays at 1), green after the fix (count is 2). **This is the test that should have existed.**

**2. `CanvasTabBar.test.tsx` — integration test closing the mocked-handler seam**

New `describe('CanvasTabBar — + button integration with real store')` block that wires `CanvasTabBar` to a real `createCanvasStore()` and asserts both the store state and the rendered DOM update on click. Covers both the dropdown variant production uses and the no-dropdown variant of the + button. Catches a different class of regression (mocked-handler-mistakes) than the main.test.ts tests catch.

**3. `e2e/canvas-create.spec.ts` — Playwright happy-path E2E**

New spec that launches the real Electron app, opens a project, navigates to the canvas tab, clicks the + add button, picks "New Canvas" from the dropdown, and asserts a brand-new canvas tab appears in the rendered tab bar. Verified passing on this branch with a fresh `npm run package` build.

## Validation

- **Typecheck:** clean
- **Tests:** 11,265 pass / 4 skipped / 0 fail (455 files; full suite). +2 new tests in `main.test.ts` for the bug, +2 new integration tests in `CanvasTabBar.test.tsx` for the seam.
- **Lint:** clean on touched files. Same 19 pre-existing errors / 1 warning on `origin/main` that zesty-lynx, perky-moth, ancient-zebra, and mighty-rabbit have all flagged in unrelated files (`AgentSettingsView.tsx`, `SatelliteDashboard.tsx`, several `assistant/*.test.ts`, `canvas-blueprint.test.ts`, etc.) — none in my diff, not blocking per Driver direction.
- **E2E:** `e2e/canvas-create.spec.ts` ✓ (1 passed, 6.7s) against fresh `npm run package` build.

## D10 hold

Per Decision D10 in `decisions` topic, this PR will hit the same Windows `blueprint-handlers.test.ts:214` failure on its Windows Unit job that all Wave 12 PRs are inheriting from `origin/main`. **This PR will not merge until Mission 74 (zesty-lynx, PR #1372) lands on main and I rebase + re-run CI.**

## Files changed

- `src/renderer/plugins/builtin/canvas/main.ts` — fix (+13/-1)
- `src/renderer/plugins/builtin/canvas/main.test.ts` — 2 red→green regression tests (+38)
- `src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx` — 2 integration tests (+78)
- `e2e/canvas-create.spec.ts` — new Playwright spec (+118)

🤖 Generated with [Claude Code](https://claude.com/claude-code)