### PR TITLE
feat(group-project): channel model redesign — general, control, inbox-<agent>

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -120,7 +120,7 @@ vi.mock('./group-project-bulletin', () => ({
 }));
 
 vi.mock('./group-project-shoulder-tap', () => ({
-  executeShoulderTap: vi.fn().mockResolvedValue({ taskId: 'tap_1', messageId: 'msg_1', delivered: [], failed: [] }),
+  executeShoulderTap: vi.fn().mockResolvedValue({ taskId: 'tap_1', delivered: [], failed: [] }),
 }));
 
 vi.mock('./clubhouse-mcp/binding-manager', () => ({

--- a/src/main/services/clubhouse-mcp/tool-registry.ts
+++ b/src/main/services/clubhouse-mcp/tool-registry.ts
@@ -12,9 +12,6 @@ import { appLog } from '../log-service';
 /** Tool suffixes gated behind the group-project shoulderTapEnabled setting. */
 const SHOULDER_TAP_SUFFIXES = new Set(['shoulder_tap', 'broadcast']);
 
-/** Hint appended to read_bulletin description when shoulder tap is enabled. */
-const SHOULDER_TAP_HINT = '\n\nCheck the "shoulder-tap" topic for direct messages to you.';
-
 /** Tool suffixes gated behind the group-project agentControlEnabled setting. */
 const AGENT_CONTROL_SUFFIXES = new Set(['wake_agent', 'start_polling', 'stop_polling']);
 
@@ -204,11 +201,6 @@ export function getScopedToolList(agentId: string): McpToolDefinition[] {
       }
 
       let description = template.definition.description;
-
-      // When shoulder tap is enabled, hint agents to check the shoulder-tap topic
-      if (shoulderTapEnabled && template.nameSuffix === 'read_bulletin') {
-        description += SHOULDER_TAP_HINT;
-      }
 
       // Inject per-wire custom instructions into tool description
       if (binding.instructions) {

--- a/src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts
@@ -576,38 +576,26 @@ describe('GroupProjectTools', () => {
     expect(result.content[0].text).toContain('required');
   });
 
-  it('read_bulletin description omits shoulder-tap hint when shoulderTapEnabled is false', () => {
-    bindingManager.bind('agent-1', {
-      targetId: 'gp_no_tap',
-      targetKind: 'group-project',
-      label: 'NoTap',
-      agentName: 'robin',
-      targetName: 'NoTap',
-    });
-
-    const tools = getScopedToolList('agent-1');
-    const readBulletin = tools.find(t => t.name.split('__').pop() === 'read_bulletin');
-    expect(readBulletin).toBeDefined();
-    expect(readBulletin!.description).not.toContain('shoulder-tap');
-  });
-
-  it('read_bulletin description includes shoulder-tap hint when shoulderTapEnabled is true', async () => {
-    const project = await groupProjectRegistry.create('TapHint');
+  it('read_bulletin description describes the channel model regardless of shoulderTapEnabled', async () => {
+    const project = await groupProjectRegistry.create('ChanModel');
     await groupProjectRegistry.update(project.id, { metadata: { shoulderTapEnabled: true } });
 
     bindingManager.bind('agent-1', {
       targetId: project.id,
       targetKind: 'group-project',
-      label: 'TapHint',
+      label: 'ChanModel',
       agentName: 'robin',
-      targetName: 'TapHint',
+      targetName: 'ChanModel',
     });
 
     const tools = getScopedToolList('agent-1');
     const readBulletin = tools.find(t => t.name.split('__').pop() === 'read_bulletin');
     expect(readBulletin).toBeDefined();
-    expect(readBulletin!.description).toContain('shoulder-tap');
-    expect(readBulletin!.description).toContain('direct messages to you');
+    // The legacy "shoulder-tap" topic hint is gone — channel-model guidance replaces it.
+    expect(readBulletin!.description).not.toContain('"shoulder-tap" topic');
+    expect(readBulletin!.description).toContain('general');
+    expect(readBulletin!.description).toContain('control');
+    expect(readBulletin!.description).toContain('inbox-<your-name>');
   });
 
   /* ---------- Agent Control Tools (wake, start/stop polling) ---------- */

--- a/src/main/services/clubhouse-mcp/tools/group-project-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/group-project-tools.ts
@@ -98,21 +98,22 @@ export function registerGroupProjectTools(): void {
     label: 'Post Bulletin',
     mcp: { targetKind: 'group-project', nameSuffix: 'post_bulletin' },
     description:
-        'Post a message to the group project bulletin board.\n\n' +
-        'The bulletin board is the PRIMARY communication channel for group coordination. ' +
-        'Post regular progress updates, questions, decisions, and status changes.\n\n' +
-        'Your identity is automatically included as the sender. The "system" topic is ' +
-        'reserved for lifecycle events — use any other topic name freely.\n\n' +
-        'TOPIC HYGIENE: Use specific, distinct topic names to keep conversations organized. ' +
-        'Suggested topics: "progress", "questions", "decisions", "blockers". Avoid dumping ' +
-        'everything into a single topic — separate concerns make it easier to find and poll.\n\n' +
-        'Keep messages concise. Prefer plain text or short markdown over large JSON payloads.',
+        'Post a message to a channel on the project board.\n\n' +
+        'CHANNEL MODEL:\n' +
+        '- "general" (protected): introductions and broad announcements. Keep traffic low.\n' +
+        '- "control" (protected): coordination — tell other agents where to look ("follow #fix-login-bug") and agree on channel naming.\n' +
+        '- "inbox-<agent-name>" (protected): an agent\'s direct inbox. Post here for 1:1 async work with that agent.\n' +
+        '- work channels: create them liberally for scoped work (e.g. "fix-login-bug", "schema-v2"). One focused topic per channel.\n\n' +
+        'Introduce yourself on "general" when you first join. Prefer scoped work channels over posting shared context to "general". ' +
+        'Post replies where the work is happening — do not cross-post.\n\n' +
+        'Your identity is set automatically. The "system" channel is reserved. ' +
+        'Keep messages concise — plain text or short markdown beats large JSON payloads.',
       inputSchema: {
         type: 'object',
         properties: {
           topic: {
             type: 'string',
-            description: 'Topic name (freeform). "system" is reserved.',
+            description: 'Channel name. "system" is reserved. Use short-kebab-case for new work channels.',
           },
           body: {
             type: 'string',
@@ -167,14 +168,12 @@ export function registerGroupProjectTools(): void {
     label: 'Read Bulletin',
     mcp: { targetKind: 'group-project', nameSuffix: 'read_bulletin' },
       description:
-        'Read the bulletin board digest — shows all topics with message counts.\n\n' +
-        'This is the key coordination primitive. When you see topics with newMessageCount > 0, ' +
-        'use read_topic to get those new messages.\n\n' +
-        'IMPORTANT: Always pass the "since" parameter with the latestTimestamp from your last ' +
-        'read. This dramatically reduces response size and token cost. Only omit "since" on ' +
-        'your very first read.\n\n' +
-        'Returns a compact JSON array of {topic, messageCount, newMessageCount, latestTimestamp}.\n\n' +
-        'Always check the "system" topic for join/leave lifecycle events.',
+        'Get a digest of channels on the project board — {topic, messageCount, newMessageCount, latestTimestamp, isProtected} per channel.\n\n' +
+        'Pass "since" (the latestTimestamp from your last read) on every call after your first to keep the digest cheap.\n' +
+        'Pass "channels" to restrict the digest to the channels you care about. Your standard poll set is:\n' +
+        '  ["general", "control", "inbox-<your-name>", ...any work channels you are actively tracking]\n' +
+        'Only drill into a channel with read_topic when its newMessageCount > 0.\n\n' +
+        'Ignoring unrelated chatter is the whole point — do not read every channel on the board.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -182,12 +181,20 @@ export function registerGroupProjectTools(): void {
             type: 'string',
             description: 'ISO 8601 timestamp. If provided, newMessageCount reflects only messages after this time.',
           },
+          channels: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional allow-list of channel names to include in the digest. Omit for all channels.',
+          },
         },
       },
     handler: async (targetId: string, _agentId: string, args: Record<string, unknown>): Promise<McpToolResult> => {
       const since = optionalString(args, 'since');
+      const channels = Array.isArray(args.channels)
+        ? (args.channels as unknown[]).filter((c): c is string => typeof c === 'string')
+        : undefined;
       const board = getBulletinBoard(targetId);
-      const digest = await board.getDigest(since);
+      const digest = await board.getDigest(since, channels);
       return {
         content: [{ type: 'text', text: JSON.stringify(digest) }],
       };
@@ -201,18 +208,16 @@ export function registerGroupProjectTools(): void {
     label: 'Read Topic',
     mcp: { targetKind: 'group-project', nameSuffix: 'read_topic' },
       description:
-        'Read messages from a specific bulletin board topic.\n\n' +
-        'IMPORTANT: Always pass the "since" parameter with the timestamp from your last ' +
-        'read to only fetch new messages. This saves significant tokens.\n\n' +
-        'Use summary=true to get truncated message bodies (~200 chars). If you need the ' +
-        'full content of a specific message, use read_message with its ID.\n\n' +
+        'Read messages from a specific channel.\n\n' +
+        'Always pass "since" (latestTimestamp from your last read of this channel) to fetch only new messages — avoids re-reading the full history.\n' +
+        'Use summary=true on large channels to get truncated bodies (~200 chars); then call read_message by id for any full body you actually need.\n\n' +
         'Returns a compact JSON array of {id, sender, topic, body, timestamp}.',
       inputSchema: {
         type: 'object',
         properties: {
           topic: {
             type: 'string',
-            description: 'Topic name to read.',
+            description: 'Channel name to read.',
           },
           since: {
             type: 'string',
@@ -299,12 +304,14 @@ export function registerGroupProjectTools(): void {
         description: project.description,
         instructions: project.instructions,
         systemInstructions:
-          'EFFICIENT POLLING: Always pass "since" (the latestTimestamp from your last read) ' +
-          'to read_bulletin and read_topic. Only fetch topics where newMessageCount > 0. ' +
-          'Use summary=true on read_topic for large topics, then read_message for specific messages.\n\n' +
-          'TOPIC HYGIENE: Use specific, distinct topic names (e.g. "progress", "blockers", "decisions"). ' +
-          'Avoid dumping all communication into one topic.\n\n' +
-          'MESSAGE FORMAT: Post in plain text or short markdown. Avoid large JSON payloads in message bodies.',
+          'CHANNEL MODEL: Every project has protected "general" and "control" channels, plus a per-agent "inbox-<agent-name>" channel. Work channels are freeform — create them with post_bulletin as needed.\n' +
+          '- general: introduce yourself when you join ("I am <name>, working on <focus>"); post announcements that affect everyone. Keep traffic low.\n' +
+          '- control: set up shared work ("new channel #fix-login-bug, follow if relevant"), agree on naming, resolve cross-stream questions.\n' +
+          '- inbox-<your-name>: your direct inbox. Check it every poll. Other agents post here for 1:1 asks.\n' +
+          '- work channels: make them liberally for focused coordination. One topic per channel. Prefer this over cross-posting to "general".\n\n' +
+          'POLLING: Call read_bulletin with since=<latestTimestamp from last read> and channels=["general","control","inbox-<your-name>", ...subscribed work channels]. ' +
+          'Only drill into a channel with read_topic when its newMessageCount > 0. Use summary=true for large reads and read_message for full bodies.\n\n' +
+          'POSTING: Introduce yourself on "general" after you first join. Post replies on the channel where the work is happening. Do not cross-post. Keep messages short — plain text or short markdown, not large JSON.',
       };
 
       if (includeMembersList) {
@@ -331,15 +338,11 @@ export function registerGroupProjectTools(): void {
     label: 'Shoulder Tap',
     mcp: { targetKind: 'group-project', nameSuffix: 'shoulder_tap' },
       description:
-        'Send an urgent direct message to a specific agent in this group project.\n\n' +
-        'WARNING: This tool is NOT for normal communication. Use the bulletin board ' +
-        '(post_bulletin / read_bulletin) for routine coordination. Shoulder tap should ' +
-        'ONLY be used when you need immediate attention from a specific agent and the ' +
-        'bulletin board is insufficient (e.g. the agent is unresponsive to bulletin posts, ' +
-        'or there is a time-critical blocker).\n\n' +
-        'The message is injected directly into the target agent\'s terminal input. ' +
-        'The target agent\'s name must match one returned by list_members.\n\n' +
-        'A record of the tap is also posted to the "shoulder-tap" bulletin board topic.',
+        'Send an urgent, ephemeral message directly into a specific agent\'s terminal.\n\n' +
+        'NOT for routine coordination — post to a channel instead. Use shoulder_tap only when a channel post is insufficient: ' +
+        'the target is unresponsive, or there is a time-critical blocker.\n\n' +
+        'The message is injected as terminal input. No bulletin record is created — if a reply is expected, ask the target to post it on your inbox channel ("inbox-<your-name>").\n\n' +
+        'The target_agent_id must match an agentId returned by list_members.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -398,14 +401,9 @@ export function registerGroupProjectTools(): void {
     label: 'Broadcast',
     mcp: { targetKind: 'group-project', nameSuffix: 'broadcast' },
       description:
-        'Broadcast an urgent message to ALL agents in this group project.\n\n' +
-        'WARNING: This tool is NOT for normal communication. Use the bulletin board ' +
-        '(post_bulletin / read_bulletin) for routine coordination. Broadcast should ' +
-        'ONLY be used for critical announcements that require immediate attention from ' +
-        'every agent (e.g. "stop all work, critical issue found", "project goals changed").\n\n' +
-        'The message is injected directly into each agent\'s terminal input. ' +
-        'You (the sender) are excluded from the broadcast.\n\n' +
-        'A record of the broadcast is also posted to the "shoulder-tap" bulletin board topic.',
+        'Broadcast an urgent, ephemeral message to every agent in this project (injected into each terminal; no bulletin record).\n\n' +
+        'NOT for routine coordination — post to "general" for that. Use broadcast only for critical, all-hands announcements ' +
+        '("stop all work, critical issue found", "project goals changed"). You (the sender) are excluded.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -752,10 +750,10 @@ export function registerGroupProjectTools(): void {
     label: 'Clear Topic',
     mcp: { targetKind: 'group-project', nameSuffix: 'clear_topic' },
     description:
-      'Delete an entire topic and all its messages from the bulletin board.\n\n' +
-      'Use this to clean up stale or completed topics that are no longer relevant. ' +
-      'This is a destructive operation — all messages in the topic will be permanently removed.\n\n' +
-      'Cannot delete the "system" topic.',
+      'Delete an entire channel and all its messages from the project board.\n\n' +
+      'Use this to clean up stale or completed work channels that are no longer relevant. ' +
+      'Destructive — all messages in the channel are permanently removed.\n\n' +
+      'The "system" channel cannot be deleted, and protected channels ("general", "control", and any "inbox-<name>") will still be recreated automatically when used.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/main/services/group-project-bulletin.test.ts
+++ b/src/main/services/group-project-bulletin.test.ts
@@ -28,7 +28,15 @@ vi.mock('./log-service', () => ({
   appLog: vi.fn(),
 }));
 
-import { getBulletinBoard, destroyBulletinBoard, _resetAllBoardsForTesting } from './group-project-bulletin';
+import {
+  getBulletinBoard,
+  destroyBulletinBoard,
+  _resetAllBoardsForTesting,
+  PROJECT_CHANNELS,
+  ensureProjectChannels,
+  ensureInboxChannel,
+  inboxChannelName,
+} from './group-project-bulletin';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 
@@ -484,6 +492,161 @@ describe('BulletinBoard', () => {
       await board.postMessage('alice', 'topic-a', 'msg3');
 
       expect(board.totalMessageCount()).toBe(3);
+    });
+  });
+
+  describe('hasTopic', () => {
+    it('returns false for an empty board', async () => {
+      const board = getBulletinBoard('gp_has_none');
+      expect(await board.hasTopic('general')).toBe(false);
+    });
+
+    it('returns true after a message is posted to that topic', async () => {
+      const board = getBulletinBoard('gp_has_some');
+      await board.postMessage('system', 'general', 'hi');
+      expect(await board.hasTopic('general')).toBe(true);
+      expect(await board.hasTopic('control')).toBe(false);
+    });
+  });
+
+  describe('getDigest channel filter', () => {
+    it('returns only the topics listed in the channels filter', async () => {
+      const board = getBulletinBoard('gp_filter');
+      await board.postMessage('a', 'general', 'g1');
+      await board.postMessage('a', 'control', 'c1');
+      await board.postMessage('a', 'feature-foo', 'f1');
+      await board.postMessage('a', 'feature-bar', 'b1');
+
+      const digest = await board.getDigest(undefined, ['general', 'control']);
+      const topics = digest.map(d => d.topic).sort();
+      expect(topics).toEqual(['control', 'general']);
+    });
+
+    it('returns all topics when channels filter is empty or omitted', async () => {
+      const board = getBulletinBoard('gp_filter_none');
+      await board.postMessage('a', 't1', 'm');
+      await board.postMessage('a', 't2', 'm');
+
+      const omitted = await board.getDigest();
+      expect(omitted.map(d => d.topic).sort()).toEqual(['t1', 't2']);
+
+      const empty = await board.getDigest(undefined, []);
+      expect(empty.map(d => d.topic).sort()).toEqual(['t1', 't2']);
+    });
+
+    it('combines since and channels filters', async () => {
+      const board = getBulletinBoard('gp_filter_since');
+      await board.postMessage('a', 'general', 'old-g');
+      await board.postMessage('a', 'control', 'old-c');
+      const cutoff = new Date().toISOString();
+      await new Promise(r => setTimeout(r, 2));
+      await board.postMessage('a', 'general', 'new-g');
+      await board.postMessage('a', 'control', 'new-c');
+
+      const digest = await board.getDigest(cutoff, ['general']);
+      expect(digest).toHaveLength(1);
+      expect(digest[0].topic).toBe('general');
+      expect(digest[0].newMessageCount).toBe(1);
+      expect(digest[0].messageCount).toBe(2);
+    });
+  });
+});
+
+describe('channel bootstrap helpers', () => {
+  beforeEach(() => {
+    store.clear();
+    _resetAllBoardsForTesting();
+  });
+
+  describe('inboxChannelName', () => {
+    it('lowercases a simple name', () => {
+      expect(inboxChannelName('Robin')).toBe('inbox-robin');
+    });
+
+    it('replaces disallowed characters with a single dash', () => {
+      expect(inboxChannelName('alice/bob')).toBe('inbox-alice-bob');
+      expect(inboxChannelName('Foo  Bar!!')).toBe('inbox-foo-bar');
+    });
+
+    it('strips leading and trailing dashes', () => {
+      expect(inboxChannelName('___robin___')).toBe('inbox-robin');
+    });
+
+    it('falls back to inbox-unknown for empty or fully invalid input', () => {
+      expect(inboxChannelName('')).toBe('inbox-unknown');
+      expect(inboxChannelName('!!!')).toBe('inbox-unknown');
+    });
+  });
+
+  describe('PROJECT_CHANNELS', () => {
+    it('reserves general and control', () => {
+      expect(PROJECT_CHANNELS).toEqual(['general', 'control']);
+    });
+  });
+
+  describe('ensureProjectChannels', () => {
+    it('seeds general and control as protected topics', async () => {
+      await ensureProjectChannels('gp_seed');
+      const board = getBulletinBoard('gp_seed');
+      const digest = await board.getDigest();
+      const byTopic = Object.fromEntries(digest.map(d => [d.topic, d]));
+      expect(byTopic.general).toBeDefined();
+      expect(byTopic.general.isProtected).toBe(true);
+      expect(byTopic.control).toBeDefined();
+      expect(byTopic.control.isProtected).toBe(true);
+    });
+
+    it('is idempotent — repeated calls do not add extra seed messages', async () => {
+      await ensureProjectChannels('gp_idem');
+      await ensureProjectChannels('gp_idem');
+      await ensureProjectChannels('gp_idem');
+      const board = getBulletinBoard('gp_idem');
+      const digest = await board.getDigest();
+      const general = digest.find(d => d.topic === 'general')!;
+      const control = digest.find(d => d.topic === 'control')!;
+      expect(general.messageCount).toBe(1);
+      expect(control.messageCount).toBe(1);
+    });
+
+    it('re-protects channels even if protection was cleared', async () => {
+      await ensureProjectChannels('gp_reprot');
+      const board = getBulletinBoard('gp_reprot');
+      board.setTopicProtected('general', false);
+      await ensureProjectChannels('gp_reprot');
+      const digest = await board.getDigest();
+      expect(digest.find(d => d.topic === 'general')!.isProtected).toBe(true);
+    });
+  });
+
+  describe('ensureInboxChannel', () => {
+    it('creates a sanitized inbox channel and marks it protected', async () => {
+      const name = await ensureInboxChannel('gp_inbox', 'Robin');
+      expect(name).toBe('inbox-robin');
+      const board = getBulletinBoard('gp_inbox');
+      const digest = await board.getDigest();
+      const inbox = digest.find(d => d.topic === 'inbox-robin');
+      expect(inbox).toBeDefined();
+      expect(inbox!.isProtected).toBe(true);
+      expect(inbox!.messageCount).toBe(1);
+    });
+
+    it('is idempotent across repeated joins', async () => {
+      await ensureInboxChannel('gp_inbox2', 'robin');
+      await ensureInboxChannel('gp_inbox2', 'robin');
+      await ensureInboxChannel('gp_inbox2', 'robin');
+      const board = getBulletinBoard('gp_inbox2');
+      const digest = await board.getDigest();
+      expect(digest.find(d => d.topic === 'inbox-robin')!.messageCount).toBe(1);
+    });
+
+    it('creates distinct inboxes for distinct agents on the same project', async () => {
+      await ensureInboxChannel('gp_multi', 'Alice');
+      await ensureInboxChannel('gp_multi', 'Bob');
+      const board = getBulletinBoard('gp_multi');
+      const digest = await board.getDigest();
+      const topics = digest.map(d => d.topic).sort();
+      expect(topics).toContain('inbox-alice');
+      expect(topics).toContain('inbox-bob');
     });
   });
 });

--- a/src/main/services/group-project-bulletin.ts
+++ b/src/main/services/group-project-bulletin.ts
@@ -165,14 +165,26 @@ class BulletinBoard {
     return message;
   }
 
-  /** Get a digest of all topics (no message bodies). */
-  async getDigest(since?: string): Promise<TopicDigest[]> {
+  /** Check whether a topic has been created (has at least one message). */
+  async hasTopic(topic: string): Promise<boolean> {
+    await this.ensureLoaded();
+    return this.topics.has(topic);
+  }
+
+  /**
+   * Get a digest of topics (no message bodies). Pass `channels` to restrict the
+   * digest to a named list — omitted topics are still present on the board but
+   * skipped in the result to reduce token cost for agents polling a small set.
+   */
+  async getDigest(since?: string, channels?: string[]): Promise<TopicDigest[]> {
     await this.ensureLoaded();
     const sinceTime = since ? new Date(since).getTime() : 0;
+    const filter = channels && channels.length > 0 ? new Set(channels) : null;
     const digests: TopicDigest[] = [];
 
     for (const [topic, messages] of this.topics) {
       if (messages.length === 0) continue;
+      if (filter && !filter.has(topic)) continue;
       const newMessages = sinceTime > 0
         ? messages.filter(m => new Date(m.timestamp).getTime() > sinceTime)
         : messages;
@@ -467,4 +479,61 @@ export function _resetAllBoardsForTesting(): void {
     board._resetForTesting();
   }
   boards.clear();
+}
+
+// --- Channel bootstrap helpers ---
+
+/** Reserved project-level channels that agents always poll. */
+export const PROJECT_CHANNELS = ['general', 'control'] as const;
+
+/**
+ * Seed the `general` and `control` channels on a project board and mark them
+ * protected so they survive retention pruning. Idempotent — safe to call on
+ * project create and again for pre-existing boards on first agent join.
+ */
+export async function ensureProjectChannels(projectId: string): Promise<void> {
+  const board = getBulletinBoard(projectId);
+  for (const name of PROJECT_CHANNELS) {
+    if (!(await board.hasTopic(name))) {
+      await board.postMessage(
+        'system',
+        name,
+        name === 'general'
+          ? 'general — broad announcements and introductions. Keep traffic low; prefer scoped work channels for focused coordination.'
+          : 'control — coordination channel. Use it to point other agents at specific work channels (e.g. "follow #fix-login-bug").',
+      );
+    }
+    board.setTopicProtected(name, true);
+  }
+}
+
+/**
+ * Build the inbox channel name for an agent. Sanitized to the set
+ * /[a-z0-9-]/ so arbitrary display names don't produce odd channel names.
+ */
+export function inboxChannelName(agentName: string): string {
+  const safe = agentName
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-+/g, '-');
+  return `inbox-${safe || 'unknown'}`;
+}
+
+/**
+ * Seed an agent's personal inbox channel and mark it protected. Idempotent.
+ * Returns the resolved channel name.
+ */
+export async function ensureInboxChannel(projectId: string, agentName: string): Promise<string> {
+  const board = getBulletinBoard(projectId);
+  const name = inboxChannelName(agentName);
+  if (!(await board.hasTopic(name))) {
+    await board.postMessage(
+      'system',
+      name,
+      `Inbox channel for ${agentName}. Other agents post here for direct, async messages. Poll this on every cycle.`,
+    );
+  }
+  board.setTopicProtected(name, true);
+  return name;
 }

--- a/src/main/services/group-project-lifecycle.test.ts
+++ b/src/main/services/group-project-lifecycle.test.ts
@@ -181,7 +181,7 @@ describe('GroupProjectLifecycle', () => {
 
     const calls = mockPtyWrite.mock.calls;
     const pollingCall = calls.find(
-      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('Group Project notification') && (c[1] as string).includes('Poll the bulletin'),
+      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('Group Project notification') && (c[1] as string).includes('start polling'),
     );
     expect(pollingCall).toBeDefined();
     expect(pollingCall![0]).toBe('agent-1');
@@ -349,7 +349,7 @@ describe('GroupProjectLifecycle', () => {
 
     const calls = mockPtyWrite.mock.calls;
     const pollingCall = calls.find(
-      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('Group Project notification') && (c[1] as string).includes('Poll the bulletin'),
+      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('Group Project notification') && (c[1] as string).includes('start polling'),
     );
     expect(pollingCall).toBeUndefined();
   });
@@ -520,5 +520,69 @@ describe('GroupProjectLifecycle', () => {
     expect(_recentLeavesForTesting.has('agent-1:gp_123')).toBe(true);
     const ts = _recentLeavesForTesting.get('agent-1:gp_123')!;
     expect(Date.now() - ts).toBeLessThan(5000);
+  });
+
+  it('auto-creates a protected inbox channel when an agent joins', async () => {
+    initGroupProjectLifecycle();
+
+    bindingManager.bind('agent-1', {
+      targetId: 'gp_inbox',
+      targetKind: 'group-project',
+      label: 'GP',
+      agentName: 'Robin',
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+
+    const board = getBulletinBoard('gp_inbox');
+    const digest = await board.getDigest();
+    const inbox = digest.find(d => d.topic === 'inbox-robin');
+    expect(inbox).toBeDefined();
+    expect(inbox!.isProtected).toBe(true);
+  });
+
+  it('retrofits general/control channels when an agent joins a pre-existing project', async () => {
+    initGroupProjectLifecycle();
+
+    // Simulate a project that was created before the channel redesign — no
+    // ensureProjectChannels has run because we're binding directly to a raw id.
+    bindingManager.bind('agent-1', {
+      targetId: 'gp_legacy',
+      targetKind: 'group-project',
+      label: 'GP',
+      agentName: 'robin',
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+
+    const board = getBulletinBoard('gp_legacy');
+    const digest = await board.getDigest();
+    const topics = digest.map(d => d.topic);
+    expect(topics).toContain('general');
+    expect(topics).toContain('control');
+  });
+
+  it('passes the inbox channel to the polling instruction', async () => {
+    const project = await groupProjectRegistry.create('Inboxer');
+    await groupProjectRegistry.update(project.id, { metadata: { pollingEnabled: true } });
+    mockGetAgentOrchestrator.mockReturnValue('claude-code');
+
+    initGroupProjectLifecycle();
+
+    bindingManager.bind('agent-1', {
+      targetId: project.id,
+      targetKind: 'group-project',
+      label: 'GP',
+      agentName: 'falcon',
+    });
+
+    await new Promise(r => setTimeout(r, 800));
+
+    const calls = mockPtyWrite.mock.calls;
+    const pollingCall = calls.find(
+      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string).includes('start polling'),
+    );
+    expect(pollingCall).toBeDefined();
+    expect(pollingCall![1]).toContain('"inbox-falcon"');
   });
 });

--- a/src/main/services/group-project-lifecycle.ts
+++ b/src/main/services/group-project-lifecycle.ts
@@ -4,7 +4,7 @@
  */
 
 import { bindingManager } from './clubhouse-mcp/binding-manager';
-import { getBulletinBoard } from './group-project-bulletin';
+import { getBulletinBoard, ensureInboxChannel, ensureProjectChannels } from './group-project-bulletin';
 import { groupProjectRegistry } from './group-project-registry';
 import * as ptyManager from './pty-manager';
 import { agentRegistry } from './agent-registry';
@@ -145,6 +145,25 @@ async function syncMemberships(agentId: string): Promise<void> {
       const projectName = project?.name || projectId;
 
       try {
+        // Retrofit: projects created before the channel-model redesign won't
+        // have general/control seeded. Safe to call on every join — idempotent.
+        await ensureProjectChannels(projectId);
+      } catch (err) {
+        appLog('core:group-project', 'warn', 'Failed to ensure project channels on join', {
+          meta: { agentId, projectId, error: err instanceof Error ? err.message : String(err) },
+        });
+      }
+
+      let inboxName: string | null = null;
+      try {
+        inboxName = await ensureInboxChannel(projectId, agentName);
+      } catch (err) {
+        appLog('core:group-project', 'warn', 'Failed to create inbox channel', {
+          meta: { agentId, projectId, error: err instanceof Error ? err.message : String(err) },
+        });
+      }
+
+      try {
         const board = getBulletinBoard(projectId);
         await board.postMessage('system', 'system', `${agentName} joined project "${projectName}"`);
       } catch (err) {
@@ -157,7 +176,7 @@ async function syncMemberships(agentId: string): Promise<void> {
       if (project?.metadata?.pollingEnabled) {
         const orchestrator = getAgentOrchestrator(agentId);
         // Small delay so the welcome message is processed first
-        setTimeout(() => injectPtyMessage(agentId, pollingStartMsg(projectName, orchestrator)), 500);
+        setTimeout(() => injectPtyMessage(agentId, pollingStartMsg(projectName, orchestrator, inboxName)), 500);
       }
     }
   }

--- a/src/main/services/group-project-registry.test.ts
+++ b/src/main/services/group-project-registry.test.ts
@@ -30,11 +30,13 @@ vi.mock('./log-service', () => ({
 }));
 
 import { groupProjectRegistry } from './group-project-registry';
+import { getBulletinBoard, _resetAllBoardsForTesting } from './group-project-bulletin';
 
 describe('GroupProjectRegistry', () => {
   beforeEach(() => {
     store.clear();
     groupProjectRegistry._resetForTesting();
+    _resetAllBoardsForTesting();
   });
 
   it('creates a project with expected shape', async () => {
@@ -155,5 +157,28 @@ describe('GroupProjectRegistry', () => {
     // Verify writeFile was called
     const fsp = await import('fs/promises');
     expect(fsp.writeFile).toHaveBeenCalled();
+  });
+
+  it('seeds protected "general" and "control" channels on create', async () => {
+    const p = await groupProjectRegistry.create('Seeded');
+    const board = getBulletinBoard(p.id);
+    const digest = await board.getDigest();
+    const byTopic = Object.fromEntries(digest.map(d => [d.topic, d]));
+    expect(byTopic.general).toBeDefined();
+    expect(byTopic.control).toBeDefined();
+    expect(byTopic.general.isProtected).toBe(true);
+    expect(byTopic.control.isProtected).toBe(true);
+  });
+
+  it('seeded channels are idempotent across repeated boots', async () => {
+    const p = await groupProjectRegistry.create('Idem');
+    const board = getBulletinBoard(p.id);
+    const before = (await board.getDigest()).find(d => d.topic === 'general')!.messageCount;
+    // Second call via ensureProjectChannels path (simulated through create of same id not possible;
+    // rely on the internal seed being idempotent)
+    const { ensureProjectChannels } = await import('./group-project-bulletin');
+    await ensureProjectChannels(p.id);
+    const after = (await board.getDigest()).find(d => d.topic === 'general')!.messageCount;
+    expect(after).toBe(before);
   });
 });

--- a/src/main/services/group-project-registry.ts
+++ b/src/main/services/group-project-registry.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { app } from 'electron';
 import type { GroupProject } from '../../shared/group-project-types';
 import { appLog } from './log-service';
+import { ensureProjectChannels } from './group-project-bulletin';
 
 function groupProjectsDir(): string {
   const dirName = app.isPackaged ? '.clubhouse' : '.clubhouse-dev';
@@ -121,6 +122,13 @@ class GroupProjectRegistry {
     };
     this.projects.set(id, project);
     this.markDirty();
+    try {
+      await ensureProjectChannels(id);
+    } catch (err) {
+      appLog('core:group-project', 'warn', 'Failed to seed project channels', {
+        meta: { projectId: id, error: err instanceof Error ? err.message : String(err) },
+      });
+    }
     return project;
   }
 

--- a/src/main/services/group-project-shoulder-tap.test.ts
+++ b/src/main/services/group-project-shoulder-tap.test.ts
@@ -102,7 +102,8 @@ describe('executeShoulderTap', () => {
     expect(result.delivered[0].status).toBe('delivered');
     expect(result.failed).toHaveLength(0);
     expect(result.taskId).toMatch(/^tap_/);
-    expect(result.messageId).toMatch(/^msg_/);
+    // Shoulder tap is ephemeral — no bulletin audit record is produced.
+    expect((result as Record<string, unknown>).messageId).toBeUndefined();
 
     // PTY write should use chunked bracketed paste (separate writes for markers)
     expect(mockPtyWrite).toHaveBeenCalled();
@@ -219,7 +220,7 @@ describe('executeShoulderTap', () => {
     agentRegistry.untrack('agent-b');
   });
 
-  it('records tap to shoulder-tap bulletin topic', async () => {
+  it('does NOT record tap to any bulletin channel (ephemeral)', async () => {
     const project = await groupProjectRegistry.create('RecordProj');
 
     agentRegistry.register('agent-r', { projectPath: '/r', orchestrator: 'claude-code', runtime: 'pty' });
@@ -239,13 +240,43 @@ describe('executeShoulderTap', () => {
     });
 
     const board = getBulletinBoard(project.id);
-    const messages = await board.getTopicMessages('shoulder-tap');
-    expect(messages).toHaveLength(1);
-    const body = JSON.parse(messages[0].body);
-    expect(body.from).toBe('user');
-    expect(body.to).toBe('agent-r');
-    expect(body.message).toBe('Check this out');
+    // Legacy "shoulder-tap" topic should not exist.
+    expect(await board.getTopicMessages('shoulder-tap')).toEqual([]);
+    // Digest should only show the auto-seeded protected channels and the
+    // inbox channel for the bound agent — no shoulder-tap channel.
+    const digest = await board.getDigest();
+    const topics = digest.map(d => d.topic).sort();
+    expect(topics).not.toContain('shoulder-tap');
+    expect(topics).toContain('general');
+    expect(topics).toContain('control');
 
     agentRegistry.untrack('agent-r');
+  });
+
+  it('injected message points reply at sender inbox when sender is an agent', async () => {
+    const project = await groupProjectRegistry.create('ReplyProj');
+    agentRegistry.register('agent-x', { projectPath: '/x', orchestrator: 'claude-code', runtime: 'pty' });
+    bindingManager.bind('agent-x', {
+      targetId: project.id,
+      targetKind: 'group-project',
+      label: 'RP',
+      agentName: 'falcon',
+      targetName: 'ReplyProj',
+      projectName: 'myapp',
+    });
+
+    await executeShoulderTap({
+      projectId: project.id,
+      senderLabel: 'robin@myapp',
+      targetAgentId: 'agent-x',
+      message: 'ping',
+    });
+
+    const bodyWrites = mockPtyWrite.mock.calls.map((c: unknown[]) => c[1] as string);
+    const fullBody = bodyWrites.join('');
+    expect(fullBody).toContain('inbox-robin');
+    expect(fullBody).toContain('ephemeral');
+
+    agentRegistry.untrack('agent-x');
   });
 });

--- a/src/main/services/group-project-shoulder-tap.ts
+++ b/src/main/services/group-project-shoulder-tap.ts
@@ -1,14 +1,15 @@
 /**
- * Shoulder Tap — urgent direct messaging for group project agents.
+ * Shoulder Tap — urgent, ephemeral direct messaging for group project agents.
  *
  * Shared by MCP tool handler (agent taps) AND IPC handler (human taps).
- * Injects a message into the target agent's PTY (or structured input) with
- * clear response instructions pointing back to the bulletin board.
+ * Injects a message into the target agent's PTY (or structured input). The
+ * tap is NOT recorded to the bulletin board — if a response is expected,
+ * the target is told to post to the sender's inbox channel.
  */
 
 import { agentRegistry } from './agent-registry';
 import * as structuredManager from './structured-manager';
-import { getBulletinBoard } from './group-project-bulletin';
+import { inboxChannelName } from './group-project-bulletin';
 import { groupProjectRegistry } from './group-project-registry';
 import { bindingManager } from './clubhouse-mcp/binding-manager';
 import { buildToolName } from './clubhouse-mcp/tool-registry';
@@ -43,9 +44,20 @@ export interface ShoulderTapDelivery {
 
 export interface ShoulderTapResult {
   taskId: string;
-  messageId: string;
   delivered: ShoulderTapDelivery[];
   failed: ShoulderTapDelivery[];
+}
+
+/**
+ * Derive the reply channel for a shoulder tap target: the sender's inbox
+ * channel if the sender is an agent (senderLabel is `agentName@projectName`),
+ * or null when the sender is the UI/human user.
+ */
+function senderReplyChannel(senderLabel: string): string | null {
+  if (!senderLabel || senderLabel === 'user') return null;
+  const senderAgentName = senderLabel.split('@')[0];
+  if (!senderAgentName) return null;
+  return inboxChannelName(senderAgentName);
 }
 
 export async function executeShoulderTap(params: ShoulderTapParams): Promise<ShoulderTapResult> {
@@ -56,15 +68,7 @@ export async function executeShoulderTap(params: ShoulderTapParams): Promise<Sho
   const project = await groupProjectRegistry.get(projectId);
   const projectName = project?.name || projectId;
 
-  // Record tap to bulletin board
-  const board = getBulletinBoard(projectId);
-  const tapRecord = JSON.stringify({
-    taskId,
-    from: senderLabel,
-    to: targetAgentId || 'all',
-    message,
-  });
-  const bulletinMsg = await board.postMessage(senderLabel, 'shoulder-tap', tapRecord);
+  const replyChannel = senderReplyChannel(senderLabel);
 
   // Find target agents
   const allBindings = bindingManager.getAllBindings();
@@ -100,18 +104,30 @@ export async function executeShoulderTap(params: ShoulderTapParams): Promise<Sho
     // Build the response tool name for this agent's group binding
     const replyToolName = buildToolName(binding, 'post_bulletin');
 
-    // Build the injected message
+    // Build the injected message. This tap is ephemeral — no bulletin record
+    // was written — so the only trail of this exchange is what the target
+    // chooses to post in reply. Point them at the sender's inbox channel.
+    const replyLines = replyChannel
+      ? [
+          `To respond, use your ${replyToolName} tool:`,
+          `  topic: "${replyChannel}"    (sender's inbox)`,
+          `  body: "TASK_RESULT:${taskId}: <your response>"`,
+          `To acknowledge: body: "TASK_ACK:${taskId}: Working on it"`,
+        ]
+      : [
+          `This tap was initiated by a human user. No channel reply is required;`,
+          `if you need to follow up, post a status update to "general".`,
+        ];
+
     const taggedMessage =
       `Group Project notification — shoulder tap from "${senderLabel}" in "${projectName}"\n` +
       `${message}\n\n` +
       `---\n` +
       `RESPONSE INSTRUCTIONS:\n` +
       `Project: "${projectName}" (ID: ${projectId})\n` +
-      `Task ID: ${taskId} | Message ID: ${bulletinMsg.id}\n\n` +
-      `To respond, use your ${replyToolName} tool:\n` +
-      `  topic: "shoulder-tap"\n` +
-      `  body: "TASK_RESULT:${taskId}: <your response>"\n` +
-      `To acknowledge: body: "TASK_ACK:${taskId}: Working on it"`;
+      `Task ID: ${taskId}\n` +
+      `This tap is ephemeral — no bulletin record was created.\n\n` +
+      replyLines.join('\n');
 
     try {
       if (reg.runtime === 'pty') {
@@ -148,5 +164,5 @@ export async function executeShoulderTap(params: ShoulderTapParams): Promise<Sho
     meta: { projectId, taskId, senderLabel, deliveredCount: delivered.length, failedCount: failed.length },
   });
 
-  return { taskId, messageId: bulletinMsg.id, delivered, failed };
+  return { taskId, delivered, failed };
 }

--- a/src/renderer/features/assistant/content/personas/project-manager.md
+++ b/src/renderer/features/assistant/content/personas/project-manager.md
@@ -12,10 +12,12 @@ You are a **project manager and delegator**. You plan, coordinate, and dispatch 
 
 ## Communication
 
-- Post mission briefs to the `missions` topic with clear scope, acceptance criteria, and branch naming
-- Monitor `progress` and `blockers` topics actively
-- Use `shoulder-tap` for urgent, targeted requests to specific agents
-- Post `decisions` when making calls that affect the team
+- Introduce yourself on `general` when you first join, then keep that channel for project-wide announcements
+- Use `control` to set up scoped work channels and tell agents where to poll (e.g. "new channel #fix-login-bug, Alice please follow")
+- Post mission briefs to a scoped work channel (e.g. `missions-<stream>`) with clear scope, acceptance criteria, and branch naming
+- Monitor the `progress` / `blockers` channels for streams you own
+- For urgent 1:1 asks, post to the target agent's `inbox-<name>` channel; escalate to `shoulder_tap` only when they are unresponsive
+- Post `decisions` on the relevant work channel when making calls that affect that stream
 
 ## Rules
 

--- a/src/shared/polling-messages.test.ts
+++ b/src/shared/polling-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pollingStartMsg, pollingStopMsg } from './polling-messages';
+import { pollingStartMsg, pollingStopMsg, pollingNudgeMsg } from './polling-messages';
 
 describe('pollingStartMsg', () => {
   it('returns Claude Code-specific instruction with /loop', () => {
@@ -28,6 +28,25 @@ describe('pollingStartMsg', () => {
       expect(msg).toContain('"My Project"');
     }
   });
+
+  it('references the standard channel poll set and the since parameter', () => {
+    const msg = pollingStartMsg('Alpha Squad', 'claude-code');
+    expect(msg).toContain('since=');
+    expect(msg).toContain('channels=');
+    expect(msg).toContain('"general"');
+    expect(msg).toContain('"control"');
+  });
+
+  it('substitutes the agent\'s inbox channel when provided', () => {
+    const msg = pollingStartMsg('Alpha Squad', 'claude-code', 'inbox-robin');
+    expect(msg).toContain('"inbox-robin"');
+    expect(msg).not.toContain('<your-name>');
+  });
+
+  it('falls back to a placeholder inbox when inbox channel is not provided', () => {
+    const msg = pollingStartMsg('Alpha Squad', 'claude-code');
+    expect(msg).toContain('inbox-<your-name>');
+  });
 });
 
 describe('pollingStopMsg', () => {
@@ -40,7 +59,7 @@ describe('pollingStopMsg', () => {
 
   it('returns generic stop for unknown orchestrator', () => {
     const msg = pollingStopMsg('Alpha Squad', undefined);
-    expect(msg).toContain('Stop');
+    expect(msg.toLowerCase()).toContain('stop');
     expect(msg).toContain('"Alpha Squad"');
     expect(msg).not.toContain('/loop');
   });
@@ -48,6 +67,22 @@ describe('pollingStopMsg', () => {
   it('returns generic stop for non-claude orchestrators', () => {
     const msg = pollingStopMsg('Alpha Squad', 'codex-cli');
     expect(msg).not.toContain('/loop');
-    expect(msg).toContain('Stop');
+    expect(msg.toLowerCase()).toContain('stop');
+  });
+});
+
+describe('pollingNudgeMsg', () => {
+  it('references the channels hint for non-Claude agents', () => {
+    const msg = pollingNudgeMsg('Alpha Squad', 'codex-cli', 'inbox-robin');
+    expect(msg).toContain('channels=');
+    expect(msg).toContain('"inbox-robin"');
+    expect(msg).toContain('"Alpha Squad"');
+    expect(msg).not.toContain('/loop');
+  });
+
+  it('prefers /loop phrasing for Claude Code', () => {
+    const msg = pollingNudgeMsg('Alpha Squad', 'claude-code', 'inbox-robin');
+    expect(msg).toContain('/loop 60s read_bulletin');
+    expect(msg).toContain('"inbox-robin"');
   });
 });

--- a/src/shared/polling-messages.ts
+++ b/src/shared/polling-messages.ts
@@ -14,9 +14,7 @@ import type { OrchestratorId } from './types';
 
 function standardChannelsHint(inboxChannel: string | null): string {
   const inboxPart = inboxChannel ? `"${inboxChannel}"` : '"inbox-<your-name>"';
-  return (
-    `channels=["general","control",${inboxPart}, ...any work channels you are actively tracking]`
-  );
+  return `channels=["general","control",${inboxPart}, ...any work channels you are actively tracking]`;
 }
 
 export function pollingStartMsg(
@@ -26,7 +24,7 @@ export function pollingStartMsg(
 ): string {
   const hint = standardChannelsHint(inboxChannel ?? null);
   const common =
-    `Group Project "${projectName}": start polling. ` +
+    `Group Project notification: start polling for "${projectName}". ` +
     'Call read_bulletin every 60 seconds with since=<latestTimestamp from your last read> and ' +
     `${hint}. ` +
     'Only drill into a channel with read_topic when its newMessageCount > 0.';
@@ -42,11 +40,11 @@ export function pollingStopMsg(projectName: string, orchestrator?: OrchestratorI
   switch (orchestrator) {
     case 'claude-code':
       return (
-        `Group Project notification: Stop polling the bulletin board for "${projectName}". ` +
+        `Group Project notification: stop polling the bulletin board for "${projectName}". ` +
         'Cancel any /loop or scheduled task you set up for this polling.'
       );
     default:
-      return `Group Project notification: Stop periodic bulletin board polling for "${projectName}".`;
+      return `Group Project notification: stop periodic bulletin board polling for "${projectName}".`;
   }
 }
 

--- a/src/shared/polling-messages.ts
+++ b/src/shared/polling-messages.ts
@@ -3,26 +3,38 @@
  *
  * Used by both the renderer (polling toggle button) and the main process
  * (auto-inject on join when polling is already enabled).
+ *
+ * Channel model: every project has protected "general" and "control" channels
+ * plus a per-agent "inbox-<agent>" channel. Agents poll the digest filtered to
+ * their standard set (general + control + own inbox + tracked work channels)
+ * to avoid paying tokens for unrelated chatter.
  */
 
 import type { OrchestratorId } from './types';
 
-export function pollingStartMsg(projectName: string, orchestrator?: OrchestratorId): string {
+function standardChannelsHint(inboxChannel: string | null): string {
+  const inboxPart = inboxChannel ? `"${inboxChannel}"` : '"inbox-<your-name>"';
+  return (
+    `channels=["general","control",${inboxPart}, ...any work channels you are actively tracking]`
+  );
+}
+
+export function pollingStartMsg(
+  projectName: string,
+  orchestrator?: OrchestratorId,
+  inboxChannel?: string | null,
+): string {
+  const hint = standardChannelsHint(inboxChannel ?? null);
+  const common =
+    `Group Project "${projectName}": start polling. ` +
+    'Call read_bulletin every 60 seconds with since=<latestTimestamp from your last read> and ' +
+    `${hint}. ` +
+    'Only drill into a channel with read_topic when its newMessageCount > 0.';
   switch (orchestrator) {
     case 'claude-code':
-      return (
-        `Group Project notification: Set up automatic polling for "${projectName}". ` +
-        'Schedule a recurring task to call read_bulletin every 60 seconds. ' +
-        'IMPORTANT: Always pass the "since" parameter with the latestTimestamp from your previous read ' +
-        'to minimize token usage. Only fetch topics where newMessageCount > 0 using read_topic with since. ' +
-        'Use /loop to automate: /loop 60s read_bulletin'
-      );
+      return `${common} Automate with: /loop 60s read_bulletin`;
     default:
-      return (
-        `Group Project notification: Poll the bulletin board for "${projectName}" every 60 seconds ` +
-        'when idle or between turns. Use read_bulletin(since=<lastTimestamp>) to check for updates. ' +
-        'Always pass the "since" parameter to minimize token usage.'
-      );
+      return common;
   }
 }
 
@@ -38,17 +50,22 @@ export function pollingStopMsg(projectName: string, orchestrator?: OrchestratorI
   }
 }
 
-export function pollingNudgeMsg(projectName: string, orchestrator?: OrchestratorId): string {
+export function pollingNudgeMsg(
+  projectName: string,
+  orchestrator?: OrchestratorId,
+  inboxChannel?: string | null,
+): string {
+  const hint = standardChannelsHint(inboxChannel ?? null);
   switch (orchestrator) {
     case 'claude-code':
       return (
-        `Group Project nudge: If you are NOT already polling the bulletin board for "${projectName}", ` +
-        'start now. Use /loop to automate: /loop 60s read_bulletin'
+        `Group Project nudge: if you are NOT already polling "${projectName}", start now. ` +
+        `Use /loop 60s read_bulletin with since=<latestTimestamp> and ${hint}.`
       );
     default:
       return (
-        `Group Project nudge: If you are NOT already polling the bulletin board for "${projectName}", ` +
-        'start polling every 60 seconds now. Use read_bulletin to check for updates.'
+        `Group Project nudge: if you are NOT already polling "${projectName}", start now ` +
+        `(every 60 seconds). Use read_bulletin with since=<latestTimestamp> and ${hint}.`
       );
   }
 }


### PR DESCRIPTION
## Summary
- Redesigns group-project communication around a small, polled set of channels so agents stop paying tokens for chatter outside their work.
- Replaces the \`shoulder-tap\` channel misfeature (it was a misreading of the shoulder-tap API, which delivers direct messages) with an ephemeral shoulder-tap + bulletin channel model.
- Introduces \`general\`, \`control\`, and per-agent \`inbox-<name>\` protected channels with explicit guidance for when to use each.

## The channel model
- **\`general\`** — broad announcements / introductions only. Low traffic.
- **\`control\`** — coordination. Agents use it to point each other at specific work channels ("follow #fix-login-bug").
- **\`inbox-<agent>\`** — per-agent direct async inbox. Every agent auto-creates one on join, and polls it every cycle. Shoulder-tap replies are now directed here instead of to a shared audit channel.
- **Scoped work channels** — created liberally by agents for focused multi-agent coordination. Pointed at via the \`control\` channel so other agents can opt in.

Agents now poll \`["general","control","inbox-<self>", ...tracked work channels]\` and ignore the rest.

## Changes
### Bulletin + registry
- \`group-project-bulletin.ts\` — add \`hasTopic(topic)\`, extend \`getDigest(since?, channels?)\` with a channel filter, add \`PROJECT_CHANNELS\`, \`ensureProjectChannels()\`, \`inboxChannelName()\`, \`ensureInboxChannel()\`. All three channel kinds are marked protected so they survive pruning.
- \`group-project-registry.ts\` — seed \`general\` + \`control\` on project create.
- \`group-project-lifecycle.ts\` — on agent join, retrofit project channels (for pre-existing projects) and auto-create the agent's inbox; pass the inbox name through to the polling instruction.

### Shoulder tap
- \`group-project-shoulder-tap.ts\` — drop the bulletin audit post (tap is now fully ephemeral) and remove \`messageId\` from the result. Tagged message now tells the recipient to reply on the **sender's inbox** channel.

### MCP tool surface
- \`clubhouse-mcp/tool-registry.ts\` — remove \`SHOULDER_TAP_HINT\` append block.
- \`clubhouse-mcp/tools/group-project-tools.ts\` — rewrite \`post_bulletin\`, \`read_bulletin\`, \`read_topic\`, \`shoulder_tap\`, \`broadcast\`, \`clear_topic\` descriptions to teach the new channel model; add \`channels: string[]\` filter param to \`read_bulletin\`; \`get_project_info.systemInstructions\` now documents the channel model end-to-end.

### Polling instructions
- \`shared/polling-messages.ts\` — \`pollingStartMsg\` / \`pollingNudgeMsg\` accept an optional inbox channel name and produce a \`channels=[…]\` hint with \`since=<latestTimestamp>\` guidance.

### Persona prose
- \`project-manager.md\` — updated Communication section to reference the channel model.

## Test Plan
- [x] \`hasTopic\` true/false paths
- [x] \`getDigest(since, channels)\` filter coverage (with + without since)
- [x] \`inboxChannelName()\` sanitization (simple, special chars, empty, fully-invalid)
- [x] \`ensureProjectChannels\` seeds + marks protected + idempotent + re-protects
- [x] \`ensureInboxChannel\` sanitized + protected + idempotent + distinct per agent
- [x] Registry seeds \`general\`/\`control\` on create and is idempotent across boots
- [x] Lifecycle auto-creates inbox on join, retrofits project channels, passes inbox to the polling instruction
- [x] Polling messages include \`since=\`, \`channels=\`, \`\"general\"\`, \`\"control\"\`; substitute inbox or \`inbox-<your-name>\` placeholder
- [x] Shoulder-tap drops \`messageId\`, writes no audit record, points reply at sender's inbox when sender is an agent
- [x] MCP \`read_bulletin\` description describes the channel model

## Manual Validation
- Launch a group project and invite two agents; confirm \`general\` + \`control\` exist, agents auto-create \`inbox-<name>\`, and all three show \`isProtected: true\`.
- Send a shoulder-tap from agent A to agent B; confirm no audit row appears on any bulletin topic and the tagged message tells B to reply on \`inbox-<A>\`.
- Start polling via the toggle; confirm the injected instruction references \`channels=["general","control","inbox-<self>", ...]\` and \`since=\`.

## Follow-ups (deferred)
- **P2**: channel retention / expiry policy (idle-channel cleanup) — ultimately an idle channel isn't burning tokens unless agents poll it, so this is lower priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)