### PR TITLE
feat(group-project): resizable + collapsible panes in expanded canvas view

### DIFF
--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { GroupProjectPanelSidebar, useGroupProjectPanelLayout } from './GroupProjectPanelSidebar';
 import type { CanvasWidgetComponentProps, AnnexAPI } from '../../../../shared/plugin-types';
 import type { TopicDigest, BulletinMessage } from '../../../../shared/group-project-types';
 import { useGroupProjectStore } from '../../../stores/groupProjectStore';
@@ -346,6 +347,17 @@ function ExpandedProjectView({
 }) {
   const { project, members, loaded, loadProjects, update, fetchDigest, fetchTopicMessages, fetchAllMessages, injectMessage, deleteMessage, deleteTopic, setTopicProtection, clearAllMessages } = ctx;
 
+  const {
+    topicsWidth,
+    topicsCollapsed,
+    messagesWidth,
+    messagesCollapsed,
+    resizeTopics,
+    toggleTopicsCollapse,
+    resizeMessages,
+    toggleMessagesCollapse,
+  } = useGroupProjectPanelLayout();
+
   const [selectedTopic, setSelectedTopic] = useState<string>(ALL_TOPICS_KEY);
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
   const [topics, setTopics] = useState<TopicDigest[]>([]);
@@ -596,8 +608,13 @@ function ExpandedProjectView({
       {/* 3-Pane Content */}
       <div className="flex flex-1 min-h-0 border-t border-surface-1">
         {/* Topic Sidebar */}
-        <div className="w-36 flex-shrink-0 border-r border-surface-1 overflow-y-auto">
-          <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider bg-ctp-accent/10 text-ctp-accent">
+        <GroupProjectPanelSidebar
+          width={topicsWidth}
+          collapsed={topicsCollapsed}
+          onResize={resizeTopics}
+          onToggleCollapse={toggleTopicsCollapse}
+        >
+          <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider bg-ctp-accent/10 text-ctp-accent sticky top-0 z-10">
             Topics
           </div>
           {/* All virtual topic */}
@@ -669,10 +686,15 @@ function ExpandedProjectView({
           {topics.length === 0 && (
             <div className="p-3 text-xs text-ctp-overlay0 italic">No topics yet</div>
           )}
-        </div>
+        </GroupProjectPanelSidebar>
 
         {/* Message List (compact preview pane) */}
-        <div className="w-48 flex-shrink-0 border-r border-surface-1 overflow-y-auto">
+        <GroupProjectPanelSidebar
+          width={messagesWidth}
+          collapsed={messagesCollapsed}
+          onResize={resizeMessages}
+          onToggleCollapse={toggleMessagesCollapse}
+        >
           {sortedMessages.length === 0 ? (
             <div className="p-3 text-xs text-ctp-overlay0 italic">
               {selectedTopic === ALL_TOPICS_KEY ? 'No messages yet' : `No messages in "${selectedTopic}"`}
@@ -712,7 +734,7 @@ function ExpandedProjectView({
               </div>
             ))
           )}
-        </div>
+        </GroupProjectPanelSidebar>
 
         {/* Message Detail (main content area) */}
         <div className="flex-1 min-w-0 overflow-y-auto p-3">

--- a/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.test.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.test.tsx
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import {
+  GroupProjectPanelSidebar,
+  useGroupProjectPanelLayout,
+  loadPanelLayout,
+  savePanelLayout,
+  PANEL_RAIL_WIDTH,
+  TOPICS_DEFAULT_WIDTH,
+  TOPICS_MIN_WIDTH,
+  TOPICS_MAX_WIDTH,
+  MESSAGES_DEFAULT_WIDTH,
+  MESSAGES_MIN_WIDTH,
+  MESSAGES_MAX_WIDTH,
+} from './GroupProjectPanelSidebar';
+
+// Stub localStorage for tests that use it
+const localStorageStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { localStorageStore[key] = value; }),
+  removeItem: vi.fn((key: string) => { delete localStorageStore[key]; }),
+});
+
+/* ---------- GroupProjectPanelSidebar component tests ---------- */
+
+describe('GroupProjectPanelSidebar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders sidebar at the given width when not collapsed', () => {
+    const { getByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={false}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    const sidebar = getByTestId('group-project-panel-sidebar');
+    expect(sidebar).toBeInTheDocument();
+    expect(sidebar.style.width).toBe('200px');
+  });
+
+  it('renders children when not collapsed', () => {
+    const { getByText } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={false}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Panel content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    expect(getByText('Panel content')).toBeInTheDocument();
+  });
+
+  it('renders a ResizeDivider when not collapsed', () => {
+    const { getByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={false}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    expect(getByTestId('resize-divider')).toBeInTheDocument();
+  });
+
+  it('calls onResize when the divider is dragged', () => {
+    const onResize = vi.fn();
+    const { getByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={false}
+        onResize={onResize}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    fireEvent.mouseDown(getByTestId('resize-divider'), { clientX: 200 });
+    fireEvent.mouseMove(document, { clientX: 230 });
+    fireEvent.mouseUp(document);
+    expect(onResize).toHaveBeenCalledWith(30);
+  });
+
+  it('calls onToggleCollapse on divider double-click', () => {
+    const onToggle = vi.fn();
+    const { getByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={false}
+        onResize={vi.fn()}
+        onToggleCollapse={onToggle}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    fireEvent.doubleClick(getByTestId('resize-divider'));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('renders a rail at PANEL_RAIL_WIDTH when collapsed', () => {
+    const { getByTestId, queryByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    expect(queryByTestId('group-project-panel-sidebar')).toBeNull();
+    expect(queryByTestId('resize-divider')).toBeNull();
+    const rail = getByTestId('group-project-panel-rail');
+    expect(rail).toBeInTheDocument();
+    expect(rail.style.width).toBe(`${PANEL_RAIL_WIDTH}px`);
+  });
+
+  it('shows the expand chevron icon in the rail', () => {
+    const { getByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    expect(getByTestId('panel-rail-icon')).toBeInTheDocument();
+  });
+
+  it('calls onToggleCollapse when rail toggle is clicked', () => {
+    const onToggle = vi.fn();
+    const { getByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={onToggle}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    fireEvent.click(getByTestId('panel-rail-toggle'));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('shows hover overlay when mouse enters the rail', () => {
+    const { getByTestId, queryByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Overlay content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    expect(queryByTestId('panel-rail-overlay')).toBeNull();
+    fireEvent.mouseEnter(getByTestId('panel-rail-toggle'));
+    const overlay = getByTestId('panel-rail-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay.style.width).toBe('200px');
+  });
+
+  it('renders children inside the overlay', () => {
+    const { getByTestId, getByText } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Overlay content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    fireEvent.mouseEnter(getByTestId('panel-rail-toggle'));
+    expect(getByText('Overlay content')).toBeInTheDocument();
+  });
+
+  it('hides overlay after mouse leaves with 150ms delay', () => {
+    const { getByTestId, queryByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    fireEvent.mouseEnter(getByTestId('panel-rail-toggle'));
+    expect(queryByTestId('panel-rail-overlay')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(getByTestId('panel-rail-toggle'));
+    // Still visible before the delay
+    expect(queryByTestId('panel-rail-overlay')).toBeInTheDocument();
+
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(queryByTestId('panel-rail-overlay')).toBeNull();
+  });
+
+  it('keeps overlay visible when mouse moves from rail into overlay', () => {
+    const { getByTestId, queryByTestId } = render(
+      <GroupProjectPanelSidebar
+        width={200}
+        collapsed={true}
+        onResize={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </GroupProjectPanelSidebar>,
+    );
+    fireEvent.mouseEnter(getByTestId('panel-rail-toggle'));
+    fireEvent.mouseLeave(getByTestId('panel-rail-toggle'));
+
+    // Move into overlay before timeout fires
+    const overlay = getByTestId('panel-rail-overlay');
+    fireEvent.mouseEnter(overlay);
+
+    act(() => { vi.advanceTimersByTime(200); });
+    // Overlay should still be visible
+    expect(queryByTestId('panel-rail-overlay')).toBeInTheDocument();
+  });
+});
+
+/* ---------- useGroupProjectPanelLayout hook tests ---------- */
+
+describe('useGroupProjectPanelLayout', () => {
+  beforeEach(() => {
+    // Clear the store object and reset mock call history
+    for (const key of Object.keys(localStorageStore)) delete localStorageStore[key];
+    vi.mocked(localStorage.getItem).mockClear();
+    vi.mocked(localStorage.setItem).mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(localStorageStore)) delete localStorageStore[key];
+    vi.useRealTimers();
+  });
+
+  it('initializes with default widths and collapsed states', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    expect(result.current.topicsWidth).toBe(TOPICS_DEFAULT_WIDTH);
+    expect(result.current.topicsCollapsed).toBe(false);
+    expect(result.current.messagesWidth).toBe(MESSAGES_DEFAULT_WIDTH);
+    expect(result.current.messagesCollapsed).toBe(false);
+  });
+
+  it('loads persisted state from localStorage', () => {
+    savePanelLayout({ topicsWidth: 160, topicsCollapsed: true, messagesWidth: 250, messagesCollapsed: false });
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    expect(result.current.topicsWidth).toBe(160);
+    expect(result.current.topicsCollapsed).toBe(true);
+    expect(result.current.messagesWidth).toBe(250);
+  });
+
+  it('resizeTopics increases topics width', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeTopics(20); });
+    expect(result.current.topicsWidth).toBe(TOPICS_DEFAULT_WIDTH + 20);
+  });
+
+  it('resizeTopics clamps to TOPICS_MIN_WIDTH', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeTopics(-9999); });
+    expect(result.current.topicsWidth).toBe(TOPICS_MIN_WIDTH);
+  });
+
+  it('resizeTopics clamps to TOPICS_MAX_WIDTH', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeTopics(9999); });
+    expect(result.current.topicsWidth).toBe(TOPICS_MAX_WIDTH);
+  });
+
+  it('toggleTopicsCollapse flips topicsCollapsed', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    expect(result.current.topicsCollapsed).toBe(false);
+    act(() => { result.current.toggleTopicsCollapse(); });
+    expect(result.current.topicsCollapsed).toBe(true);
+    act(() => { result.current.toggleTopicsCollapse(); });
+    expect(result.current.topicsCollapsed).toBe(false);
+  });
+
+  it('resizeMessages increases messages width', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeMessages(30); });
+    expect(result.current.messagesWidth).toBe(MESSAGES_DEFAULT_WIDTH + 30);
+  });
+
+  it('resizeMessages clamps to MESSAGES_MIN_WIDTH', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeMessages(-9999); });
+    expect(result.current.messagesWidth).toBe(MESSAGES_MIN_WIDTH);
+  });
+
+  it('resizeMessages clamps to MESSAGES_MAX_WIDTH', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeMessages(9999); });
+    expect(result.current.messagesWidth).toBe(MESSAGES_MAX_WIDTH);
+  });
+
+  it('toggleMessagesCollapse flips messagesCollapsed', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    expect(result.current.messagesCollapsed).toBe(false);
+    act(() => { result.current.toggleMessagesCollapse(); });
+    expect(result.current.messagesCollapsed).toBe(true);
+  });
+
+  it('saves layout to localStorage after debounce', () => {
+    const { result } = renderHook(() => useGroupProjectPanelLayout());
+    act(() => { result.current.resizeTopics(50); });
+    // Not yet saved (debounced) — setItem not called yet
+    expect(vi.mocked(localStorage.setItem)).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(350); });
+    const saved = loadPanelLayout();
+    expect(saved.topicsWidth).toBe(TOPICS_DEFAULT_WIDTH + 50);
+  });
+
+  it('handles corrupt localStorage gracefully', () => {
+    localStorage.setItem('clubhouse_group_project_panel_layout', 'not-valid-json{{{');
+    const layout = loadPanelLayout();
+    expect(layout.topicsWidth).toBe(TOPICS_DEFAULT_WIDTH);
+    expect(layout.topicsCollapsed).toBe(false);
+    expect(layout.messagesWidth).toBe(MESSAGES_DEFAULT_WIDTH);
+    expect(layout.messagesCollapsed).toBe(false);
+  });
+});

