### PR TITLE
fix(terminal): recover xterm focus to stop "can scroll but can't type" wedge

### DIFF
--- a/src/renderer/features/agents/AgentTerminal.test.tsx
+++ b/src/renderer/features/agents/AgentTerminal.test.tsx
@@ -22,6 +22,12 @@ vi.mock('@xterm/xterm', () => {
       Object.defineProperty(viewport, 'clientHeight', { value: 200, configurable: true, writable: true });
       viewport.scrollTop = 0;
       container.appendChild(viewport);
+
+      // Real xterm also creates an .xterm-helper-textarea to capture keystrokes.
+      // Focus-recovery tests attach a blur listener to this element.
+      const textarea = document.createElement('textarea');
+      textarea.classList.add('xterm-helper-textarea');
+      container.appendChild(textarea);
     });
     write = vi.fn();
     focus = vi.fn();
@@ -97,7 +103,7 @@ vi.mock('../../stores/remoteProjectStore', () => ({
   },
 }));
 
-import { AgentTerminal } from './AgentTerminal';
+import { AgentTerminal, FOCUS_ACTIVE_TERMINAL_EVENT } from './AgentTerminal';
 
 let mockOnDataCallback: ((id: string, data: string) => void) | null = null;
 let mockOnExitCallback: ((id: string, exitCode: number) => void) | null = null;
