### PR TITLE
fix(experimental): close Structured Mode bleed in agent dialogs + runtime

### DIFF
--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -47,6 +47,14 @@ vi.mock('./headless-settings', () => ({
   getSpawnMode: (...args: unknown[]) => mockGetSpawnMode(...args),
 }));
 
+// Mock experimental-settings — default to structuredMode ON so existing
+// structured-spawn tests don't need to be rewritten. Tests that need the
+// flag off can override mockGetExperimentalSettings.
+const mockGetExperimentalSettings = vi.fn(() => ({ structuredMode: true }));
+vi.mock('./experimental-settings', () => ({
+  getSettings: () => mockGetExperimentalSettings(),
+}));
+
 // Mock hook-server
 vi.mock('./hook-server', () => ({
   waitReady: vi.fn(() => Promise.resolve(12345)),
@@ -1296,6 +1304,35 @@ describe('agent-system', () => {
         cwd: '/project',
         kind: 'quick',
         mission: '   ',
+      });
+
+      expect(mockStartStructured).not.toHaveBeenCalled();
+      expect(mockPtySpawn).toHaveBeenCalled();
+    });
+
+    it('falls back to PTY for a quick agent in structured spawn mode when experimental.structuredMode flag is off', async () => {
+      mockGetExperimentalSettings.mockReturnValueOnce({ structuredMode: false });
+      await spawnAgent({
+        agentId: 'test-structured',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'quick',
+        mission: 'test',
+      });
+
+      expect(mockStartStructured).not.toHaveBeenCalled();
+      expect(mockPtySpawn).toHaveBeenCalled();
+    });
+
+    it('falls back to PTY for a durable agent with structuredMode=true when experimental.structuredMode flag is off', async () => {
+      mockGetExperimentalSettings.mockReturnValueOnce({ structuredMode: false });
+      await spawnAgent({
+        agentId: 'test-durable-structured',
+        projectPath: '/project',
+        cwd: '/project',
+        kind: 'durable',
+        mission: 'build feature',
+        structuredMode: true,
       });
 
       expect(mockStartStructured).not.toHaveBeenCalled();

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -13,6 +13,7 @@ import { getDurableConfig, addSessionEntry } from './agent-config';
 import { materializeAgent, cleanupStaleJsonInTomlConfigs } from './materialization-service';
 import * as profileSettings from './profile-settings';
 import { readProjectAgentDefaults, readLaunchWrapper, readDefaultMcps } from './agent-settings-service';
+import * as experimentalSettings from './experimental-settings';
 import * as structuredManager from './structured-manager';
 import { applyLaunchWrapper } from '../orchestrators/shared';
 import type { LaunchWrapperConfig, FreeAgentPermissionMode } from '../../shared/types';
@@ -171,7 +172,12 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
     // Durable agents opt in via per-agent structuredMode config flag.
     // TODO: Apply launch wrapper transform to structured path once adapter architecture supports external binary override
     const spawnMode = headlessSettings.getSpawnMode(params.projectPath);
-    const useStructured = (spawnMode === 'structured' && params.kind === 'quick') || params.structuredMode;
+    // Structured Mode is gated behind an experimental flag. When the flag is off,
+    // ignore both the per-agent durable config and project spawn-mode preference
+    // so existing behavior is preserved for opted-out users.
+    const structuredFlagEnabled = !!experimentalSettings.getSettings().structuredMode;
+    const useStructured = structuredFlagEnabled
+      && ((spawnMode === 'structured' && params.kind === 'quick') || !!params.structuredMode);
     const hasMission = !!params.mission && params.mission.trim() !== '';
     // For durable agents in structured mode without a mission, use a default open-ended prompt.
     // This allows the structured UI to launch and accept messages interactively.

--- a/src/renderer/features/agents/AddAgentDialog.test.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { AddAgentDialog } from './AddAgentDialog';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 
@@ -39,7 +39,7 @@ function resetStores() {
         id: 'claude-code',
         displayName: 'Claude Code',
         shortName: 'CC',
-        capabilities: { headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true },
+        capabilities: { headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true, structuredMode: true },
       },
     ],
     availability: { 'claude-code': { available: true } },
@@ -56,6 +56,8 @@ describe('AddAgentDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStores();
+    // Reset experimental flag mock to default (off) for each test.
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
   });
 
   it('renders without crash', () => {
@@ -142,5 +144,46 @@ describe('AddAgentDialog', () => {
     expect(defaultProps.onCreate).toHaveBeenCalledWith(
       'test-agent', 'indigo', 'default', true, 'claude-code', undefined, undefined, undefined,
     );
+  });
+
+  describe('Structured Mode gating (experimental flag)', () => {
+    it('hides Structured Mode toggle when experimental.structuredMode is off (default)', async () => {
+      render(<AddAgentDialog {...defaultProps} />);
+      // Wait for async settings load to settle
+      await waitFor(() => {
+        expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('structured-mode-field')).not.toBeInTheDocument();
+      expect(screen.queryByText('Use Structured Mode')).not.toBeInTheDocument();
+    });
+
+    it('shows Structured Mode toggle when experimental.structuredMode is on', async () => {
+      window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({ structuredMode: true });
+      render(<AddAgentDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByTestId('structured-mode-field')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Use Structured Mode')).toBeInTheDocument();
+    });
+
+    it('keeps Structured Mode hidden when getExperimentalSettings rejects', async () => {
+      window.clubhouse.app.getExperimentalSettings = vi.fn().mockRejectedValue(new Error('IPC down'));
+      render(<AddAgentDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('structured-mode-field')).not.toBeInTheDocument();
+    });
+
+    it('does not propagate structuredMode in onCreate when flag is off', async () => {
+      render(<AddAgentDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+      });
+      fireEvent.click(screen.getByText('Create Agent'));
+      // Last positional arg (structuredMode) must be undefined
+      const callArgs = (defaultProps.onCreate as any).mock.calls[0];
+      expect(callArgs[callArgs.length - 1]).toBeUndefined();
+    });
   });
 });

--- a/src/renderer/features/agents/AddAgentDialog.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.tsx
@@ -31,6 +31,17 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
   const supportsPermissions = selectedOrch?.capabilities?.permissions ?? false;
   const supportsStructured = selectedOrch?.capabilities?.structuredMode ?? false;
 
+  // Structured Mode is gated behind an experimental flag — hide the toggle
+  // entirely when the flag is off so the surface is invisible to opted-out users.
+  const [structuredModeFlag, setStructuredModeFlag] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => { if (!cancelled) setStructuredModeFlag(!!flags.structuredMode); })
+      .catch(() => { /* leave hidden on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     if (!projectPath) return;
     Promise.all([
@@ -47,7 +58,10 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
-    onCreate(name.trim(), color, model, useWorktree, orchestrator, freeAgentMode || undefined, selectedMcps.length > 0 ? selectedMcps : undefined, structuredMode || undefined);
+    // Never propagate structuredMode when the experimental flag is off — keeps
+    // a stale checkbox state from a prior render from leaking into the agent.
+    const sm = structuredModeFlag && structuredMode ? true : undefined;
+    onCreate(name.trim(), color, model, useWorktree, orchestrator, freeAgentMode || undefined, selectedMcps.length > 0 ? selectedMcps : undefined, sm);
   };
 
   return (
@@ -160,23 +174,26 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
             </span>
           </label>
 
-          {/* Structured Mode */}
-          <label
-            className={`flex items-center gap-2 mb-3 ${supportsStructured ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
-            title={supportsStructured ? 'Run in structured mode with rich event streaming' : 'Not supported by this orchestrator'}
-          >
-            <input
-              type="checkbox"
-              checked={structuredMode}
-              onChange={(e) => setStructuredMode(e.target.checked)}
-              disabled={!supportsStructured}
-              className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
-            />
-            <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use Structured Mode</span>
-            <span className="text-[10px] text-ctp-subtext0/70 ml-1">
-              {supportsStructured ? '(rich event UI)' : '(not supported)'}
-            </span>
-          </label>
+          {/* Structured Mode (experimental — hidden unless opted in) */}
+          {structuredModeFlag && (
+            <label
+              data-testid="structured-mode-field"
+              className={`flex items-center gap-2 mb-3 ${supportsStructured ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+              title={supportsStructured ? 'Run in structured mode with rich event streaming' : 'Not supported by this orchestrator'}
+            >
+              <input
+                type="checkbox"
+                checked={structuredMode}
+                onChange={(e) => setStructuredMode(e.target.checked)}
+                disabled={!supportsStructured}
+                className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
+              />
+              <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use Structured Mode</span>
+              <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+                {supportsStructured ? '(rich event UI)' : '(not supported)'}
+              </span>
+            </label>
+          )}
 
           {/* Free Agent Mode */}
           <label

--- a/src/renderer/features/agents/TemplateConfigDialog.test.tsx
+++ b/src/renderer/features/agents/TemplateConfigDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TemplateConfigDialog } from './TemplateConfigDialog';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 
@@ -79,6 +79,8 @@ describe('TemplateConfigDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStores();
+    // Reset experimental flag mock to default (off) for each test.
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
   });
 
   it('renders with persona name in header', () => {
@@ -179,5 +181,36 @@ describe('TemplateConfigDialog', () => {
     const call = defaultProps.onCreate.mock.calls[0][0];
     expect(call.persona.id).toBe('qa');
     expect(call.persona.content).toBe('# QA\nTesting instructions...');
+  });
+
+  describe('Structured Mode gating (experimental flag)', () => {
+    it('hides Structured Mode toggle when experimental.structuredMode is off (default)', async () => {
+      render(<TemplateConfigDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('structured-mode-field')).not.toBeInTheDocument();
+      expect(screen.queryByText('Use Structured Mode')).not.toBeInTheDocument();
+    });
+
+    it('shows Structured Mode toggle when experimental.structuredMode is on', async () => {
+      window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({ structuredMode: true });
+      render(<TemplateConfigDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByTestId('structured-mode-field')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Use Structured Mode')).toBeInTheDocument();
+    });
+
+    it('forces structuredMode to false in submitted config when flag is off', async () => {
+      render(<TemplateConfigDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(window.clubhouse.app.getExperimentalSettings).toHaveBeenCalled();
+      });
+      fireEvent.click(screen.getByText('Create Agent'));
+      expect(defaultProps.onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ structuredMode: false }),
+      );
+    });
   });
 });

