### PR TITLE
fix(copilot-cli): paste-preview quiescence wait fixes swallowed Enter

### DIFF
--- a/src/main/orchestrators/base-provider.test.ts
+++ b/src/main/orchestrators/base-provider.test.ts
@@ -163,6 +163,24 @@ describe('BaseProvider', () => {
     });
   });
 
+  describe('getPasteSubmitTiming', () => {
+    it('returns fixed-delay defaults with no quiescence wait', () => {
+      const timing = provider.getPasteSubmitTiming();
+      expect(timing.initialDelayMs).toBe(500);
+      expect(timing.retryDelayMs).toBe(300);
+      expect(timing.finalCheckDelayMs).toBe(250);
+      expect(timing.chunkSize).toBe(512);
+      expect(timing.chunkDelayMs).toBe(50);
+      expect(timing.postEndMarkerDelayMs).toBe(150);
+      // Regression guard: default path MUST stay on fixed-delay, not quiescence.
+      // Quiescence is an opt-in for CLIs with variable paste-preview render
+      // times (e.g. GHCP). Claude Code and other well-behaved CLIs rely on
+      // the simple fixed delay and should not poll.
+      expect(timing.quiescenceMs).toBeUndefined();
+      expect(timing.quiescencePollMs).toBeUndefined();
+    });
+  });
+
   describe('getExitCommand', () => {
     it('returns /exit with carriage return', () => {
       expect(provider.getExitCommand()).toBe('/exit\r');

--- a/src/main/orchestrators/claude-code-provider.test.ts
+++ b/src/main/orchestrators/claude-code-provider.test.ts
@@ -739,4 +739,23 @@ describe('ClaudeCodeProvider', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('getPasteSubmitTiming', () => {
+    it('inherits base defaults and does NOT enable quiescence (Claude works perfectly on fixed delays)', () => {
+      const timing = provider.getPasteSubmitTiming();
+      // Base defaults — Claude Code does NOT override these.
+      expect(timing.initialDelayMs).toBe(500);
+      expect(timing.retryDelayMs).toBe(300);
+      expect(timing.finalCheckDelayMs).toBe(250);
+      expect(timing.chunkSize).toBe(512);
+      expect(timing.chunkDelayMs).toBe(50);
+      expect(timing.postEndMarkerDelayMs).toBe(150);
+      // Regression guard: if someone adds quiescence to the Claude path by
+      // accident (e.g. copy-pasting the GHCP override), this test fails loud.
+      // Claude's paste-preview render is deterministic and fast — quiescence
+      // adds latency for no gain.
+      expect(timing.quiescenceMs).toBeUndefined();
+      expect(timing.quiescencePollMs).toBeUndefined();
+    });
+  });
 });

--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -92,14 +92,16 @@ describe('CopilotCliProvider', () => {
   });
 
   describe('getPasteSubmitTiming', () => {
-    it('returns GHCP-specific timing with extended delays', () => {
+    it('returns GHCP-specific timing with extended delays and quiescence wait', () => {
       const timing = provider.getPasteSubmitTiming();
-      expect(timing.initialDelayMs).toBe(1200);
-      expect(timing.retryDelayMs).toBe(600);
+      expect(timing.initialDelayMs).toBe(2500);
+      expect(timing.retryDelayMs).toBe(800);
       expect(timing.finalCheckDelayMs).toBe(400);
       expect(timing.chunkSize).toBe(256);
       expect(timing.chunkDelayMs).toBe(120);
       expect(timing.postEndMarkerDelayMs).toBe(300);
+      expect(timing.quiescenceMs).toBe(200);
+      expect(timing.quiescencePollMs).toBe(50);
     });
 
     it('uses longer delays than the base provider defaults', () => {

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -110,22 +110,26 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
   // ── Paste timing ────────────────────────────────────────────────────────
 
   /**
-   * Copilot CLI processes bracketed paste more slowly than Claude Code.
-   * Use longer delays to give it time to render the paste preview before
-   * sending Enter keystrokes.
+   * Copilot CLI processes bracketed paste more slowly than Claude Code,
+   * and its paste-preview render time is variable (network-bound, jitter-
+   * prone in beta builds).  A fixed pre-Enter delay races against that
+   * render and causes `\r` to be folded into the paste payload, leaving
+   * the command sitting in the input box.
    *
-   * The latest GHCP beta introduced additional latency in paste handling,
-   * so these values include extra headroom to avoid race conditions where
-   * Enter arrives before the paste preview is ready.
+   * Use buffer-quiescence detection: poll the PTY buffer and only fire
+   * Enter once it's been unchanged for `quiescenceMs`.  The fixed delays
+   * remain as caps so we still proceed if quiescence never settles.
    */
   override getPasteSubmitTiming(): PasteSubmitTiming {
     return {
-      initialDelayMs: 1200,
-      retryDelayMs: 600,
+      initialDelayMs: 2500,       // raised cap; quiescence usually fires earlier
+      retryDelayMs: 800,
       finalCheckDelayMs: 400,
       chunkSize: 256,
       chunkDelayMs: 120,
       postEndMarkerDelayMs: 300,
+      quiescenceMs: 200,
+      quiescencePollMs: 50,
     };
   }
 

--- a/src/main/orchestrators/types.ts
+++ b/src/main/orchestrators/types.ts
@@ -109,6 +109,19 @@ export interface PasteSubmitTiming {
    * the paste content on slower CLIs.  Default 150.
    */
   postEndMarkerDelayMs?: number;
+  /**
+   * When set, replaces the fixed `initialDelayMs` / `retryDelayMs` sleeps
+   * before each Enter keystroke with a buffer-quiescence wait (poll until
+   * the PTY buffer length is unchanged for this many ms).  The fixed
+   * delays become caps on how long to wait for quiescence.
+   *
+   * Use for CLIs whose paste-preview render time is variable (e.g. GitHub
+   * Copilot CLI) — a fixed delay races against network jitter and can
+   * cause `\r` to be swallowed inside the bracketed-paste payload.
+   */
+  quiescenceMs?: number;
+  /** Poll interval (ms) for the quiescence wait.  Default 50. */
+  quiescencePollMs?: number;
 }
 
 // ── Capability Sub-interfaces ───────────────────────────────────────────────

--- a/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.test.ts
@@ -53,7 +53,7 @@ vi.mock('../../../orchestrators', () => ({
   getProvider: (id: string) => mockGetProvider(id),
 }));
 
-import { registerAgentTools, writeChunkedBracketedPaste } from './agent-tools';
+import { registerAgentTools, writeChunkedBracketedPaste, waitForBufferQuiescence } from './agent-tools';
 import { getScopedToolList, callTool, buildToolName, _resetForTesting as resetTools } from '../tool-registry';
 import { mcpAdapter } from '../mcp-adapter';
 import { bindingManager } from '../binding-manager';
@@ -325,6 +325,75 @@ describe('AgentTools', () => {
       // Drain the final check delay
       await vi.advanceTimersByTimeAsync(600);
       await promise;
+    });
+
+    it('Claude Code path: fires \\r at exact fixed initialDelayMs and never polls the buffer (regression guard)', async () => {
+      // Claude works perfectly on fixed-delay timing. This test pins down
+      // that contract: NO quiescence polling, \r at exactly 500ms after the
+      // paste sequence ends, and getBuffer called exactly twice (the
+      // boundary reads in submitAfterPaste — never inside a poll loop).
+      mockAgentRegistryGet.mockReturnValue({ runtime: 'pty', orchestrator: 'claude-code' });
+      // Default beforeEach provider mock: 500/300/250, chunk 512/50, postEnd 150, NO quiescenceMs
+      mockPtyGetBuffer.mockReturnValue('');
+
+      const promise = callTool('agent-1', sendToolName, { message: 'l1\nl2', task_id: 'r1' });
+
+      // Paste sequence: 50 + 50 + 150 = 250ms before submitAfterPaste runs
+      await vi.advanceTimersByTimeAsync(250);
+      expect(mockPtyWrite.mock.calls.filter(c => c[1] === '\r')).toHaveLength(0);
+
+      // At paste+499ms: still no \r (fixed 500ms wait, no early-fire from quiescence)
+      await vi.advanceTimersByTimeAsync(499);
+      expect(mockPtyWrite.mock.calls.filter(c => c[1] === '\r')).toHaveLength(0);
+
+      // At paste+500ms: first \r fires exactly on time
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockPtyWrite.mock.calls.filter(c => c[1] === '\r')).toHaveLength(1);
+
+      // Drain retry + final check
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise;
+
+      // CRITICAL regression check: exactly 2 getBuffer calls (bufferBefore +
+      // bufferAfterFirst). If quiescence ever leaks onto the Claude path,
+      // this jumps to many more from the poll loop and the test fails loud.
+      expect(mockPtyGetBuffer).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses quiescence wait instead of fixed initialDelayMs when quiescenceMs is set', async () => {
+      mockAgentRegistryGet.mockReturnValue({ runtime: 'pty', orchestrator: 'copilot-cli' });
+      mockGetProvider.mockReturnValue({
+        getPasteSubmitTiming: () => ({
+          initialDelayMs: 2000,         // large cap; quiescence should fire well before
+          retryDelayMs: 200,
+          finalCheckDelayMs: 100,
+          chunkSize: 256,
+          chunkDelayMs: 30,
+          postEndMarkerDelayMs: 50,
+          quiescenceMs: 100,
+          quiescencePollMs: 25,
+        }),
+      });
+
+      // Stable buffer from the start — paste preview "already rendered"
+      mockPtyGetBuffer.mockReturnValue('settled');
+
+      const promise = callTool('agent-1', sendToolName, { message: 'l1\nl2', task_id: 'q1' });
+
+      // Paste sequence: 30 + 30 + 50 = 110ms before submitAfterPaste runs
+      await vi.advanceTimersByTimeAsync(110);
+      expect(mockPtyWrite.mock.calls.filter(c => c[1] === '\r')).toHaveLength(0);
+
+      // Quiescence settles ~100ms later (well before the 2000ms cap)
+      await vi.advanceTimersByTimeAsync(120);
+      expect(mockPtyWrite.mock.calls.filter(c => c[1] === '\r')).toHaveLength(1);
+
+      // Drain retry quiescence + final check
+      await vi.advanceTimersByTimeAsync(500);
+      await promise;
+
+      // Buffer never grew, so retry sends a 2nd \r
+      expect(mockPtyWrite.mock.calls.filter(c => c[1] === '\r')).toHaveLength(2);
     });
 
     it('falls back to default timing when provider not found', async () => {
@@ -932,6 +1001,62 @@ describe('AgentTools', () => {
       const result = await callTool('agent-1', connectToolName, {});
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('is sleeping');
+    });
+  });
+
+  describe('waitForBufferQuiescence', () => {
+    it('resolves quiet=true after buffer is unchanged for quiescenceMs', async () => {
+      mockPtyGetBuffer.mockReturnValue('stable-12345');
+
+      const promise = waitForBufferQuiescence('agent-x', {
+        quiescenceMs: 100,
+        maxWaitMs: 500,
+        pollMs: 25,
+      });
+
+      await vi.advanceTimersByTimeAsync(150);
+      const result = await promise;
+
+      expect(result.quiet).toBe(true);
+      expect(result.waitedMs).toBeLessThan(200);
+    });
+
+    it('resolves quiet=false when buffer keeps changing past maxWaitMs', async () => {
+      let len = 0;
+      mockPtyGetBuffer.mockImplementation(() => 'x'.repeat(++len));
+
+      const promise = waitForBufferQuiescence('agent-x', {
+        quiescenceMs: 100,
+        maxWaitMs: 200,
+        pollMs: 25,
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+      const result = await promise;
+
+      expect(result.quiet).toBe(false);
+      expect(result.waitedMs).toBeGreaterThanOrEqual(200);
+    });
+
+    it('resolves quiet=true after buffer settles following an initial growth burst', async () => {
+      let calls = 0;
+      mockPtyGetBuffer.mockImplementation(() => {
+        calls++;
+        // Initial read + first 3 polls show growth, then stable
+        const len = calls < 5 ? calls * 10 : 50;
+        return 'x'.repeat(len);
+      });
+
+      const promise = waitForBufferQuiescence('agent-x', {
+        quiescenceMs: 100,
+        maxWaitMs: 1000,
+        pollMs: 25,
+      });
+
+      await vi.advanceTimersByTimeAsync(300);
+      const result = await promise;
+
+      expect(result.quiet).toBe(true);
     });
   });
 });

--- a/src/main/services/clubhouse-mcp/tools/agent-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/agent-tools.ts
@@ -77,12 +77,53 @@ export async function writeChunkedBracketedPaste(
 }
 
 /**
+ * Wait until the agent's PTY buffer length is unchanged for `quiescenceMs`,
+ * or until `maxWaitMs` elapses (whichever comes first).
+ *
+ * Used to detect when a TUI like GitHub Copilot CLI has finished rendering
+ * its paste-preview UI before sending the submit Enter.  GHCP's preview
+ * render time varies with network latency; a fixed sleep races against it,
+ * causing the `\r` to be folded into the bracketed paste and swallowed.
+ *
+ * Returns `quiet: true` if the buffer settled, `quiet: false` if maxWait
+ * fired first.  Either way the caller should proceed — quiet:false just
+ * means we gave up waiting and will fall back to the existing retry logic.
+ */
+export async function waitForBufferQuiescence(
+  agentId: string,
+  options: { quiescenceMs: number; maxWaitMs: number; pollMs?: number },
+): Promise<{ quiet: boolean; waitedMs: number }> {
+  const pollMs = options.pollMs ?? 50;
+  const startTs = Date.now();
+  let lastLen = ptyManager.getBuffer(agentId)?.length ?? 0;
+  let lastChangeTs = startTs;
+
+  while (Date.now() - startTs < options.maxWaitMs) {
+    await sleep(pollMs);
+    const cur = ptyManager.getBuffer(agentId)?.length ?? 0;
+    if (cur !== lastLen) {
+      lastLen = cur;
+      lastChangeTs = Date.now();
+    } else if (Date.now() - lastChangeTs >= options.quiescenceMs) {
+      return { quiet: true, waitedMs: Date.now() - startTs };
+    }
+  }
+  return { quiet: false, waitedMs: Date.now() - startTs };
+}
+
+/**
  * Submit content that was just pasted into an agent's PTY.
  *
  * Sends `\r` (Enter) with provider-specific delays and buffer health checks.
  * If the first Enter doesn't trigger processing (buffer doesn't grow), a
  * second Enter is sent as a retry — some CLIs show a paste preview that
  * requires Enter to accept before another Enter actually submits.
+ *
+ * When `timing.quiescenceMs` is set, the fixed `initialDelayMs` and
+ * `retryDelayMs` sleeps are replaced with quiescence waits capped at those
+ * values.  This addresses GitHub Copilot CLI's variable paste-preview
+ * render time — a fixed 1200ms delay races against network jitter and
+ * causes the `\r` to be folded into the paste payload (then ignored).
  */
 export async function submitAfterPaste(
   agentId: string,
@@ -90,10 +131,26 @@ export async function submitAfterPaste(
 ): Promise<void> {
   const bufferBefore = ptyManager.getBuffer(agentId)?.length ?? 0;
 
-  await sleep(timing.initialDelayMs);
+  if (timing.quiescenceMs) {
+    await waitForBufferQuiescence(agentId, {
+      quiescenceMs: timing.quiescenceMs,
+      maxWaitMs: timing.initialDelayMs,
+      pollMs: timing.quiescencePollMs,
+    });
+  } else {
+    await sleep(timing.initialDelayMs);
+  }
   ptyManager.write(agentId, '\r');
 
-  await sleep(timing.retryDelayMs);
+  if (timing.quiescenceMs) {
+    await waitForBufferQuiescence(agentId, {
+      quiescenceMs: timing.quiescenceMs,
+      maxWaitMs: timing.retryDelayMs,
+      pollMs: timing.quiescencePollMs,
+    });
+  } else {
+    await sleep(timing.retryDelayMs);
+  }
   const bufferAfterFirst = ptyManager.getBuffer(agentId)?.length ?? 0;
   if (bufferAfterFirst > bufferBefore) return; // First Enter worked
 


### PR DESCRIPTION
## Problem

When the Clubhouse MCP sends a message into a Copilot CLI agent, the command text often **stays in GHCP's input box without executing** — the Enter at the end of the paste gets swallowed. Claude Code (the well-behaved twin) handles the same wire protocol perfectly.

User report: *\"MCP Clubhouse copy-pastes into the term to work, with GitHub Copilot it sometimes doesn't pickup the Enter and leaves the command/text sitting on the term window not executing.\"*

## Root cause

The injection mechanism wraps the message body in bracketed-paste markers and writes a separate `\r` after the closing marker:

```
\x1b[200~  <body>  \x1b[201~  <fixed delay>  \r
```

`<fixed delay>` was a `setTimeout` (1200 ms for GHCP). On slow turns — beta latency, network jitter — GHCP's paste-preview UI hasn't finished rendering by the time that delay fires. The `\r` lands inside the still-open paste wrapper. Copilot's input tokenizer treats `\r` *inside* the BPM payload as buffer content, not as submit ([github/copilot-cli#1437](https://github.com/github/copilot-cli/issues/1437), [#2411](https://github.com/github/copilot-cli/issues/2411), [#1733](https://github.com/github/copilot-cli/issues/1733)). Both the first `\r` and the retry `\r` get swallowed; the buffer-growth heuristic stays false because GHCP doesn't echo until paste is accepted; result is a stuck input box.

Claude Code doesn't hit this because its tokenizer was hardened to submit on CR-at-end-of-paste ([anthropics/claude-code#43169](https://github.com/anthropics/claude-code/issues/43169)).

## Fix

Replace the fixed pre-Enter sleep with a **buffer-quiescence wait** when `timing.quiescenceMs` is set: poll `ptyManager.getBuffer(agentId)` and only fire `\r` once the buffer length has been unchanged for `quiescenceMs`. The existing `initialDelayMs` / `retryDelayMs` become caps — we still proceed if quiescence never settles.

Enabled on GHCP only:

| field | before | after |
|---|---|---|
| `quiescenceMs` | — | **200** (new) |
| `quiescencePollMs` | — | **50** (new) |
| `initialDelayMs` (cap) | 1200 | 2500 |
| `retryDelayMs` (cap) | 600 | 800 |

The caps are larger because they're now true ceilings — quiescence almost always fires far sooner. They only matter on a stuck/never-quiet buffer.

## Why Claude can't regress

Three structural reasons + three explicit tests:

**Structural:**
1. `ClaudeCodeProvider` does not override `getPasteSubmitTiming` → inherits base defaults
2. Base defaults do **not** set `quiescenceMs`
3. `submitAfterPaste` only enters the quiescence branch when `timing.quiescenceMs` is truthy → Claude falls through to the unmodified `await sleep(timing.initialDelayMs)` path, byte-for-byte

**Tests:**
- `base-provider.test.ts` — defaults must have `quiescenceMs` and `quiescencePollMs` undefined
- `claude-code-provider.test.ts` — Claude inherits base defaults and must NOT enable quiescence
- `agent-tools.test.ts` — *\"Claude Code path: fires `\\r` at exact fixed initialDelayMs and never polls the buffer (regression guard)\"* — asserts no `\r` at +499 ms, `\r` at exactly +500 ms, and `getBuffer` called **exactly twice** (proves no poll loop ran). Quiescence accidentally leaking onto Claude would balloon that count to ~10+ and fail loud.

## Test plan

- [x] New unit tests for `waitForBufferQuiescence` (stable / never-quiet / settle-after-burst)
- [x] New behavior test for `submitAfterPaste` quiescence path on GHCP timing
- [x] New regression tests pinning Claude to fixed-delay path (3 tests across 3 files)
- [x] Existing 5083 unit tests still green (5086 now, +3 net)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [ ] Manual: send multi-line message from one Clubhouse agent to a GHCP agent; confirm Enter submits reliably across multiple sends
- [ ] Manual: send same message to a Claude Code agent; confirm timing/feel is unchanged

## Files

- `src/main/services/clubhouse-mcp/tools/agent-tools.ts` — new `waitForBufferQuiescence` helper, `submitAfterPaste` opt-in branch
- `src/main/orchestrators/types.ts` — `quiescenceMs` + `quiescencePollMs` on `PasteSubmitTiming`
- `src/main/orchestrators/copilot-cli-provider.ts` — enables quiescence, raises caps
- 4 test files — new behavior tests + regression guards