### PR TITLE
feat(plugin-sdk): expose mcpIds on AgentInfo (@since 0.9)

### DIFF
--- a/src/renderer/plugins/plugin-api-agents.ts
+++ b/src/renderer/plugins/plugin-api-agents.ts
@@ -42,6 +42,7 @@ export function createAgentsAPI(ctx: PluginContext, manifest?: PluginManifest): 
           orchestrator: a.orchestrator,
           freeAgentMode: a.freeAgentMode,
           pluginMetadata: a.pluginMetadata,
+          mcpIds: a.mcpIds,
         }));
     },
 

--- a/src/renderer/plugins/plugin-api-factory.test.ts
+++ b/src/renderer/plugins/plugin-api-factory.test.ts
@@ -1581,6 +1581,24 @@ describe('plugin-api-factory', () => {
         expect(alpha.pluginMetadata).toEqual({ boardId: 'b1', cardId: 'c1' });
       });
 
+      it('includes mcpIds when present on agent', () => {
+        useAgentStore.setState((s) => ({
+          agents: {
+            ...s.agents,
+            'agent-1': { ...s.agents['agent-1'], mcpIds: ['mcp-1', 'mcp-2'] },
+          },
+        }));
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        const alpha = api.agents.list().find((a) => a.id === 'agent-1')!;
+        expect(alpha.mcpIds).toEqual(['mcp-1', 'mcp-2']);
+      });
+
+      it('returns mcpIds as undefined when not set on store agent', () => {
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        const beta = api.agents.list().find((a) => a.id === 'agent-2')!;
+        expect(beta.mcpIds).toBeUndefined();
+      });
+
       it('includes parentAgentId for child agents', () => {
         const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
         const beta = api.agents.list().find((a) => a.id === 'agent-2')!;

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -512,6 +512,8 @@ export interface AgentInfo {
   freeAgentMode?: boolean;
   /** Plugin-supplied metadata attached at spawn time. @since 0.8 */
   pluginMetadata?: Record<string, string>;
+  /** IDs of MCP servers attached to this agent via launch wrapper. @since 0.9 */
+  mcpIds?: string[];
 }
 
 export interface PluginAgentDetailedStatus {


### PR DESCRIPTION
## Summary
- Adds `mcpIds?: string[]` to the `AgentInfo` interface so plugins can read which MCP servers are attached to a durable agent.
- Marked `@since 0.9` — this is a read-side surfacing of data that `createDurable()` already accepted on the write side.
- Closes #1391.

## Why
Plugins (specifically the Lounge agent-tags work) need to render MCP count badges (e.g. "5 MCPs") next to agents. The data already lived on the internal `Agent` type and was wired through `createDurable`, but `AgentInfo` — the type plugins receive from `api.agents.list()` — didn't expose it.

## Changes
- `src/shared/plugin-types.ts` — Add `mcpIds?: string[]` to `AgentInfo` with `@since 0.9` JSDoc tag.
- `src/renderer/plugins/plugin-api-agents.ts` — Pass `a.mcpIds` through in the `list()` mapping.
- `src/renderer/plugins/plugin-api-factory.test.ts` — Two new test cases: one verifies `mcpIds` is returned when set on the underlying agent, one verifies it's `undefined` when unset.

## Compatibility
- Backward compatible — additive optional field on an existing interface.
- No change to permissions or API version validation; plugins on older `engine.api` still work, they just won't see the new field documented.
- `CompletedQuickAgentInfo` intentionally not changed — quick agents inherit MCP context from their spawn options rather than carrying static attachments.

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 11,611 passing (incl. 2 new tests)
- [x] Targeted: `vitest run src/renderer/plugins/plugin-api-factory.test.ts` — all `list()` tests green
- [ ] Manual: load a plugin against this build, call `api.agents.list()`, confirm `mcpIds` populates for an agent created via `createDurable({ mcpIds: [...] })`

## Notes
The repo's `npm run lint` reports 22 pre-existing errors in unrelated files (e.g. `AgentSettingsView.tsx`, `elk-layout.ts`); none are in this PR's diff.