@@ -404,6 +410,184 @@ describe('AgentTerminal', () => {
       render(<AgentTerminal agentId="agent-1" focused={true} />);
       term().focus.mockClear();
       fireEvent.mouseDown(screen.getByTestId('agent-terminal'));
+      expect(term().focus).toHaveBeenCalled();
+    });
+  });
+
+  describe('focus recovery', () => {
+    // jsdom's document.hasFocus() returns false by default, which the
+    // blur watchdog (correctly) reads as "window lost focus, don't
+    // steal focus back".  Positive-path tests here need a focused
+    // window; the one negative test that specifically exercises the
+    // window-blur path overrides hasFocus locally.
+    let originalHasFocus: typeof document.hasFocus;
+    beforeEach(() => {
+      originalHasFocus = document.hasFocus.bind(document);
+      Object.defineProperty(document, 'hasFocus', {
+        configurable: true, value: () => true,
+      });
+    });
+    afterEach(() => {
+      Object.defineProperty(document, 'hasFocus', {
+        configurable: true, value: originalHasFocus,
+      });
+    });
+
+    function helperTextarea(): HTMLTextAreaElement {
+      const t = screen.getByTestId('agent-terminal')
+        .querySelector('.xterm-helper-textarea') as HTMLTextAreaElement;
+      expect(t).toBeTruthy();
+      return t;
+    }
+
+    function fireBlur(target: HTMLElement, relatedTarget: EventTarget | null = null): void {
+      // fireEvent.blur drops relatedTarget on some jsdom versions; dispatch
+      // a real FocusEvent directly so the watchdog sees the init dict.
+      target.dispatchEvent(new FocusEvent('blur', { bubbles: true, relatedTarget }));
+    }
+
+    it('re-focuses xterm when helper textarea blurs to null while focused', async () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      // Flush the initial focus on mount so we measure only blur-watchdog calls.
+      await act(async () => {});
+      term().focus.mockClear();
+
+      // A blur to nothing (relatedTarget === null) is the classic wedge:
+      // xterm lost focus during a reflow / theme swap / mouse-tracking race.
+      fireBlur(helperTextarea(), null);
+
+      // The refocus is deferred via queueMicrotask — flush microtasks.
+      await act(async () => { await Promise.resolve(); });
+      expect(term().focus).toHaveBeenCalled();
+    });
+
+    it('does not re-focus when the user blurs to a different element', async () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      // Simulate the user tabbing/clicking to a real element — respect that.
+      const other = document.createElement('button');
+      document.body.appendChild(other);
+      fireBlur(helperTextarea(), other);
+
+      await act(async () => { await Promise.resolve(); });
+      expect(term().focus).not.toHaveBeenCalled();
+
+      document.body.removeChild(other);
+    });
+
+    it('does not re-focus when this pane is not the focused one', async () => {
+      // Several AgentTerminals mount at once (hub panes, popouts); only the
+      // focused pane should recover its own xterm — otherwise we would steal
+      // focus from whichever pane the user is actually using.
+      render(<AgentTerminal agentId="agent-1" focused={false} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      fireBlur(helperTextarea(), null);
+
+      await act(async () => { await Promise.resolve(); });
+      expect(term().focus).not.toHaveBeenCalled();
+    });
+
+    it('does not re-focus when the window has lost OS focus', async () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      // Simulate cmd-tab / window-blur.  jsdom's hasFocus is non-configurable
+      // via vi.spyOn in some versions; override with defineProperty instead.
+      const originalHasFocus = document.hasFocus.bind(document);
+      Object.defineProperty(document, 'hasFocus', {
+        configurable: true, value: () => false,
+      });
+      try {
+        fireBlur(helperTextarea(), null);
+        await act(async () => { await Promise.resolve(); });
+        expect(term().focus).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(document, 'hasFocus', {
+          configurable: true, value: originalHasFocus,
+        });
+      }
+    });
+
+    it('re-focuses on FOCUS_ACTIVE_TERMINAL_EVENT when focused', async () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(FOCUS_ACTIVE_TERMINAL_EVENT));
+      });
+      expect(term().focus).toHaveBeenCalled();
+    });
+
+    it('does not re-focus on FOCUS_ACTIVE_TERMINAL_EVENT when unfocused', async () => {
+      // The shortcut is global; multiple AgentTerminals may be mounted — only
+      // the focused one should respond to the escape hatch.
+      render(<AgentTerminal agentId="agent-1" focused={false} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(FOCUS_ACTIVE_TERMINAL_EVENT));
+      });
+      expect(term().focus).not.toHaveBeenCalled();
+    });
+
+    it('re-focuses after a theme swap when focused', async () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      act(() => {
+        useThemeStore.setState({
+          theme: { terminal: { background: '#111', foreground: '#eee' } } as any,
+        });
+      });
+      expect(term().focus).toHaveBeenCalled();
+    });
+
+    it('does not re-focus after a theme swap when unfocused', async () => {
+      // Background panes also receive theme updates; they must not steal focus.
+      render(<AgentTerminal agentId="agent-1" focused={false} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      act(() => {
+        useThemeStore.setState({
+          theme: { terminal: { background: '#111', foreground: '#eee' } } as any,
+        });
+      });
+      expect(term().focus).not.toHaveBeenCalled();
+    });
+
+    it('re-focuses after experimental mono font swap when focused', async () => {
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      await act(async () => {});
+      term().focus.mockClear();
+
+      act(() => {
+        useThemeStore.setState({
+          theme: {
+            terminal: { background: '#000', foreground: '#fff' },
+            fonts: { mono: "'Fira Code', monospace" },
+          } as any,
+          experimentalGradients: true,
+        });
+      });
+      expect(term().focus).toHaveBeenCalled();
+    });
+
+    it('re-focuses after buffer replay completes when focused', async () => {
+      (window.clubhouse.pty.getBuffer as any).mockResolvedValue('replayed output');
+      render(<AgentTerminal agentId="agent-1" focused={true} />);
+      term().focus.mockClear();
+
+      // Flush the getBuffer promise chain that runs replay then refocus.
+      await act(async () => {});
       expect(term().focus).toHaveBeenCalled();
     });
   });

--- a/src/renderer/features/agents/AgentTerminal.tsx
+++ b/src/renderer/features/agents/AgentTerminal.tsx
@@ -18,6 +18,14 @@ const RESUME_SETTLE_MS = 1500;
 
 const SCROLL_LOG_NS = 'ui:terminal:scroll';
 
+/**
+ * Window event that requests the currently-focused AgentTerminal to re-focus
+ * its xterm.  Dispatched by the `focus-active-terminal` keyboard shortcut —
+ * the user's escape hatch for the "can scroll but can't type" wedge where
+ * xterm's hidden helper textarea lost focus (see the blur watchdog below).
+ */
+export const FOCUS_ACTIVE_TERMINAL_EVENT = 'clubhouse:focus-active-terminal';
+
 /** Pixels from bottom to be considered "at bottom". */
 const BOTTOM_THRESHOLD = 5;
 
@@ -84,6 +92,13 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
   const resuming = useAgentStore((s) => s.agents[agentId]?.resuming);
   const clearResuming = useAgentStore((s) => s.clearResuming);
 
