### PR TITLE
fix(experimental): hide experimental UI when feature flag is off

### DIFF
--- a/e2e/assistant/assistant-disabled.spec.ts
+++ b/e2e/assistant/assistant-disabled.spec.ts
@@ -1,24 +1,19 @@
 /**
  * E2E tests for the assistant when the experimental flag is DISABLED.
  *
- * Mission 73 — Assistant visual crash on view (P1).
+ * Originally written for Mission 73 (Assistant visual crash on view P1) when
+ * the rail's Assistant button was always visible regardless of flag state and
+ * clicking it produced a blank page. That gap has since been closed: the rail
+ * now hides the Assistant button entirely when the flag is off, and the Help
+ * button takes its place. These tests cover the new gating contract:
  *
- * Before the fix, the assistant page was wrapped in `{assistantEnabled && ...}`
- * in App.tsx. When the flag was off — the default in stable builds — the
- * assistant tab rendered only the title bar and banners with no main content,
- * which Mason reported as a "visual crash on view".
+ *   1. With the flag disabled, the rail shows the Help button (not Assistant).
+ *   2. The placeholder still renders as defense-in-depth — if the user reaches
+ *      the assistant tab via the keyboard shortcut (which is not gated), the
+ *      AssistantView's internal flag check shows the disabled placeholder
+ *      with a recovery button rather than a blank content area.
  *
- * These tests verify the fix end-to-end by reaching the assistant tab from
- * a stable-build-like state (flag explicitly disabled) via the rail button,
- * and asserting:
- *   1. The page resolves to the disabled placeholder, not a blank content area.
- *   2. The recovery button ("Open Experimental Settings") is present and routes
- *      back to the settings page.
- *   3. No JS errors are emitted on navigation.
- *
- * Uses an isolated Electron instance with a clean user data dir so no state
- * leaks from the main `assistant.spec.ts` file (which intentionally enables
- * the flag in its launch helper).
+ * Uses an isolated Electron instance with a clean user data dir.
  */
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
@@ -70,10 +65,19 @@ async function findRendererWindow(
 
 /**
  * Launch a clean Clubhouse instance with the assistant experimental flag
- * EXPLICITLY disabled (default for stable builds).
+ * EXPLICITLY disabled (default for stable builds). Pre-writes the settings
+ * file before launch so the rail's mount-time flag fetch sees the disabled
+ * value (writing via IPC after mount would not retroactively re-render the
+ * rail's gated button).
  */
 async function launchDisabledInstance(): Promise<DisabledInstance> {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clubhouse-e2e-assistant-disabled-'));
+
+  fs.writeFileSync(
+    path.join(userDataDir, 'experimental-settings.json'),
+    JSON.stringify({ assistant: false }, null, 2),
+    'utf-8',
+  );
 
   const electronApp = await electron.launch({
     args: ['--disable-gpu', MAIN_ENTRY],
@@ -104,22 +108,6 @@ async function launchDisabledInstance(): Promise<DisabledInstance> {
     // Onboarding already completed
   }
 
-  // Explicitly DISABLE the assistant flag to simulate a stable build's default state.
-  await window.evaluate(async () => {
-    const w = window as unknown as {
-      clubhouse?: {
-        app?: {
-          getExperimentalSettings?: () => Promise<Record<string, boolean>>;
-          saveExperimentalSettings?: (s: Record<string, boolean>) => Promise<void>;
-        };
-      };
-    };
-    if (w.clubhouse?.app?.getExperimentalSettings && w.clubhouse?.app?.saveExperimentalSettings) {
-      const expSettings = await w.clubhouse.app.getExperimentalSettings();
-      await w.clubhouse.app.saveExperimentalSettings({ ...expSettings, assistant: false });
-    }
-  });
-
   return { electronApp, window, userDataDir, pageErrors };
 }
 
@@ -142,24 +130,49 @@ test.beforeEach(() => {
   instance.pageErrors.length = 0;
 });
 
-test('clicking nav-assistant when flag is disabled shows placeholder, not blank page', async () => {
+test('rail shows Help button (not Assistant) when assistant flag is disabled', async () => {
   const { window } = instance;
 
-  // Wait for the rail to mount
-  const assistantBtn = window.locator('[data-testid="nav-assistant"]');
-  await expect(assistantBtn).toBeVisible({ timeout: 10_000 });
+  // The Help button — the pre-experiment default — should be visible.
+  const helpBtn = window.locator('[data-testid="nav-help"]');
+  await expect(helpBtn).toBeVisible({ timeout: 10_000 });
 
-  // Click the assistant rail button — same flow as a stable-build user would take
-  await assistantBtn.click();
+  // The Assistant button must not be in the DOM at all when the flag is off.
+  await expect(window.locator('[data-testid="nav-assistant"]')).toHaveCount(0);
 
-  // The assistant view should mount and resolve to the disabled state.
-  // Before the Mission 73 fix, this navigation produced an empty content area
-  // (the title bar would render but the assistant view itself was gated out
-  // of the JSX entirely by `{assistantEnabled && ...}`).
+  expect(instance.pageErrors).toHaveLength(0);
+});
+
+/**
+ * Dispatch the toggle-assistant keyboard event directly. Playwright's
+ * keyboard.press() goes through OS-level key translation, which on macOS
+ * turns Shift+`.` into `>` and would not match the binding `Meta+Shift+.`.
+ * Synthesizing the KeyboardEvent locally with the literal key the
+ * eventToBinding() handler expects sidesteps that translation.
+ */
+async function fireToggleAssistantShortcut(window: Page): Promise<void> {
+  await window.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: '.',
+      metaKey: true,
+      shiftKey: true,
+      bubbles: true,
+    }));
+  });
+}
+
+test('keyboard shortcut to assistant shows disabled placeholder, not blank page', async () => {
+  const { window } = instance;
+
+  // The toggle-assistant keyboard shortcut (Meta+Shift+.) is registered
+  // independently of the rail button gating, so a user who memorized it can
+  // still trigger navigation to the assistant tab. The AssistantView's own
+  // flag check should then render the disabled placeholder — never a blank
+  // content area (the original Mission 73 bug).
+  await fireToggleAssistantShortcut(window);
+
   const assistantView = window.locator('[data-testid="assistant-view"]');
   await expect(assistantView).toBeVisible({ timeout: 10_000 });
-
-  // The data attribute should resolve away from "loading" to "disabled".
   await expect(assistantView).toHaveAttribute('data-assistant-state', 'disabled', {
     timeout: 10_000,
   });
@@ -167,12 +180,10 @@ test('clicking nav-assistant when flag is disabled shows placeholder, not blank 
   // The recovery button should be present.
   await expect(window.locator('[data-testid="assistant-open-settings-button"]')).toBeVisible();
 
-  // The chat UI elements should NOT be present (the bug they replaced).
+  // The chat UI must not appear in the disabled state.
   await expect(window.locator('[data-testid="assistant-feed-empty"]')).toHaveCount(0);
   await expect(window.locator('[data-testid="assistant-message-input"]')).toHaveCount(0);
 
-  // No JS errors on navigation — the original bug was visual emptiness, but
-  // we want this guard so a future regression that throws is caught here too.
   expect(instance.pageErrors).toHaveLength(0);
 });
 
@@ -180,10 +191,10 @@ test('clicking "Open Experimental Settings" routes to settings page', async () =
   const { window } = instance;
 
   // The previous test left us on the assistant tab in the disabled state.
-  // Re-open if we got navigated away.
+  // Re-open via the synthesized keyboard shortcut if we got navigated away.
   const assistantView = window.locator('[data-testid="assistant-view"]');
   if (!(await assistantView.isVisible().catch(() => false))) {
-    await window.locator('[data-testid="nav-assistant"]').click();
+    await fireToggleAssistantShortcut(window);
     await expect(assistantView).toBeVisible({ timeout: 10_000 });
   }
   await expect(assistantView).toHaveAttribute('data-assistant-state', 'disabled', {

--- a/e2e/assistant/helpers.ts
+++ b/e2e/assistant/helpers.ts
@@ -62,9 +62,23 @@ async function findRendererWindow(
 /**
  * Launch an isolated Clubhouse instance for assistant E2E tests.
  * Uses a temporary CLUBHOUSE_USER_DATA directory for clean state.
+ *
+ * The assistant feature is gated behind `experimental.assistant` in both the
+ * AssistantView and the rail's nav-assistant button. The rail reads the flag
+ * once on mount, so we must pre-write the settings file BEFORE launching
+ * electron — writing post-mount via IPC would leave the rail in its initial
+ * (Help button) state and `nav-assistant` would never appear.
  */
 export async function launchAssistantInstance(): Promise<AssistantInstance> {
   const userDataDir = createTempUserData();
+
+  // Pre-write the experimental settings so the flag is on from the very first
+  // read (settings-store reads from `userData/experimental-settings.json`).
+  fs.writeFileSync(
+    path.join(userDataDir, 'experimental-settings.json'),
+    JSON.stringify({ assistant: true }, null, 2),
+    'utf-8',
+  );
 
   const electronApp = await electron.launch({
     args: ['--disable-gpu', MAIN_ENTRY],
@@ -91,15 +105,6 @@ export async function launchAssistantInstance(): Promise<AssistantInstance> {
   } catch {
     // Onboarding already completed
   }
-
-  // Enable assistant experimental flag (assistant is gated behind it in stable builds)
-  await window.evaluate(async () => {
-    const w = window as any;
-    if (w.clubhouse?.app?.getExperimentalSettings) {
-      const expSettings = await w.clubhouse.app.getExperimentalSettings();
-      await w.clubhouse.app.saveExperimentalSettings({ ...expSettings, assistant: true });
-    }
-  });
 
   return { electronApp, window, userDataDir };
 }

--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -1,18 +1,47 @@
 import { _electron as electron } from '@playwright/test';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 const APP_PATH = path.resolve(__dirname, '..');
 const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
+
+export interface LaunchOptions {
+  /**
+   * Experimental flags to seed before the app starts. Pass these via
+   * `experimental` rather than calling `saveExperimentalSettings` after
+   * mount — UI surfaces gated on these flags (e.g. the rail Assistant
+   * button) read them once on mount and won't react to a later IPC write.
+   *
+   * When provided, a temp `userData` directory is created and seeded with
+   * `experimental-settings.json`, then passed to electron via the
+   * `CLUBHOUSE_USER_DATA` env var.
+   */
+  experimental?: Record<string, boolean>;
+}
 
 /**
  * Launch the Electron app and return the renderer window (skipping DevTools).
  * DevTools opens automatically for unpackaged builds, so firstWindow() may
  * return the DevTools page instead of the renderer.
  */
-export async function launchApp() {
+export async function launchApp(opts: LaunchOptions = {}) {
+  let userDataDir: string | undefined;
+  const env = { ...process.env };
+  if (opts.experimental) {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clubhouse-e2e-'));
+    fs.writeFileSync(
+      path.join(userDataDir, 'experimental-settings.json'),
+      JSON.stringify(opts.experimental, null, 2),
+      'utf-8',
+    );
+    env.CLUBHOUSE_USER_DATA = userDataDir;
+  }
+
   const electronApp = await electron.launch({
     args: [MAIN_ENTRY],
     cwd: APP_PATH,
+    env,
   });
 
   // Collect all windows that open, then pick the renderer (non-devtools) one.
@@ -37,7 +66,7 @@ export async function launchApp() {
     // Modal never appeared — onboarding was already completed
   }
 
-  return { electronApp, window: rendererWindow };
+  return { electronApp, window: rendererWindow, userDataDir };
 }
 
 async function findRendererWindow(

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -64,16 +64,12 @@ async function getTitleBarText(): Promise<string> {
 // ---------------------------------------------------------------------------
 
 test.beforeAll(async () => {
-  ({ electronApp, window } = await launchApp());
-
-  // Enable experimental features needed by navigation tests
-  await window.evaluate(async () => {
-    const w = window as any;
-    if (w.clubhouse?.app?.getExperimentalSettings) {
-      const expSettings = await w.clubhouse.app.getExperimentalSettings();
-      await w.clubhouse.app.saveExperimentalSettings({ ...expSettings, assistant: true, agentQueue: true });
-    }
-  });
+  // Pre-seed experimental flags before launch — the rail's Assistant button
+  // is gated on `experimental.assistant` and only reads the flag once on
+  // mount, so a post-mount IPC write would not make the button appear.
+  ({ electronApp, window } = await launchApp({
+    experimental: { assistant: true, agentQueue: true },
+  }));
 
   // Expose Zustand stores globally so tests can inspect state via evaluate().
   await window.evaluate(() => {

--- a/e2e/smoke-blank-screen.spec.ts
+++ b/e2e/smoke-blank-screen.spec.ts
@@ -26,16 +26,12 @@ let window: Page;
 const consoleErrors: string[] = [];
 
 test.beforeAll(async () => {
-  ({ electronApp, window } = await launchApp());
-
-  // Enable experimental features needed by smoke tests (assistant is gated)
-  await window.evaluate(async () => {
-    const w = window as any;
-    if (w.clubhouse?.app?.getExperimentalSettings) {
-      const expSettings = await w.clubhouse.app.getExperimentalSettings();
-      await w.clubhouse.app.saveExperimentalSettings({ ...expSettings, assistant: true, agentQueue: true });
-    }
-  });
+  // Pre-seed experimental flags before launch — the rail's Assistant button
+  // is gated on `experimental.assistant` and only reads the flag once on
+  // mount, so a post-mount IPC write would not make the button appear.
+  ({ electronApp, window } = await launchApp({
+    experimental: { assistant: true, agentQueue: true },
+  }));
 
   window.on('console', (msg) => {
     if (msg.type() === 'error') {

--- a/src/main/services/settings-store.test.ts
+++ b/src/main/services/settings-store.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as path from 'path';
 
+const mockGetPath = vi.fn(() => '/tmp/test-app');
+
 vi.mock('electron', () => ({
-  app: { getPath: () => '/tmp/test-app' },
+  app: { getPath: (...args: unknown[]) => mockGetPath(...args as []) },
 }));
 
 vi.mock('fs', () => ({
@@ -31,6 +33,7 @@ const DEFAULTS: TestSettings = {
 describe('settings-store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetPath.mockReturnValue('/tmp/test-app');
     resetAllSettingsStoresForTests();
   });
 
@@ -235,6 +238,39 @@ describe('settings-store', () => {
       const [callA, callB] = vi.mocked(fs.promises.writeFile).mock.calls;
       expect(callA[0]).toContain('store-a.json');
       expect(callB[0]).toContain('store-b.json');
+    });
+  });
+
+  describe('userData path resolution', () => {
+    // Regression test: createSettingsStore previously captured `app.getPath('userData')`
+    // at construction time. That ran during module-load (e.g. when ipc/app-handlers
+    // imported a settings module), which is *before* main/index.ts gets to call
+    // `app.setPath('userData', CLUBHOUSE_USER_DATA)` for tests / dual-instance
+    // workflows. The eager capture silently locked the store to the default
+    // location, so test pre-seeded settings files in the override dir were ignored
+    // and the IPC roundtrip returned defaults.
+    it('reads from the current userData path on each get, not the path at construction', () => {
+      mockGetPath.mockReturnValue('/tmp/initial');
+      const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
+
+      // Simulate `app.setPath('userData', …)` running after the store was created.
+      mockGetPath.mockReturnValue('/tmp/overridden');
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ name: 'from-override', count: 7, nested: { flag: true } }));
+
+      expect(store.get()).toEqual({ name: 'from-override', count: 7, nested: { flag: true } });
+      const readCall = vi.mocked(fs.readFileSync).mock.calls[0];
+      expect(readCall[0]).toBe(path.join('/tmp/overridden', 'test.json'));
+    });
+
+    it('writes to the current userData path on each save, not the path at construction', async () => {
+      mockGetPath.mockReturnValue('/tmp/initial');
+      const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
+
+      mockGetPath.mockReturnValue('/tmp/overridden');
+      await store.save({ name: 'written', count: 1, nested: { flag: false } });
+
+      const writeCall = vi.mocked(fs.promises.writeFile).mock.calls[0];
+      expect(writeCall[0]).toBe(path.join('/tmp/overridden', 'test.json'));
     });
   });
 

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -36,7 +36,13 @@ export function createSettingsStore<T>(
   migrate?: (raw: Record<string, unknown>) => T,
   options?: { mode?: number },
 ): SettingsStore<T> {
-  const filePath = path.join(app.getPath('userData'), filename);
+  // Resolve filePath lazily on each access. `createSettingsStore` runs at
+  // module-load time (e.g. when ipc/app-handlers imports a settings module),
+  // which is *before* main/index.ts gets to call `app.setPath('userData', …)`
+  // for CLUBHOUSE_USER_DATA. Capturing the path eagerly would freeze it to
+  // the default userData location and silently ignore the override, so any
+  // pre-seeded settings file in the test's temp dir would never be read.
+  const getFilePath = () => path.join(app.getPath('userData'), filename);
   let cachedSettings: T | null = null;
   let cacheLoaded = false;
   let pendingWrite: Promise<void> = Promise.resolve();
@@ -51,6 +57,7 @@ export function createSettingsStore<T>(
   }
 
   function loadSettings(): void {
+    const filePath = getFilePath();
     try {
       const raw = fs.readFileSync(filePath, 'utf-8');
       cachedSettings = parseSettings(raw);
@@ -70,6 +77,7 @@ export function createSettingsStore<T>(
   function queueWrite(settings: T): Promise<void> {
     const snapshot = cloneSettings(settings);
     const serialized = JSON.stringify(snapshot, null, 2);
+    const filePath = getFilePath();
     const writeTask = pendingWrite
       .catch((err): void => {
         console.warn(`[settings-store] Previous write to ${filename} failed:`, err instanceof Error ? err.message : err);

--- a/src/renderer/features/agents/AgentSettingsView.test.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.test.tsx
@@ -152,6 +152,7 @@ describe('AgentSettingsView', () => {
     resetStores();
 
     // Setup IPC mocks
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
     window.clubhouse.agentSettings.readInstructions = vi.fn().mockResolvedValue('Agent instructions');
     window.clubhouse.agentSettings.saveInstructions = vi.fn().mockResolvedValue(undefined);
     window.clubhouse.agentSettings.readPermissions = vi.fn().mockResolvedValue({ allow: ['Read(**)'] });

--- a/src/renderer/features/agents/AgentSettingsView.test.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.test.tsx
@@ -286,6 +286,25 @@ describe('AgentSettingsView', () => {
       expect(screen.getByText('Free Agent Mode')).toBeInTheDocument();
     });
 
+    it('hides Structured Mode toggle when experimental.structuredMode is off (default)', async () => {
+      renderSettings();
+      // Wait for async settings load to settle
+      await waitFor(() => {
+        expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('structured-mode-field')).not.toBeInTheDocument();
+      expect(screen.queryByText('Structured Mode')).not.toBeInTheDocument();
+    });
+
+    it('shows Structured Mode toggle when experimental.structuredMode is on', async () => {
+      window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({ structuredMode: true });
+      renderSettings();
+      await waitFor(() => {
+        expect(screen.getByTestId('structured-mode-field')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Structured Mode')).toBeInTheDocument();
+    });
+
     it('shows shared settings info note', () => {
       renderSettings();
       expect(screen.getByText(/Skills, agent definitions, and MCP settings/)).toBeInTheDocument();

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -227,6 +227,18 @@ export function AgentSettingsView({ agent }: Props) {
   // Structured Mode state (main agent)
   const [structuredMode, setStructuredMode] = useState(agent.structuredMode ?? false);
 
+  // Structured Mode is gated behind an experimental flag. When the flag is off
+  // the toggle is hidden — any persisted per-agent value is preserved on disk
+  // but not editable until the user opts in via experimental settings.
+  const [structuredModeFlag, setStructuredModeFlag] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => { if (!cancelled) setStructuredModeFlag(!!flags.structuredMode); })
+      .catch(() => { /* leave disabled on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
   // Quick Agent Defaults state
   const projectPath = projects.find((p) => p.id === agent.projectId)?.path;
   const [qadSystemPrompt, setQadSystemPrompt] = useState('');
@@ -757,37 +769,39 @@ export function AgentSettingsView({ agent }: Props) {
                 )}
               </div>
 
-              {/* Structured Mode */}
-              <div>
-                <label
-                  className={`flex items-center gap-2 ${
-                    !isRunning && (capabilities?.structuredMode ?? false)
-                      ? 'cursor-pointer'
-                      : 'cursor-not-allowed opacity-50'
-                  }`}
-                  title={
-                    !(capabilities?.structuredMode ?? false)
-                      ? 'Not supported by this orchestrator'
-                      : isRunning
-                      ? 'Stop agent to change this setting'
-                      : 'Run in structured mode with rich event streaming'
-                  }
-                >
-                  <input
-                    type="checkbox"
-                    checked={structuredMode}
-                    onChange={(e) => handleStructuredModeChange(e.target.checked)}
-                    disabled={isRunning || !(capabilities?.structuredMode ?? false)}
-                    className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
-                  />
-                  <span className="text-sm text-ctp-text">Structured Mode</span>
-                </label>
-                {structuredMode && (capabilities?.structuredMode ?? false) && (
-                  <p className="mt-1 text-[10px] text-ctp-subtext0 pl-6">
-                    This agent will run with rich event streaming instead of a PTY terminal.
-                  </p>
-                )}
-              </div>
+              {/* Structured Mode (experimental — hidden unless opted in) */}
+              {structuredModeFlag && (
+                <div data-testid="structured-mode-field">
+                  <label
+                    className={`flex items-center gap-2 ${
+                      !isRunning && (capabilities?.structuredMode ?? false)
+                        ? 'cursor-pointer'
+                        : 'cursor-not-allowed opacity-50'
+                    }`}
+                    title={
+                      !(capabilities?.structuredMode ?? false)
+                        ? 'Not supported by this orchestrator'
+                        : isRunning
+                        ? 'Stop agent to change this setting'
+                        : 'Run in structured mode with rich event streaming'
+                    }
+                  >
+                    <input
+                      type="checkbox"
+                      checked={structuredMode}
+                      onChange={(e) => handleStructuredModeChange(e.target.checked)}
+                      disabled={isRunning || !(capabilities?.structuredMode ?? false)}
+                      className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
+                    />
+                    <span className="text-sm text-ctp-text">Structured Mode</span>
+                  </label>
+                  {structuredMode && (capabilities?.structuredMode ?? false) && (
+                    <p className="mt-1 text-[10px] text-ctp-subtext0 pl-6">
+                      This agent will run with rich event streaming instead of a PTY terminal.
+                    </p>
+                  )}
+                </div>
+              )}
 
               {/* Free Agent Mode */}
               <div>

--- a/src/renderer/features/command-palette/use-command-source.test.ts
+++ b/src/renderer/features/command-palette/use-command-source.test.ts
@@ -171,6 +171,7 @@ vi.mock('../../plugins/plugin-commands', () => ({
 const mockStorageRead = vi.fn();
 const mockStorageWrite = vi.fn();
 const mockIsPreviewEligible = vi.fn().mockResolvedValue(true);
+const mockGetExperimentalSettings = vi.fn().mockResolvedValue({} as Record<string, boolean>);
 (window as any).clubhouse = {
   ...(window as any).clubhouse,
   plugin: {
@@ -180,6 +181,7 @@ const mockIsPreviewEligible = vi.fn().mockResolvedValue(true);
   app: {
     ...(window as any).clubhouse?.app,
     isPreviewEligible: mockIsPreviewEligible,
+    getExperimentalSettings: mockGetExperimentalSettings,
   },
 };
 
@@ -206,6 +208,8 @@ describe('useCommandSource', () => {
     mockStorageWrite.mockResolvedValue(undefined);
     // Default: preview-eligible (restored after clearAllMocks)
     mockIsPreviewEligible.mockResolvedValue(true);
+    // Default: experimental flags off (restored after clearAllMocks)
+    mockGetExperimentalSettings.mockResolvedValue({});
   });
 
   it('annex commands hidden when not preview-eligible', async () => {
@@ -663,5 +667,30 @@ describe('useCommandSource', () => {
     expect(item).toBeDefined();
     expect(item.label).toBe('Export Canvas as Blueprint');
     expect(item.category).toBe('Actions');
+  });
+
+  // ── Assistant gating: nav:assistant hidden unless experimental.assistant is on ──
+
+  it('hides nav:assistant when experimental.assistant flag is off (default)', async () => {
+    const { result } = renderHook(() => useCommandSource());
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(findItem(result.current, 'nav:assistant')).toBeUndefined();
+  });
+
+  it('shows nav:assistant when experimental.assistant flag is on', async () => {
+    mockGetExperimentalSettings.mockResolvedValueOnce({ assistant: true });
+    const { result } = renderHook(() => useCommandSource());
+    await waitFor(() => {
+      expect(findItem(result.current, 'nav:assistant')).toBeDefined();
+    });
+    const item = findItem(result.current, 'nav:assistant');
+    expect(item.label).toBe('Open Assistant');
+    expect(item.category).toBe('Navigation');
+  });
+
+  it('still shows nav:help regardless of assistant flag', async () => {
+    const { result } = renderHook(() => useCommandSource());
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(findItem(result.current, 'nav:help')).toBeDefined();
   });
 });

--- a/src/renderer/features/command-palette/use-command-source.ts
+++ b/src/renderer/features/command-palette/use-command-source.ts
@@ -81,6 +81,15 @@ export function useCommandSource(): CommandItem[] {
     }).catch(() => {});
   }, []);
 
+  // Hide assistant-related commands until the user opts in via experimental
+  // settings, so non-opted-in users don't discover the feature via the palette.
+  const [assistantEnabled, setAssistantEnabled] = useState(false);
+  useEffect(() => {
+    window.clubhouse.app.getExperimentalSettings().then((flags) => {
+      setAssistantEnabled(!!flags.assistant);
+    }).catch(() => {});
+  }, []);
+
   // Load hubs from non-active projects so the palette shows all hubs
   const [otherProjectHubs, setOtherProjectHubs] = useState<CrossProjectHub[]>([]);
   // Load canvases from non-active projects (reactive via store subscriptions)
@@ -418,13 +427,15 @@ export function useCommandSource(): CommandItem[] {
       shortcut: getShortcut(shortcuts, 'toggle-help'),
       execute: () => toggleHelp(),
     });
-    items.push({
-      id: 'nav:assistant',
-      label: 'Open Assistant',
-      category: 'Navigation',
-      shortcut: getShortcut(shortcuts, 'toggle-assistant'),
-      execute: () => useUIStore.getState().toggleAssistant(),
-    });
+    if (assistantEnabled) {
+      items.push({
+        id: 'nav:assistant',
+        label: 'Open Assistant',
+        category: 'Navigation',
+        shortcut: getShortcut(shortcuts, 'toggle-assistant'),
+        execute: () => useUIStore.getState().toggleAssistant(),
+      });
+    }
     items.push({
       id: 'nav:about',
       label: 'Open About',
@@ -433,7 +444,7 @@ export function useCommandSource(): CommandItem[] {
     });
 
     return items;
-  }, [activeProjectId, pluginsMap, projectEnabled, shortcuts, setExplorerTab, setActiveProject, toggleHelp, openAbout]);
+  }, [activeProjectId, pluginsMap, projectEnabled, shortcuts, setExplorerTab, setActiveProject, toggleHelp, openAbout, assistantEnabled]);
 
   const settingsItems = useMemo((): CommandItem[] =>
     SETTINGS_PAGES.map((sp) => {

--- a/src/renderer/features/help/HelpView.test.tsx
+++ b/src/renderer/features/help/HelpView.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useUIStore } from '../../stores/uiStore';
+import { usePluginStore } from '../../plugins/plugin-store';
+import { HelpView } from './HelpView';
+
+vi.mock('./HelpSectionNav', () => ({
+  HelpSectionNav: () => <div data-testid="help-section-nav" />,
+}));
+vi.mock('./HelpTopicList', () => ({
+  HelpTopicList: () => <div data-testid="help-topic-list" />,
+}));
+vi.mock('./HelpContentPane', () => ({
+  HelpContentPane: () => <div data-testid="help-content-pane" />,
+}));
+vi.mock('./HelpSearchResults', () => ({
+  HelpSearchResults: () => <div data-testid="help-search-results" />,
+}));
+
+function resetStores() {
+  useUIStore.setState({
+    helpSectionId: 'general',
+    helpTopicId: null,
+    helpSearchQuery: '',
+  });
+  usePluginStore.setState({
+    plugins: {},
+    appEnabled: [],
+    projectEnabled: {},
+  });
+}
+
+describe('HelpView Ask Assistant button gating', () => {
+  beforeEach(() => {
+    resetStores();
+    vi.clearAllMocks();
+  });
+
+  it('hides "Ask Assistant" button when experimental.assistant is off', async () => {
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
+    render(<HelpView />);
+    await waitFor(() => {
+      expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('ask-assistant-button')).not.toBeInTheDocument();
+  });
+
+  it('shows "Ask Assistant" button when experimental.assistant is on', async () => {
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({ assistant: true });
+    render(<HelpView />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ask-assistant-button')).toBeInTheDocument();
+    });
+  });
+
+  it('hides "Ask Assistant" button when the flag fetch rejects', async () => {
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockRejectedValue(new Error('IPC down'));
+    render(<HelpView />);
+    await waitFor(() => {
+      expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('ask-assistant-button')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/features/help/HelpView.test.tsx
+++ b/src/renderer/features/help/HelpView.test.tsx
@@ -34,10 +34,13 @@ describe('HelpView Ask Assistant button gating', () => {
   beforeEach(() => {
     resetStores();
     vi.clearAllMocks();
+    // Restore a working default before each test — `restoreMocks: true` in
+    // vitest config will revert per-test vi.fn() overrides to a no-op that
+    // returns undefined, which would crash the component's .then() call.
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
   });
 
   it('hides "Ask Assistant" button when experimental.assistant is off', async () => {
-    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
     render(<HelpView />);
     await waitFor(() => {
       expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();

--- a/src/renderer/features/help/HelpView.tsx
+++ b/src/renderer/features/help/HelpView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useEffect, useState } from 'react';
 import { useUIStore } from '../../stores/uiStore';
 import { usePluginStore } from '../../plugins/plugin-store';
 import { HELP_SECTIONS, HelpSection } from './help-content';
@@ -67,27 +67,40 @@ export function HelpView() {
 
   const setExplorerTab = useUIStore((s) => s.setExplorerTab);
 
+  // Only show "Ask Assistant" when the experimental flag is enabled, so users
+  // who haven't opted in don't see a button that opens a disabled placeholder.
+  const [assistantEnabled, setAssistantEnabled] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => { if (!cancelled) setAssistantEnabled(!!flags.assistant); })
+      .catch(() => { /* leave disabled on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
   return (
     <div className="h-full min-h-0 flex flex-col">
       <div className="flex items-center border-b border-surface-0 bg-ctp-mantle flex-shrink-0">
         <div className="flex-1">
           <HelpSearchInput query={helpSearchQuery} onQueryChange={setHelpSearchQuery} />
         </div>
-        <button
-          onClick={() => setExplorerTab('assistant')}
-          className="flex items-center gap-1.5 px-3 py-2 text-xs text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-0 transition-colors cursor-pointer flex-shrink-0"
-          title="Ask the assistant"
-          data-testid="ask-assistant-button"
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="3" y="11" width="18" height="10" rx="2" />
-            <circle cx="12" cy="5" r="2" />
-            <line x1="12" y1="7" x2="12" y2="11" />
-            <line x1="8" y1="16" x2="8" y2="16.01" />
-            <line x1="16" y1="16" x2="16" y2="16.01" />
-          </svg>
-          <span>Ask Assistant</span>
-        </button>
+        {assistantEnabled && (
+          <button
+            onClick={() => setExplorerTab('assistant')}
+            className="flex items-center gap-1.5 px-3 py-2 text-xs text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-0 transition-colors cursor-pointer flex-shrink-0"
+            title="Ask the assistant"
+            data-testid="ask-assistant-button"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="11" width="18" height="10" rx="2" />
+              <circle cx="12" cy="5" r="2" />
+              <line x1="12" y1="7" x2="12" y2="11" />
+              <line x1="8" y1="16" x2="8" y2="16.01" />
+              <line x1="16" y1="16" x2="16" y2="16.01" />
+            </svg>
+            <span>Ask Assistant</span>
+          </button>
+        )}
       </div>
       <div className={`flex-1 min-h-0 grid ${isSearching ? 'grid-cols-[300px_1fr]' : 'grid-cols-[200px_240px_1fr]'}`}>
         {isSearching ? (

--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -22,9 +22,16 @@ const mockAnnexClient = {
   retry: vi.fn(),
 };
 
+// Mock the app IPC surface used by the rail's experimental-flag fetch.
+// Default: assistant disabled, so the rail renders the Help button (the
+// pre-experiment default). Tests can override per-case via vi.spyOn.
+const mockApp = {
+  getExperimentalSettings: vi.fn(() => Promise.resolve({} as Record<string, boolean>)),
+};
+
 vi.stubGlobal('window', {
   ...globalThis.window,
-  clubhouse: { annexClient: mockAnnexClient },
+  clubhouse: { annexClient: mockAnnexClient, app: mockApp },
 });
 
 function makeProject(overrides: Partial<Project> = {}): Project {
@@ -695,15 +702,75 @@ describe('ProjectRail annex-gated plugins', () => {
     expect(canvasBtn.className).not.toContain('opacity-40');
   });
 
-  it('assistant and settings are always visible regardless of host mode', () => {
+  it('help (default) and settings are always visible regardless of host mode', () => {
     useAnnexClientStore.setState({
       satellites: [makeSatellite({ id: 'sat-1' })],
     });
     useUIStore.setState({ activeHostId: 'sat-1' });
 
     render(<ProjectRail />);
-    expect(screen.getByTestId('nav-assistant')).toBeInTheDocument();
+    // With the assistant flag off (default), the rail shows the Help button.
+    expect(screen.getByTestId('nav-help')).toBeInTheDocument();
     expect(screen.getByTestId('nav-settings')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Experimental: assistant feature flag tests
+// ---------------------------------------------------------------------------
+
+describe('ProjectRail assistant feature flag gating', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(_cb: () => void) {}
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+    resetStores();
+    mockApp.getExperimentalSettings.mockReset();
+  });
+
+  it('renders the Help button (and not Assistant) when experimental.assistant is off', async () => {
+    mockApp.getExperimentalSettings.mockResolvedValue({});
+    render(<ProjectRail />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('nav-help')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('nav-assistant')).not.toBeInTheDocument();
+  });
+
+  it('renders the Assistant button (and not Help) when experimental.assistant is on', async () => {
+    mockApp.getExperimentalSettings.mockResolvedValue({ assistant: true });
+    render(<ProjectRail />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('nav-assistant')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('nav-help')).not.toBeInTheDocument();
+  });
+
+  it('falls back to Help when the experimental settings IPC fails', async () => {
+    mockApp.getExperimentalSettings.mockRejectedValue(new Error('IPC down'));
+    render(<ProjectRail />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('nav-help')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('nav-assistant')).not.toBeInTheDocument();
+  });
+
+  it('Help button toggles help mode in the UI store', async () => {
+    mockApp.getExperimentalSettings.mockResolvedValue({});
+    render(<ProjectRail />);
+    const helpBtn = await screen.findByTestId('nav-help');
+    fireEvent.click(helpBtn);
+    expect(useUIStore.getState().explorerTab).toBe('help');
+  });
+
+  it('Assistant button toggles assistant mode when flag is on', async () => {
+    mockApp.getExperimentalSettings.mockResolvedValue({ assistant: true });
+    render(<ProjectRail />);
+    const assistantBtn = await screen.findByTestId('nav-assistant');
+    fireEvent.click(assistantBtn);
+    expect(useUIStore.getState().explorerTab).toBe('assistant');
   });
 });
 

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -259,6 +259,7 @@ export function ProjectRail() {
   const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
   const toggleSettings = useUIStore((s) => s.toggleSettings);
   const toggleAssistant = useUIStore((s) => s.toggleAssistant);
+  const toggleHelp = useUIStore((s) => s.toggleHelp);
   const explorerTab = useUIStore((s) => s.explorerTab);
   const setExplorerTab = useUIStore((s) => s.setExplorerTab);
   const previousExplorerTab = useUIStore((s) => s.previousExplorerTab);
@@ -277,6 +278,18 @@ export function ProjectRail() {
   const inSettings = explorerTab === 'settings';
   const inHelp = explorerTab === 'help';
   const inAssistant = explorerTab === 'assistant';
+
+  // Experimental: assistant feature flag. While loading (null) we render the
+  // default Help button so the rail is never blank during the IPC round-trip.
+  // When enabled, the rail shows the Assistant button in place of Help.
+  const [assistantEnabled, setAssistantEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => { if (!cancelled) setAssistantEnabled(!!flags.assistant); })
+      .catch(() => { if (!cancelled) setAssistantEnabled(false); });
+    return () => { cancelled = true; };
+  }, []);
   const isAppPlugin = explorerTab.startsWith('plugin:app:');
   const isHome = activeProjectId === null && !inSettings && !inHelp && !inAssistant && !isAppPlugin;
 
@@ -729,39 +742,73 @@ export function ProjectRail() {
         )}
 
         {/* ================================================================
-            Common footer: Help & Settings
+            Common footer: Help/Assistant & Settings
+            The Assistant button replaces Help only when the experimental
+            flag is enabled. Until the flag resolves, render Help so the
+            rail isn't blank during the async fetch.
             ================================================================ */}
         <div className="border-t border-surface-2 my-1 flex-shrink-0" />
-        <button
-          onClick={toggleAssistant}
-          title="Assistant"
-          data-testid="nav-assistant"
-          className={`w-full h-10 flex items-center gap-3 cursor-pointer rounded-lg flex-shrink-0 ${
-            expanded ? 'hover:bg-surface-0' : ''
-          }`}
-        >
-          <div
-            className={`
-              w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0
-              transition-colors duration-100
-              ${inAssistant
-                ? 'bg-ctp-accent text-white shadow-lg shadow-ctp-accent/30'
-                : expanded
-                  ? 'text-ctp-subtext0'
-                  : 'text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text'
-              }
-            `}
+        {assistantEnabled === true ? (
+          <button
+            onClick={toggleAssistant}
+            title="Assistant"
+            data-testid="nav-assistant"
+            className={`w-full h-10 flex items-center gap-3 cursor-pointer rounded-lg flex-shrink-0 ${
+              expanded ? 'hover:bg-surface-0' : ''
+            }`}
           >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="3" y="11" width="18" height="10" rx="2" />
-              <circle cx="12" cy="5" r="2" />
-              <line x1="12" y1="7" x2="12" y2="11" />
-              <line x1="8" y1="16" x2="8" y2="16.01" />
-              <line x1="16" y1="16" x2="16" y2="16.01" />
-            </svg>
-          </div>
-          <span className={`text-xs font-medium truncate pr-3 whitespace-nowrap text-ctp-text transition-opacity duration-200 ${expanded ? 'opacity-100' : 'opacity-0'}`}>Assistant</span>
-        </button>
+            <div
+              className={`
+                w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0
+                transition-colors duration-100
+                ${inAssistant
+                  ? 'bg-ctp-accent text-white shadow-lg shadow-ctp-accent/30'
+                  : expanded
+                    ? 'text-ctp-subtext0'
+                    : 'text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text'
+                }
+              `}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="11" width="18" height="10" rx="2" />
+                <circle cx="12" cy="5" r="2" />
+                <line x1="12" y1="7" x2="12" y2="11" />
+                <line x1="8" y1="16" x2="8" y2="16.01" />
+                <line x1="16" y1="16" x2="16" y2="16.01" />
+              </svg>
+            </div>
+            <span className={`text-xs font-medium truncate pr-3 whitespace-nowrap text-ctp-text transition-opacity duration-200 ${expanded ? 'opacity-100' : 'opacity-0'}`}>Assistant</span>
+          </button>
+        ) : (
+          <button
+            onClick={toggleHelp}
+            title="Help"
+            data-testid="nav-help"
+            className={`w-full h-10 flex items-center gap-3 cursor-pointer rounded-lg flex-shrink-0 ${
+              expanded ? 'hover:bg-surface-0' : ''
+            }`}
+          >
+            <div
+              className={`
+                w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0
+                transition-colors duration-100
+                ${inHelp
+                  ? 'bg-ctp-accent text-white shadow-lg shadow-ctp-accent/30'
+                  : expanded
+                    ? 'text-ctp-subtext0'
+                    : 'text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text'
+                }
+              `}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </div>
+            <span className={`text-xs font-medium truncate pr-3 whitespace-nowrap text-ctp-text transition-opacity duration-200 ${expanded ? 'opacity-100' : 'opacity-0'}`}>Help</span>
+          </button>
+        )}
         <button
           onClick={toggleSettings}
           title="Settings"


### PR DESCRIPTION
## Summary
- Restored the principle that an experimental feature must be **invisible** unless the user has opted in. Audited every flag in `ExperimentalSettings` and closed four UI leaks where the experimental surface was shown to users who hadn't opted in.
- Most visible fix: when `experimental.assistant` is off, the **Help** button comes back in the left rail (replacing the always-on Assistant button).

## Changes

### `experimental.assistant` — three leaks closed

| Surface | Before | After |
|---|---|---|
| `ProjectRail` footer | Assistant button always rendered; clicking went to disabled placeholder. Help button no longer reachable from rail. | Renders **Help** when flag off (`toggleHelp`), **Assistant** when flag on. Falls back to Help during async fetch and on IPC failure so the rail is never blank. |
| `HelpView` header | "Ask Assistant" button always visible; clicking opened disabled placeholder. | Hidden when flag off. |
| Command palette | `nav:assistant` ("Open Assistant") always registered. | Gated on `experimental.assistant`. |

### `experimental.structuredMode` — wired up

Was a dead flag: listed in the experimental settings page but never read. The per-agent **Structured Mode** toggle in `AgentSettingsView` was unconditionally rendered. Now:
- Toggle hidden when `experimental.structuredMode` is off.
- Existing per-agent `agent.structuredMode` values on disk are preserved — they just aren't editable until the user opts in.

### Already correctly gated (verified, no change needed)

- Experimental Settings page — already gated by `isPreviewEligible()` in `AccessoryPanel.tsx:23-28`. Non-preview users don't see it in settings nav.
- `experimental.agentQueue`, `experimental.sessions` — gated at plugin registration in `builtin/index.ts`. No UI when off.
- `experimental.themeGradients` — gated in `DisplaySettingsView` and `themeStore`. Graceful degradation.

## Files

| File | Change |
|---|---|
| `src/renderer/panels/ProjectRail.tsx` | Conditional Help/Assistant button based on flag |
| `src/renderer/features/help/HelpView.tsx` | Conditional "Ask Assistant" button |
| `src/renderer/features/agents/AgentSettingsView.tsx` | Conditional Structured Mode field |
| `src/renderer/features/command-palette/use-command-source.ts` | Conditional `nav:assistant` entry |
| `src/renderer/panels/ProjectRail.test.tsx` | New tests + global mock for `getExperimentalSettings` |
| `src/renderer/features/help/HelpView.test.tsx` | **New** test file for Ask Assistant gating |
| `src/renderer/features/agents/AgentSettingsView.test.tsx` | New tests for Structured Mode gating |
| `src/renderer/features/command-palette/use-command-source.test.ts` | New tests for `nav:assistant` gating |

## Test Plan

- [x] `ProjectRail`: renders Help when assistant flag off (default)
- [x] `ProjectRail`: renders Assistant when assistant flag on
- [x] `ProjectRail`: falls back to Help when IPC rejects
- [x] `ProjectRail`: Help button toggles `explorerTab='help'`; Assistant button toggles `explorerTab='assistant'`
- [x] `HelpView`: hides Ask Assistant button when flag off (default & on IPC failure)
- [x] `HelpView`: shows Ask Assistant button when flag on
- [x] `AgentSettingsView`: hides Structured Mode toggle when flag off (default)
- [x] `AgentSettingsView`: shows Structured Mode toggle when flag on
- [x] `useCommandSource`: hides `nav:assistant` when flag off; shows when flag on; `nav:help` always present
- [x] `npm run typecheck` clean
- [x] `npm test` — 11474 passed / 4 skipped, 0 failed

## Manual Validation

To verify the assistant fix in a running app:
1. Open Experimental Settings → toggle **Assistant** off → restart.
2. Confirm the rail footer now shows **Help** (question-mark icon), not Assistant.
3. Open Help → confirm the "Ask Assistant" button is gone.
4. Open ⌘K command palette → confirm "Open Assistant" is not in the list.
5. Toggle the flag back on + restart → all three reappear.

For Structured Mode:
1. With `experimental.structuredMode` off, open any agent's Settings → Main Agent tab → confirm the Structured Mode checkbox is gone (Free Agent Mode is still there).
2. Toggle the flag on → restart → confirm Structured Mode reappears.

## Notes

- `npm run lint` reports 22 pre-existing errors in unrelated files (assistant tests, canvas-blueprint test, canvas-command-handler) that are not introduced by this PR. The lines I touched lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)