--- a/src/renderer/features/agents/TemplateConfigDialog.tsx
+++ b/src/renderer/features/agents/TemplateConfigDialog.tsx
@@ -47,6 +47,17 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
   const supportsPermissions = selectedOrch?.capabilities?.permissions ?? false;
   const supportsStructured = selectedOrch?.capabilities?.structuredMode ?? false;
 
+  // Structured Mode is gated behind an experimental flag — hide the toggle
+  // entirely when the flag is off so the surface is invisible to opted-out users.
+  const [structuredModeFlag, setStructuredModeFlag] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => { if (!cancelled) setStructuredModeFlag(!!flags.structuredMode); })
+      .catch(() => { /* leave hidden on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     if (!projectPath) return;
     Promise.all([
@@ -69,7 +80,8 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
       orchestrator,
       useWorktree,
       freeAgentMode,
-      structuredMode,
+      // Never propagate structuredMode when the experimental flag is off.
+      structuredMode: structuredModeFlag ? structuredMode : false,
       mcpIds: selectedMcps.length > 0 ? selectedMcps : undefined,
     });
   };
@@ -198,23 +210,26 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
             <span className="text-[10px] text-ctp-subtext0/70 ml-1">(isolated branch + directory)</span>
           </label>
 
-          {/* Structured Mode */}
-          <label
-            className={`flex items-center gap-2 mb-3 ${supportsStructured ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
-            title={supportsStructured ? 'Run in structured mode with rich event streaming' : 'Not supported by this orchestrator'}
-          >
-            <input
-              type="checkbox"
-              checked={structuredMode}
-              onChange={(e) => setStructuredMode(e.target.checked)}
-              disabled={!supportsStructured}
-              className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
-            />
-            <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use Structured Mode</span>
-            <span className="text-[10px] text-ctp-subtext0/70 ml-1">
-              {supportsStructured ? '(rich event UI)' : '(not supported)'}
-            </span>
-          </label>
+          {/* Structured Mode (experimental — hidden unless opted in) */}
+          {structuredModeFlag && (
+            <label
+              data-testid="structured-mode-field"
+              className={`flex items-center gap-2 mb-3 ${supportsStructured ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+              title={supportsStructured ? 'Run in structured mode with rich event streaming' : 'Not supported by this orchestrator'}
+            >
+              <input
+                type="checkbox"
+                checked={structuredMode}
+                onChange={(e) => setStructuredMode(e.target.checked)}
+                disabled={!supportsStructured}
+                className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
+              />
+              <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use Structured Mode</span>
+              <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+                {supportsStructured ? '(rich event UI)' : '(not supported)'}
+              </span>
+            </label>
+          )}
 
           {/* Free Agent Mode */}
           <label

--- a/src/renderer/panels/MainContentView.test.tsx
+++ b/src/renderer/panels/MainContentView.test.tsx
@@ -480,9 +480,12 @@ describe('MainContentView structured mode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStores();
+    // Default to experimental.structuredMode ON so existing assertions about
+    // StructuredAgentView routing keep working. Individual tests can override.
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({ structuredMode: true });
   });
 
