### PR TITLE
fix(settings): allow turning off an orchestrator toggle when CLI is not installed

### DIFF
--- a/src/renderer/features/settings/OrchestratorSettingsView.test.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.test.tsx
@@ -269,10 +269,11 @@ describe('OrchestratorSettingsView', () => {
             },
           });
           render(<OrchestratorSettingsView />);
-          const toggleButtons = screen.getAllByRole('button');
-          const claudeToggle = toggleButtons.find(
-            (btn) => btn.className.includes('toggle-track') && btn.getAttribute('data-on') === 'false'
-          );
+          // Find the claude-code toggle specifically: not-installed orchs show an error message
+          // beneath them — navigate from that error text up to the row's toggle button
+          const errorText = screen.getByText('CLI not found');
+          const row = errorText.closest('.flex.items-center.justify-between');
+          const claudeToggle = row?.querySelector('.toggle-track');
           expect(claudeToggle).toBeTruthy();
           expect(claudeToggle).toBeDisabled();
           expect(claudeToggle).toHaveAttribute('title', 'CLI not found — install to enable');

--- a/src/renderer/features/settings/OrchestratorSettingsView.test.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.test.tsx
@@ -230,6 +230,82 @@ describe('OrchestratorSettingsView', () => {
         render(<OrchestratorSettingsView />);
         expect(screen.getByText('No orchestrators registered.')).toBeInTheDocument();
       });
+
+      describe('toggle disabled state when not installed', () => {
+        it('toggle is NOT disabled when orchestrator is enabled but not installed (can turn it off)', () => {
+          useOrchestratorStore.setState({
+            enabled: ['claude-code'],
+            availability: { 'claude-code': { available: false, error: 'CLI not found' } },
+          });
+          render(<OrchestratorSettingsView />);
+          const toggleButtons = screen.getAllByRole('button');
+          const orchToggle = toggleButtons.find((btn) =>
+            btn.className.includes('toggle-track') && btn.getAttribute('data-on') === 'true'
+          );
+          expect(orchToggle).toBeTruthy();
+          expect(orchToggle).not.toBeDisabled();
+        });
+
+        it('toggle IS disabled when orchestrator is disabled and not installed (cannot turn it on)', () => {
+          useOrchestratorStore.setState({
+            enabled: ['other-cli'],
+            allOrchestrators: [
+              {
+                id: 'claude-code',
+                displayName: 'Claude Code',
+                shortName: 'CC',
+                capabilities: { headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true },
+              },
+              {
+                id: 'other-cli',
+                displayName: 'Other CLI',
+                shortName: 'OC',
+                capabilities: { headless: true, structuredOutput: false, hooks: false, sessionResume: false, permissions: false },
+              },
+            ],
+            availability: {
+              'claude-code': { available: false, error: 'CLI not found' },
+              'other-cli': { available: true },
+            },
+          });
+          render(<OrchestratorSettingsView />);
+          const toggleButtons = screen.getAllByRole('button');
+          const claudeToggle = toggleButtons.find(
+            (btn) => btn.className.includes('toggle-track') && btn.getAttribute('data-on') === 'false'
+          );
+          expect(claudeToggle).toBeTruthy();
+          expect(claudeToggle).toBeDisabled();
+          expect(claudeToggle).toHaveAttribute('title', 'CLI not found — install to enable');
+        });
+
+        it('toggle is NOT disabled for last enabled orchestrator when it is not installed', () => {
+          // The "only enabled + not installed" case: isOnlyEnabled && notInstalled → should allow turning off
+          useOrchestratorStore.setState({
+            enabled: ['claude-code'],
+            availability: { 'claude-code': { available: false, error: 'CLI not found' } },
+          });
+          render(<OrchestratorSettingsView />);
+          const toggleButtons = screen.getAllByRole('button');
+          const orchToggle = toggleButtons.find((btn) =>
+            btn.className.includes('toggle-track') && btn.getAttribute('data-on') === 'true'
+          );
+          expect(orchToggle).not.toBeDisabled();
+        });
+
+        it('toggle IS disabled for last enabled orchestrator when it IS installed', () => {
+          useOrchestratorStore.setState({
+            enabled: ['claude-code'],
+            availability: { 'claude-code': { available: true } },
+          });
+          render(<OrchestratorSettingsView />);
+          const toggleButtons = screen.getAllByRole('button');
+          const orchToggle = toggleButtons.find((btn) =>
+            btn.className.includes('toggle-track') && btn.getAttribute('data-on') === 'true'
+          );
+          expect(orchToggle).toBeDisabled();
+          expect(orchToggle).toHaveAttribute('title', 'At least one orchestrator must be enabled');
+        });
+      });
     });
   });
 