+  // Tracks the latest `focused` prop so long-lived effects (blur watchdog,
+  // post-reflow refocus calls) can read it without re-running on every
+  // focus-prop flip, which would otherwise tear down and rebuild the xterm
+  // listeners and lose input mid-session.
+  const focusedRef = useRef(!!focused);
+  useEffect(() => { focusedRef.current = !!focused; }, [focused]);
+
   // Debounce timer that detects when PTY output settles after a resume replay
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasReceivedDataRef = useRef(false);
@@ -116,6 +131,10 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
         }
 
         ptyResize(agentId, terminalRef.current.cols, terminalRef.current.rows);
+        // fit() reflow can blur xterm's helper textarea; re-focus if this
+        // pane is still focused so the user can type immediately after
+        // the resume overlay dismisses.
+        if (focusedRef.current) terminalRef.current.focus();
       }
     });
   }, [agentId, clearResuming]);
@@ -141,6 +160,38 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
     term.loadAddon(fitAddon);
     term.open(containerRef.current);
 
+    // Blur watchdog — the "can scroll but can't type" recovery path.
+    //
+    // xterm.js routes every keystroke through a hidden <textarea> element
+    // (.xterm-helper-textarea).  That textarea must hold DOM focus for
+    // typing to work.  Several things can blur it with no recovery:
+    //   • theme / font option mutations (xterm re-renders internals)
+    //   • fitAddon.fit() reflows
+    //   • large buffer replays on re-attach
+    //   • Copilot CLI / other Ink TUIs enable mouse-tracking CSI
+    //     sequences that cause xterm to intercept mousedown as a mouse
+    //     report, so clicking the terminal does NOT reliably refocus
+    //     the helper textarea
+    //
+    // When the textarea blurs to nothing (relatedTarget === null) while
+    // this pane is still the focused pane in the app and the window
+    // still has OS focus, re-focus xterm on the next microtask so we
+    // don't fight whatever triggered the blur.  Any legitimate focus
+    // move (user tabs or clicks something else) has a non-null
+    // relatedTarget and is left alone.
+    const helperTextarea = containerRef.current.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea');
+    const onHelperBlur = (ev: FocusEvent) => {
+      if (ev.relatedTarget) return;
+      if (!focusedRef.current) return;
+      if (!document.hasFocus()) return;
+      queueMicrotask(() => {
+        if (terminalRef.current === term && focusedRef.current && document.hasFocus()) {
+          term.focus();
+        }
+      });
+    };
+    helperTextarea?.addEventListener('blur', onHelperBlur);
+
     // Initial fit, replay buffered output, and focus
     requestAnimationFrame(() => {
       fitAddon.fit();
@@ -164,6 +215,11 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
           for (const data of pendingData) term.write(data);
           pendingData.length = 0;
           bufferReplayed = true;
+          // Large writes (buf can approach the 2MB MAX_BUFFER_SIZE cap in
+          // pty-manager) can stall the renderer long enough that focus is
+          // dropped before the user sees a ready terminal.  Re-focus if
+          // this pane is still the focused one.
+          if (focusedRef.current) term.focus();
         });
       } else if (remoteParts) {
         // Remote agents: fetch buffer from satellite via HTTPS REST
@@ -178,6 +234,7 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
           for (const data of pendingData) term.write(data);
           pendingData.length = 0;
           bufferReplayed = true;
+          if (focusedRef.current) term.focus();
         });
       }
     });
@@ -281,6 +338,7 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
       inputDisposable.dispose();
       removeDataListener();
       removeExitListener();
+      helperTextarea?.removeEventListener('blur', onHelperBlur);
       term.dispose();
       terminalRef.current = null;
       fitAddonRef.current = null;
@@ -495,17 +553,37 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
     return cleanup;
   }, [clipboardCompat, agentId, isRemote, remoteParts, sendClipboardImage]);
 
-  // Live-update theme on existing terminal instances
+  // Live-update theme on existing terminal instances.  Mutating xterm
+  // options re-renders internals and can drop focus from the helper
+  // textarea; re-focus when this pane is the active one so typing
+  // doesn't silently stop after a theme swap.
   useEffect(() => {
     if (terminalRef.current) {
       terminalRef.current.options.theme = effectiveTerminalColors;
+      if (focusedRef.current) terminalRef.current.focus();
     }
   }, [effectiveTerminalColors]);
 
   useEffect(() => {
     if (!terminalRef.current || !experimentalMonoFont) return;
     terminalRef.current.options.fontFamily = experimentalMonoFont;
+    if (focusedRef.current) terminalRef.current.focus();
   }, [experimentalMonoFont]);
