### PR TITLE
fix(memory): badge cache pruning, feed history cap, file cache deactivation, annex error logging, wire serialization

### DIFF
--- a/src/main/services/annex-client.test.ts
+++ b/src/main/services/annex-client.test.ts
@@ -97,6 +97,12 @@ vi.mock('http', async (importOriginal) => {
   };
 });
 
+// Mock https module for REST endpoints (requestFileTree, requestBulletinDigest, etc.)
+vi.mock('https', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('https')>();
+  return { ...actual, get: vi.fn() };
+});
+
 import * as annexClient from './annex-client';
 import * as annexPeers from './annex-peers';
 import * as annexIdentity from './annex-identity';
@@ -104,6 +110,7 @@ import * as annexSettings from './annex-settings';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { IPC } from '../../shared/ipc-channels';
 import * as http from 'http';
+import * as https from 'https';
 
 /** Reset all mock implementations after vi.clearAllMocks() */
 function resetAllMocks() {
@@ -1045,6 +1052,146 @@ describe('annex-client', () => {
       expect(satsAfter[0].lastError).toBe('Heartbeat ping failed');
 
       vi.useRealTimers();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // LB-AN-001: REST error handlers log warnings instead of swallowing errors
+  // -------------------------------------------------------------------------
+
+  describe('LB-AN-001: REST endpoint error logging', () => {
+    const FINGERPRINT = 'AA:BB:CC:EE';
+
+    async function connectSatellite() {
+      const { WebSocket: WsMock } = await import('ws');
+
+      mockHttpGetIdentity({
+        fingerprint: FINGERPRINT,
+        alias: 'Rest Satellite',
+        icon: 'server',
+        color: 'blue',
+        publicKey: 'rest-pub-key',
+      });
+
+      vi.mocked(annexPeers.getPeer).mockReturnValue({
+        fingerprint: FINGERPRINT,
+        alias: 'Rest Satellite',
+        icon: 'server',
+        color: 'blue',
+        publicKey: 'rest-pub-key',
+        pairedAt: '2024-01-01',
+        lastSeen: '2024-01-01',
+      });
+
+      let openCb: (() => void) | null = null;
+
+      vi.mocked(WsMock).mockImplementation(function (this: any) {
+        this.readyState = 1;
+        this.on = vi.fn().mockImplementation((event: string, cb: any) => {
+          if (event === 'open') openCb = cb;
+          return this;
+        });
+        this.send = vi.fn();
+        this.ping = vi.fn();
+        this.close = vi.fn();
+        this.terminate = vi.fn();
+        this.removeListener = vi.fn();
+        return this;
+      } as any);
+
+      vi.useFakeTimers();
+      annexClient.startClient();
+      await bonjourFindCallback!(makeService());
+      await vi.advanceTimersByTimeAsync(0);
+      openCb!();
+      vi.useRealTimers();
+    }
+
+    function mockHttpsGetNetworkError() {
+      vi.mocked(https.get).mockImplementation((_url: any, _opts: any, _cb: any) => {
+        const req = {
+          on: vi.fn().mockImplementation((event: string, cb: any) => {
+            if (event === 'error') cb(new Error('ECONNREFUSED'));
+            return req;
+          }),
+          setTimeout: vi.fn(),
+          destroy: vi.fn(),
+        };
+        return req as any;
+      });
+    }
+
+    function mockHttpsGetMalformedJson() {
+      vi.mocked(https.get).mockImplementation((_url: any, _opts: any, cb: any) => {
+        const res = {
+          statusCode: 200,
+          resume: vi.fn(),
+          on: vi.fn().mockImplementation((event: string, handler: any) => {
+            if (event === 'data') handler(Buffer.from('not json!!!'));
+            if (event === 'end') handler();
+            return res;
+          }),
+        };
+        cb(res);
+        const req = { on: vi.fn().mockReturnThis(), setTimeout: vi.fn(), destroy: vi.fn() };
+        return req as any;
+      });
+    }
+
+    it('requestFileTree logs warn on network error', async () => {
+      await connectSatellite();
+      const { appLog } = await import('./log-service');
+      vi.mocked(appLog).mockClear();
+      mockHttpsGetNetworkError();
+
+      await annexClient.requestFileTree(FINGERPRINT, 'proj-1');
+
+      expect(appLog).toHaveBeenCalledWith(
+        'core:annex-client', 'warn', 'File tree request failed',
+        expect.objectContaining({ meta: expect.objectContaining({ fingerprint: FINGERPRINT }) }),
+      );
+    });
+
+    it('requestFileTree logs warn on JSON parse failure', async () => {
+      await connectSatellite();
+      const { appLog } = await import('./log-service');
+      vi.mocked(appLog).mockClear();
+      mockHttpsGetMalformedJson();
+
+      await annexClient.requestFileTree(FINGERPRINT, 'proj-1');
+
+      expect(appLog).toHaveBeenCalledWith(
+        'core:annex-client', 'warn', 'File tree response JSON parse failed',
+        expect.objectContaining({ meta: expect.objectContaining({ fingerprint: FINGERPRINT }) }),
+      );
+    });
+
+    it('requestBulletinDigest logs warn on network error', async () => {
+      await connectSatellite();
+      const { appLog } = await import('./log-service');
+      vi.mocked(appLog).mockClear();
+      mockHttpsGetNetworkError();
+
+      await annexClient.requestBulletinDigest(FINGERPRINT, 'gp-1');
+
+      expect(appLog).toHaveBeenCalledWith(
+        'core:annex-client', 'warn', 'Bulletin digest request failed',
+        expect.objectContaining({ meta: expect.objectContaining({ fingerprint: FINGERPRINT }) }),
+      );
+    });
+
+    it('requestBulletinTopicMessages logs warn on network error', async () => {
+      await connectSatellite();
+      const { appLog } = await import('./log-service');
+      vi.mocked(appLog).mockClear();
+      mockHttpsGetNetworkError();
+
+      await annexClient.requestBulletinTopicMessages(FINGERPRINT, 'gp-1', 'progress');
+
+      expect(appLog).toHaveBeenCalledWith(
+        'core:annex-client', 'warn', 'Bulletin topic messages request failed',
+        expect.objectContaining({ meta: expect.objectContaining({ fingerprint: FINGERPRINT }) }),
+      );
     });
   });
 });

--- a/src/main/services/annex-client.ts
+++ b/src/main/services/annex-client.ts
@@ -193,7 +193,10 @@ async function seedAndGetBuffer(satelliteId: string, agentId: string): Promise<s
         res.on('data', (chunk: Buffer) => chunks.push(chunk));
         res.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
       });
