### PR TITLE
fix: batch terminal writes via rAF in AgentTerminal and UtilityTerminal

### DIFF
--- a/src/renderer/features/agents/AgentTerminal.batching.test.tsx
+++ b/src/renderer/features/agents/AgentTerminal.batching.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Write-batching tests for AgentTerminal.
+ *
+ * Isolated in a separate file to avoid rAF mock lifecycle conflicts with
+ * other AgentTerminal tests (specifically the resume overlay tests that use
+ * vi.useFakeTimers, which corrupts vi.stubGlobal rAF state via restoreMocks).
+ */
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useThemeStore } from '../../stores/themeStore';
+import { useAgentStore } from '../../stores/agentStore';
+import { useClipboardSettingsStore } from '../../stores/clipboardSettingsStore';
+
+// Shared state holders for mock instances
+const g = globalThis as any;
+g.__testTerminal = null;
+g.__testFitAddon = null;
+g.__testAttachClipboard = vi.fn().mockReturnValue(vi.fn());
+
+vi.mock('@xterm/xterm', () => {
+  class Terminal {
+    loadAddon = vi.fn();
+    open = vi.fn().mockImplementation((container: HTMLElement) => {
+      const viewport = document.createElement('div');
+      viewport.classList.add('xterm-viewport');
+      Object.defineProperty(viewport, 'scrollHeight', { value: 200, configurable: true, writable: true });
+      Object.defineProperty(viewport, 'clientHeight', { value: 200, configurable: true, writable: true });
+      viewport.scrollTop = 0;
+      container.appendChild(viewport);
+    });
+    write = vi.fn();
+    focus = vi.fn();
+    dispose = vi.fn();
+    onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    options: Record<string, any> = {};
+    cols = 80;
+    rows = 24;
+    constructor(opts?: any) {
+      (globalThis as any).__testTerminal = this;
+      if (opts?.theme) this.options.theme = opts.theme;
+    }
+  }
+  return { Terminal };
+});
+
+vi.mock('@xterm/addon-fit', () => {
+  class FitAddon {
+    fit = vi.fn();
+    constructor() {
+      (globalThis as any).__testFitAddon = this;
+    }
+  }
+  return { FitAddon };
+});
+
+vi.mock('../terminal/clipboard', () => ({
+  attachClipboardHandlers: (...args: any[]) => (globalThis as any).__testAttachClipboard(...args),
+}));
+
+vi.mock('../../plugins/renderer-logger', () => ({
+  rendererLog: vi.fn(),
+}));
+
+g.__annexMockState = {
+  sendPtyInput: vi.fn(),
+  sendClipboardImage: vi.fn(),
+  requestPtyBuffer: vi.fn().mockResolvedValue(''),
+  sendPtyResize: vi.fn(),
+};
+
+vi.mock('../../stores/annexClientStore', () => {
+  const g = globalThis as any;
+  const useAnnexClientStore: any = (selector: any) => selector(g.__annexMockState);
+  useAnnexClientStore.getState = () => g.__annexMockState;
+  useAnnexClientStore.setState = vi.fn();
+  useAnnexClientStore.subscribe = vi.fn(() => vi.fn());
+  return {
+    useAnnexClientStore,
+    satellitePtyDataBus: { on: vi.fn(() => vi.fn()) },
+  };
+});
+
+vi.mock('../../themes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../themes')>();
+  return { ...actual };
+});
+
+vi.mock('../../stores/remoteProjectStore', () => ({
+  isRemoteAgentId: (id: string) => id.startsWith('remote||'),
+  parseNamespacedId: (id: string) => {
+    if (!id.startsWith('remote||')) return null;
+    const parts = id.split('||');
+    return { satelliteId: parts[1], agentId: parts[2] };
+  },
+}));
+
+import { AgentTerminal } from './AgentTerminal';
+
+let mockOnDataCallback: ((id: string, data: string) => void) | null = null;
+const mockRemoveDataListener = vi.fn();
+const mockRemoveExitListener = vi.fn();
+const mockDisconnect = vi.fn();
+
+describe('AgentTerminal write batching', () => {
+  let rafQueue: Array<() => void>;
+
+  beforeEach(() => {
+    g.__testTerminal = null;
+    g.__testFitAddon = null;
+    g.__testAttachClipboard.mockClear();
+    g.__testAttachClipboard.mockReturnValue(vi.fn());
+    g.__annexMockState = {
+      sendPtyInput: vi.fn(),
+      sendClipboardImage: vi.fn(),
+      requestPtyBuffer: vi.fn().mockResolvedValue(''),
+      sendPtyResize: vi.fn(),
+    };
+    mockOnDataCallback = null;
+    mockRemoveDataListener.mockClear();
+    mockRemoveExitListener.mockClear();
+    mockDisconnect.mockClear();
+
+    // Deferred rAF — queue callbacks instead of firing immediately
+    rafQueue = [];
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      if (id > 0 && id <= rafQueue.length) rafQueue[id - 1] = () => {};
+    });
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(_cb: () => void) {}
+      observe = vi.fn();
+      disconnect = mockDisconnect;
+      unobserve = vi.fn();
+    });
+
+    window.clubhouse.pty.write = vi.fn();
+    window.clubhouse.pty.resize = vi.fn();
+    window.clubhouse.pty.getBuffer = vi.fn().mockResolvedValue('');
+    window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: any) => {
+      mockOnDataCallback = cb;
+      return mockRemoveDataListener;
+    });
+    window.clubhouse.pty.onExit = vi.fn().mockImplementation((cb: any) => {
+      return mockRemoveExitListener;
+    });
+
+    useThemeStore.setState({
+      theme: { terminal: { background: '#000', foreground: '#fff' } } as any,
+    });
+
+    useClipboardSettingsStore.setState({
+      clipboardCompat: false,
+      loaded: false,
+      loadSettings: vi.fn(),
+      saveSettings: vi.fn(),
+    });
+
+    useAgentStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          projectId: 'proj-1',
+          name: 'test',
+          kind: 'durable',
+          status: 'running',
+          color: 'indigo',
+        },
+      },
+    });
+  });
+
+  function term() { return g.__testTerminal; }
+
+  function flushRAF() {
+    while (rafQueue.length) rafQueue.shift()!();
+  }
+
+  async function mountAndInit() {
+    render(<AgentTerminal agentId="agent-1" />);
+    // Flush mount rAF → getBuffer().then() → bufferReplayed = true
+    await act(async () => { flushRAF(); });
+    term().write.mockClear();
+    rafQueue.length = 0;
+  }
+
+  it('batches multiple data chunks into a single term.write call', async () => {
+    await mountAndInit();
+
+    // Simulate 5 rapid data chunks — rAF won't fire until we flush
+    act(() => {
+      mockOnDataCallback!('agent-1', 'chunk1');
+      mockOnDataCallback!('agent-1', 'chunk2');
+      mockOnDataCallback!('agent-1', 'chunk3');
+      mockOnDataCallback!('agent-1', 'chunk4');
+      mockOnDataCallback!('agent-1', 'chunk5');
+    });
+
+    // No writes yet — batched, waiting for rAF
+    expect(term().write).not.toHaveBeenCalled();
+
+    // Flush the batched write
+    act(() => { flushRAF(); });
+
+    expect(term().write).toHaveBeenCalledTimes(1);
+    expect(term().write).toHaveBeenCalledWith('chunk1chunk2chunk3chunk4chunk5');
+  });
+
+  it('allows subsequent batches after a flush', async () => {
+    await mountAndInit();
+
+    // First batch
+    act(() => {
+      mockOnDataCallback!('agent-1', 'a');
+      mockOnDataCallback!('agent-1', 'b');
+    });
+    act(() => { flushRAF(); });
+    expect(term().write).toHaveBeenCalledWith('ab');
+
+    term().write.mockClear();
+    rafQueue.length = 0;
+
+    // Second batch
+    act(() => {
+      mockOnDataCallback!('agent-1', 'c');
+      mockOnDataCallback!('agent-1', 'd');
+    });
+    act(() => { flushRAF(); });
+    expect(term().write).toHaveBeenCalledWith('cd');
+  });
+
+  it('cancels pending flush on unmount', async () => {
+    const { unmount } = render(<AgentTerminal agentId="agent-1" />);
+    await act(async () => { flushRAF(); });
+    term().write.mockClear();
+    rafQueue.length = 0;
+
+    act(() => { mockOnDataCallback!('agent-1', 'pending'); });
+    expect(rafQueue.length).toBeGreaterThan(0);
+
+    unmount();
+
+    // Flush after unmount — cancelled callbacks should be no-ops
+    flushRAF();
+    expect(term().write).not.toHaveBeenCalled();
+  });
+
+  it('does not batch data for non-matching agent IDs', async () => {
+    await mountAndInit();
+    const countAfterMount = rafQueue.length;
+
+    act(() => { mockOnDataCallback!('agent-2', 'other data'); });
+
+    // No new rAF scheduled for non-matching agent
+    expect(rafQueue.length).toBe(countAfterMount);
+  });
+});

