### PR TITLE
fix(blueprints): unify import, allow save/open anywhere, fix version mismatch

### DIFF
--- a/src/main/ipc/blueprint-handlers.test.ts
+++ b/src/main/ipc/blueprint-handlers.test.ts
@@ -4,6 +4,13 @@ vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn(),
   },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => ({})),
+  },
+  dialog: {
+    showSaveDialog: vi.fn(),
+    showOpenDialog: vi.fn(),
+  },
 }));
 
 vi.mock('../services/project-store', () => ({
@@ -21,13 +28,14 @@ vi.mock('fs/promises', () => ({
   realpath: vi.fn((p: string) => Promise.resolve(p)),
   stat: vi.fn(),
   unlink: vi.fn(),
+  writeFile: vi.fn(),
 }));
 
 vi.mock('../services/path-sandbox', () => ({
   assertAllowedPath: vi.fn(async () => undefined),
 }));
 
-import { ipcMain } from 'electron';
+import { ipcMain, dialog } from 'electron';
 import * as fsp from 'fs/promises';
 import * as projectStore from '../services/project-store';
 import { assertAllowedPath } from '../services/path-sandbox';
@@ -343,6 +351,165 @@ describe('blueprint-handlers', () => {
       const result = await handler({}, bp);
       expect(result).toBe(false);
       expect(fsp.unlink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('BLUEPRINT.SAVE_TO_FILE', () => {
+    it('writes the supplied content to the user-chosen path', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePath: '/Users/me/Desktop/squad.json',
+      } as any);
+      vi.mocked(fsp.writeFile).mockResolvedValueOnce(undefined as never);
+
+      const handler = getHandler('blueprint:save-to-file');
+      const result = await handler({}, 'squad.json', '{"name":"Squad"}');
+
+      expect(result).toEqual({ canceled: false, filePath: '/Users/me/Desktop/squad.json' });
+      expect(fsp.writeFile).toHaveBeenCalledWith(
+        '/Users/me/Desktop/squad.json',
+        '{"name":"Squad"}',
+        'utf-8',
+      );
+    });
+
+    it('honors paths outside any registered project (no path-sandbox check)', async () => {
+      // Critical: SAVE_TO_FILE must NOT call assertAllowedPath, or the user
+      // wouldn't be able to save a blueprint to ~/Desktop.
+      vi.mocked(dialog.showSaveDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePath: '/somewhere/outside/projects/x.json',
+      } as any);
+      vi.mocked(fsp.writeFile).mockResolvedValueOnce(undefined as never);
+
+      const handler = getHandler('blueprint:save-to-file');
+      await handler({}, 'x.json', '{}');
+
+      expect(assertAllowedPath).not.toHaveBeenCalled();
+      expect(fsp.writeFile).toHaveBeenCalled();
+    });
+
+    it('returns canceled when the user dismisses the dialog', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValueOnce({
+        canceled: true,
+        filePath: undefined,
+      } as any);
+
+      const handler = getHandler('blueprint:save-to-file');
+      const result = await handler({}, 'x.json', '{}');
+
+      expect(result).toEqual({ canceled: true });
+      expect(fsp.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('returns the error message when writeFile fails', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePath: '/readonly/x.json',
+      } as any);
+      vi.mocked(fsp.writeFile).mockRejectedValueOnce(new Error('EROFS: read-only'));
+
+      const handler = getHandler('blueprint:save-to-file');
+      const result = await handler({}, 'x.json', '{}') as any;
+
+      expect(result.canceled).toBe(false);
+      expect(result.filePath).toBe('/readonly/x.json');
+      expect(result.error).toContain('EROFS');
+    });
+  });
+
+  describe('BLUEPRINT.OPEN_AND_READ', () => {
+    it('opens a dialog and returns parsed contents of the chosen file', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePaths: ['/Users/me/Downloads/team.json'],
+      } as any);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce(JSON.stringify({
+        schemaVersion: 1,
+        name: 'Team',
+        canvas: { views: [], wires: [] },
+      }) as never);
+
+      const handler = getHandler('blueprint:open-and-read');
+      const result = await handler({}) as any;
+
+      expect(result.canceled).toBe(false);
+      expect(result.filePath).toBe('/Users/me/Downloads/team.json');
+      expect(result.data).toEqual({
+        schemaVersion: 1,
+        name: 'Team',
+        canvas: { views: [], wires: [] },
+      });
+    });
+
+    it('honors paths outside any registered project (no path-sandbox check)', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePaths: ['/elsewhere/blueprint.json'],
+      } as any);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce('{}' as never);
+
+      const handler = getHandler('blueprint:open-and-read');
+      await handler({});
+
+      expect(assertAllowedPath).not.toHaveBeenCalled();
+      expect(fsp.readFile).toHaveBeenCalled();
+    });
+
+    it('returns canceled when the user dismisses the dialog', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+        canceled: true,
+        filePaths: [],
+      } as any);
+
+      const handler = getHandler('blueprint:open-and-read');
+      const result = await handler({});
+
+      expect(result).toEqual({ canceled: true });
+      expect(fsp.readFile).not.toHaveBeenCalled();
+    });
+
+    it('returns canceled when the user picks no file (empty filePaths)', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePaths: [],
+      } as any);
+
+      const handler = getHandler('blueprint:open-and-read');
+      const result = await handler({});
+
+      expect(result).toEqual({ canceled: true });
+    });
+
+    it('returns an error when the file is invalid JSON', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePaths: ['/tmp/broken.json'],
+      } as any);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce('not valid json' as never);
+
+      const handler = getHandler('blueprint:open-and-read');
+      const result = await handler({}) as any;
+
+      expect(result.canceled).toBe(false);
+      expect(result.filePath).toBe('/tmp/broken.json');
+      expect(result.error).toBeDefined();
+      expect(result.data).toBeUndefined();
+    });
+
+    it('rejects oversized files (10 MB limit)', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+        canceled: false,
+        filePaths: ['/tmp/huge.json'],
+      } as any);
+      vi.mocked(fsp.stat).mockResolvedValueOnce({ size: 11 * 1024 * 1024 } as any);
+
+      const handler = getHandler('blueprint:open-and-read');
+      const result = await handler({}) as any;
+
+      expect(result.canceled).toBe(false);
+      expect(result.error).toContain('too large');
+      expect(fsp.readFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/ipc/blueprint-handlers.ts
+++ b/src/main/ipc/blueprint-handlers.ts
@@ -69,20 +69,91 @@ function extractSummary(filePath: string, data: Record<string, unknown>, source:
 }
 
 export function registerBlueprintHandlers(): void {
-  // SAVE_DIALOG — from Mission 51 (blueprint export)
-  ipcMain.handle(IPC.BLUEPRINT.SAVE_DIALOG, withValidatedArgs(
-    [stringArg()],
-    async (_event, defaultName: string) => {
+  /**
+   * SAVE_TO_FILE — combined save dialog + write.
+   *
+   * Opens a native save dialog and, if the user picks a path, writes the
+   * provided JSON content there. The dialog itself is the user-consent gate,
+   * so this deliberately skips the renderer-facing path sandbox: a user
+   * exporting a blueprint should be able to save it anywhere on disk
+   * (e.g. ~/Desktop, ~/Documents) without us second-guessing the choice.
+   *
+   * The IPC is indivisible — the renderer can't supply a target path; it
+   * comes from the dialog return inside main. So a malicious renderer can't
+   * leverage this to write to arbitrary locations without user interaction.
+   */
+  ipcMain.handle(IPC.BLUEPRINT.SAVE_TO_FILE, withValidatedArgs(
+    [stringArg(), stringArg({ minLength: 0 })],
+    async (_event, defaultName: string, content: string): Promise<{
+      canceled: boolean;
+      filePath?: string;
+      error?: string;
+    }> => {
       const win = BrowserWindow.getFocusedWindow();
       if (!win) return { canceled: true };
-      const result = await dialog.showSaveDialog(win, {
+      const dialogResult = await dialog.showSaveDialog(win, {
         title: 'Save Blueprint',
         defaultPath: defaultName,
         filters: [{ name: 'Blueprint files', extensions: ['json'] }],
       });
-      return { canceled: result.canceled, filePath: result.filePath };
+      if (dialogResult.canceled || !dialogResult.filePath) {
+        return { canceled: true };
+      }
+      try {
+        await fsp.writeFile(dialogResult.filePath, content, 'utf-8');
+        return { canceled: false, filePath: dialogResult.filePath };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        appLog('core:blueprint', 'error', 'Failed to write blueprint to user-chosen path', {
+          meta: { filePath: dialogResult.filePath, error: message },
+        });
+        return { canceled: false, filePath: dialogResult.filePath, error: message };
+      }
     },
   ));
+
+  /**
+   * OPEN_AND_READ — combined open dialog + read.
+   *
+   * Lets the user pick a blueprint .json file from anywhere on disk and
+   * returns its parsed contents. Same consent model as SAVE_TO_FILE: the OS
+   * dialog is the gate, so we bypass the sandbox. Returns `{ canceled: true }`
+   * if the user cancels, or `{ canceled: false, data, filePath }` on success.
+   * Read or parse failures return `{ canceled: false, error }`.
+   */
+  ipcMain.handle(IPC.BLUEPRINT.OPEN_AND_READ, async (): Promise<{
+    canceled: boolean;
+    data?: Record<string, unknown>;
+    filePath?: string;
+    error?: string;
+  }> => {
+    const win = BrowserWindow.getFocusedWindow();
+    if (!win) return { canceled: true };
+    const dialogResult = await dialog.showOpenDialog(win, {
+      title: 'Open Blueprint',
+      filters: [{ name: 'Blueprint files', extensions: ['json'] }],
+      properties: ['openFile'],
+    });
+    if (dialogResult.canceled || dialogResult.filePaths.length === 0) {
+      return { canceled: true };
+    }
+    const filePath = dialogResult.filePaths[0];
+    try {
+      const stat = await fsp.stat(filePath);
+      if (stat.size > MAX_BLUEPRINT_SIZE_BYTES) {
+        return { canceled: false, filePath, error: `File too large (max ${MAX_BLUEPRINT_SIZE_BYTES / 1024 / 1024} MB)` };
+      }
+      const raw = await fsp.readFile(filePath, 'utf-8');
+      const data = JSON.parse(raw) as Record<string, unknown>;
+      return { canceled: false, filePath, data };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      appLog('core:blueprint', 'error', 'Failed to open user-chosen blueprint file', {
+        meta: { filePath, error: message },
+      });
+      return { canceled: false, filePath, error: message };
+    }
+  });
 
   /**
    * BLUEPRINT.LIST — Scan .clubhouse/blueprints/*.json across all project paths.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -495,8 +495,23 @@ const api = {
     }) => ipcRenderer.invoke(IPC.FILE.SEARCH, rootPath, query, options),
   },
   blueprint: {
-    saveDialog: (defaultName: string) =>
-      ipcRenderer.invoke(IPC.BLUEPRINT.SAVE_DIALOG, defaultName) as Promise<{ canceled: boolean; filePath?: string }>,
+    /**
+     * Open a native save dialog and write the supplied JSON content to the
+     * chosen path. The user picking a path is the consent gate — this can
+     * write anywhere on disk, no project-directory sandbox.
+     */
+    saveToFile: (defaultName: string, content: string) =>
+      ipcRenderer.invoke(IPC.BLUEPRINT.SAVE_TO_FILE, defaultName, content) as Promise<{
+        canceled: boolean; filePath?: string; error?: string;
+      }>,
+    /**
+     * Open a native file dialog and read+parse the chosen file. Bypasses the
+     * project-directory sandbox, same consent model as saveToFile.
+     */
+    openAndRead: () =>
+      ipcRenderer.invoke(IPC.BLUEPRINT.OPEN_AND_READ) as Promise<{
+        canceled: boolean; data?: Record<string, unknown>; filePath?: string; error?: string;
+      }>,
     /** Scan .clubhouse/blueprints/ across all projects and return summaries. */
     list: () => ipcRenderer.invoke(IPC.BLUEPRINT.LIST) as Promise<Array<{
       filePath: string; name: string; description?: string;

--- a/src/renderer/features/blueprints/BlueprintGallery.test.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.test.tsx
@@ -63,11 +63,17 @@ vi.mock('../../plugins/builtin/canvas/main', () => ({
 const mockBlueprintList = vi.fn();
 const mockBlueprintRead = vi.fn();
 const mockBlueprintDelete = vi.fn();
+const mockBlueprintOpenAndRead = vi.fn();
 
 beforeEach(() => {
   (globalThis as any).window ??= {};
   (globalThis as any).window.clubhouse = {
-    blueprint: { list: mockBlueprintList, read: mockBlueprintRead, delete: mockBlueprintDelete },
+    blueprint: {
+      list: mockBlueprintList,
+      read: mockBlueprintRead,
+      delete: mockBlueprintDelete,
+      openAndRead: mockBlueprintOpenAndRead,
+    },
   };
 });
 
@@ -290,5 +296,103 @@ describe('BlueprintGallery', () => {
     });
     // Manifest import should NOT have been called
     expect(mockManifestImport).not.toHaveBeenCalled();
+  });
+
+  // ── Open from file (arbitrary path, bypasses sandbox) ──────────
+
+  it('renders an "Open from file…" button in the header', async () => {
+    state.blueprintGalleryOpen = true;
+    mockBlueprintList.mockResolvedValue([]);
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-open-from-file')).toBeDefined(); });
+  });
+
+  it('imports a manifest blueprint chosen via the OS file picker', async () => {
+    state.blueprintGalleryOpen = true;
+    mockBlueprintList.mockResolvedValue([]);
+    mockBlueprintOpenAndRead.mockResolvedValue({
+      canceled: false,
+      filePath: '/Users/me/Downloads/squad.json',
+      data: {
+        schemaVersion: 1,
+        id: 'bp-import-1',
+        name: 'Manifest from disk',
+        version: '1.0.0',
+        createdAt: '2026-04-25',
+        canvas: { views: [], wires: [] },
+      },
+    });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-open-from-file')).toBeDefined(); });
+
+    fireEvent.click(screen.getByTestId('blueprint-gallery-open-from-file'));
+
+    await waitFor(() => {
+      expect(mockBlueprintOpenAndRead).toHaveBeenCalled();
+      expect(mockManifestImport).toHaveBeenCalled();
+      expect(mockInsertCanvas).toHaveBeenCalled();
+    });
+  });
+
+  it('imports a legacy blueprint chosen via the OS file picker', async () => {
+    state.blueprintGalleryOpen = true;
+    mockBlueprintList.mockResolvedValue([]);
+    mockBlueprintOpenAndRead.mockResolvedValue({
+      canceled: false,
+      filePath: '/elsewhere/legacy.json',
+      data: {
+        version: 1,
+        name: 'Legacy from disk',
+        views: [],
+      },
+    });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-open-from-file')).toBeDefined(); });
+
+    fireEvent.click(screen.getByTestId('blueprint-gallery-open-from-file'));
+
+    await waitFor(() => {
+      expect(mockLegacyImport).toHaveBeenCalled();
+      expect(mockInsertCanvas).toHaveBeenCalled();
+    });
+  });
+
+  it('does nothing visible when the user cancels the file picker', async () => {
+    state.blueprintGalleryOpen = true;
+    mockBlueprintList.mockResolvedValue([]);
+    mockBlueprintOpenAndRead.mockResolvedValue({ canceled: true });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-open-from-file')).toBeDefined(); });
+
+    fireEvent.click(screen.getByTestId('blueprint-gallery-open-from-file'));
+
+    await waitFor(() => {
+      expect(mockBlueprintOpenAndRead).toHaveBeenCalled();
+    });
+    expect(mockInsertCanvas).not.toHaveBeenCalled();
+    expect(mockCloseBlueprintGallery).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when the chosen file is unreadable', async () => {
+    state.blueprintGalleryOpen = true;
+    mockBlueprintList.mockResolvedValue([]);
+    mockBlueprintOpenAndRead.mockResolvedValue({
+      canceled: false,
+      filePath: '/tmp/broken.json',
+      error: 'Unexpected token in JSON',
+    });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-open-from-file')).toBeDefined(); });
+
+    fireEvent.click(screen.getByTestId('blueprint-gallery-open-from-file'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('blueprint-gallery-error')).toBeDefined();
+    });
+    expect(screen.getByText(/Unexpected token/)).toBeDefined();
   });
 });

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -3,6 +3,7 @@ import { useUIStore } from '../../stores/uiStore';
 import type { BlueprintSummary } from '../../../shared/blueprint-summary';
 import { importBlueprint as legacyImportBlueprint, validateBlueprint } from '../../plugins/builtin/canvas/canvas-blueprint';
 import { importBlueprint as manifestImportBlueprint } from './blueprint-import';
+import { parseAnyBlueprint, buildWireDefinitionsFromResult } from './parse-blueprint';
 import { getProjectCanvasStore, useAppCanvasStore } from '../../plugins/builtin/canvas/main';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAgentStore } from '../../stores/agentStore';
@@ -146,6 +147,41 @@ export function BlueprintGallery() {
     }
   }, [activeProjectId, close]);
 
+  const handleOpenFromFile = useCallback(async () => {
+    setError(null);
+    setImporting('__open_from_file__');
+    try {
+      const result = await window.clubhouse.blueprint.openAndRead();
+      if (result.canceled) return;
+      if (result.error || !result.data) {
+        throw new Error(result.error || 'Failed to read file');
+      }
+
+      const agents = Object.values(useAgentStore.getState().agents);
+      const projects = useProjectStore.getState().projects.map((p) => ({
+        id: p.id, name: p.name, path: p.path,
+      }));
+      const parsed = parseAnyBlueprint(result.data, {
+        agents,
+        projects,
+        activeProjectId: activeProjectId ?? undefined,
+      });
+
+      const store = activeProjectId
+        ? getProjectCanvasStore(activeProjectId)
+        : useAppCanvasStore;
+      store.getState().insertCanvas(parsed.canvas);
+      for (const wire of buildWireDefinitionsFromResult(parsed)) {
+        store.getState().addWireDefinition(wire);
+      }
+      close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setImporting(null);
+    }
+  }, [activeProjectId, close]);
+
   const handleDelete = useCallback(async (bp: BlueprintSummary) => {
     const deleted = await window.clubhouse.blueprint.delete(bp.filePath);
     if (deleted) {
@@ -189,6 +225,15 @@ export function BlueprintGallery() {
         <div className="flex items-center justify-between px-4 py-3 border-b border-surface-0">
           <h2 className="text-sm font-semibold text-ctp-text">Import Blueprint</h2>
           <div className="flex items-center gap-2">
+            <button
+              onClick={handleOpenFromFile}
+              disabled={importing === '__open_from_file__'}
+              className="text-[10px] px-2 py-0.5 bg-ctp-mantle border border-surface-0 rounded text-ctp-subtext1 hover:text-ctp-text hover:border-ctp-accent disabled:opacity-50"
+              data-testid="blueprint-gallery-open-from-file"
+              title="Open a blueprint .json from anywhere on disk"
+            >
+              {importing === '__open_from_file__' ? 'Opening…' : 'Open from file…'}
+            </button>
             {/* Sort dropdown */}
             <select
               value={sortMode}

--- a/src/renderer/features/blueprints/blueprint-bundle.ts
+++ b/src/renderer/features/blueprints/blueprint-bundle.ts
@@ -232,11 +232,13 @@ export async function saveBundleToClipboard(bundle: BlueprintBundle): Promise<Bu
 export async function saveBundleToFile(bundle: BlueprintBundle): Promise<BundleExportResult> {
   const defaultName = `${slugify(bundle.name)}-bundle.json`;
   try {
-    const result = await window.clubhouse.blueprint.saveDialog(defaultName);
-    if (result.canceled || !result.filePath) {
+    const result = await window.clubhouse.blueprint.saveToFile(defaultName, serializeBundle(bundle));
+    if (result.canceled) {
       return { success: false, destination: 'file', error: 'Cancelled' };
     }
-    await window.clubhouse.file.write(result.filePath, serializeBundle(bundle));
+    if (result.error) {
+      return { success: false, destination: 'file', error: result.error, filePath: result.filePath };
+    }
     return { success: true, destination: 'file', filePath: result.filePath };
   } catch (err) {
     return { success: false, destination: 'file', error: err instanceof Error ? err.message : String(err) };

--- a/src/renderer/features/blueprints/blueprint-destinations.test.ts
+++ b/src/renderer/features/blueprints/blueprint-destinations.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BlueprintManifest } from '../../../shared/blueprint-types';
+import { saveToBlueprintsDir, saveToClipboard, saveToFile } from './blueprint-destinations';
+
+// ── Fixtures & mocks ─────────────────────────────────────────────────
+
+function makeManifest(overrides: Partial<BlueprintManifest> = {}): BlueprintManifest {
+  return {
+    id: 'bp-1',
+    name: 'My Blueprint',
+    version: '1.0.0',
+    schemaVersion: 1,
+    createdAt: '2026-04-25T12:00:00.000Z',
+    canvas: { views: [], wires: [] },
+    ...overrides,
+  };
+}
+
+const mockFileWrite = vi.fn();
+const mockFileMkdir = vi.fn();
+const mockSaveToFile = vi.fn();
+const mockClipboardWriteText = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as any).window ??= {};
+  (globalThis as any).window.clubhouse = {
+    file: { write: mockFileWrite, mkdir: mockFileMkdir },
+    blueprint: { saveToFile: mockSaveToFile },
+  };
+  (globalThis as any).navigator ??= {};
+  (globalThis as any).navigator.clipboard = { writeText: mockClipboardWriteText };
+});
+
+// ── saveToBlueprintsDir ──────────────────────────────────────────────
+
+describe('saveToBlueprintsDir', () => {
+  it('creates the blueprints directory and writes a slugified filename', async () => {
+    mockFileMkdir.mockResolvedValueOnce(undefined);
+    mockFileWrite.mockResolvedValueOnce(undefined);
+
+    const result = await saveToBlueprintsDir(
+      makeManifest({ name: 'My Cool Blueprint!' }),
+      '/Users/me/projects/foo',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.destination).toBe('blueprints-dir');
+    expect(result.filePath).toBe('/Users/me/projects/foo/.clubhouse/blueprints/my-cool-blueprint.json');
+    expect(mockFileMkdir).toHaveBeenCalledWith('/Users/me/projects/foo/.clubhouse/blueprints');
+  });
+
+  it('returns failure when mkdir/write throws', async () => {
+    mockFileMkdir.mockRejectedValueOnce(new Error('EACCES'));
+
+    const result = await saveToBlueprintsDir(makeManifest(), '/p');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('EACCES');
+  });
+});
+
+// ── saveToClipboard ──────────────────────────────────────────────────
+
+describe('saveToClipboard', () => {
+  it('writes serialised manifest JSON to the system clipboard', async () => {
+    mockClipboardWriteText.mockResolvedValueOnce(undefined);
+
+    const result = await saveToClipboard(makeManifest());
+
+    expect(result.success).toBe(true);
+    expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
+    const payload = mockClipboardWriteText.mock.calls[0][0];
+    const parsed = JSON.parse(payload);
+    expect(parsed.name).toBe('My Blueprint');
+    expect(parsed.schemaVersion).toBe(1);
+  });
+
+  it('returns failure when clipboard rejects', async () => {
+    mockClipboardWriteText.mockRejectedValueOnce(new Error('Permission denied'));
+
+    const result = await saveToClipboard(makeManifest());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Permission denied');
+  });
+});
+
+// ── saveToFile ────────────────────────────────────────────────────────
+
+describe('saveToFile', () => {
+  it('routes through the combined saveToFile IPC (no separate file.write)', async () => {
+    // Critical: this is the regression guard for "can't save outside the
+    // project directory". The renderer must NOT route via window.clubhouse.file.write
+    // because that path is sandboxed.
+    mockSaveToFile.mockResolvedValueOnce({
+      canceled: false,
+      filePath: '/Users/me/Desktop/board.json',
+    });
+
+    const manifest = makeManifest({ name: 'Board' });
+    const result = await saveToFile(manifest);
+
+    expect(result.success).toBe(true);
+    expect(result.filePath).toBe('/Users/me/Desktop/board.json');
+
+    // Verify the IPC was called with a slug filename + serialised JSON content.
+    expect(mockSaveToFile).toHaveBeenCalledTimes(1);
+    const [defaultName, content] = mockSaveToFile.mock.calls[0];
+    expect(defaultName).toBe('board.json');
+    const parsed = JSON.parse(content);
+    expect(parsed.name).toBe('Board');
+
+    // Must NOT use the sandboxed file.write IPC.
+    expect(mockFileWrite).not.toHaveBeenCalled();
+  });
+
+  it('returns Cancelled when the user dismisses the save dialog', async () => {
+    mockSaveToFile.mockResolvedValueOnce({ canceled: true });
+
+    const result = await saveToFile(makeManifest());
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cancelled');
+  });
+
+  it('surfaces write errors returned from the IPC', async () => {
+    mockSaveToFile.mockResolvedValueOnce({
+      canceled: false,
+      filePath: '/readonly/board.json',
+      error: 'EROFS: read-only filesystem',
+    });
+
+    const result = await saveToFile(makeManifest());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('EROFS');
+    expect(result.filePath).toBe('/readonly/board.json');
+  });
+
+  it('catches IPC rejection', async () => {
+    mockSaveToFile.mockRejectedValueOnce(new Error('IPC channel closed'));
+
+    const result = await saveToFile(makeManifest());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('IPC channel closed');
+  });
+});

--- a/src/renderer/features/blueprints/blueprint-destinations.ts
+++ b/src/renderer/features/blueprints/blueprint-destinations.ts
@@ -63,20 +63,26 @@ export async function saveToClipboard(
 
 /**
  * Open a native save dialog and write the blueprint to the chosen location.
+ *
+ * Uses the combined `blueprint.saveToFile` IPC so that the user-picked path
+ * is honored verbatim — including paths outside any registered project
+ * directory (e.g. ~/Desktop, ~/Documents). The dialog itself is the consent
+ * gate; the renderer never gets to supply a target path directly.
  */
 export async function saveToFile(
   manifest: BlueprintManifest,
 ): Promise<ExportResult> {
   const defaultName = `${slugify(manifest.name)}.json`;
+  const json = serializeManifest(manifest);
 
   try {
-    const result = await window.clubhouse.blueprint.saveDialog(defaultName);
-    if (result.canceled || !result.filePath) {
+    const result = await window.clubhouse.blueprint.saveToFile(defaultName, json);
+    if (result.canceled) {
       return { success: false, destination: 'file', error: 'Cancelled' };
     }
-
-    const json = serializeManifest(manifest);
-    await window.clubhouse.file.write(result.filePath, json);
+    if (result.error) {
+      return { success: false, destination: 'file', error: result.error, filePath: result.filePath };
+    }
     return { success: true, destination: 'file', filePath: result.filePath };
   } catch (err) {
     return {

--- a/src/renderer/features/blueprints/parse-blueprint.test.ts
+++ b/src/renderer/features/blueprints/parse-blueprint.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectBlueprintFormat,
+  parseAnyBlueprint,
+  parseAnyBlueprintText,
+  buildWireDefinitionsFromResult,
+} from './parse-blueprint';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const LEGACY_BLUEPRINT = {
+  version: 1,
+  name: 'Legacy BP',
+  views: [
+    { type: 'agent', title: 'A', position: { x: 0, y: 0 }, size: { width: 480, height: 480 }, metadata: {} },
+    { type: 'anchor', title: 'Anchor', position: { x: 500, y: 0 }, size: { width: 240, height: 50 }, metadata: {}, label: 'Notes' },
+  ],
+};
+
+const MANIFEST_BLUEPRINT = {
+  id: 'bp-1',
+  name: 'Manifest BP',
+  version: '1.0.0',
+  schemaVersion: 1,
+  createdAt: '2026-04-25T12:00:00.000Z',
+  canvas: {
+    views: [
+      { refId: 'v1', type: 'agent', displayName: 'Alpha', position: { x: 0, y: 0 }, size: { width: 480, height: 480 }, agentRef: 'a1' },
+      { refId: 'v2', type: 'anchor', displayName: 'Hub', position: { x: 600, y: 0 }, size: { width: 240, height: 50 } },
+    ],
+    wires: [{ sourceRef: 'v1', targetRef: 'v2' }],
+  },
+  agents: [{ refId: 'a1', name: 'Alpha', matchBy: { name: 'Alpha' } }],
+};
+
+// ── detectBlueprintFormat ────────────────────────────────────────────
+
+describe('detectBlueprintFormat', () => {
+  it('detects manifest format by schemaVersion + canvas object', () => {
+    expect(detectBlueprintFormat(MANIFEST_BLUEPRINT)).toBe('manifest');
+  });
+
+  it('detects legacy format by numeric version + views array', () => {
+    expect(detectBlueprintFormat(LEGACY_BLUEPRINT)).toBe('legacy');
+  });
+
+  it('throws on null', () => {
+    expect(() => detectBlueprintFormat(null)).toThrow('expected a JSON object');
+  });
+
+  it('throws on non-object', () => {
+    expect(() => detectBlueprintFormat('hello')).toThrow('expected a JSON object');
+    expect(() => detectBlueprintFormat(42)).toThrow('expected a JSON object');
+  });
+
+  it('throws with schemaVersion-specific message when schemaVersion is wrong', () => {
+    expect(() => detectBlueprintFormat({ schemaVersion: 99, canvas: { views: [] } })).toThrow(
+      'Unsupported blueprint schemaVersion: 99',
+    );
+  });
+
+  it('throws on shape that matches neither format', () => {
+    expect(() => detectBlueprintFormat({ name: 'whatever' })).toThrow('Not a recognisable blueprint');
+  });
+
+  it('does not mistake string version for legacy', () => {
+    // String version with no schemaVersion or canvas → not recognisable
+    expect(() => detectBlueprintFormat({ version: '1.0.0', views: [] })).toThrow('Not a recognisable blueprint');
+  });
+});
+
+// ── parseAnyBlueprint ────────────────────────────────────────────────
+
+describe('parseAnyBlueprint', () => {
+  it('imports a legacy blueprint to a CanvasInstance', () => {
+    const result = parseAnyBlueprint(LEGACY_BLUEPRINT);
+    expect(result.format).toBe('legacy');
+    expect(result.canvas.name).toBe('Legacy BP');
+    expect(result.canvas.views).toHaveLength(2);
+    expect(result.pendingWires).toEqual([]);
+    expect(result.stubs).toEqual([]);
+    expect(result.refIdToViewId.size).toBe(0);
+  });
+
+  it('imports a manifest blueprint to a CanvasInstance with stubs and pending wires', () => {
+    const result = parseAnyBlueprint(MANIFEST_BLUEPRINT, { agents: [], projects: [] });
+    expect(result.format).toBe('manifest');
+    expect(result.canvas.name).toBe('Manifest BP');
+    expect(result.canvas.views).toHaveLength(2);
+    // Wire from the manifest is preserved as a pending wire awaiting resolution
+    expect(result.pendingWires).toHaveLength(1);
+    expect(result.pendingWires[0]).toEqual({ sourceRef: 'v1', targetRef: 'v2' });
+    // Agent stub recorded for v1 (no agents on this machine → not_found)
+    expect(result.stubs).toHaveLength(1);
+    expect(result.stubs[0].badge).toBe('not_found');
+    // refIdToViewId populated for both views
+    expect(result.refIdToViewId.size).toBe(2);
+  });
+
+  it('imports a manifest blueprint without ctx (defaults to no agents/projects)', () => {
+    const result = parseAnyBlueprint(MANIFEST_BLUEPRINT);
+    expect(result.format).toBe('manifest');
+    expect(result.canvas.views).toHaveLength(2);
+    // No agents to match against → stub stays unbound
+    expect(result.stubs[0].badge).toBe('not_found');
+  });
+
+  it('throws on invalid legacy blueprint (missing version)', () => {
+    expect(() => parseAnyBlueprint({ name: 'X', views: [] })).toThrow('Not a recognisable blueprint');
+  });
+
+  it('throws on legacy blueprint with future numeric version', () => {
+    expect(() => parseAnyBlueprint({ version: 999, name: 'Future', views: [] })).toThrow('Unsupported blueprint version');
+  });
+
+  it('throws on manifest with bad schemaVersion', () => {
+    expect(() => parseAnyBlueprint({ schemaVersion: 2, canvas: { views: [] } })).toThrow('Unsupported blueprint schemaVersion: 2');
+  });
+});
+
+// ── parseAnyBlueprintText ────────────────────────────────────────────
+
+describe('parseAnyBlueprintText', () => {
+  it('parses valid JSON text', () => {
+    const result = parseAnyBlueprintText(JSON.stringify(LEGACY_BLUEPRINT));
+    expect(result.format).toBe('legacy');
+    expect(result.canvas.views).toHaveLength(2);
+  });
+
+  it('parses a serialised manifest blueprint (semver string version is OK)', () => {
+    const result = parseAnyBlueprintText(JSON.stringify(MANIFEST_BLUEPRINT), { agents: [], projects: [] });
+    expect(result.format).toBe('manifest');
+  });
+
+  it('throws on invalid JSON with a clear message', () => {
+    expect(() => parseAnyBlueprintText('{not json')).toThrow('Not a valid JSON file');
+  });
+});
+
+// ── buildWireDefinitionsFromResult ───────────────────────────────────
+
+describe('buildWireDefinitionsFromResult', () => {
+  it('returns no wires when there are no pending wires', () => {
+    const result = parseAnyBlueprint(LEGACY_BLUEPRINT);
+    expect(buildWireDefinitionsFromResult(result)).toEqual([]);
+  });
+
+  it('skips wires whose source agent view has no bound agent', () => {
+    // Manifest with no matching agent on this machine — source view has no agentId
+    const result = parseAnyBlueprint(MANIFEST_BLUEPRINT, { agents: [], projects: [] });
+    expect(buildWireDefinitionsFromResult(result)).toEqual([]);
+  });
+
+  it('emits a wire entry when the source agent view is bound', () => {
+    // Provide an agent that matches the manifest's "Alpha" agent
+    const matchedAgent: any = {
+      id: 'agent-real-id',
+      name: 'Alpha',
+      orchestrator: null,
+      model: null,
+      status: 'sleeping',
+    };
+    const result = parseAnyBlueprint(MANIFEST_BLUEPRINT, { agents: [matchedAgent], projects: [] });
+    const wires = buildWireDefinitionsFromResult(result);
+    expect(wires).toHaveLength(1);
+    expect(wires[0].agentId).toBe('agent-real-id');
+    expect(wires[0].targetKind).toBe('browser'); // anchor target → falls back to browser
+    expect(wires[0].label).toContain('v1');
+    expect(wires[0].label).toContain('v2');
+  });
+});

--- a/src/renderer/features/blueprints/parse-blueprint.ts
+++ b/src/renderer/features/blueprints/parse-blueprint.ts
@@ -1,0 +1,178 @@
+// ── Unified blueprint parser ─────────────────────────────────────────
+//
+// Detects whether arbitrary JSON data is a legacy CanvasBlueprint or a
+// modern BlueprintManifest, validates it, and routes it to the correct
+// importer. Used by drag-and-drop, paste, the Blueprint Gallery, and the
+// "Open from file…" picker so all four entry points share one code path.
+
+import type { CanvasInstance, AgentCanvasView, PluginCanvasView } from '../../plugins/builtin/canvas/canvas-types';
+import type { McpBindingEntry } from '../../stores/mcpBindingStore';
+import type { BlueprintWire } from '../../../shared/blueprint-types';
+import { importBlueprint as legacyImportBlueprint, validateBlueprint as legacyValidate } from '../../plugins/builtin/canvas/canvas-blueprint';
+import { importBlueprint as manifestImportBlueprint, type ExistingProject, type AgentStubInfo, type ProjectMatchResult } from './blueprint-import';
+import type { Agent } from '../../../shared/types';
+
+// ── Format detection ────────────────────────────────────────────────
+
+export type BlueprintFormat = 'manifest' | 'legacy';
+
+/**
+ * Inspect a JSON value and decide which blueprint format it claims to be.
+ * Throws with a user-facing message if the shape is recognisable as neither.
+ */
+export function detectBlueprintFormat(data: unknown): BlueprintFormat {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Not a blueprint: expected a JSON object');
+  }
+  const obj = data as Record<string, unknown>;
+
+  // Manifest format is identified by schemaVersion + a nested canvas object.
+  // The top-level `version` field is a free-form semver string that is
+  // informational only — schemaVersion drives compatibility.
+  if (typeof obj.schemaVersion === 'number') {
+    if (obj.schemaVersion !== 1) {
+      throw new Error(`Unsupported blueprint schemaVersion: ${String(obj.schemaVersion)} (expected 1)`);
+    }
+    if (typeof obj.canvas !== 'object' || obj.canvas === null) {
+      throw new Error('Invalid blueprint: schemaVersion 1 requires a "canvas" object');
+    }
+    return 'manifest';
+  }
+
+  // Legacy format has a numeric `version` and a top-level `views` array.
+  if (typeof obj.version === 'number' && Array.isArray(obj.views)) {
+    return 'legacy';
+  }
+
+  throw new Error('Not a recognisable blueprint (missing schemaVersion or numeric version)');
+}
+
+// ── Parse result ────────────────────────────────────────────────────
+
+export interface ParseContext {
+  /** Existing agents on this machine — used to match manifest agentRefs. */
+  agents: Agent[];
+  /** Existing projects on this machine — used to match manifest projectRefs. */
+  projects: ExistingProject[];
+  /** The project the importing canvas should belong to, if any. */
+  activeProjectId?: string;
+}
+
+export interface ParseResult {
+  format: BlueprintFormat;
+  canvas: CanvasInstance;
+  /** Manifest-only: wires waiting to be wired up to bound agents. */
+  pendingWires: BlueprintWire[];
+  /** Manifest-only: blueprint refId → runtime view ID. */
+  refIdToViewId: Map<string, string>;
+  /** Manifest-only: agent stubs awaiting binding. */
+  stubs: AgentStubInfo[];
+  /** Manifest-only: how each project ref resolved against existing projects. */
+  projectMatches: ProjectMatchResult[];
+}
+
+// ── Parse + import ──────────────────────────────────────────────────
+
+/**
+ * Parse arbitrary JSON data as a blueprint and produce a ready-to-insert
+ * canvas. Throws with a user-facing message on validation failure.
+ *
+ * Manifest imports require `ctx` so they can match agents/projects against
+ * what already exists on this machine. Legacy imports ignore `ctx`.
+ */
+export function parseAnyBlueprint(data: unknown, ctx?: ParseContext): ParseResult {
+  const format = detectBlueprintFormat(data);
+
+  if (format === 'manifest') {
+    const safeCtx: ParseContext = ctx ?? { agents: [], projects: [] };
+    const result = manifestImportBlueprint(
+      data as Parameters<typeof manifestImportBlueprint>[0],
+      safeCtx.agents,
+      safeCtx.projects,
+      safeCtx.activeProjectId,
+    );
+    return {
+      format,
+      canvas: result.canvas,
+      pendingWires: result.pendingWires,
+      refIdToViewId: result.refIdToViewId,
+      stubs: result.stubs,
+      projectMatches: result.projectMatches,
+    };
+  }
+
+  const error = legacyValidate(data);
+  if (error) throw new Error(error);
+  const canvas = legacyImportBlueprint(data as Parameters<typeof legacyImportBlueprint>[0]);
+  return {
+    format,
+    canvas,
+    pendingWires: [],
+    refIdToViewId: new Map(),
+    stubs: [],
+    projectMatches: [],
+  };
+}
+
+/**
+ * JSON.parse with a friendlier error, then run parseAnyBlueprint on the
+ * result. Most consumers want this — they have raw text, not a parsed object.
+ */
+export function parseAnyBlueprintText(text: string, ctx?: ParseContext): ParseResult {
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error('Not a valid JSON file');
+  }
+  return parseAnyBlueprint(data, ctx);
+}
+
+// ── Wire materialisation ────────────────────────────────────────────
+
+/**
+ * Convert manifest pendingWires into runtime McpBindingEntry rows so the
+ * canvas store can register them. Wires whose source view has no bound agent
+ * are skipped — they remain in `pendingWires` until the user binds an agent.
+ *
+ * This is a thin wrapper around the resolution logic that previously lived
+ * inline in BlueprintGallery. Centralising it means drag/drop, paste, gallery,
+ * and open-from-file all restore wires the same way.
+ */
+export function buildWireDefinitionsFromResult(result: ParseResult): McpBindingEntry[] {
+  const entries: McpBindingEntry[] = [];
+  if (result.pendingWires.length === 0) return entries;
+
+  const viewById = new Map(result.canvas.views.map((v) => [v.id, v]));
+
+  for (const wire of result.pendingWires) {
+    const sourceViewId = result.refIdToViewId.get(wire.sourceRef);
+    const targetViewId = result.refIdToViewId.get(wire.targetRef);
+    if (!sourceViewId || !targetViewId) continue;
+
+    const sourceView = viewById.get(sourceViewId);
+    const targetView = viewById.get(targetViewId);
+    if (!sourceView || !targetView || sourceView.type !== 'agent') continue;
+
+    const agentView = sourceView as AgentCanvasView;
+    if (!agentView.agentId) continue;
+
+    const targetKind: McpBindingEntry['targetKind'] =
+      targetView.type === 'agent' ? 'agent'
+      : targetView.type === 'plugin' && (targetView as PluginCanvasView).pluginWidgetType.includes('group-project') ? 'group-project'
+      : 'browser';
+
+    entries.push({
+      agentId: agentView.agentId,
+      targetId: targetViewId,
+      targetKind,
+      label: `${wire.sourceRef} → ${wire.targetRef}`,
+      agentName: wire.sourceRef,
+      targetName: wire.targetRef,
+      instructions: wire.instructions,
+      disabledTools: wire.disabledTools,
+    });
+  }
+
+  return entries;
+}

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -34,6 +34,8 @@ import type { PluginAPI, CanvasWidgetMetadata, AgentInfo } from '../../../../sha
 import { getRegisteredWidgetType } from '../../canvas-widget-registry';
 import { useBlueprintDrop } from './useBlueprintDrop';
 import { getProjectCanvasStore, useAppCanvasStore } from './main';
+import { buildWireDefinitionsFromResult, type ParseResult } from '../../../features/blueprints/parse-blueprint';
+import { useAgentStore } from '../../../stores/agentStore';
 
 /** Pixels to pan per arrow key press (2 grid units). */
 const ARROW_PAN_STEP = 40;
@@ -217,19 +219,32 @@ export function CanvasWorkspace({
   const [blueprintError, setBlueprintError] = useState<string | null>(null);
   const projectId = api.context.projectId ?? null;
 
-  const handleBlueprintImport = useCallback((canvas: import('./canvas-types').CanvasInstance) => {
+  const handleBlueprintImport = useCallback((result: ParseResult) => {
     const store = projectId ? getProjectCanvasStore(projectId) : useAppCanvasStore;
-    store.getState().insertCanvas(canvas);
+    store.getState().insertCanvas(result.canvas);
+    // Manifest format may carry pending wires — restore the ones whose source
+    // agent already resolved on this machine. (Drag/drop into a foreign project
+    // typically won't match; the canvas still imports cleanly without wires.)
+    for (const wire of buildWireDefinitionsFromResult(result)) {
+      store.getState().addWireDefinition(wire);
+    }
   }, [projectId]);
 
   const handleBlueprintError = useCallback((message: string) => {
     setBlueprintError(message);
   }, []);
 
+  const getBlueprintParseContext = useCallback(() => ({
+    agents: Object.values(useAgentStore.getState().agents),
+    projects: useProjectStore.getState().projects.map((p) => ({ id: p.id, name: p.name, path: p.path })),
+    activeProjectId: projectId ?? undefined,
+  }), [projectId]);
+
   const { isDragOver: isBlueprintDragOver } = useBlueprintDrop({
     containerRef,
     onImport: handleBlueprintImport,
     onError: handleBlueprintError,
+    getParseContext: getBlueprintParseContext,
   });
 
   // Auto-dismiss blueprint error toast after 4 seconds

--- a/src/renderer/plugins/builtin/canvas/useBlueprintDrop.test.ts
+++ b/src/renderer/plugins/builtin/canvas/useBlueprintDrop.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useBlueprintDrop } from './useBlueprintDrop';
 
-// Valid blueprint fixture
-const VALID_BLUEPRINT = {
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const VALID_LEGACY = {
   version: 1,
   name: 'Test Blueprint',
   views: [
@@ -11,8 +12,24 @@ const VALID_BLUEPRINT = {
     { type: 'anchor', title: 'Anchor 1', position: { x: 400, y: 0 }, size: { width: 250, height: 100 }, metadata: {}, label: 'My Anchor' },
   ],
 };
+const VALID_LEGACY_JSON = JSON.stringify(VALID_LEGACY);
 
-const VALID_BLUEPRINT_JSON = JSON.stringify(VALID_BLUEPRINT);
+// Manifest format — what fresh exports look like (semver string version + schemaVersion: 1)
+const VALID_MANIFEST = {
+  id: 'bp-test',
+  name: 'Manifest Test',
+  version: '1.0.0',
+  schemaVersion: 1,
+  createdAt: '2026-04-25T12:00:00.000Z',
+  canvas: {
+    views: [
+      { refId: 'v1', type: 'agent', displayName: 'Alpha', position: { x: 0, y: 0 }, size: { width: 480, height: 480 }, agentRef: 'a1' },
+    ],
+    wires: [],
+  },
+  agents: [{ refId: 'a1', name: 'Alpha', matchBy: { name: 'Alpha' } }],
+};
+const VALID_MANIFEST_JSON = JSON.stringify(VALID_MANIFEST);
 
 /** Create a mock File with the given name and text content. */
 function createMockFile(name: string, content: string, type = 'application/json'): File {
@@ -74,7 +91,7 @@ describe('useBlueprintDrop', () => {
       const { result } = renderDropHook();
       expect(result.current.isDragOver).toBe(false);
 
-      const file = createMockFile('blueprint.json', VALID_BLUEPRINT_JSON);
+      const file = createMockFile('blueprint.json', VALID_LEGACY_JSON);
       act(() => {
         container.dispatchEvent(createDragEvent('dragenter', [file]));
       });
@@ -85,7 +102,7 @@ describe('useBlueprintDrop', () => {
     it('sets isDragOver to false on dragleave', () => {
       const { result } = renderDropHook();
 
-      const file = createMockFile('blueprint.json', VALID_BLUEPRINT_JSON);
+      const file = createMockFile('blueprint.json', VALID_LEGACY_JSON);
       act(() => {
         container.dispatchEvent(createDragEvent('dragenter', [file]));
       });
@@ -100,7 +117,7 @@ describe('useBlueprintDrop', () => {
     it('handles nested dragenter/dragleave from child elements', () => {
       const { result } = renderDropHook();
 
-      const file = createMockFile('blueprint.json', VALID_BLUEPRINT_JSON);
+      const file = createMockFile('blueprint.json', VALID_LEGACY_JSON);
       // Enter parent, then enter child (two enters before one leave)
       act(() => {
         container.dispatchEvent(createDragEvent('dragenter', [file]));
@@ -124,7 +141,7 @@ describe('useBlueprintDrop', () => {
     it('resets isDragOver on drop', async () => {
       const { result } = renderDropHook();
 
-      const file = createMockFile('blueprint.json', VALID_BLUEPRINT_JSON);
+      const file = createMockFile('blueprint.json', VALID_LEGACY_JSON);
       act(() => {
         container.dispatchEvent(createDragEvent('dragenter', [file]));
       });
@@ -138,20 +155,35 @@ describe('useBlueprintDrop', () => {
   });
 
   describe('file drop import', () => {
-    it('imports valid .json blueprint file on drop', async () => {
+    it('imports valid legacy .json blueprint file on drop', async () => {
       renderDropHook();
 
-      const file = createMockFile('blueprint.json', VALID_BLUEPRINT_JSON);
+      const file = createMockFile('blueprint.json', VALID_LEGACY_JSON);
       await act(async () => {
         container.dispatchEvent(createDragEvent('drop', [file]));
       });
 
       expect(onImport).toHaveBeenCalledTimes(1);
-      const imported = onImport.mock.calls[0][0];
-      expect(imported.name).toBe('Test Blueprint');
-      expect(imported.views).toHaveLength(2);
-      expect(imported.views[0].type).toBe('agent');
-      expect(imported.views[1].type).toBe('anchor');
+      const result = onImport.mock.calls[0][0];
+      expect(result.format).toBe('legacy');
+      expect(result.canvas.name).toBe('Test Blueprint');
+      expect(result.canvas.views).toHaveLength(2);
+    });
+
+    it('imports a manifest blueprint (semver string version) on drop', async () => {
+      renderDropHook();
+
+      const file = createMockFile('manifest.json', VALID_MANIFEST_JSON);
+      await act(async () => {
+        container.dispatchEvent(createDragEvent('drop', [file]));
+      });
+
+      // Previously this case threw "Unsupported blueprint version: 1.0.0"
+      expect(onError).not.toHaveBeenCalled();
+      expect(onImport).toHaveBeenCalledTimes(1);
+      const result = onImport.mock.calls[0][0];
+      expect(result.format).toBe('manifest');
+      expect(result.canvas.name).toBe('Manifest Test');
     });
 
     it('calls onError for invalid JSON in .json file', async () => {
@@ -194,8 +226,8 @@ describe('useBlueprintDrop', () => {
     it('only imports the first .json file when multiple dropped', async () => {
       renderDropHook();
 
-      const file1 = createMockFile('first.json', VALID_BLUEPRINT_JSON);
-      const file2 = createMockFile('second.json', VALID_BLUEPRINT_JSON);
+      const file1 = createMockFile('first.json', VALID_LEGACY_JSON);
+      const file2 = createMockFile('second.json', VALID_LEGACY_JSON);
       await act(async () => {
         container.dispatchEvent(createDragEvent('drop', [file1, file2]));
       });
@@ -207,33 +239,69 @@ describe('useBlueprintDrop', () => {
       renderDropHook();
 
       const pngFile = createMockFile('image.png', 'binary', 'image/png');
-      const jsonFile = createMockFile('blueprint.json', VALID_BLUEPRINT_JSON);
+      const jsonFile = createMockFile('blueprint.json', VALID_LEGACY_JSON);
       await act(async () => {
         container.dispatchEvent(createDragEvent('drop', [pngFile, jsonFile]));
       });
 
       expect(onImport).toHaveBeenCalledTimes(1);
-      expect(onImport.mock.calls[0][0].name).toBe('Test Blueprint');
+      expect(onImport.mock.calls[0][0].canvas.name).toBe('Test Blueprint');
+    });
+
+    it('passes parse context to manifest imports for agent matching', async () => {
+      const matchedAgent: any = { id: 'agent-real', name: 'Alpha', orchestrator: null, model: null, status: 'sleeping' };
+      const getParseContext = vi.fn(() => ({
+        agents: [matchedAgent],
+        projects: [],
+        activeProjectId: 'proj-1',
+      }));
+      renderHook(() => useBlueprintDrop({ containerRef, onImport, onError, getParseContext }));
+
+      const file = createMockFile('manifest.json', VALID_MANIFEST_JSON);
+      await act(async () => {
+        container.dispatchEvent(createDragEvent('drop', [file]));
+      });
+
+      expect(getParseContext).toHaveBeenCalled();
+      const result = onImport.mock.calls[0][0];
+      // Agent should match and stub binding should be populated
+      expect(result.stubs).toHaveLength(1);
+      expect(result.stubs[0].badge).toBe('connected');
+      expect(result.stubs[0].boundAgentId).toBe('agent-real');
     });
   });
 
   describe('clipboard paste', () => {
-    it('imports valid blueprint JSON from clipboard paste', async () => {
+    it('imports valid legacy blueprint JSON from clipboard paste', async () => {
       renderDropHook();
 
       await act(async () => {
-        container.dispatchEvent(createPasteEvent(VALID_BLUEPRINT_JSON));
+        container.dispatchEvent(createPasteEvent(VALID_LEGACY_JSON));
       });
 
       expect(onImport).toHaveBeenCalledTimes(1);
-      const imported = onImport.mock.calls[0][0];
-      expect(imported.name).toBe('Test Blueprint');
+      const result = onImport.mock.calls[0][0];
+      expect(result.format).toBe('legacy');
+      expect(result.canvas.name).toBe('Test Blueprint');
+    });
+
+    it('imports valid manifest blueprint JSON from clipboard paste', async () => {
+      renderDropHook();
+
+      await act(async () => {
+        container.dispatchEvent(createPasteEvent(VALID_MANIFEST_JSON));
+      });
+
+      // Previously this silently failed because the legacy validator rejected the semver string version
+      expect(onError).not.toHaveBeenCalled();
+      expect(onImport).toHaveBeenCalledTimes(1);
+      expect(onImport.mock.calls[0][0].format).toBe('manifest');
     });
 
     it('prevents default on successful blueprint paste', async () => {
       renderDropHook();
 
-      const event = createPasteEvent(VALID_BLUEPRINT_JSON);
+      const event = createPasteEvent(VALID_LEGACY_JSON);
       await act(async () => {
         container.dispatchEvent(event);
       });
@@ -255,26 +323,32 @@ describe('useBlueprintDrop', () => {
     it('ignores JSON that does not look like a blueprint', async () => {
       renderDropHook();
 
-      // Has JSON structure but missing "version" and "views" fields
+      // Has JSON structure but missing the version/schemaVersion/views markers
       await act(async () => {
         container.dispatchEvent(createPasteEvent('{"name": "test"}'));
       });
 
       expect(onImport).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
     });
 
-    it('does not prevent default for invalid blueprint JSON', async () => {
+    it('surfaces an error when blueprint-shaped JSON fails to validate', async () => {
       renderDropHook();
 
-      // Has "version" and "views" keywords but is actually invalid
-      const badBlueprint = JSON.stringify({ version: 999, views: 'not-an-array' });
+      // Has "version" and "views" keywords but is actually invalid (future numeric version).
+      // Previously this silently dropped — users got no feedback. Now we surface the error.
+      const badBlueprint = JSON.stringify({ version: 999, views: [] });
       const event = createPasteEvent(badBlueprint);
       await act(async () => {
         container.dispatchEvent(event);
       });
 
-      expect(event.preventDefault).not.toHaveBeenCalled();
       expect(onImport).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0]).toContain('Unsupported blueprint version');
+      // We still preventDefault — we consumed the paste (with an error toast),
+      // so the user's clipboard text shouldn't be inserted into a focused input.
+      expect(event.preventDefault).toHaveBeenCalled();
     });
 
     it('ignores empty clipboard', async () => {

--- a/src/renderer/plugins/builtin/canvas/useBlueprintDrop.ts
+++ b/src/renderer/plugins/builtin/canvas/useBlueprintDrop.ts
@@ -1,11 +1,15 @@
 // ── Blueprint Drag-Drop + Clipboard Paste Hook ─────────────────────
 //
 // Provides drag-drop and Ctrl+V paste support for importing blueprint
-// JSON files directly onto the canvas workspace.
+// JSON files (legacy CanvasBlueprint or modern BlueprintManifest) directly
+// onto the canvas workspace.
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { importBlueprint, validateBlueprint } from './canvas-blueprint';
-import type { CanvasInstance } from './canvas-types';
+import {
+  parseAnyBlueprintText,
+  type ParseContext,
+  type ParseResult,
+} from '../../../features/blueprints/parse-blueprint';
 
 export interface BlueprintDropState {
   /** Whether a valid file is being dragged over the drop zone */
@@ -15,10 +19,16 @@ export interface BlueprintDropState {
 export interface UseBlueprintDropOptions {
   /** Ref to the container element acting as the drop zone */
   containerRef: React.RefObject<HTMLDivElement | null>;
-  /** Callback when a valid blueprint is imported */
-  onImport: (canvas: CanvasInstance) => void;
+  /** Callback when a valid blueprint is parsed — consumer applies it to the store. */
+  onImport: (result: ParseResult) => void;
   /** Callback for user-facing error messages */
   onError: (message: string) => void;
+  /**
+   * Returns the live agent/project state for matching manifest refs.
+   * Optional — legacy blueprints don't need it. If omitted, manifests
+   * import with no matches (stubs stay unbound, wires stay pending).
+   */
+  getParseContext?: () => ParseContext;
 }
 
 /**
@@ -63,33 +73,15 @@ function getJsonFiles(e: DragEvent): File[] {
 }
 
 /**
- * Try to parse and import a blueprint from raw JSON text.
- * Returns the imported CanvasInstance or throws with a user-facing message.
- */
-function parseAndImportBlueprint(text: string): CanvasInstance {
-  let data: unknown;
-  try {
-    data = JSON.parse(text);
-  } catch {
-    throw new Error('Not a valid JSON file');
-  }
-
-  const error = validateBlueprint(data);
-  if (error) throw new Error(error);
-
-  return importBlueprint(data as any);
-}
-
-/**
  * Hook that adds blueprint drag-drop and clipboard paste to a canvas container.
  *
  * - Drag a .json file onto the canvas to import it
  * - Press Ctrl/Cmd+V with blueprint JSON in clipboard to import
  * - Shows visual drop overlay while dragging
  * - Ignores non-.json files silently
- * - Shows error toast for invalid blueprint JSON
+ * - Shows error toast for invalid blueprint JSON (drop and paste both surface errors)
  */
-export function useBlueprintDrop({ containerRef, onImport, onError }: UseBlueprintDropOptions): BlueprintDropState {
+export function useBlueprintDrop({ containerRef, onImport, onError, getParseContext }: UseBlueprintDropOptions): BlueprintDropState {
   const [isDragOver, setIsDragOver] = useState(false);
   // Track nested dragenter/dragleave events (child elements fire extra events)
   const dragCounterRef = useRef(0);
@@ -135,31 +127,41 @@ export function useBlueprintDrop({ containerRef, onImport, onError }: UseBluepri
     // Import the first .json file
     try {
       const text = await files[0].text();
-      const canvas = parseAndImportBlueprint(text);
-      onImport(canvas);
+      const result = parseAnyBlueprintText(text, getParseContext?.());
+      onImport(result);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to import blueprint');
     }
-  }, [onImport, onError]);
+  }, [onImport, onError, getParseContext]);
 
   // ── Clipboard paste handler ─────────────────────────────────────────
 
-  const handlePaste = useCallback(async (e: ClipboardEvent) => {
+  const handlePaste = useCallback((e: ClipboardEvent) => {
     const text = e.clipboardData?.getData('text/plain');
     if (!text) return;
 
-    // Quick check: must look like JSON with blueprint fields
+    // Quick heuristic: only attempt parse if it looks like a blueprint JSON.
+    // Both the legacy ({ version, views }) and manifest ({ schemaVersion, canvas })
+    // formats start with `{` and contain at least one of these keys.
     const trimmed = text.trim();
-    if (!trimmed.startsWith('{') || !trimmed.includes('"version"') || !trimmed.includes('"views"')) return;
+    if (!trimmed.startsWith('{')) return;
+    const looksLikeBlueprint =
+      trimmed.includes('"schemaVersion"') ||
+      (trimmed.includes('"version"') && trimmed.includes('"views"'));
+    if (!looksLikeBlueprint) return;
 
     try {
-      const canvas = parseAndImportBlueprint(trimmed);
-      e.preventDefault(); // Only prevent default if we successfully parsed
-      onImport(canvas);
-    } catch {
-      // Not a valid blueprint — let the paste event propagate normally
+      const result = parseAnyBlueprintText(trimmed, getParseContext?.());
+      e.preventDefault(); // We're consuming this paste — stop default text insertion
+      onImport(result);
+    } catch (err) {
+      // The clipboard *looked* like a blueprint (passed the heuristic) but failed
+      // to parse. Surface the error so the user knows their paste was rejected,
+      // rather than silently dropping it.
+      e.preventDefault();
+      onError(err instanceof Error ? err.message : 'Failed to import blueprint');
     }
-  }, [onImport]);
+  }, [onImport, onError, getParseContext]);
 
   // ── Attach event listeners ──────────────────────────────────────────
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -442,7 +442,18 @@ export const IPC = {
     LIST: 'blueprint:list',
     READ: 'blueprint:read',
     DELETE: 'blueprint:delete',
-    SAVE_DIALOG: 'blueprint:save-dialog',
+    /**
+     * Open a save dialog and write the chosen path in one IPC call.
+     * The user picking the path in the OS dialog is the consent gate, so this
+     * bypasses the renderer-facing path sandbox and accepts any writable path.
+     */
+    SAVE_TO_FILE: 'blueprint:save-to-file',
+    /**
+     * Open a file dialog and read+parse the chosen file in one IPC call.
+     * Same consent model as SAVE_TO_FILE — bypasses the sandbox so users can
+     * import blueprints from anywhere on disk (e.g. ~/Downloads).
+     */
+    OPEN_AND_READ: 'blueprint:open-and-read',
   },
   AGENT_QUEUE: {
     CREATE: 'agent-queue:create',

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -196,7 +196,8 @@ vi.stubGlobal('clubhouse', {
     search: async () => [],
   },
   blueprint: {
-    saveDialog: async () => ({ canceled: true }),
+    saveToFile: async () => ({ canceled: true }),
+    openAndRead: async () => ({ canceled: true }),
     list: vi.fn(async () => []),
     read: vi.fn(async () => null),
     delete: vi.fn(async () => true),


### PR DESCRIPTION
## Summary
- Blueprint import/export had four user-reported bugs that this PR fixes together: can't save outside project dirs, can't open from arbitrary paths, paste silently fails, and drag-drop rejects fresh exports with a misleading version error.
- Introduces a unified `parseAnyBlueprint` helper that detects legacy vs manifest format and routes to the right importer, used by drag-drop, paste, the Blueprint Gallery, and the new "Open from file…" file picker.
- Replaces the sandboxed save flow with combined-IPC channels (`SAVE_TO_FILE`, `OPEN_AND_READ`) where the OS dialog itself is the consent gate, so users can save/load blueprints anywhere on disk.

## Bug context

User reported on the latest beta:

1. **Save outside project directory blocked.** Save dialog let you pick `~/Desktop/x.json` but the write failed because `IPC.FILE.WRITE` runs through `assertAllowedPath`, which only allows registered project dirs and the app data dir.
2. **No way to load from an arbitrary file.** The Blueprint Gallery only listed `.clubhouse/blueprints/*.json` from registered projects. There was no file-picker entry point for blueprints sitting in `~/Downloads`.
3. **Paste-to-blueprint silently failed.** `useBlueprintDrop`'s paste handler heuristically detected blueprint-shaped JSON and ran it through `validateBlueprint`, which requires `typeof version === 'number'`. Manifest exports stamp `version: "1.0.0"` (semver string) + `schemaVersion: 1`, so validation rejected them — and the catch block silently dropped the error.
4. **Drag-drop showed `Unsupported blueprint version: 1.0.0 (max supported: 1)`** — same root cause as #3, just visible because the drop path surfaces errors instead of swallowing them.

## Changes

### `src/renderer/features/blueprints/parse-blueprint.ts` (new)
- `detectBlueprintFormat(data)`: returns `'manifest' | 'legacy'`, throws for anything else with a clear message that points at `schemaVersion` or numeric `version`.
- `parseAnyBlueprint(data, ctx?)`: pure function that dispatches to the right importer. Manifest path takes optional `ctx = { agents, projects, activeProjectId }` for ref matching; legacy path ignores `ctx`.
- `parseAnyBlueprintText(text, ctx?)`: JSON.parse + parseAnyBlueprint, with a friendly "Not a valid JSON file" error.
- `buildWireDefinitionsFromResult(result)`: lifts the wire-restoration logic that previously lived inline in `BlueprintGallery` so drag/drop, paste, gallery-card, and open-from-file all materialise wires the same way.

### `src/main/ipc/blueprint-handlers.ts`
- Removed `IPC.BLUEPRINT.SAVE_DIALOG`.
- Added `IPC.BLUEPRINT.SAVE_TO_FILE(defaultName, content)` — opens save dialog AND writes the chosen path in one main-process IPC call. Indivisible: the renderer can't supply a target path, so a malicious renderer can't leverage this to write to arbitrary locations without user interaction. Bypasses `assertAllowedPath` because the OS dialog is the consent gate.
- Added `IPC.BLUEPRINT.OPEN_AND_READ()` — same model for opens. Returns `{ canceled, data?, filePath?, error? }`. Enforces the existing 10 MB size limit.

### `src/renderer/features/blueprints/blueprint-destinations.ts`
- `saveToFile()` now uses `blueprint.saveToFile` IPC. Drops the dependency on the sandboxed `file.write`.

### `src/renderer/features/blueprints/blueprint-bundle.ts`
- `saveBundleToFile()` had the same sandbox bug; same migration.

### `src/renderer/plugins/builtin/canvas/useBlueprintDrop.ts`
- Rewired to `parseAnyBlueprintText` so drag-drop and paste both accept legacy AND manifest formats.
- New `getParseContext?: () => ParseContext` option lets the consumer plug in live agent/project state (CanvasWorkspace does this).
- Paste no longer silently swallows validation failures — when the JSON looks like a blueprint (heuristic match) but fails validation, `onError` is called and `preventDefault` is still called so the user's clipboard text isn't accidentally inserted into a focused input.
- `onImport` callback now receives a `ParseResult` (not a bare `CanvasInstance`) so the consumer can apply pending wires for manifest format.

### `src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx`
- Updated the `useBlueprintDrop` consumer to use the new `ParseResult` API and apply manifest pending wires via `buildWireDefinitionsFromResult`.

### `src/renderer/features/blueprints/BlueprintGallery.tsx`
- New "Open from file…" button in the gallery header. Calls `blueprint.openAndRead`, runs the result through the unified parser, and inserts canvas + wires.

### `src/preload/index.ts` + `src/shared/ipc-channels.ts` + `test/setup-renderer.ts`
- Renamed bridge methods to match new IPC. `saveDialog` → `saveToFile(defaultName, content)`, plus new `openAndRead()`.

## Test Plan

### Automated (237 blueprint tests pass; 11,656 total)

- [x] **`parse-blueprint.test.ts`** (new, 19 tests) — format detection on legacy/manifest/null/strings/wrong schemaVersion; routing produces correct CanvasInstance + pendingWires + stubs; `buildWireDefinitionsFromResult` skips unbound source agents and emits one entry per wire when bound.
- [x] **`blueprint-destinations.test.ts`** (new, 8 tests) — guards regression: `saveToFile` MUST route via `blueprint.saveToFile` IPC and MUST NOT touch the sandboxed `file.write`.
- [x] **`blueprint-handlers.test.ts`** (+11 tests) — `SAVE_TO_FILE` writes to the dialog-chosen path, returns canceled, surfaces write errors, does NOT call `assertAllowedPath`. `OPEN_AND_READ` returns parsed data, returns canceled (both flag and empty filePaths), surfaces parse errors, rejects oversized files, does NOT call `assertAllowedPath`.
- [x] **`useBlueprintDrop.test.ts`** (+3 tests) — drop manifest format succeeds (regression for the `1.0.0` error), paste manifest format succeeds, paste of bad-but-blueprint-shaped JSON now surfaces error to `onError` instead of dropping silently.
- [x] **`BlueprintGallery.test.tsx`** (+4 tests) — open-from-file button renders, imports manifest format, imports legacy format, no-op on cancel, surfaces error on read failure.

### Manual Validation

- [ ] Export a canvas → "Save to file…" → choose `~/Desktop/x.json` → file is written, dialog reports success (used to fail with "Access denied").
- [ ] Open the gallery → "Open from file…" → pick the file from `~/Desktop` → canvas appears.
- [ ] Drag the same exported `~/Desktop/x.json` onto the canvas → canvas appears (no `Unsupported blueprint version: 1.0.0` error).
- [ ] Copy the same JSON, focus canvas, ⌘V → canvas appears.
- [ ] Paste obviously-malformed-but-blueprint-shaped JSON (e.g. `{"version": 999, "views": []}`) → error toast surfaces (used to silently drop).
- [ ] Existing flows (save to `.clubhouse/blueprints/`, copy to clipboard, double-click gallery card) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)