-      req.on('error', () => resolve(''));
+      req.on('error', (err) => {
+        appLog('core:annex-client', 'warn', 'Agent buffer fetch failed', { meta: { satelliteId, agentId, error: err.message } });
+        resolve('');
+      });
       req.on('timeout', () => { req.destroy(); resolve(''); });
     });
 
@@ -858,10 +861,16 @@ export function requestFileTree(fingerprint: string, projectId: string, options?
       res.on('data', (chunk: Buffer) => chunks.push(chunk));
       res.on('end', () => {
         try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8'))); }
-        catch { resolve([]); }
+        catch (err) {
+          appLog('core:annex-client', 'warn', 'File tree response JSON parse failed', { meta: { fingerprint, error: String(err) } });
+          resolve([]);
+        }
       });
     });
-    req.on('error', () => resolve([]));
+    req.on('error', (err) => {
+      appLog('core:annex-client', 'warn', 'File tree request failed', { meta: { fingerprint, error: err.message } });
+      resolve([]);
+    });
     req.on('timeout', () => { req.destroy(); resolve([]); });
   });
 }
@@ -912,10 +921,16 @@ export function requestBulletinDigest(fingerprint: string, groupProjectId: strin
       res.on('data', (chunk: Buffer) => chunks.push(chunk));
       res.on('end', () => {
         try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8'))); }
-        catch { resolve([]); }
+        catch (err) {
+          appLog('core:annex-client', 'warn', 'Bulletin digest response JSON parse failed', { meta: { fingerprint, error: String(err) } });
+          resolve([]);
+        }
       });
     });