-  it('renders StructuredAgentView for a running durable agent with structuredMode', () => {
+  it('renders StructuredAgentView for a running durable agent with structuredMode', async () => {
     useAgentStore.setState({
       agents: {
         'a-1': {
@@ -499,10 +502,41 @@ describe('MainContentView structured mode', () => {
     });
 
     render(<MainContentView />);
-    expect(screen.getByTestId('structured-agent-view')).toBeInTheDocument();
+    // Wait for experimental flag fetch to settle
+    await act(async () => { await Promise.resolve(); });
+    expect(await screen.findByTestId('structured-agent-view')).toBeInTheDocument();
     expect(screen.getByTestId('structured-agent-view')).toHaveAttribute('data-agent-id', 'a-1');
     expect(screen.queryByTestId('agent-terminal')).not.toBeInTheDocument();
     expect(screen.queryByTestId('headless-agent')).not.toBeInTheDocument();
+  });
+
+  it('does NOT render StructuredAgentView when experimental.structuredMode flag is off (even if agent has structuredMode set)', async () => {
+    // Override the beforeEach default — experimental flag is off
+    window.clubhouse.app.getExperimentalSettings = vi.fn().mockResolvedValue({});
+    useAgentStore.setState({
+      agents: {
+        'a-1': {
+          id: 'a-1',
+          projectId: 'proj-1',
+          status: 'running',
+          kind: 'durable',
+          name: 'structured-agent',
+          color: 'blue',
+          structuredMode: true,
+        } as any,
+      },
+      activeAgentId: 'a-1',
+    });
+
+    render(<MainContentView />);
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    // Falls through to PTY (AgentTerminal) — preserves pre-experimental behavior.
+    expect(screen.getByTestId('agent-terminal')).toBeInTheDocument();
+    expect(screen.queryByTestId('structured-agent-view')).not.toBeInTheDocument();
   });
 
   it('renders AgentTerminal for a running agent without structuredMode', async () => {
@@ -573,7 +607,7 @@ describe('MainContentView structured mode', () => {
     expect(screen.queryByTestId('structured-agent-view')).not.toBeInTheDocument();
   });
 
-  it('shows satellite disconnected overlay over structured agent view on remote project', () => {
+  it('shows satellite disconnected overlay over structured agent view on remote project', async () => {
     const satelliteId = 'sat-fp';
     const remoteProjectId = `remote||${satelliteId}||proj-1`;
 
@@ -612,7 +646,8 @@ describe('MainContentView structured mode', () => {
     });
 
     render(<MainContentView />);
-    expect(screen.getByTestId('structured-agent-view')).toBeInTheDocument();
+    await act(async () => { await Promise.resolve(); });
+    expect(await screen.findByTestId('structured-agent-view')).toBeInTheDocument();
     expect(screen.getByTestId('satellite-disconnected-overlay')).toBeInTheDocument();
   });
 });

--- a/src/renderer/panels/MainContentView.tsx
+++ b/src/renderer/panels/MainContentView.tsx
@@ -68,6 +68,19 @@ export function MainContentView() {
   const [terminalFocused, setTerminalFocused] = useState(false);
   const prevProjectIdRef = useRef(activeProjectId);
 
+  // Structured Mode is gated behind an experimental flag. Even if an agent has
+  // structuredMode persisted in its config (e.g. set when the flag was on), we
+  // must not route into StructuredAgentView when the flag is off — otherwise
+  // toggling the flag off would still change visible behavior.
+  const [structuredModeFlag, setStructuredModeFlag] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    window.clubhouse.app.getExperimentalSettings()
+      .then((flags) => { if (!cancelled) setStructuredModeFlag(!!flags.structuredMode); })
+      .catch(() => { /* leave disabled on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     if (!isAgentView) {
       setTerminalFocused(false);
@@ -185,8 +198,10 @@ export function MainContentView() {
       );
     }
 
-    // Structured running agents get the rich chat feed instead of a terminal
-    if (activeAgent.structuredMode) {
+    // Structured running agents get the rich chat feed instead of a terminal.
+    // Gated on the experimental flag so a persisted structuredMode doesn't keep
+    // changing behavior after the flag is turned off.
+    if (activeAgent.structuredMode && structuredModeFlag) {
       return (
         <div className="relative h-full">
           <StructuredAgentView agentId={activeAgentId!} />


### PR DESCRIPTION
## Summary
- Hide the **Structured Mode** checkbox in the +Agent dialog (`AddAgentDialog`) and persona/template configuration dialog (`TemplateConfigDialog`) when `experimental.structuredMode` is off — these were the last two UI surfaces leaking the toggle after PR #1404.
- Treat the `experimental.structuredMode` flag as a **hard gate at runtime**, not just a UI gate: when it is off, agents always run with their pre-experimental behavior (PTY) even if a per-agent durable config still has `structuredMode: true` from a prior opt-in. Persisted config stays on disk so toggling back on restores prior state seamlessly.

## Why this matters

Project rule: experimental features are completely invisible when off. That means **no UI surfaces** *and* **no behavior changes**. The previous experimental-fix PR (#1404) closed several UI leaks but only for the in-place `AgentSettingsView` — the agent **creation** dialogs were missed, and the runtime still honored persisted `structuredMode` regardless of the flag. So an opted-out user could:

1. See the Structured Mode checkbox in the +Agent dialog (the bug Mason reported).
2. Have an agent that was set to structuredMode while the flag was on continue to launch in structured mode after the flag is turned off, with `MainContentView` routing to `StructuredAgentView` instead of `AgentTerminal`.

Both are violations of the invisibility principle.

## Changes

### UI gating (renderer)

| File | Change |
|---|---|
| `src/renderer/features/agents/AddAgentDialog.tsx` | Read `experimental.structuredMode` on mount; hide the toggle entirely when off; defensively strip `structuredMode` from the `onCreate` payload when off so a stale local state cannot leak. |
| `src/renderer/features/agents/TemplateConfigDialog.tsx` | Same gating pattern; submit `structuredMode: false` when the flag is off. |
| `src/renderer/panels/MainContentView.tsx` | Read the flag and bypass `StructuredAgentView` when off — agent falls through to `AgentTerminal`. |

### Runtime gating (main)

| File | Change |
|---|---|
| `src/main/services/agent-system.ts` | Read `experimental-settings` and force `useStructured = false` when the flag is off, regardless of per-agent durable config or project spawn-mode preference. |

### Tests

| File | Coverage |
|---|---|
| `src/renderer/features/agents/AddAgentDialog.test.tsx` | New \"Structured Mode gating\" describe block: hidden when off (default), shown when on, hidden on IPC failure, payload sanitized when off. |
| `src/renderer/features/agents/TemplateConfigDialog.test.tsx` | New gating describe block: hidden when off, shown when on, `structuredMode: false` enforced in submitted config when off. |
| `src/renderer/panels/MainContentView.test.tsx` | `beforeEach` mocks the flag on (so existing structured-routing assertions stay valid) + new case for flag off + agent has structuredMode → renders `AgentTerminal`. |
| `src/main/services/agent-system.test.ts` | Module-level mock for `experimental-settings` defaulting to flag on (existing structured-spawn cases unchanged) + two new cases that flip the flag off and assert PTY fallback for both quick-structured-spawn-mode and durable-with-structuredMode paths. |

## Test Plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 11613 passed, 4 skipped, 0 failed
- [x] `eslint` on every touched file — 0 errors (the 22 errors in `npm run lint` output are all pre-existing in unrelated files, same set noted in PR #1404)

### Component-level

- [x] `AddAgentDialog`: Structured Mode toggle hidden by default
- [x] `AddAgentDialog`: Structured Mode toggle shown when `structuredMode: true`
- [x] `AddAgentDialog`: hidden when `getExperimentalSettings` rejects
- [x] `AddAgentDialog`: `onCreate` last positional arg is `undefined` when flag is off
- [x] `TemplateConfigDialog`: same three gating cases + payload `structuredMode: false`
- [x] `MainContentView`: flag-off + `agent.structuredMode=true` → `AgentTerminal`, not `StructuredAgentView`

### Backend

- [x] `agent-system`: quick agent in `structured` spawn mode — when flag off → falls back to PTY
- [x] `agent-system`: durable agent with `structuredMode: true` — when flag off → falls back to PTY
- [x] `agent-system`: existing structured-spawn assertions still pass with the new module-level mock (flag on)

## Manual Validation

To verify in a running app:

1. Open Experimental Settings → confirm **Structured Mode** is off (default) → restart.
2. Click **+Agent** in the agent rail → confirm the **Use Structured Mode** checkbox is **gone** (Free Agent Mode is still there).
3. Open the persona gallery (e.g. Templates → pick any persona) → in the configuration dialog, confirm **Use Structured Mode** is **gone**.
4. (Behavior change) If you previously had a durable agent with `structuredMode: true` saved on disk — start it now → confirm it launches as a regular PTY terminal, not the structured chat feed.
5. Toggle **Structured Mode** on in Experimental Settings → restart → confirm:
   - Both creation dialogs show the checkbox again.
   - The previously-saved structured agent now launches in structured mode again (its config was preserved).

## Notes

- Persisted `structuredMode` per-agent values are intentionally **not deleted** when the flag is off — they remain on disk so toggling back on is reversible. This matches the ergonomics of how the prior PR handled the `AgentSettingsView` toggle, and keeps the state model simple.
- This PR does not touch other experimental flags (`assistant`, `agentQueue`, `themeGradients`, `sessions`) — they were already correctly gated by PR #1404 and pre-existing plugin/registry-level checks. I audited each and confirmed no further bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)