### PR TITLE
test(terminal): close regression gaps in AgentTerminal write batching

### DIFF
--- a/src/renderer/features/agents/AgentTerminal.batching.test.tsx
+++ b/src/renderer/features/agents/AgentTerminal.batching.test.tsx
@@ -16,6 +16,8 @@ const g = globalThis as any;
 g.__testTerminal = null;
 g.__testFitAddon = null;
 g.__testAttachClipboard = vi.fn().mockReturnValue(vi.fn());
+g.__satelliteBusListener = null;
+g.__satelliteBusUnsubscribe = vi.fn();
 
 vi.mock('@xterm/xterm', () => {
   class Terminal {
@@ -76,7 +78,12 @@ vi.mock('../../stores/annexClientStore', () => {
   useAnnexClientStore.subscribe = vi.fn(() => vi.fn());
   return {
     useAnnexClientStore,
-    satellitePtyDataBus: { on: vi.fn(() => vi.fn()) },
+    satellitePtyDataBus: {
+      on: (cb: (satId: string, agentId: string, data: string) => void) => {
+        g.__satelliteBusListener = cb;
+        return g.__satelliteBusUnsubscribe;
+      },
+    },
   };
 });
 
@@ -119,6 +126,8 @@ describe('AgentTerminal write batching', () => {
     mockRemoveDataListener.mockClear();
     mockRemoveExitListener.mockClear();
     mockDisconnect.mockClear();
+    g.__satelliteBusListener = null;
+    g.__satelliteBusUnsubscribe.mockClear();
 
     // Deferred rAF — queue callbacks instead of firing immediately
     rafQueue = [];
@@ -164,6 +173,14 @@ describe('AgentTerminal write batching', () => {
           id: 'agent-1',
           projectId: 'proj-1',
           name: 'test',
+          kind: 'durable',
+          status: 'running',
+          color: 'indigo',
+        },
+        'remote||sat-1||agent-1': {
+          id: 'remote||sat-1||agent-1',
+          projectId: 'proj-1',
+          name: 'remote-test',
           kind: 'durable',
           status: 'running',
           color: 'indigo',
@@ -255,5 +272,151 @@ describe('AgentTerminal write batching', () => {
 
     // No new rAF scheduled for non-matching agent
     expect(rafQueue.length).toBe(countAfterMount);
+  });
+
+  describe('satellite/remote PTY path', () => {
+    async function mountRemoteAndInit() {
+      g.__annexMockState.requestPtyBuffer = vi.fn().mockResolvedValue('');
+      render(<AgentTerminal agentId="remote||sat-1||agent-1" />);
+      // Flush mount rAF → requestPtyBuffer().then() → bufferReplayed = true
+      await act(async () => { flushRAF(); });
+      term().write.mockClear();
+      rafQueue.length = 0;
+    }
+
+    it('batches multiple chunks from satellite into a single term.write call', async () => {
+      await mountRemoteAndInit();
+
+      act(() => {
+        g.__satelliteBusListener!('sat-1', 'agent-1', 'r1');
+        g.__satelliteBusListener!('sat-1', 'agent-1', 'r2');
+        g.__satelliteBusListener!('sat-1', 'agent-1', 'r3');
+      });
+
+      // No writes yet — batched, waiting for rAF
+      expect(term().write).not.toHaveBeenCalled();
+
+      act(() => { flushRAF(); });
+
+      expect(term().write).toHaveBeenCalledTimes(1);
+      expect(term().write).toHaveBeenCalledWith('r1r2r3');
+    });
+
+    it('filters non-matching satellite IDs', async () => {
+      await mountRemoteAndInit();
+      const countAfterMount = rafQueue.length;
+
+      act(() => {
+        g.__satelliteBusListener!('sat-OTHER', 'agent-1', 'foreign');
+      });
+
+      // No new rAF scheduled — filter should reject the wrong satId
+      expect(rafQueue.length).toBe(countAfterMount);
+      expect(term().write).not.toHaveBeenCalled();
+    });
+
+    it('filters non-matching agent IDs on the satellite path', async () => {
+      await mountRemoteAndInit();
+      const countAfterMount = rafQueue.length;
+
+      act(() => {
+        g.__satelliteBusListener!('sat-1', 'agent-OTHER', 'foreign');
+      });
+
+      // Right satellite, wrong agent — must not batch
+      expect(rafQueue.length).toBe(countAfterMount);
+      expect(term().write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pre-replay buffering gate', () => {
+    /**
+     * The component buffers live PTY data in `pendingData[]` until the initial
+     * scrollback fetch resolves. Without these tests, a regression that flips
+     * the `bufferReplayed` gate would silently lose initial output or interleave
+     * it with live streaming. We exercise the deferred-replay path by holding
+     * the buffer-fetch promise unresolved while we fire live data.
+     */
+
+    it('local: queues live data during buffer fetch, drains in order after replay', async () => {
+      let resolveBuffer!: (s: string) => void;
+      window.clubhouse.pty.getBuffer = vi.fn().mockImplementation(
+        () => new Promise<string>((r) => { resolveBuffer = r; }),
+      );
+
+      render(<AgentTerminal agentId="agent-1" />);
+      // Fire mount rAF — this calls getBuffer() but the promise stays pending
+      await act(async () => { flushRAF(); });
+
+      // Live data arrives before replay completes — must be queued, not written
+      act(() => {
+        mockOnDataCallback!('agent-1', 'live-1');
+        mockOnDataCallback!('agent-1', 'live-2');
+      });
+
+      expect(term().write).not.toHaveBeenCalled();
+      expect(rafQueue.length).toBe(0); // No rAF scheduled — gate is closed
+
+      // Resolve the buffer fetch — drain should happen in order:
+      // buffered output first, then each pending chunk as a separate write
+      await act(async () => { resolveBuffer('BUF'); });
+
+      expect(term().write).toHaveBeenNthCalledWith(1, 'BUF');
+      expect(term().write).toHaveBeenNthCalledWith(2, 'live-1');
+      expect(term().write).toHaveBeenNthCalledWith(3, 'live-2');
+    });
+
+    it('satellite: queues live data during buffer fetch, drains in order after replay', async () => {
+      let resolveBuffer!: (s: string) => void;
+      g.__annexMockState.requestPtyBuffer = vi.fn().mockImplementation(
+        () => new Promise<string>((r) => { resolveBuffer = r; }),
+      );
+
+      render(<AgentTerminal agentId="remote||sat-1||agent-1" />);
+      await act(async () => { flushRAF(); });
+
+      // Live data arrives via the satellite bus before replay
+      act(() => {
+        g.__satelliteBusListener!('sat-1', 'agent-1', 'live-r1');
+        g.__satelliteBusListener!('sat-1', 'agent-1', 'live-r2');
+      });
+
+      expect(term().write).not.toHaveBeenCalled();
+      expect(rafQueue.length).toBe(0);
+
+      await act(async () => { resolveBuffer('REMOTE-BUF'); });
+
+      expect(term().write).toHaveBeenNthCalledWith(1, 'REMOTE-BUF');
+      expect(term().write).toHaveBeenNthCalledWith(2, 'live-r1');
+      expect(term().write).toHaveBeenNthCalledWith(3, 'live-r2');
+    });
+
+    it('resumes batched writes after replay completes', async () => {
+      let resolveBuffer!: (s: string) => void;
+      window.clubhouse.pty.getBuffer = vi.fn().mockImplementation(
+        () => new Promise<string>((r) => { resolveBuffer = r; }),
+      );
+
+      render(<AgentTerminal agentId="agent-1" />);
+      await act(async () => { flushRAF(); });
+
+      // Resolve replay with no buffered content, no pre-replay chunks
+      await act(async () => { resolveBuffer(''); });
+      term().write.mockClear();
+      rafQueue.length = 0;
+
+      // After the gate opens, new chunks must batch via rAF (not write directly)
+      act(() => {
+        mockOnDataCallback!('agent-1', 'post-1');
+        mockOnDataCallback!('agent-1', 'post-2');
+      });
+
+      expect(term().write).not.toHaveBeenCalled();
+
+      act(() => { flushRAF(); });
+
+      expect(term().write).toHaveBeenCalledTimes(1);
+      expect(term().write).toHaveBeenCalledWith('post-1post-2');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds 6 tests to `AgentTerminal.batching.test.tsx` to lock in behavior introduced by #1389 that had no automated coverage
- Closes the two **Tier 1 regression gaps** identified during review of #1389: the satellite/remote PTY batching path, and the pre-replay buffering gate
- Tests-only PR — no production code touched. Companion to #1389; underlying issues (exit-handler ordering, log-meta accuracy) remain for a future PR

## Why

PR #1389 added rAF write-batching to `AgentTerminal.tsx` and `UtilityTerminal.tsx`, but the new test file only exercised the local PTY happy path. Two important code paths shipped untested:

1. **Satellite/remote PTY batching** — the `satellitePtyDataBus.on(...)` listener feeds `enqueueWrite('annex', ...)`. The mock in the merged PR was a stub (`vi.fn(() => vi.fn())`) that never exposed the listener, so no test ever fired bus events. A future refactor could break batching, drop the satId/agentId filter, or skip the `bufferReplayed` gate on this path with no failing test.

2. **Pre-replay buffering gate** — data arriving before the initial `getBuffer()` / `requestPtyBuffer()` promise resolves must queue into `pendingData[]`, then drain in arrival order after replay. All existing batching tests bypassed this state via `mountAndInit()`. A regression that flipped the gate would silently lose initial scrollback or interleave it with live streaming.

## Changes

**Mocks** (so the satellite path and deferred replay can be tested):
- `satellitePtyDataBus.on` now captures the listener via `globalThis.__satelliteBusListener` (was a no-op stub)
- New `g.__satelliteBusUnsubscribe` mock + reset in `beforeEach`
- Added `remote||sat-1||agent-1` to the `useAgentStore` fixture

**New tests** (added inside the existing `AgentTerminal write batching` describe):

`describe('satellite/remote PTY path')`:
- Batches multiple chunks from satellite into a single `term.write` call
- Filters non-matching satellite IDs (no rAF scheduled, no write)
- Filters non-matching agent IDs on the satellite path

`describe('pre-replay buffering gate')`:
- Local: queues live data during buffer fetch, drains in order after replay (asserts `term.write` order: `BUF` → `live-1` → `live-2`)
- Satellite: same gate behavior on the remote path
- Resumes batched writes after replay completes (verifies the gate transition — post-replay chunks batch via rAF instead of writing directly)

The pre-replay tests use a deferred Promise pattern (`new Promise(r => { resolveBuffer = r; })`) so the test controls when the buffer fetch resolves, exercising the closed-gate state.

## Test Plan

- [x] All 6 new tests pass
- [x] All 4 existing batching tests still pass (10/10 in the file)
- [x] Full renderer/agents suite passes (569 tests across 30 files)
- [x] No new lint errors introduced (lint diff is zero against main)

## Validation Notes

- `npm test` shows 12 pre-existing failures in `src/main/services/...` (unrelated to this PR — same failures on `main`, traced to missing modules `elkjs`, `@xterm/headless`)
- `npm run lint` shows 22 pre-existing errors on `main`; this PR adds 0 new ones
- `npm run typecheck` has pre-existing missing-module errors unrelated to renderer code

## Related

- Companion to #1389 (the rAF batching fix)
- Out of scope (deliberately deferred): exit-handler ordering with pending batched data, `logDataWrite` per-chunk vs. per-write semantics, effect re-run cleanup test, `ShellTerminal.tsx` parallel coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)