-    req.on('error', () => resolve([]));
+    req.on('error', (err) => {
+      appLog('core:annex-client', 'warn', 'Bulletin digest request failed', { meta: { fingerprint, error: err.message } });
+      resolve([]);
+    });
     req.on('timeout', () => { req.destroy(); resolve([]); });
   });
 }
@@ -942,10 +957,16 @@ export function requestBulletinTopicMessages(fingerprint: string, groupProjectId
       res.on('data', (chunk: Buffer) => chunks.push(chunk));
       res.on('end', () => {
         try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8'))); }
-        catch { resolve([]); }
+        catch (err) {
+          appLog('core:annex-client', 'warn', 'Bulletin topic messages response JSON parse failed', { meta: { fingerprint, error: String(err) } });
+          resolve([]);
+        }
       });
     });
-    req.on('error', () => resolve([]));
+    req.on('error', (err) => {
+      appLog('core:annex-client', 'warn', 'Bulletin topic messages request failed', { meta: { fingerprint, error: err.message } });
+      resolve([]);
+    });
     req.on('timeout', () => { req.destroy(); resolve([]); });
   });
 }
@@ -996,10 +1017,16 @@ export function requestBulletinAllMessages(
       res.on('data', (chunk: Buffer) => chunks.push(chunk));
       res.on('end', () => {
         try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8'))); }
-        catch { resolve([]); }
+        catch (err) {
+          appLog('core:annex-client', 'warn', 'Bulletin all-messages response JSON parse failed', { meta: { fingerprint, error: String(err) } });
+          resolve([]);
+        }
       });
     });
-    req.on('error', () => resolve([]));
+    req.on('error', (err) => {
+      appLog('core:annex-client', 'warn', 'Bulletin all-messages request failed', { meta: { fingerprint, error: err.message } });
+      resolve([]);
+    });
     req.on('timeout', () => { req.destroy(); resolve([]); });
   });
 }

--- a/src/renderer/features/assistant/assistant-agent.test.ts
+++ b/src/renderer/features/assistant/assistant-agent.test.ts
@@ -530,4 +530,39 @@ describe('assistant-agent', () => {
       });
     });
   });
+
+  describe('LB-AG-005: feed history cap', () => {
+    it('loadHistory caps feed at MAX_FEED_ITEMS (500) when more are stored', async () => {
+      const oversized = Array.from({ length: 501 }, (_, i) => ({
+        type: 'message' as const,
+        message: { id: `msg-${i}`, role: 'user' as const, content: `msg ${i}`, timestamp: i },
+      }));
+      mockLoadHistory.mockResolvedValueOnce(oversized);
+      await agent.loadHistory();
+      expect(agent.getFeedItems()).toHaveLength(500);
+    });
+
+    it('loadHistory keeps the most recent items when capping', async () => {
+      const oversized = Array.from({ length: 502 }, (_, i) => ({
+        type: 'message' as const,
+        message: { id: `msg-${i}`, role: 'user' as const, content: `msg ${i}`, timestamp: i },
+      }));
+      mockLoadHistory.mockResolvedValueOnce(oversized);
+      await agent.loadHistory();
+      const items = agent.getFeedItems();
+      // First 2 items (oldest) should be trimmed; item at index 2 becomes index 0
+      expect(items[0].message?.content).toBe('msg 2');
+      expect(items[499].message?.content).toBe('msg 501');
+    });
+
+    it('loadHistory preserves all items when under the cap', async () => {
+      const under = Array.from({ length: 10 }, (_, i) => ({
+        type: 'message' as const,
+        message: { id: `msg-${i}`, role: 'user' as const, content: `msg ${i}`, timestamp: i },
+      }));
+      mockLoadHistory.mockResolvedValueOnce(under);
+      await agent.loadHistory();
+      expect(agent.getFeedItems()).toHaveLength(10);
+    });
+  });
 });