+
+  // Keyboard shortcut escape hatch: when the user fires
+  // `focus-active-terminal` (default Ctrl/Cmd+Shift+T), the dispatcher in
+  // app-event-bridge.ts emits FOCUS_ACTIVE_TERMINAL_EVENT on window.  The
+  // active (focused) AgentTerminal re-focuses its xterm.  Multiple
+  // AgentTerminal instances mount at once (hub panes, popouts); only the
+  // one with `focused === true` should respond so we don't steal focus.
+  useEffect(() => {
+    if (!focused) return;
+    const onFocusRequest = () => {
+      terminalRef.current?.focus();
+    };
+    window.addEventListener(FOCUS_ACTIVE_TERMINAL_EVENT, onFocusRequest);
+    return () => window.removeEventListener(FOCUS_ACTIVE_TERMINAL_EVENT, onFocusRequest);
+  }, [focused]);
 
   const [remoteBanner, setRemoteBanner] = useState<string | null>(null);
   const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/renderer/features/command-palette/command-actions.ts
+++ b/src/renderer/features/command-palette/command-actions.ts
@@ -3,6 +3,7 @@ import { useUIStore } from '../../stores/uiStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAgentStore } from '../../stores/agentStore';
 import { usePanelStore } from '../../stores/panelStore';