--- a/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { ResizeDivider } from '../../../components/ResizeDivider';
+
+/* ---------- Constants ---------- */
+
+export const PANEL_RAIL_WIDTH = 28;
+
+export const TOPICS_DEFAULT_WIDTH = 144;
+export const TOPICS_MIN_WIDTH = 80;
+export const TOPICS_MAX_WIDTH = 280;
+
+export const MESSAGES_DEFAULT_WIDTH = 192;
+export const MESSAGES_MIN_WIDTH = 100;
+export const MESSAGES_MAX_WIDTH = 400;
+
+const PANEL_STORAGE_KEY = 'clubhouse_group_project_panel_layout';
+
+/* ---------- Layout State ---------- */
+
+interface GroupProjectPanelLayoutState {
+  topicsWidth: number;
+  topicsCollapsed: boolean;
+  messagesWidth: number;
+  messagesCollapsed: boolean;
+}
+
+const DEFAULT_LAYOUT: GroupProjectPanelLayoutState = {
+  topicsWidth: TOPICS_DEFAULT_WIDTH,
+  topicsCollapsed: false,
+  messagesWidth: MESSAGES_DEFAULT_WIDTH,
+  messagesCollapsed: false,
+};
+
+export function loadPanelLayout(): GroupProjectPanelLayoutState {
+  try {
+    const raw = localStorage.getItem(PANEL_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<GroupProjectPanelLayoutState>;
+      return {
+        topicsWidth: parsed.topicsWidth ?? TOPICS_DEFAULT_WIDTH,
+        topicsCollapsed: parsed.topicsCollapsed ?? false,
+        messagesWidth: parsed.messagesWidth ?? MESSAGES_DEFAULT_WIDTH,
+        messagesCollapsed: parsed.messagesCollapsed ?? false,
+      };
+    }
+  } catch { /* ignore */ }
+  return { ...DEFAULT_LAYOUT };
+}
+
+export function savePanelLayout(layout: GroupProjectPanelLayoutState): void {
+  try {
+    localStorage.setItem(PANEL_STORAGE_KEY, JSON.stringify(layout));
+  } catch { /* ignore */ }
+}
+
+/* ---------- Hook ---------- */
+
+export function useGroupProjectPanelLayout() {
+  const [layout, setLayout] = useState<GroupProjectPanelLayoutState>(loadPanelLayout);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => savePanelLayout(layout), 300);
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, [layout]);
+
+  const resizeTopics = useCallback((delta: number) => {
+    setLayout((l) => ({
+      ...l,
+      topicsWidth: Math.min(TOPICS_MAX_WIDTH, Math.max(TOPICS_MIN_WIDTH, l.topicsWidth + delta)),
+    }));
+  }, []);
+
+  const toggleTopicsCollapse = useCallback(() => {
+    setLayout((l) => ({ ...l, topicsCollapsed: !l.topicsCollapsed }));
+  }, []);
+
+  const resizeMessages = useCallback((delta: number) => {
+    setLayout((l) => ({
+      ...l,
+      messagesWidth: Math.min(MESSAGES_MAX_WIDTH, Math.max(MESSAGES_MIN_WIDTH, l.messagesWidth + delta)),
+    }));
+  }, []);
+
+  const toggleMessagesCollapse = useCallback(() => {
+    setLayout((l) => ({ ...l, messagesCollapsed: !l.messagesCollapsed }));
+  }, []);
+
+  return {
+    ...layout,
+    resizeTopics,
+    toggleTopicsCollapse,
+    resizeMessages,
+    toggleMessagesCollapse,
+  };
+}
+
+/* ---------- Component ---------- */
+
+interface GroupProjectPanelSidebarProps {
+  width: number;
+  collapsed: boolean;
+  onResize: (delta: number) => void;
+  onToggleCollapse: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * A controlled resizable+collapsible sidebar panel for the group project expanded view.
+ * When collapsed, shows a narrow rail that reveals a floating overlay on hover.
+ */
+export function GroupProjectPanelSidebar({
+  width,
+  collapsed,
+  onResize,
+  onToggleCollapse,
+  children,
+}: GroupProjectPanelSidebarProps) {
+  const [hovered, setHovered] = useState(false);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleEnter = useCallback(() => {
+    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    setHovered(true);
+  }, []);
+
+  const handleLeave = useCallback(() => {
+    hoverTimerRef.current = setTimeout(() => setHovered(false), 150);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    };
+  }, []);
+
+  if (collapsed) {
+    return (
+      <div
+        className="relative flex-shrink-0"
+        style={{ width: PANEL_RAIL_WIDTH }}
+        data-testid="group-project-panel-rail"
+      >
+        {/* Collapsed rail strip */}
+        <div
+          className="h-full border-r border-surface-1 bg-ctp-mantle/30 flex items-center justify-center cursor-pointer"
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          onClick={onToggleCollapse}
+          title="Expand panel"
+          data-testid="panel-rail-toggle"
+        >
+          <span className="text-[8px] text-ctp-subtext0 select-none" data-testid="panel-rail-icon">
+            &#x25B6;
+          </span>
+        </div>
+
+        {/* Hover overlay — floats over the content area */}
+        {hovered && (
+          <div
+            className="absolute top-0 left-0 z-10 h-full shadow-xl border-r border-surface-1 bg-ctp-mantle overflow-y-auto"
+            style={{ width }}
+            onMouseEnter={handleEnter}
+            onMouseLeave={handleLeave}
+            data-testid="panel-rail-overlay"
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="flex-shrink-0 overflow-y-auto"
+        style={{ width }}
+        data-testid="group-project-panel-sidebar"
+      >
+        {children}
+      </div>
+      <ResizeDivider
+        onResize={onResize}
+        onToggleCollapse={onToggleCollapse}
+        collapsed={false}
+        collapseDirection="left"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the fixed-width 3-pane layout in the expanded group project canvas card with fully resizable, collapsible panels
- Topics sidebar and message list can each be drag-resized, collapsed to a narrow rail, and peeked via a floating overlay on hover — matching the project rail / explorer rail UX in the main app
- Panel widths and collapsed state persist across sessions via localStorage

## Changes
- **`GroupProjectPanelSidebar.tsx`** (new) — `GroupProjectPanelSidebar` controlled component: shows a panel with a `ResizeDivider` when expanded, or a 28px rail + hover overlay when collapsed. `useGroupProjectPanelLayout` hook manages widths and collapsed states with 300ms-debounced localStorage persistence.
- **`GroupProjectCanvasWidget.tsx`** — `ExpandedProjectView` now calls `useGroupProjectPanelLayout` and wraps the topics sidebar and message list in `GroupProjectPanelSidebar`. Fixed `w-36`/`w-48` widths are replaced with state-driven `style={{ width }}`. Added `sticky top-0` to the Topics header so it stays visible while scrolling.
- **`GroupProjectPanelSidebar.test.tsx`** (new) — 24 tests covering: render at width, ResizeDivider present, drag-resize callback, double-click collapse, rail width, expand icon, rail click callback, hover overlay show/hide with delay, overlay persistence across rail→overlay transition, hook defaults, localStorage load/save with debounce, width clamping (min/max for both panels), collapse toggles, corrupt storage fallback.

## Test Plan
- [x] `GroupProjectPanelSidebar` renders sidebar at given width (not collapsed)
- [x] `GroupProjectPanelSidebar` renders `ResizeDivider` when not collapsed
- [x] `onResize` called when divider dragged
- [x] `onToggleCollapse` called on divider double-click
- [x] Collapsed state renders rail at `PANEL_RAIL_WIDTH` (28px); no sidebar or divider
- [x] Rail toggle click fires `onToggleCollapse`
- [x] Hover on rail shows overlay at correct width
- [x] Mouse-leave hides overlay after 150ms delay
- [x] Moving from rail into overlay before timeout keeps overlay visible
- [x] Hook defaults: `topicsWidth=144`, `messagesWidth=192`, both uncollapsed
- [x] `resizeTopics` / `resizeMessages` update width and clamp to min/max
- [x] `toggleTopicsCollapse` / `toggleMessagesCollapse` flip boolean
- [x] Layout saves to localStorage after 300ms debounce
- [x] Loads persisted state on init; handles corrupt JSON gracefully

## Manual Validation
1. Open a group project canvas card and expand it to > 500px wide
2. Hover over the divider between Topics and Messages — drag handle appears; drag to resize
3. Double-click the divider (or click the ◀ chevron) to collapse the Topics panel to a 28px rail
4. Hover the rail — full panel floats as an overlay; mouse-out hides it; click the rail to pin it back open
5. Repeat for the Message List panel
6. Reload the app — confirm widths and collapsed states are restored