--- a/src/renderer/features/assistant/assistant-agent.ts
+++ b/src/renderer/features/assistant/assistant-agent.ts
@@ -46,6 +46,7 @@ const statusListeners = new Set<StatusListener>();
 const modeListeners = new Set<ModeListener>();
 const orchestratorListeners = new Set<OrchestratorListener>();
 const agentIdListeners = new Set<AgentIdListener>();
+const MAX_FEED_ITEMS = 500;
 const pendingItems: FeedItem[] = [];
 let cleanupListeners: Array<() => void> = [];
 let messageQueue: string[] = [];
@@ -69,6 +70,9 @@ function setAgentId(agentId: string | null): void {
 
 function pushItem(item: FeedItem): void {
   pendingItems.push(item);
+  if (pendingItems.length > MAX_FEED_ITEMS) {
+    pendingItems.splice(0, pendingItems.length - MAX_FEED_ITEMS);
+  }
   notifyFeedListeners();
 }
 
@@ -542,7 +546,8 @@ export async function loadHistory(): Promise<void> {
     const items = await window.clubhouse.assistant.loadHistory();
     if (items && Array.isArray(items) && items.length > 0) {
       pendingItems.length = 0;
-      for (const item of items) {
+      const capped = items.length > MAX_FEED_ITEMS ? items.slice(-MAX_FEED_ITEMS) : items;
+      for (const item of capped) {
         pendingItems.push(item);
       }
       notifyFeedListeners();

--- a/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
@@ -1014,4 +1014,62 @@ describe('hydrateFromRemote', () => {
       expect(store.getState().minimapAutoHide).toBe(false);
     });
   });
+
+  describe('LB-CB-001: loadWires re-entry guard', () => {
+    const mockMcpBindingWires = {
+      bind: vi.fn().mockResolvedValue(undefined),
+      setInstructions: vi.fn().mockResolvedValue(undefined),
+      setDisabledTools: vi.fn().mockResolvedValue(undefined),
+    };
+
+    beforeEach(() => {
+      (globalThis as any).window = {
+        ...(globalThis as any).window,
+        clubhouse: {
+          ...((globalThis as any).window?.clubhouse || {}),
+          mcpBinding: mockMcpBindingWires,
+          groupProject: { get: vi.fn().mockResolvedValue(null) },
+        },
+      };
+      mockMcpBindingWires.bind.mockClear();
+    });
+
+    it('second concurrent loadWires call is a no-op (re-entry guard)', async () => {
+      const wire = { agentId: 'a1', targetId: 'a2', targetKind: 'agent' as const, label: 'L', agentName: 'x', targetName: 'y', projectName: 'p' };
+      let resolveRead!: (v: unknown) => void;
+      const slowStorage: ScopedStorage = {
+        read: vi.fn(() => new Promise((resolve) => { resolveRead = resolve; })),
+        write: vi.fn(),
+        delete: vi.fn(),
+        list: vi.fn().mockResolvedValue([]),
+      };
+
+      // Kick off first load (will block on storage.read)
+      const first = store.getState().loadWires(slowStorage);
+      // Second concurrent call should return immediately without re-entering
+      const second = store.getState().loadWires(slowStorage);
+
+      // Resolve both
+      resolveRead([wire]);
+      await Promise.all([first, second]);
+
+      // storage.read should only have been called once despite two concurrent calls
+      expect(slowStorage.read).toHaveBeenCalledTimes(1);
+    });
+
+    it('loadWires can run again after completing', async () => {
+      const wire = { agentId: 'a1', targetId: 'a2', targetKind: 'agent' as const, label: 'L', agentName: 'x', targetName: 'y', projectName: 'p' };
+      const storage = createMockStorage({ 'canvas-wires': [wire] });
+
+      await store.getState().loadWires(storage);
+      expect(store.getState().wiresLoaded).toBe(true);
+
+      // Reset wiresLoaded to simulate a fresh state (e.g. new session)
+      store.setState({ wiresLoaded: false, wireDefinitions: [] });
+
+      // Second sequential call should proceed normally
+      await store.getState().loadWires(storage);
+      expect(store.getState().wireDefinitions).toHaveLength(1);
+    });
+  });
 });