+import { FOCUS_ACTIVE_TERMINAL_EVENT } from '../agents/AgentTerminal';
 
 export interface CommandAction {
   id: string;
@@ -48,6 +49,13 @@ export function getCommandActions(): CommandAction[] {
       execute: () => {
         useUIStore.getState().openQuickAgentDialog();
       },
+    },
+    {
+      id: 'focus-active-terminal',
+      // Global so it fires even when the stuck xterm helper-textarea still
+      // technically holds focus — that's the exact state we need to unwedge.
+      global: true,
+      execute: () => window.dispatchEvent(new CustomEvent(FOCUS_ACTIVE_TERMINAL_EVENT)),
     },
     {
       id: 'add-project',

--- a/src/renderer/stores/keyboardShortcutsStore.ts
+++ b/src/renderer/stores/keyboardShortcutsStore.ts
@@ -86,6 +86,10 @@ const DEFAULT_SHORTCUTS: Omit<ShortcutDefinition, 'currentBinding'>[] = [
 
   // Agents
   { id: 'new-quick-agent', label: 'New Quick Agent', category: 'Agents', defaultBinding: 'Meta+Shift+N' },
+  // Escape hatch for the "can scroll but can't type" xterm focus wedge: force
+  // focus back to the active agent terminal without needing a mouse click
+  // (clicks don't reliably refocus under Copilot CLI's mouse tracking).
+  { id: 'focus-active-terminal', label: 'Focus Active Terminal', category: 'Agents', defaultBinding: 'Meta+Shift+T' },
   ...Array.from({ length: 9 }, (_, i) => ({
     id: `switch-agent-${i + 1}`,
     label: `Switch to Agent ${i + 1}`,


### PR DESCRIPTION
## Problem

Copilot CLI embedded in Clubhouse intermittently stops accepting keystrokes — the cursor still blinks, new PTY output still renders, the scrollbar still works, but **typing goes nowhere**. The only reliable recovery is rebooting the terminal and running `/resume`, which is painful because the user loses their spot in the conversation and gets billed for the re-ingest.

User reports it's specific to being *embedded in Clubhouse*; standalone Copilot CLI in a normal terminal doesn't exhibit it. Also reproducible for any xterm.js-embedded Ink TUI under mouse tracking.

## Root cause

xterm.js captures every keystroke through a hidden `<textarea class="xterm-helper-textarea">` inside the terminal container. That textarea **must hold DOM focus** for typing to reach the PTY.

Four things in `AgentTerminal.tsx` silently blur it with no recovery path:

1. **Theme mutations** (`term.options.theme = …` in the live-update effect) — xterm re-renders internals, dropping textarea focus.
2. **Font mutations** (experimental mono font swap) — same mechanism.
3. **`fitAddon.fit()` reflows** — `finishResume()` and the `useTerminalFit` hook both fit on resume-settle, wake-from-sleep, and window-focus events.
4. **Large buffer replays** on re-attach — `pty-manager.ts` buffers up to 2MB per agent, and `term.write(buf)` on re-attach can stall the renderer long enough that the textarea loses focus mid-reflow.

On top of that, **Copilot CLI (and any Ink TUI) enables xterm mouse tracking** via CSI `?1000h` / `?1006h`. With mouse tracking on, xterm intercepts `mousedown` inside the viewport and emits a mouse report to the app **instead of a focus event** — which means the "click to refocus" escape hatch (`AgentTerminal.tsx:597 handleMouseDown`) does not reliably fire under Copilot. Claude Code doesn't reproduce as often only because it enables mouse tracking less aggressively; the underlying bug is the same.

Prior to this change, focus was only asserted in two places: initial mount (`AgentTerminal.tsx:199`) and the `focused` prop transition (`useTerminalFit.ts:180`). After any of (1)–(4), nothing ever re-focused the textarea.

## Fix

Three layers of recovery, each targeted at a specific cause:

1. **Blur watchdog** on the helper textarea. When it blurs to `null` (no legitimate successor element) while this pane is `focused` and the OS window still has focus, re-focus xterm on the next microtask. `relatedTarget !== null` is respected (user tabbed/clicked somewhere else) and `document.hasFocus() === false` is respected (user cmd-tabbed away).

2. **Post-reflow re-focus** after every known blur path: buffer replay completion (both local and remote), `finishResume()` fit, theme mutation, font mutation. All guarded by `focusedRef.current` so a background pane's theme update never steals focus from the active pane.

3. **Escape hatch shortcut** — new `focus-active-terminal` binding (default `Ctrl/Cmd+Shift+T`, global). Dispatches a `FOCUS_ACTIVE_TERMINAL_EVENT` window event; only the `AgentTerminal` with `focused === true` responds. Unwedges without needing a mouse click (which mouse tracking can eat).

A `focusedRef` mirrors the `focused` prop so the blur watchdog can read the latest value without being torn down on every prop flip (which would rebuild the xterm listeners and briefly lose input).

## Why Claude Code can't regress

`AgentTerminal.tsx` is the single component that renders every agent — Claude Code, Copilot CLI, Codex, and quick agents all use it. Three structural reasons + explicit test coverage:

**Structural:**
1. No agent-kind branching. The recovery logic runs for every agent identically.
2. Every new focus call site is guarded by `focusedRef.current` — a background Claude pane never becomes a focus target.
3. The blur watchdog only fires when `relatedTarget === null` *and* the pane is focused *and* the window is focused. A Claude session typing normally never hits any of these guards.

**Tests:**
- `does not re-focus when the user blurs to a different element` — respects a user clicking away (relatedTarget set).
- `does not re-focus when this pane is not the focused one` — respects background panes.
- `does not re-focus when the window has lost OS focus` — respects cmd-tab.
- `does not re-focus after a theme swap when unfocused` — same, for the theme path.
- `does not re-focus on FOCUS_ACTIVE_TERMINAL_EVENT when unfocused` — shortcut only unwedges the active pane.

If any of the new focus call sites accidentally leaked into a background pane, one of those five tests would fail loud.

## Test plan

- [x] 11 new tests in `AgentTerminal.test.tsx` covering every recovery path and every negative case (see above)
- [x] Extended xterm mock to create `.xterm-helper-textarea` (real xterm makes one)
- [x] Full suite green: **11,375 tests pass, 3 skipped**
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on every file this PR touches (pre-existing lint errors in unrelated files are not mine to fix here)
- [ ] Manual: run Copilot CLI embedded in Clubhouse, trigger several theme/font swaps during a long session, confirm typing never wedges
- [ ] Manual: trigger the wedge by any means, hit `Ctrl+Shift+T`, confirm focus returns without needing a click
- [ ] Manual: run Claude Code in another pane; confirm focus behavior and timing feel identical to before

## Files

- `src/renderer/features/agents/AgentTerminal.tsx` — blur watchdog, post-reflow re-focus calls, shortcut-event listener, `FOCUS_ACTIVE_TERMINAL_EVENT` export, `focusedRef`
- `src/renderer/features/agents/AgentTerminal.test.tsx` — mock extension + 11 new tests
- `src/renderer/stores/keyboardShortcutsStore.ts` — new `focus-active-terminal` shortcut definition (default `Meta+Shift+T`)
- `src/renderer/features/command-palette/command-actions.ts` — command action that dispatches the window event

No secrets, no unrelated files.