--- a/src/renderer/features/agents/AgentTerminal.test.tsx
+++ b/src/renderer/features/agents/AgentTerminal.test.tsx
@@ -777,4 +777,7 @@ describe('AgentTerminal', () => {
       expect(term().options.theme).toEqual({ background: '#eff1f5', foreground: '#4c4f69' });
     });
   });
+
+  // Write batching tests are in AgentTerminal.batching.test.tsx
+  // (isolated to avoid rAF mock lifecycle conflicts with resume overlay tests)
 });

--- a/src/renderer/features/agents/AgentTerminal.tsx
+++ b/src/renderer/features/agents/AgentTerminal.tsx
@@ -231,14 +231,35 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
     let removeDataListener: () => void;
     let removeExitListener: () => void;
 
+    // Batch PTY data writes using rAF to avoid line-wrap glitches during
+    // rapid streaming.  Matches the batching strategy in ShellTerminal.
+    let batchedData = '';
+    let flushScheduled = false;
+    let flushId = 0;
+
+    const flushBatch = () => {
+      const batch = batchedData;
+      batchedData = '';
+      flushScheduled = false;
+      term.write(batch);
+    };
+
+    const enqueueWrite = (source: 'local' | 'annex', data: string) => {
+      logDataWrite(source, data.length);
+      batchedData += data;
+      if (!flushScheduled) {
+        flushScheduled = true;
+        flushId = requestAnimationFrame(flushBatch);
+      }
+    };
+
     if (!isRemote) {
       // Local PTY: receive from local pty manager
       removeDataListener = window.clubhouse.pty.onData(
         (id: string, data: string) => {
           if (id !== agentId) return;
           if (bufferReplayed) {
-            logDataWrite('local', data.length);
-            term.write(data);
+            enqueueWrite('local', data);
           } else {
             pendingData.push(data);
           }
@@ -267,8 +288,7 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
         (incomingSatId: string, incomingAgentId: string, data: string) => {
           if (incomingSatId !== satId || incomingAgentId !== origAgentId) return;
           if (bufferReplayed) {
-            logDataWrite('annex', data.length);
-            term.write(data);
+            enqueueWrite('annex', data);
           } else {
             pendingData.push(data);
           }
@@ -278,6 +298,7 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
     }
 
     return () => {
+      if (flushScheduled) cancelAnimationFrame(flushId);
       inputDisposable.dispose();
       removeDataListener();
       removeExitListener();

--- a/src/renderer/features/agents/UtilityTerminal.test.tsx
+++ b/src/renderer/features/agents/UtilityTerminal.test.tsx
@@ -146,4 +146,107 @@ describe('UtilityTerminal', () => {
     });
     expect(term().options.fontFamily).toBeUndefined();
   });
+
+  describe('write batching', () => {
+    let rafQueue: Array<{ id: number; cb: () => void }> = [];
+    let nextRafId: number;
+    let mockOnDataCallback: ((id: string, data: string) => void) | null = null;
+
+    function flushRAF() {
+      const current = [...rafQueue];
+      rafQueue = [];
+      current.forEach(({ cb }) => cb());
+    }
+
+    beforeEach(() => {
+      rafQueue = [];
+      nextRafId = 1;
+      mockOnDataCallback = null;
+      vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+        const id = nextRafId++;
+        rafQueue.push({ id, cb });
+        return id;
+      });
+      vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+        rafQueue = rafQueue.filter((entry) => entry.id !== id);
+      });
+      window.clubhouse.pty.onData = vi.fn().mockImplementation((cb: any) => {
+        mockOnDataCallback = cb;
+        return vi.fn();
+      });
+      // Make write observable
+      g.__testTerminal = null;
+    });
+
+    it('batches multiple data chunks into a single term.write call', () => {
+      render(<UtilityTerminal agentId="agent-1" worktreePath="/worktrees/agent-1" />);
+      // Flush mount rAFs (fit/resize)
+      flushRAF();
+      term().write = vi.fn();
+
+      // Simulate rapid data chunks
+      act(() => {
+        mockOnDataCallback!('utility_agent-1', 'chunk1');
+        mockOnDataCallback!('utility_agent-1', 'chunk2');
+        mockOnDataCallback!('utility_agent-1', 'chunk3');
+      });
+
+      // No writes yet — waiting for rAF
+      expect(term().write).not.toHaveBeenCalled();
+
+      // Flush
+      act(() => { flushRAF(); });
+
+      expect(term().write).toHaveBeenCalledTimes(1);
+      expect(term().write).toHaveBeenCalledWith('chunk1chunk2chunk3');
+    });
+
+    it('allows subsequent batches after a flush', () => {
+      render(<UtilityTerminal agentId="agent-1" worktreePath="/worktrees/agent-1" />);
+      flushRAF();
+      term().write = vi.fn();
+
+      act(() => {
+        mockOnDataCallback!('utility_agent-1', 'a');
+        mockOnDataCallback!('utility_agent-1', 'b');
+      });
+      act(() => { flushRAF(); });
+      expect(term().write).toHaveBeenCalledWith('ab');
+
+      term().write = vi.fn();
+
+      act(() => {
+        mockOnDataCallback!('utility_agent-1', 'c');
+        mockOnDataCallback!('utility_agent-1', 'd');
+      });
+      act(() => { flushRAF(); });
+      expect(term().write).toHaveBeenCalledWith('cd');
+    });
+
+    it('cancels pending flush on unmount', () => {
+      const { unmount } = render(
+        <UtilityTerminal agentId="agent-1" worktreePath="/worktrees/agent-1" />,
+      );
+      flushRAF();
+      term().write = vi.fn();
+
+      act(() => { mockOnDataCallback!('utility_agent-1', 'pending'); });
+      expect(rafQueue.length).toBeGreaterThan(0);
+
+      unmount();
+
+      flushRAF();
+      expect(term().write).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule rAF for non-matching PTY IDs', () => {
+      render(<UtilityTerminal agentId="agent-1" worktreePath="/worktrees/agent-1" />);
+      flushRAF();
+      const queueLengthAfterMount = rafQueue.length;
+
+      act(() => { mockOnDataCallback!('utility_agent-2', 'other data'); });
+
+      expect(rafQueue.length).toBe(queueLengthAfterMount);
+    });
+  });
 });

