### PR TITLE
fix(canvas): unclip + button dropdown by moving it outside overflow-x-auto (Mission 75)

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasTabBar.test.tsx
@@ -75,6 +75,22 @@ describe('CanvasTabBar', () => {
     expect(defaultProps.onAddCanvas).toHaveBeenCalled();
   });
 
+  it('+ button is NOT inside the scrollable tabs container (overflow-x-auto regression guard)', () => {
+    // When overflow-x is set to auto, CSS computes overflow-y as auto too,
+    // clipping any absolutely-positioned dropdown that extends below the
+    // container. This test enforces that the + button lives in a sibling
+    // container so its dropdown is never clipped in real browsers.
+    render(<CanvasTabBar {...defaultProps} onAddFromBlueprint={vi.fn()} />);
+    const addButton = screen.getByTestId('canvas-add-button');
+    const tab = screen.getByTestId('canvas-tab-c1');
+
+    // The button and a canvas tab must NOT share the same immediate parent.
+    // If this fails, the button has been moved back inside the scrollable div.
+    expect(addButton.parentElement).not.toBe(tab.parentElement);
+    // And the scrollable tabs container must not contain the + button.
+    expect(tab.parentElement?.contains(addButton)).toBe(false);
+  });
+
   it('right-click on tab shows context menu with Export as Blueprint', () => {
     const onExportBlueprint = vi.fn();
     render(<CanvasTabBar {...defaultProps} onExportBlueprint={onExportBlueprint} />);

--- a/src/renderer/plugins/builtin/canvas/CanvasTabBar.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasTabBar.tsx
@@ -40,24 +40,32 @@ export function CanvasTabBar({
   }, [addMenuOpen]);
 
   return (
+    // Outer chrome — no overflow so the + button dropdown is not clipped.
+    // Tabs scroll inside their own inner container; the + button stays pinned
+    // at the right as a sibling. (Bug: Mission 68 added the dropdown but left
+    // it inside overflow-x-auto, which CSS promotes to overflow: auto on both
+    // axes, clipping the absolutely-positioned dropdown below the tab bar.)
     <div
-      className="flex items-center gap-0.5 px-1.5 py-1 bg-ctp-mantle border-b border-surface-0 min-h-[32px] overflow-x-auto flex-shrink-0"
+      className="flex items-center bg-ctp-mantle border-b border-surface-0 min-h-[32px] flex-shrink-0"
       data-testid="canvas-tab-bar"
     >
-      {canvases.map((canvas) => (
-        <CanvasTab
-          key={canvas.id}
-          canvas={canvas}
-          active={canvas.id === activeCanvasId}
-          canClose={canvases.length > 1}
-          onSelect={() => onSelectCanvas(canvas.id)}
-          onRemove={() => onRemoveCanvas(canvas.id)}
-          onRename={(name) => onRenameCanvas(canvas.id, name)}
-          onPopOut={onPopOutCanvas ? () => onPopOutCanvas(canvas.id, canvas.name) : undefined}
-          onExportBlueprint={onExportBlueprint ? () => onExportBlueprint(canvas.id) : undefined}
-        />
-      ))}
-      <div className="relative flex-shrink-0" ref={addMenuRef}>
+      <div className="flex items-center gap-0.5 pl-1.5 py-1 overflow-x-auto flex-1 min-w-0">
+        {canvases.map((canvas) => (
+          <CanvasTab
+            key={canvas.id}
+            canvas={canvas}
+            active={canvas.id === activeCanvasId}
+            canClose={canvases.length > 1}
+            onSelect={() => onSelectCanvas(canvas.id)}
+            onRemove={() => onRemoveCanvas(canvas.id)}
+            onRename={(name) => onRenameCanvas(canvas.id, name)}
+            onPopOut={onPopOutCanvas ? () => onPopOutCanvas(canvas.id, canvas.name) : undefined}
+            onExportBlueprint={onExportBlueprint ? () => onExportBlueprint(canvas.id) : undefined}
+          />
+        ))}
+      </div>
+      {/* + button lives outside the scroll container so its dropdown is never clipped */}
+      <div className="relative flex-shrink-0 py-1 pl-0.5 pr-1.5" ref={addMenuRef}>
         <button
           onClick={() => {
             if (onAddFromBlueprint) {
@@ -74,7 +82,7 @@ export function CanvasTabBar({
         </button>
         {addMenuOpen && (
           <div
-            className="absolute top-full left-0 mt-1 bg-ctp-base border border-surface-0 rounded-lg shadow-lg py-1 min-w-[160px] z-50"
+            className="absolute top-full right-0 mt-1 bg-ctp-base border border-surface-0 rounded-lg shadow-lg py-1 min-w-[160px] z-50"
             data-testid="canvas-add-menu"
           >
             <button


### PR DESCRIPTION
## Summary

- **Root cause (CSS)**: Mission 68 added a dropdown to the tab-bar `+` button but left it inside the `overflow-x-auto` wrapper. Per the CSS spec, setting `overflow-x: auto` forces the computed `overflow-y` from `visible` → `auto`, making the wrapper a scroll container that clips any absolutely-positioned children whose bounds extend below the container boundary. The dropdown rendered in the DOM but was visually clipped and unreachable — so clicking `+` appeared to do nothing.
- **Fix**: Extract the tab list into its own `overflow-x-auto` inner container and place the `+` button as a sibling outside that container. The outer wrapper has no overflow restriction, so the dropdown is never clipped.
- **Bonus**: The `+` button now stays pinned at the right edge while only the tabs scroll, which is better UX than the original where the button could scroll off-screen with many open canvases.

## Changes

- `CanvasTabBar.tsx` — restructure: outer `div` loses `overflow-x-auto gap-0.5 px-1.5 py-1`; new inner `div` wraps only canvas tabs with `overflow-x-auto flex-1 min-w-0 pl-1.5 py-1 gap-0.5`; `+` button container becomes a flex sibling with `py-1 pl-0.5 pr-1.5`. Dropdown alignment changed from `left-0` → `right-0` (button is at the right edge).
- `CanvasTabBar.test.tsx` — add `+ button is NOT inside the scrollable tabs container (overflow-x-auto regression guard)` structural test asserting the button and a canvas tab have different parent elements, so a regression back to the clipped layout is caught before it ships.

## Root Cause Timeline

| Mission | What happened |
|---------|---------------|
| 71 | Fixed null-projectId singleton bug — `addCanvas()` mutations were discarded on each re-render |
| 68 | Added "New Canvas / From Blueprint" dropdown to the `+` button **but** placed it inside `overflow-x-auto`, clipping it |
| **75 (this PR)** | Moves the `+` button outside the scroll container — dropdown is no longer clipped |

## Test Plan

- [x] All 10 `CanvasTabBar` unit tests pass (including new regression guard)
- [x] Full suite: **11,357 pass / 4 skipped / 0 fail** (456 files)
- [x] TypeScript: clean (`tsc --noEmit`)
- [x] Lint: clean on touched files (22 pre-existing errors in unrelated files, same as baseline)
- [ ] **Manual QA**: Open a project → Canvas tab → click `+` → confirm dropdown appears with "New Canvas" and "From Blueprint" → click "New Canvas" → confirm a new canvas tab is created
- [ ] **Manual QA**: Open many canvases until tabs overflow → confirm `+` button stays pinned at right while tabs scroll
- [ ] **Manual QA**: Click `+` → "From Blueprint" → confirm blueprint gallery opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)