--- a/src/renderer/plugins/builtin/canvas/canvas-store.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.ts
@@ -174,6 +174,7 @@ function syncDerivedState(canvases: CanvasInstance[], activeCanvasId: string): P
 
 export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
   const initialCanvas = createCanvasInstance();
+  let _wiresLoading = false;
 
   return create<CanvasState>((set, get) => ({
     canvases: [initialCanvas],
@@ -266,6 +267,8 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
     },
 
     loadWires: async (storage) => {
+      if (_wiresLoading) return;
+      _wiresLoading = true;
       try {
         const saved = await storage.read(STORAGE_KEY_WIRES) as McpBindingEntry[] | null;
         if (!saved || !Array.isArray(saved) || saved.length === 0) {
@@ -336,6 +339,8 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         // Storage read failed — skip wire restore, but mark as loaded so
         // auto-save is not permanently blocked.
         set({ wiresLoaded: true });
+      } finally {
+        _wiresLoading = false;
       }
     },
 

--- a/src/renderer/plugins/builtin/files/FileViewer.test.tsx
+++ b/src/renderer/plugins/builtin/files/FileViewer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { FileViewer } from './FileViewer';
+import { FileViewer, clearFileCache } from './FileViewer';
 import { fileState } from './state';
 import { createMockAPI } from '../../testing';
 
@@ -68,6 +68,7 @@ function selectFile(path: string) {
 describe('FileViewer', () => {
   beforeEach(() => {
     fileState.reset();
+    clearFileCache();
     lastOnSave = null;
   });
 
@@ -191,5 +192,34 @@ describe('FileViewer', () => {
     });
 
     expect(screen.queryByText('Ln 1, Col 1')).not.toBeInTheDocument();
+  });
+
+  describe('LB-PU-001: module-level cache cleared on deactivate', () => {
+    it('clearFileCache is exported and callable without throwing', () => {
+      expect(() => clearFileCache()).not.toThrow();
+    });
+
+    it('clearFileCache causes next file load to re-fetch from API', async () => {
+      const api = createViewerAPI();
+      const { unmount } = render(<FileViewer api={api} />);
+
+      // Load a file — populates the module-level cache
+      selectFile('hello.ts');
+      await waitFor(() => expect(screen.getByTestId('monaco-editor')).toBeInTheDocument());
+      expect(api.files.readFile).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      // Simulate plugin deactivation: clear the module-level cache
+      clearFileCache();
+
+      // Re-mount with the same file already selected in state
+      const api2 = createViewerAPI();
+      render(<FileViewer api={api2} />);
+
+      selectFile('hello.ts');
+      await waitFor(() => expect(api2.files.readFile).toHaveBeenCalledTimes(1));
+      // api2 must have been called — proves the cache was cleared and re-fetched
+    });
   });
 });

--- a/src/renderer/plugins/builtin/files/FileViewer.ts
+++ b/src/renderer/plugins/builtin/files/FileViewer.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import type { PluginAPI } from '../../../../shared/plugin-types';
 import { fileState } from './state';
 import type { Tab, ScrollState } from './state';
@@ -33,6 +33,13 @@ interface LoadedFile {
   content: string;
   binaryData: string;
   fileType: FileType;
+}
+
+// Module-level cache shared across component mounts; cleared on plugin deactivation.
+const _fileCache = new Map<string, LoadedFile>();
+
+export function clearFileCache(): void {
+  _fileCache.clear();
 }
 
 // ── Unsaved Changes Dialog ────────────────────────────────────────────
@@ -134,9 +141,6 @@ export function FileViewer({ api }: { api: PluginAPI }) {
   const [cursorLine, setCursorLine] = useState(1);
   const [cursorColumn, setCursorColumn] = useState(1);
 
-  // Cache of loaded file data per path to avoid reloading on tab switch
-  const fileCache = useRef<Map<string, LoadedFile>>(new Map());
-
   // ── Subscribe to tab state changes ────────────────────────────────
 
   useEffect(() => {
@@ -157,7 +161,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
 
   const loadFile = useCallback(async (relativePath: string): Promise<LoadedFile> => {
     // Check cache first
-    const cached = fileCache.current.get(relativePath);
+    const cached = _fileCache.get(relativePath);
     if (cached) return cached;
 
     const ext = getExtension(relativePath);
@@ -201,7 +205,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
       result.fileType = 'none';
     }
 
-    fileCache.current.set(relativePath, result);
+    _fileCache.set(relativePath, result);
     return result;
   }, [api]);
 
@@ -277,7 +281,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
         pendingAction: () => {
           // Dispose the Monaco model for this file
           disposeModel(tab.filePath);
-          fileCache.current.delete(tab.filePath);
+          _fileCache.delete(tab.filePath);
           fileState.closeTab(tabId);
         },
       });
@@ -285,7 +289,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
     }
 
     disposeModel(tab.filePath);
-    fileCache.current.delete(tab.filePath);
+    _fileCache.delete(tab.filePath);
     fileState.closeTab(tabId);
   }, []);
 
