### PR TITLE
fix(terminal): restore focus after fit() reflow on pane focus (#1387)

### DIFF
--- a/src/renderer/features/terminal/useTerminalFit.test.ts
+++ b/src/renderer/features/terminal/useTerminalFit.test.ts
@@ -238,9 +238,36 @@ describe('useTerminalFit', () => {
 
       rerender({ focused: true });
 
-      expect(mockFocus).toHaveBeenCalledTimes(1);
+      // Focus is called twice: once before fit (so the user sees a focused
+      // cursor immediately) and once after fit (to recover from the blur
+      // that xterm's reflow can cause — see issue #1387).
+      expect(mockFocus).toHaveBeenCalledTimes(2);
       expect(mockFit).toHaveBeenCalledTimes(1);
       expect(mockResize).toHaveBeenCalledWith('s1', 80, 24);
+    });
+
+    it('refocuses xterm after fit() to recover from reflow-induced blur', () => {
+      // Regression for issue #1387: switching back to an actively-streaming
+      // agent left the terminal unresponsive because fit() blurs xterm's
+      // helper textarea but the pane-focus effect did not refocus afterwards.
+      const callOrder: string[] = [];
+      mockFit.mockImplementation(() => callOrder.push('fit'));
+      mockFocus.mockImplementation(() => callOrder.push('focus'));
+
+      const { rerender } = renderHook(
+        ({ focused }) => useTerminalFit('s1', terminalRef, fitAddonRef, containerRef, focused),
+        { initialProps: { focused: false } },
+      );
+
+      callOrder.length = 0;
+      mockFit.mockClear();
+      mockFocus.mockClear();
+
+      rerender({ focused: true });
+
+      // Pre-fit focus (immediate cursor), fit (reflow blurs textarea),
+      // post-fit focus (recovery).
+      expect(callOrder).toEqual(['focus', 'fit', 'focus']);
     });
 
     it('does not call fit or resize when focused is false', () => {

--- a/src/renderer/features/terminal/useTerminalFit.ts
+++ b/src/renderer/features/terminal/useTerminalFit.ts
@@ -203,6 +203,10 @@ export function useTerminalFit(
           terminalRef.current.cols,
           terminalRef.current.rows,
         );
+        // fit() reflow can blur xterm's helper textarea — refocus so the
+        // user can type immediately after switching back to an actively
+        // streaming agent (issue #1387).
+        terminalRef.current.focus();
       }
     });
   }, [focused, sessionId, onResize]);


### PR DESCRIPTION
## Summary
- Fixes #1387 — terminal input was unresponsive when switching back to an agent that was actively streaming output.
- Root cause: the `useTerminalFit` pane-focus effect called `term.focus()` *before* `fit()`, but `fit()`'s reflow blurs xterm's hidden helper textarea. Other paths in this codebase (`finishResume`, buffer replay, theme/font handlers) already refocus defensively after a reflow — this one was missed.
- The blur watchdog in `AgentTerminal` did not always recover this case because reflow-induced blurs can have a non-null `relatedTarget` and slip past its strict `relatedTarget === null` check. Active streaming made the wedge reliable: continuous `term.write()` calls keep nudging xterm's renderer, increasing the chance of a blur landing in the gap between the synchronous pre-fit focus and the (previously absent) post-fit refocus.

## Changes
- `src/renderer/features/terminal/useTerminalFit.ts` — in the pane-focus `useEffect`, call `terminalRef.current.focus()` after `fit()` and `restoreViewportScroll` complete.
- `src/renderer/features/terminal/useTerminalFit.test.ts`:
  - New regression test `refocuses xterm after fit() to recover from reflow-induced blur` asserts the call order is `focus → fit → focus`.
  - Updated existing `calls fit, resize, and focus when focused becomes true` to expect 2 focus calls.

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (11610 / 11610, 4 skipped — same baseline as main)
- [x] `npm run lint` — no new lint errors introduced (existing errors in unrelated files)
- [x] New unit test fails before the fix, passes after — confirmed locally

## Manual Validation
1. Start a long-running streaming command in Agent A (e.g. test suite, build).
2. Switch to a different project while output is streaming.
3. Switch back to the original project / Agent A while it is still producing output.
4. Confirm typing in the input area registers immediately — previously the cursor appeared but keystrokes were dropped.

## Notes / Risk
- Surgical change to one effect path; the same defensive pattern is already used in the codebase (`finishResume` at `AgentTerminal.tsx:137`).
- The new `term.focus()` runs in the same rAF callback as `fit()`/`restoreViewportScroll`, gated by the existing `if (!focused) return;` early-return at the top of the effect — so it cannot steal focus from an unfocused pane.
- If the bug persists in the field after this lands, the next steps would be to broaden the blur watchdog (recover from `relatedTarget === document.body`) and/or sample focus during streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)