### PR TITLE
fix(quality-sprint): assistant tests, silent catch handlers (TC-CRIT-03/04, CQ-16, LB-IPC-002/003, LB-OA-004)

### DIFF
--- a/src/main/ipc/agent-queue-handlers.ts
+++ b/src/main/ipc/agent-queue-handlers.ts
@@ -15,7 +15,11 @@ import { withValidatedArgs, stringArg, objectArg } from './validation';
 function broadcastChanged(): void {
   agentQueueRegistry.list().then((queues) => {
     broadcastToAllWindows(IPC.AGENT_QUEUE.CHANGED, queues);
-  }).catch(() => { /* ignore */ });
+  }).catch((err) => {
+    appLog('core:agent-queue', 'warn', 'Failed to broadcast agent queue changes', {
+      meta: { error: err instanceof Error ? err.message : String(err) },
+    });
+  });
 }
 
 let handlersRegistered = false;

--- a/src/main/ipc/group-project-handlers.ts
+++ b/src/main/ipc/group-project-handlers.ts
@@ -23,7 +23,11 @@ import type { PasteSubmitTiming } from '../orchestrators';
 function broadcastChanged(): void {
   groupProjectRegistry.list().then((projects) => {
     broadcastToAllWindows(IPC.GROUP_PROJECT.CHANGED, projects);
-  }).catch(() => { /* ignore */ });
+  }).catch((err) => {
+    appLog('core:group-project', 'warn', 'Failed to broadcast group project changes', {
+      meta: { error: err instanceof Error ? err.message : String(err) },
+    });
+  });
 }
 
 let handlersRegistered = false;

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -31,7 +31,11 @@ export function registerAllHandlers(): void {
   // Auto-detect available CLIs on first run so users only see providers
   // they actually have installed.  Fire-and-forget: store.save() updates
   // the in-memory cache synchronously; the disk write is async.
-  autoDetectDefaults(getAllProviders()).catch(() => {});
+  autoDetectDefaults(getAllProviders()).catch((err) => {
+    logService.appLog('core:orchestrator', 'warn', 'Auto-detect orchestrator defaults failed', {
+      meta: { error: err instanceof Error ? err.message : String(err) },
+    });
+  });
 
   // Initialize logging service early so handlers can use it
   logService.init();

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -322,8 +322,10 @@ async function spawnPtyAgent(
     waitMcpBridgeReady().then(async (port) => {
       mcpPort = port;
       await injectClubhouseMcp(params.cwd, params.agentId, port, nonce, provider.conventions);
-    }).catch(() => {
-      // MCP bridge not started (feature disabled) — continue without it
+    }).catch((err) => {
+      appLog('core:mcp', 'warn', 'MCP bridge injection skipped', {
+        meta: { agentId: params.agentId, error: err instanceof Error ? err.message : String(err) },
+      });
     }),
     provider.buildSpawnCommand({
       cwd: params.cwd,

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -73,7 +73,9 @@ export function createSettingsStore<T>(
     const snapshot = cloneSettings(settings);
     const serialized = JSON.stringify(snapshot, null, 2);
     const writeTask = pendingWrite
-      .catch((_err): void => {})
+      .catch((err): void => {
+        console.warn(`[settings-store] Previous write to ${filename} failed:`, err instanceof Error ? err.message : err);
+      })
       .then(() => fs.promises.writeFile(filePath, serialized, options?.mode != null ? { encoding: 'utf-8', mode: options.mode } : 'utf-8'));
     pendingWrite = writeTask;
     return writeTask;

--- a/src/renderer/features/assistant/AssistantActionCard.test.tsx
+++ b/src/renderer/features/assistant/AssistantActionCard.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AssistantActionCard } from './AssistantActionCard';
+import type { ActionCardData } from './types';
+
+function makeAction(overrides: Partial<ActionCardData> = {}): ActionCardData {
+  return {
+    id: 'action-1',
+    toolName: 'create_project',
+    description: 'Create a new project',
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+describe('AssistantActionCard', () => {
+  it('renders with completed status', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'completed' })} />);
+    expect(screen.getByTestId('assistant-action-card')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-action-card')).toHaveAttribute('data-status', 'completed');
+  });
+
+  it('renders human-friendly tool name', () => {
+    render(<AssistantActionCard action={makeAction({ toolName: 'create_project' })} />);
+    expect(screen.getByText('Create project')).toBeInTheDocument();
+  });
+
+  it('renders unknown tool name as-is with underscores replaced', () => {
+    render(<AssistantActionCard action={makeAction({ toolName: 'some_unknown_tool' })} />);
+    expect(screen.getByText('some unknown tool')).toBeInTheDocument();
+  });
+
+  it('shows description in header', () => {
+    render(<AssistantActionCard action={makeAction({ description: 'My action' })} />);
+    expect(screen.getByText('My action')).toBeInTheDocument();
+  });
+
+  it('expands on header click', () => {
+    const action = makeAction({
+      status: 'completed',
+      input: { path: '/foo' },
+    });
+    render(<AssistantActionCard action={action} />);
+    const card = screen.getByTestId('assistant-action-card');
+    // Initially closed for completed (no error/pending)
+    expect(card.querySelector('details')).not.toBeInTheDocument();
+    fireEvent.click(card.querySelector('button')!);
+    expect(card.querySelector('details')).toBeInTheDocument();
+  });
+
+  it('collapses after second click on header', () => {
+    const action = makeAction({ status: 'completed', input: { path: '/foo' } });
+    render(<AssistantActionCard action={action} />);
+    const headerBtn = screen.getByTestId('assistant-action-card').querySelector('button')!;
+    fireEvent.click(headerBtn);
+    fireEvent.click(headerBtn);
+    expect(screen.getByTestId('assistant-action-card').querySelector('details')).not.toBeInTheDocument();
+  });
+
+  it('shows approval controls for pending_approval status', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'pending_approval' })} />);
+    expect(screen.getByTestId('action-approve')).toBeInTheDocument();
+    expect(screen.getByTestId('action-skip')).toBeInTheDocument();
+  });
+
+  it('does not show approval controls for completed status', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'completed' })} />);
+    expect(screen.queryByTestId('action-approve')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('action-skip')).not.toBeInTheDocument();
+  });
+
+  it('calls onApprove with action id when approve clicked', () => {
+    const onApprove = vi.fn();
+    render(
+      <AssistantActionCard
+        action={makeAction({ id: 'act-42', status: 'pending_approval' })}
+        onApprove={onApprove}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-approve'));
+    expect(onApprove).toHaveBeenCalledWith('act-42');
+  });
+
+  it('calls onSkip with action id when skip clicked', () => {
+    const onSkip = vi.fn();
+    render(
+      <AssistantActionCard
+        action={makeAction({ id: 'act-42', status: 'pending_approval' })}
+        onSkip={onSkip}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-skip'));
+    expect(onSkip).toHaveBeenCalledWith('act-42');
+  });
+
+  it('auto-expands for error status and shows error message', () => {
+    const action = makeAction({ status: 'error', error: 'Something went wrong' });
+    render(<AssistantActionCard action={action} />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('strips JSON wrapper from error message', () => {
+    render(
+      <AssistantActionCard
+        action={makeAction({ status: 'error', error: '{"message":"File not found"}' })}
+      />
+    );
+    expect(screen.getByText('File not found')).toBeInTheDocument();
+  });
+
+  it('auto-expands for pending_approval status', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'pending_approval' })} />);
+    // The approval controls section is rendered (auto-expanded)
+    expect(screen.getByTestId('action-approve')).toBeInTheDocument();
+  });
+
+  it('shows duration in ms for completed actions under 1s', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'completed', durationMs: 450 })} />);
+    expect(screen.getByText('450ms')).toBeInTheDocument();
+  });
+
+  it('shows duration in seconds for completed actions >= 1s', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'completed', durationMs: 2500 })} />);
+    expect(screen.getByText('2.5s')).toBeInTheDocument();
+  });
+
+  it('shows result summary for completed creation tools', () => {
+    render(
+      <AssistantActionCard
+        action={makeAction({
+          status: 'completed',
+          toolName: 'create_project',
+          output: '{"name":"My Project","id":"p1"}',
+        })}
+      />
+    );
+    expect(screen.getByText('project "My Project" created')).toBeInTheDocument();
+  });
+
+  it('renders running state with spinning icon', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'running' })} />);
+    const card = screen.getByTestId('assistant-action-card');
+    expect(card).toHaveAttribute('data-status', 'running');
+    // The spinning SVG uses animate-spin class
+    expect(card.querySelector('svg.animate-spin')).toBeInTheDocument();
+  });
+
+  it('shows skipped text when expanded in skipped state', () => {
+    render(<AssistantActionCard action={makeAction({ status: 'skipped' })} />);
+    const headerBtn = screen.getByTestId('assistant-action-card').querySelector('button')!;
+    fireEvent.click(headerBtn);
+    expect(screen.getByText(/Action skipped by user/)).toBeInTheDocument();
+  });
+});