--- a/src/renderer/features/agents/UtilityTerminal.tsx
+++ b/src/renderer/features/agents/UtilityTerminal.tsx
@@ -59,10 +59,25 @@ export function UtilityTerminal({ agentId, worktreePath }: Props) {
       window.clubhouse.pty.write(ptyId, data);
     });
 
+    // Batch PTY data writes using rAF to avoid line-wrap glitches during
+    // rapid output.  Matches the batching strategy in ShellTerminal.
+    let batchedData = '';
+    let flushScheduled = false;
+    let flushId = 0;
+
     const removeDataListener = window.clubhouse.pty.onData(
       (id: string, data: string) => {
         if (id === ptyId) {
-          term.write(data);
+          batchedData += data;
+          if (!flushScheduled) {
+            flushScheduled = true;
+            flushId = requestAnimationFrame(() => {
+              const batch = batchedData;
+              batchedData = '';
+              flushScheduled = false;
+              term.write(batch);
+            });
+          }
         }
       }
     );
@@ -84,6 +99,7 @@ export function UtilityTerminal({ agentId, worktreePath }: Props) {
     resizeObserver.observe(containerRef.current);
 
     return () => {
+      if (flushScheduled) cancelAnimationFrame(flushId);
       inputDisposable.dispose();
       removeDataListener();
       resizeObserver.disconnect();


### PR DESCRIPTION
## Summary

Applies `requestAnimationFrame` write batching to **AgentTerminal** and **UtilityTerminal**, matching the existing pattern in ShellTerminal. This fixes a rendering glitch where leading characters (bullets, dots, indentation) appear at the end of adjacent lines during rapid streaming output.

## Problem

`AgentTerminal.tsx` and `UtilityTerminal.tsx` called `term.write(data)` directly per PTY chunk -- potentially hundreds of times per second during AI agent streaming. xterm.js's internal line-wrap/reflow state can't keep up, causing visual corruption that self-corrects on scroll or resize.

`ShellTerminal.tsx` already solved this by batching writes via `requestAnimationFrame` -- concatenating chunks between frames and flushing once per paint cycle.

## Changes

- **AgentTerminal.tsx**: Added rAF batching for both local PTY and remote/satellite data paths via shared `enqueueWrite()` helper. Added `cancelAnimationFrame` cleanup on unmount.
- **UtilityTerminal.tsx**: Added the same rAF batching pattern for its PTY data handler. Added cleanup.

## Tests

- **AgentTerminal.batching.test.tsx** (4 new tests): Batches multiple chunks into one write, subsequent batches after flush, cancel on unmount, ignores non-matching agent IDs. Isolated in a separate file to avoid rAF mock lifecycle conflicts with the resume overlay tests.
- **UtilityTerminal.test.tsx** (4 new tests): Same coverage -- batching, sequential batches, cancel on unmount, non-matching agent filter.

## Validation

- `npm run typecheck` -- clean
- `npm test` -- 10,547 passed, 7 skipped (428 test files)

Fixes Agent-Clubhouse/Clubhouse#1388
