### PR TITLE
feat: add --agent and --source CLI flag support for durable agents

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -232,6 +232,42 @@ describe('CopilotCliProvider', () => {
       expect(result.args).toContain('--allow-tool');
       expect(result.args.filter(a => a === '--allow-tool')).toHaveLength(2);
     });
+
+    it('adds --agent flag when agentFile is set', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        agentFile: 'k8s-assistant',
+      });
+      expect(result.args).toContain('--agent');
+      expect(result.args[result.args.indexOf('--agent') + 1]).toBe('k8s-assistant');
+    });
+
+    it('adds --source flag when agentSource is set', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        agentSource: '/home/user/.copilot/agents',
+      });
+      expect(result.args).toContain('--source');
+      expect(result.args[result.args.indexOf('--source') + 1]).toBe('/home/user/.copilot/agents');
+    });
+
+    it('adds both --agent and --source when both are set', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        agentFile: 'k8s-assistant',
+        agentSource: '/home/user/.copilot/agents',
+      });
+      expect(result.args).toContain('--agent');
+      expect(result.args).toContain('--source');
+      expect(result.args[result.args.indexOf('--agent') + 1]).toBe('k8s-assistant');
+      expect(result.args[result.args.indexOf('--source') + 1]).toBe('/home/user/.copilot/agents');
+    });
+
+    it('does not add --agent or --source when not set', async () => {
+      const result = await provider.buildSpawnCommand({ cwd: '/project' });
+      expect(result.args).not.toContain('--agent');
+      expect(result.args).not.toContain('--source');
+    });
   });
 
   describe('getExitCommand', () => {

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -173,6 +173,13 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
       args.push('-p', parts.join('\n\n'));
     }
 
+    if (opts.agentFile) {
+      args.push('--agent', opts.agentFile);
+    }
+    if (opts.agentSource) {
+      args.push('--source', opts.agentSource);
+    }
+
     return { binary, args };
   }
 

--- a/src/main/orchestrators/types.ts
+++ b/src/main/orchestrators/types.ts
@@ -19,6 +19,10 @@ export interface SpawnOpts {
   freeAgentMode?: boolean;
   /** Permission mode for autonomous execution: 'auto' uses Claude's auto-approve classifier, 'skip-all' bypasses all permissions */
   permissionMode?: 'auto' | 'skip-all';
+  /** CLI agent name to load (passed as --agent to Copilot CLI) */
+  agentFile?: string;
+  /** Source directory for agent file (passed as --source to Copilot CLI) */
+  agentSource?: string;
 }
 
 export interface HeadlessOpts extends SpawnOpts {

--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -1808,4 +1808,70 @@ describe('agent-system', () => {
       expect(mockPtySpawn).toHaveBeenCalled();
     });
   });
+
+  describe('durable config fallback for agentFile / agentSource', () => {
+    it('threads agentFile and agentSource from durable config to buildSpawnCommand', async () => {
+      mockGetDurableConfig.mockReturnValue({
+        id: 'agent-1',
+        name: 'agent-1',
+        agentFile: 'k8s-assistant',
+        agentSource: '/home/user/.copilot/agents',
+      });
+
+      await spawnAgent({
+        agentId: 'agent-1',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'durable',
+      });
+
+      expect(mockProvider.buildSpawnCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentFile: 'k8s-assistant',
+          agentSource: '/home/user/.copilot/agents',
+        }),
+      );
+    });
+
+    it('does not override caller-provided agentFile with durable config', async () => {
+      mockGetDurableConfig.mockReturnValue({
+        id: 'agent-1',
+        name: 'agent-1',
+        agentFile: 'stored-agent',
+        agentSource: '/stored/path',
+      });
+
+      await spawnAgent({
+        agentId: 'agent-1',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'durable',
+        agentFile: 'caller-agent',
+      });
+
+      expect(mockProvider.buildSpawnCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentFile: 'caller-agent',
+        }),
+      );
+    });
+
+    it('does not set agentFile/agentSource when durable config has none', async () => {
+      mockGetDurableConfig.mockReturnValue({
+        id: 'agent-1',
+        name: 'agent-1',
+      });
+
+      await spawnAgent({
+        agentId: 'agent-1',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'durable',
+      });
+
+      const callArgs = mockProvider.buildSpawnCommand.mock.calls[0][0];
+      expect(callArgs.agentFile).toBeUndefined();
+      expect(callArgs.agentSource).toBeUndefined();
+    });
+  });
 });

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -21,6 +21,14 @@ import { waitReady as waitMcpBridgeReady } from './clubhouse-mcp/bridge-server';
 import { injectClubhouseMcp } from './clubhouse-mcp/injection';
 import { bindingManager } from './clubhouse-mcp/binding-manager';
 import { isMcpEnabled } from './mcp-settings';