--- a/src/renderer/features/assistant/AssistantInput.test.tsx
+++ b/src/renderer/features/assistant/AssistantInput.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { AssistantInput } from './AssistantInput';
+
+describe('AssistantInput', () => {
+  it('renders the input and send button', () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    expect(screen.getByTestId('assistant-message-input')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-send-button')).toBeInTheDocument();
+  });
+
+  it('shows idle placeholder by default', () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    expect(screen.getByPlaceholderText('Ask anything…')).toBeInTheDocument();
+  });
+
+  it('shows responding placeholder when status is responding', () => {
+    render(<AssistantInput onSend={vi.fn()} status="responding" />);
+    expect(screen.getByPlaceholderText('Waiting for response…')).toBeInTheDocument();
+  });
+
+  it('shows starting placeholder when status is starting', () => {
+    render(<AssistantInput onSend={vi.fn()} status="starting" />);
+    expect(screen.getByPlaceholderText('Starting assistant…')).toBeInTheDocument();
+  });
+
+  it('updates input value as user types', async () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, 'hello');
+    expect(input).toHaveValue('hello');
+  });
+
+  it('calls onSend with trimmed message on Enter', async () => {
+    const onSend = vi.fn();
+    render(<AssistantInput onSend={onSend} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, '  hello world  ');
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+    expect(onSend).toHaveBeenCalledWith('hello world');
+  });
+
+  it('clears input after sending via Enter', async () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, 'hello');
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+    expect(input).toHaveValue('');
+  });
+
+  it('does not submit on Shift+Enter', async () => {
+    const onSend = vi.fn();
+    render(<AssistantInput onSend={onSend} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, 'hello');
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input).toHaveValue('hello');
+  });
+
+  it('calls onSend when send button is clicked', async () => {
+    const onSend = vi.fn();
+    render(<AssistantInput onSend={onSend} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, 'test message');
+    fireEvent.click(screen.getByTestId('assistant-send-button'));
+    expect(onSend).toHaveBeenCalledWith('test message');
+  });
+
+  it('does not call onSend with empty input', async () => {
+    const onSend = vi.fn();
+    render(<AssistantInput onSend={onSend} status="idle" />);
+    fireEvent.keyDown(screen.getByTestId('assistant-message-input'), { key: 'Enter' });
+    fireEvent.click(screen.getByTestId('assistant-send-button'));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not call onSend with whitespace-only input', async () => {
+    const onSend = vi.fn();
+    render(<AssistantInput onSend={onSend} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, '   ');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('disables textarea and send button when disabled prop is true', () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" disabled />);
+    expect(screen.getByTestId('assistant-message-input')).toBeDisabled();
+    expect(screen.getByTestId('assistant-send-button')).toBeDisabled();
+  });
+
+  it('does not send when disabled even with text entered', async () => {
+    const onSend = vi.fn();
+    render(<AssistantInput onSend={onSend} status="idle" disabled />);
+    const input = screen.getByTestId('assistant-message-input');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.click(screen.getByTestId('assistant-send-button'));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('send button is disabled when input is empty', () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    expect(screen.getByTestId('assistant-send-button')).toBeDisabled();
+  });
+
+  it('send button is enabled when input has text', async () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    const input = screen.getByTestId('assistant-message-input');
+    await userEvent.type(input, 'hello');
+    expect(screen.getByTestId('assistant-send-button')).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add behavioral unit tests for `AssistantActionCard` and `AssistantInput` (0% → covered, TC-CRIT-03/04)
- Replace 5 silent `.catch(() => {})` handlers with `logger.warn` calls so failures are visible in logs (CQ-16, LB-IPC-002/003, LB-OA-004, MCP bridge)
- Note: `window.confirm` migration (VQ D-1..D-4) was already complete in `origin/main` — no changes needed

## Changes

### Tests (TC-CRIT-03 — AssistantActionCard)
- `AssistantActionCard.test.tsx`: 18 behavioral tests covering all action states (`pending_approval`, `running`, `completed`, `error`, `skipped`), expand/collapse toggle, approve/skip button callbacks, error message rendering (including JSON unwrapping), duration display, result summary for creation tools

### Tests (TC-CRIT-04 — AssistantInput)
- `AssistantInput.test.tsx`: 15 behavioral tests covering input value handling, send on Enter, Shift+Enter does not send, send on button click, empty/whitespace input blocked, disabled state (textarea + button), status-aware placeholder text, button enabled/disabled state

### Silent catch fixes (CQ-16, LB-IPC-002/003, LB-OA-004, MCP bridge)
- `src/main/ipc/index.ts` — orchestrator auto-detect failure now logged at `warn`
- `src/main/ipc/group-project-handlers.ts` — group project broadcast failure now logged at `warn` (LB-IPC-002)
- `src/main/ipc/agent-queue-handlers.ts` — agent queue broadcast failure now logged at `warn` (LB-IPC-003)
- `src/main/services/agent-system.ts` — MCP bridge injection failure now logged at `warn` (includes agentId context)
- `src/main/services/settings-store.ts` — settings file write failure now logged via `console.warn` (LB-OA-004)

## Test Plan
- [x] `AssistantActionCard.test.tsx` — 18 tests pass
- [x] `AssistantInput.test.tsx` — 15 tests pass
- [x] Full test suite — 11,494 tests pass (459 files)
- [x] TypeScript typecheck — clean
- [x] ESLint on changed files — clean (pre-existing errors in unrelated files)