@@ -324,7 +328,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
       fileState.setTabDirty(activeTab.id, false);
       fileState.triggerRefresh();
       // Update cache
-      const cached = fileCache.current.get(activeTab.filePath);
+      const cached = _fileCache.get(activeTab.filePath);
       if (cached) {
         cached.content = newContent;
       }

--- a/src/renderer/plugins/builtin/files/main.ts
+++ b/src/renderer/plugins/builtin/files/main.ts
@@ -3,7 +3,7 @@ import type { PluginContext, PluginAPI, PluginModule } from '../../../../shared/
 import { fileState } from './state';
 import { disposeAllModels } from './MonacoEditor';
 import { FileTree } from './FileTree';
-import { FileViewer } from './FileViewer';
+import { FileViewer, clearFileCache } from './FileViewer';
 import { SearchPanel } from './SearchPanel';
 import { FileViewerCanvasWidget } from './FileViewerCanvasWidget';
 
@@ -100,6 +100,7 @@ export function activate(ctx: PluginContext, api: PluginAPI): void {
 export function deactivate(): void {
   fileState.reset();
   disposeAllModels();
+  clearFileCache();
 }
 
 function SidebarWrapper({ api }: { api: PluginAPI }) {

--- a/src/renderer/stores/projectStore.test.ts
+++ b/src/renderer/stores/projectStore.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Project } from '../../shared/types';
+import { useBadgeStore } from './badgeStore';
+import { useBadgeSettingsStore } from './badgeSettingsStore';
 
 // ---------- IPC mock ----------
 const mockProject = {
@@ -48,6 +50,8 @@ describe('projectStore', () => {
       gitStatus: {},
       projectIcons: {},
     });
+    useBadgeStore.setState({ badges: {} });
+    useBadgeSettingsStore.setState({ enabled: true, pluginBadges: true, projectRailBadges: true, projectOverrides: {} });
   });
 
   // ---- defaults ----
@@ -211,6 +215,23 @@ describe('projectStore', () => {
       await getState().removeProject('proj_2');
 
       expect(getState().activeProjectId).toBe('proj_1');
+    });
+
+    it('LB-SM-002: clears badge store entries for the removed project', async () => {
+      const p = makeProject();
+      useProjectStore.setState({ projects: [p], activeProjectId: 'proj_1' });
+      // Plant badges for this project
+      useBadgeStore.getState().setBadge('core:agents', 'count', 3, { kind: 'explorer-tab', projectId: 'proj_1', tabId: 'agents' });
+      useBadgeStore.getState().setBadge('plugin:files', 'dot', 1, { kind: 'explorer-tab', projectId: 'proj_1', tabId: 'plugin:files' });
+      // Plant a badge for a different project (should survive)
+      useBadgeStore.getState().setBadge('core:agents', 'count', 5, { kind: 'explorer-tab', projectId: 'proj_2', tabId: 'agents' });
+
+      await getState().removeProject('proj_1');
+
+      // proj_1 badges should be gone
+      expect(useBadgeStore.getState().getProjectBadge('proj_1')).toBeNull();
+      // proj_2 badge should remain
+      expect(useBadgeStore.getState().getProjectBadge('proj_2')).not.toBeNull();
     });
   });
 