--- a/src/renderer/features/settings/OrchestratorSettingsView.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.tsx
@@ -195,7 +195,10 @@ function AppAgentSettings() {
           const avail = availability[o.id];
           const isOnlyEnabled = isEnabled && enabled.length === 1;
           const notInstalled = avail && !avail.available;
-          const toggleDisabled = isOnlyEnabled || !!notInstalled;
+          // Allow turning OFF a not-installed orchestrator; only block:
+          // 1. turning ON something not installed
+          // 2. turning OFF the last working (available) orchestrator
+          const toggleDisabled = (isOnlyEnabled && !notInstalled) || (!!notInstalled && !isEnabled);
 
           return (
             <div key={o.id} className="flex items-center justify-between py-2 px-3 rounded-lg bg-ctp-mantle border border-surface-0">
@@ -225,7 +228,7 @@ function AppAgentSettings() {
                 disabled={toggleDisabled}
                 className="toggle-track"
                 data-on={String(isEnabled)}
-                title={notInstalled ? 'CLI not found — install to enable' : isOnlyEnabled ? 'At least one orchestrator must be enabled' : undefined}
+                title={!!notInstalled && !isEnabled ? 'CLI not found — install to enable' : isOnlyEnabled && !notInstalled ? 'At least one orchestrator must be enabled' : undefined}
               >
                 <span className="toggle-knob" />
               </button>

--- a/src/renderer/stores/orchestratorStore.test.ts
+++ b/src/renderer/stores/orchestratorStore.test.ts
@@ -102,14 +102,42 @@ describe('orchestratorStore', () => {
       expect(useOrchestratorStore.getState().enabled).toEqual(['claude-code']);
     });
 
-    it('prevents disabling the last orchestrator', async () => {
-      useOrchestratorStore.setState({ enabled: ['claude-code'] });
+    it('prevents disabling the last orchestrator when it is installed', async () => {
+      useOrchestratorStore.setState({
+        enabled: ['claude-code'],
+        availability: { 'claude-code': { available: true } },
+      });
 
       await useOrchestratorStore.getState().setEnabled('claude-code', false);
 
       // Should still have claude-code
       expect(useOrchestratorStore.getState().enabled).toEqual(['claude-code']);
       expect((window as any).clubhouse.app.saveOrchestratorSettings).not.toHaveBeenCalled();
+    });
+
+    it('prevents disabling the last orchestrator when availability is unknown', async () => {
+      useOrchestratorStore.setState({
+        enabled: ['claude-code'],
+        availability: {},
+      });
+
+      await useOrchestratorStore.getState().setEnabled('claude-code', false);
+
+      expect(useOrchestratorStore.getState().enabled).toEqual(['claude-code']);
+      expect((window as any).clubhouse.app.saveOrchestratorSettings).not.toHaveBeenCalled();
+    });
+
+    it('allows disabling the last orchestrator when it is not installed', async () => {
+      useOrchestratorStore.setState({
+        enabled: ['claude-code'],
+        availability: { 'claude-code': { available: false, error: 'CLI not found' } },
+      });
+      (window as any).clubhouse.app.saveOrchestratorSettings.mockResolvedValue(undefined);
+
+      await useOrchestratorStore.getState().setEnabled('claude-code', false);
+
+      expect(useOrchestratorStore.getState().enabled).toEqual([]);
+      expect((window as any).clubhouse.app.saveOrchestratorSettings).toHaveBeenCalledWith({ enabled: [] });
     });
 
     it('reverts on save error', async () => {

--- a/src/renderer/stores/orchestratorStore.ts
+++ b/src/renderer/stores/orchestratorStore.ts
@@ -39,8 +39,12 @@ export const useOrchestratorStore = create<OrchestratorState>((set, get) => ({
       next = current.includes(id) ? current : [...current, id];
     } else {
       next = current.filter((e) => e !== id);
-      // Don't allow disabling all orchestrators
-      if (next.length === 0) return;
+      // Don't allow disabling all orchestrators unless the last one is not installed
+      if (next.length === 0) {
+        const { availability } = get();
+        const lastIsUnavailable = availability[id] && !availability[id].available;
+        if (!lastIsUnavailable) return;
+      }
     }
     await optimisticUpdate(set, get,
       { enabled: next },


### PR DESCRIPTION
## Summary
- Fixes a bug where an orchestrator toggle was stuck ON and disabled when the CLI was not installed, making it impossible to turn off
- Allows users to turn OFF an orchestrator that is enabled but not installed; only blocks turning it back ON until the CLI is found
- Updates the store guard to allow an empty enabled list when the last orchestrator is confirmed unavailable

## Changes
- **`OrchestratorSettingsView.tsx`**: Revised `toggleDisabled` logic — was `isOnlyEnabled || !!notInstalled`; now `(isOnlyEnabled && !notInstalled) || (!!notInstalled && !isEnabled)` so a not-installed+enabled toggle is interactive (can be turned off), while a not-installed+disabled toggle stays locked (can't be turned on)
- **`OrchestratorSettingsView.tsx`**: Updated tooltip `title` to reflect the new conditions
- **`orchestratorStore.ts`**: Updated `setEnabled` to allow the enabled list to reach `[]` when the last orchestrator being disabled is confirmed unavailable (`availability[id].available === false`)
- **Tests**: Added 4 new UI cases and 2 new store cases covering the bug scenario and boundary conditions

## Test Plan
- [x] Toggle is NOT disabled when orchestrator is enabled but CLI not found (user can turn it off)
- [x] Toggle IS disabled when orchestrator is disabled and CLI not found (user can't turn it on; tooltip shows "CLI not found — install to enable")
- [x] Toggle is NOT disabled for last-enabled orchestrator when it is not installed
- [x] Toggle IS disabled for last-enabled orchestrator when it IS installed (normal protection preserved)
- [x] Store allows disabling the last orchestrator when it is not installed
- [x] Store prevents disabling the last orchestrator when availability is unknown (safe default)
- [x] Store prevents disabling the last orchestrator when it is installed

## Manual Validation
1. Open the app without Claude Code installed
2. Navigate to Settings → Orchestrators & Agents
3. Confirm the Claude Code toggle shows ON with a red dot
4. Confirm the toggle is now clickable — click it to turn it OFF
5. Confirm the toggle moves to OFF and stays there
6. Confirm that clicking the now-OFF toggle does nothing (can't re-enable without installing)