+import * as os from 'os';
+
+/** Expand leading `~` or `~/` to the user's home directory. */
+function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
 
 // Re-export registry functions for backward compatibility
 export { getAgentProjectPath, getAgentOrchestrator, getAgentNonce, untrackAgent, resolveOrchestrator } from './agent-registry';
@@ -50,6 +58,10 @@ export interface SpawnAgentParams {
   companionWorkspace?: string;
   /** Permission mode override for resume (preserves pre-restart mode) */
   permissionMode?: FreeAgentPermissionMode;
+  /** CLI agent name to load (e.g. --agent k8s-assistant) */
+  agentFile?: string;
+  /** Source directory for agent file (e.g. --source ~/.copilot/agents/) */
+  agentSource?: string;
 }
 
 export function isHeadlessAgent(agentId: string): boolean {
@@ -148,6 +160,8 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
           if (params.freeAgentMode === undefined) params = { ...params, freeAgentMode: durableConfig.freeAgentMode };
           if (params.structuredMode === undefined && durableConfig.structuredMode) params = { ...params, structuredMode: durableConfig.structuredMode };
           if (params.model === undefined && durableConfig.model) params = { ...params, model: durableConfig.model };
+          if (params.agentFile === undefined && durableConfig.agentFile) params = { ...params, agentFile: durableConfig.agentFile };
+          if (params.agentSource === undefined && durableConfig.agentSource) params = { ...params, agentSource: durableConfig.agentSource };
         }
       } catch { /* config not available — use caller-provided values */ }
     }
@@ -186,6 +200,9 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
       });
       agentRegistry.setRuntime(params.agentId, 'structured');
       const adapter = provider.createStructuredAdapter();
+      const extraArgs: string[] = [];
+      if (params.agentFile) extraArgs.push('--agent', params.agentFile);
+      if (params.agentSource) extraArgs.push('--source', expandHome(params.agentSource));
       await structuredManager.startStructuredSession(params.agentId, adapter, {
         mission: structuredMission,
         systemPrompt: params.systemPrompt,
@@ -196,6 +213,7 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
         freeAgentMode: params.freeAgentMode,
         permissionMode,
         commandPrefix,
+        ...(extraArgs.length > 0 ? { extraArgs } : {}),
       }, (exitAgentId) => {
         if (params.kind !== 'durable') bindingManager.unbindAgent(exitAgentId);
         untrackAgent(exitAgentId);
@@ -318,6 +336,8 @@ async function spawnPtyAgent(
       permissionMode,
       resume: params.resume,
       sessionId: params.sessionId,
+      agentFile: params.agentFile,
+      agentSource: params.agentSource ? expandHome(params.agentSource) : undefined,
     }),
   ]);
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -211,6 +211,10 @@ export interface DurableAgentConfig {
   mcpOverride?: boolean;
   /** Persona template ID applied at creation. Used to re-inject instructions on materialization. */
   persona?: string;
+  /** CLI agent name to load (e.g. "k8s-assistant" → --agent k8s-assistant) */
+  agentFile?: string;
+  /** Directory to search for the agent file (e.g. "~/.copilot/agents/" → --source ...) */
+  agentSource?: string;
 }
 
 /** Maps an orchestrator ID to its wrapper subcommand */
@@ -912,6 +916,10 @@ export interface SpawnAgentParams {
   sessionId?: string;
   /** Permission mode override for resume (preserves pre-restart mode) */
   permissionMode?: FreeAgentPermissionMode;
+  /** CLI agent name to load (e.g. --agent k8s-assistant) */
+  agentFile?: string;
+  /** Source directory for agent file (e.g. --source ~/.copilot/agents/) */
+  agentSource?: string;
 }
 
 export type AgentDetailedState = 'idle' | 'working' | 'needs_permission' | 'tool_error';


### PR DESCRIPTION
Thread agentFile and agentSource fields through the spawn pipeline:
- DurableAgentConfig: new optional fields for persistence
- SpawnAgentParams (IPC + internal): new fields for threading
- SpawnOpts: provider interface extended
- copilot-cli-provider: generates --agent/--source flags
- agent-system: durable config fallback + tilde expansion
- Structured path: passes flags via extraArgs