--- a/src/renderer/stores/projectStore.ts
+++ b/src/renderer/stores/projectStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { Project } from '../../shared/types';
+import { useBadgeStore } from './badgeStore';
 
 interface ProjectState {
   projects: Project[];
@@ -76,6 +77,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           : s.activeProjectId;
       return { projects, activeProjectId, gitStatus, projectIcons };
     });
+    useBadgeStore.getState().clearProjectBadges(id);
   },
 
   pickAndAddProject: async () => {


### PR DESCRIPTION
## Summary
- **LB-SM-002** — Prune badge cache when a project is deleted to prevent stale badge entries accumulating indefinitely
- **LB-AG-005** — Cap assistant feed history at 500 items (in `pushItem` and `loadHistory`) to prevent unbounded memory growth in long sessions
- **LB-PU-001** — Move FileViewer file content cache to module scope and clear it on plugin deactivation to free stale data
- **LB-AN-001** — Replace 9 silent `req.on('error')` and JSON `catch {}` handlers in `annex-client.ts` with `appLog('warn')` calls
- **LB-CB-001** — Add `_wiresLoading` re-entry guard to `canvas-store.loadWires` to prevent concurrent wire restoration corrupting state

## Changes

### `src/renderer/stores/projectStore.ts`
- `removeProject` now calls `useBadgeStore.getState().clearProjectBadges(id)` after removing the project from state

### `src/renderer/features/assistant/assistant-agent.ts`
- Added `MAX_FEED_ITEMS = 500` constant
- `pushItem` trims oldest items when the feed exceeds 500
- `loadHistory` caps history at 500 most-recent items on restore

### `src/renderer/plugins/builtin/files/FileViewer.ts`
- Moved per-component `useRef` file cache to module-level `_fileCache` Map
- Added exported `clearFileCache()` function
- All `fileCache.current.*` references updated to `_fileCache.*`

### `src/renderer/plugins/builtin/files/main.ts`
- `deactivate()` now imports and calls `clearFileCache()`

### `src/main/services/annex-client.ts`
- `requestFileTree` — network error and JSON parse failure both log `appLog('warn')`
- `requestBulletinDigest` — same
- `requestBulletinTopicMessages` — same
- `requestBulletinAllMessages` — same
- `seedAndGetBuffer` — agent buffer fetch network error logs `appLog('warn')`

### `src/renderer/plugins/builtin/canvas/canvas-store.ts`
- Added `_wiresLoading` closure variable in `createCanvasStore`
- `loadWires` returns early if already in progress; resets flag in `finally`

## Test Plan
- [x] `projectStore.test.ts` — `LB-SM-002: clears badge store entries for the removed project` — verifies `getProjectBadge` returns null after `removeProject`, and other project badges survive
- [x] `assistant-agent.test.ts` — 3 new `LB-AG-005` tests: cap at 500 items, most-recent items kept, under-cap preserved
- [x] `FileViewer.test.tsx` — 2 new `LB-PU-001` tests: `clearFileCache` is callable, cleared cache causes re-fetch on next mount
- [x] `annex-client.test.ts` — 4 new `LB-AN-001` tests: network errors and JSON parse failures in REST endpoints log `appLog('warn')`
- [x] `canvas-store.test.ts` — 2 new `LB-CB-001` tests: concurrent `loadWires` calls only run storage.read once; sequential calls both succeed
- [x] All 11,510 existing tests pass
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] No new lint errors in changed files

## Manual Validation
- Delete a project and confirm no stale badge count persists in the dock or project rail
- Open 500+ messages in the assistant chat and confirm the feed stays bounded
- Deactivate the Files plugin and re-activate; confirm file content is re-fetched (not stale cache)
- Disconnect from a satellite and confirm network errors appear in app logs