### PR TITLE
chore(lint): clean up 22 lint errors and 1 warning

### DIFF
--- a/e2e/assistant/builder-persona.spec.ts
+++ b/e2e/assistant/builder-persona.spec.ts
@@ -17,7 +17,6 @@ import {
   AssistantInstance,
   launchAssistantInstance,
   cleanupAssistantInstance,
-  openAssistantPanel,
   resetAssistant,
   sendAssistantMessage,
   waitForFeedContent,

--- a/src/main/ipc/mcp-binding-handlers.ts
+++ b/src/main/ipc/mcp-binding-handlers.ts
@@ -19,14 +19,6 @@ import { appLog } from '../services/log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { withValidatedArgs, stringArg, objectArg, arrayArg } from './validation';
 
-/** Verify the agentId refers to a registered agent. Throws if not. */
-function assertAgentRegistered(agentId: string): void {
-  if (!agentRegistry.get(agentId)) {
-    appLog('core:mcp', 'warn', 'Rejected MCP binding request — agent not registered', { meta: { agentId } });
-    throw new Error(`Agent not registered: ${agentId}`);
-  }
-}
-
 /** Valid values for BindingTargetKind. */
 const VALID_TARGET_KINDS = new Set<BindingTargetKind>([
   'browser', 'agent', 'terminal', 'group-project', 'agent-queue', 'plugin', 'assistant',

--- a/src/main/orchestrators/base-provider.ts
+++ b/src/main/orchestrators/base-provider.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { execFile } from 'child_process';

--- a/src/main/orchestrators/instructions-paths.test.ts
+++ b/src/main/orchestrators/instructions-paths.test.ts
@@ -36,9 +36,6 @@ import { CodexCliProvider } from './codex-cli-provider';
 
 
 describe('Instructions path resolution', () => {
-  // path.join normalizes separators for cross-platform compat ('\project' on Windows)
-  const projectDir = path.join('/project');
-
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: binaries found at standard paths

--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -352,7 +352,6 @@ async function writeAgents(projectPath: string, agents: DurableAgentConfig[]): P
     // Log when agent count decreases — this is the signal for data loss
     const prevCount = entry.agents.length;
     if (agents.length < prevCount) {
-      const prevIds = new Set(entry.agents.map((a) => a.id));
       const newIds = new Set(agents.map((a) => a.id));
       const removed = entry.agents.filter((a) => !newIds.has(a.id));
       appLog('core:agent-config', 'warn', `Agent count decreased: ${prevCount} → ${agents.length}`, {

--- a/src/main/services/clubhouse-mcp/tools/browser-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/browser-tools.ts
@@ -8,7 +8,7 @@ import { bindingManager } from '../binding-manager';
 import { mcpAdapter } from '../mcp-adapter';
 import type { McpToolResult } from '../types';
 import { appLog } from '../../log-service';
-import { requireString, optionalString, numberWithDefault, stringWithDefault } from './validation';
+import { requireString, numberWithDefault, stringWithDefault } from './validation';
 
 /**
  * Read-only expressions that are safe to auto-allow without user confirmation.

--- a/src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts
@@ -1053,7 +1053,7 @@ describe('GroupProjectTools', () => {
     const binding = makeBinding({ agentId: 'agent-1', targetId: project.id, targetName: 'DelMsgProj' });
     const postName = buildToolName(binding, 'post_bulletin');
 
-    const r1 = await callTool('agent-1', postName, { topic: 'cleanup', body: 'keep me' });
+    await callTool('agent-1', postName, { topic: 'cleanup', body: 'keep me' });
     const r2 = await callTool('agent-1', postName, { topic: 'cleanup', body: 'delete me' });
     const r3 = await callTool('agent-1', postName, { topic: 'cleanup', body: 'delete me too' });
 

--- a/src/main/services/config-pipeline.test.ts
+++ b/src/main/services/config-pipeline.test.ts
@@ -512,7 +512,6 @@ describe('config-pipeline', () => {
   describe('concurrent restore serialization', () => {
     it('serializes concurrent restoreForAgent calls via mutex', async () => {
       const callOrder: string[] = [];
-      const absPath = path.resolve('/project/.claude/settings.json');
 
       // Make readFile return content so snapshot exists
       vi.mocked(fsp.readFile).mockResolvedValue('{"hooks":{}}');

--- a/src/main/services/group-project-bulletin.test.ts
+++ b/src/main/services/group-project-bulletin.test.ts
@@ -468,7 +468,7 @@ describe('BulletinBoard', () => {
   describe('getMessageById', () => {
     it('finds a message across topics', async () => {
       const board = getBulletinBoard('gp_getmsg');
-      const msg1 = await board.postMessage('alice', 'topic-a', 'hello');
+      await board.postMessage('alice', 'topic-a', 'hello');
       const msg2 = await board.postMessage('bob', 'topic-b', 'world');
 
       const found = await board.getMessageById(msg2.id);

--- a/src/main/window-security-guards.test.ts
+++ b/src/main/window-security-guards.test.ts
@@ -19,17 +19,19 @@ vi.mock('electron', () => ({
 }));
 
 import { applyWindowSecurityGuards } from './window-security-guards';
-import { appLog } from './services/log-service';
+
+type Listener = (...args: unknown[]) => unknown;
+type WindowOpenHandler = (details: { url: string }) => unknown;
 
 function createMockWindow() {
-  const listeners: Record<string, Function> = {};
-  let windowOpenHandler: Function | null = null;
+  const listeners: Record<string, Listener> = {};
+  let windowOpenHandler: WindowOpenHandler | null = null;
   return {
     webContents: {
-      on: vi.fn((event: string, handler: Function) => {
+      on: vi.fn((event: string, handler: Listener) => {
         listeners[event] = handler;
       }),
-      setWindowOpenHandler: vi.fn((handler: Function) => {
+      setWindowOpenHandler: vi.fn((handler: WindowOpenHandler) => {
         windowOpenHandler = handler;
       }),
     },

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -29,7 +29,6 @@ export function AgentSettingsView({ agent }: Props) {
   const { closeAgentSettings, updateAgent, loadDurableAgents } = useAgentStore();
   const { projects, activeProjectId } = useProjectStore();
   const activeProject = projects.find((p) => p.id === activeProjectId);
-  const colorInfo = AGENT_COLORS.find((c) => c.id === agent.color);
   const worktreePath = agent.worktreePath || activeProject?.path || '';
   const { options: MODEL_OPTIONS } = useModelOptions();
   const enabled = useOrchestratorStore((s) => s.enabled);

--- a/src/renderer/features/agents/AgentTerminal.batching.test.tsx
+++ b/src/renderer/features/agents/AgentTerminal.batching.test.tsx
@@ -152,7 +152,7 @@ describe('AgentTerminal write batching', () => {
       mockOnDataCallback = cb;
       return mockRemoveDataListener;
     });
-    window.clubhouse.pty.onExit = vi.fn().mockImplementation((cb: any) => {
+    window.clubhouse.pty.onExit = vi.fn().mockImplementation((_cb: any) => {
       return mockRemoveExitListener;
     });
 

--- a/src/renderer/features/annex/SatelliteDashboard.tsx
+++ b/src/renderer/features/annex/SatelliteDashboard.tsx
@@ -5,7 +5,7 @@
  * projects and agents. This decouples Home from the Canvas plugin so
  * Home always renders useful content regardless of canvas/annex state.
  */
-import { useMemo, useCallback, useState } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useAnnexClientStore } from '../../stores/annexClientStore';
 import {
   useRemoteProjectStore,

--- a/src/renderer/features/assistant/action-card.test.ts
+++ b/src/renderer/features/assistant/action-card.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ActionCardData, ActionCardStatus, FeedItem } from './types';
+import type { ActionCardData, FeedItem } from './types';
 
 // The global test setup (setup-renderer.ts) provides window.clubhouse with all
 // required mocks including assistant.saveHistory, assistant.loadHistory, etc.

--- a/src/renderer/features/assistant/assistant-ui.test.ts
+++ b/src/renderer/features/assistant/assistant-ui.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useUIStore } from '../../stores/uiStore';
 import { AssistantFeed } from './AssistantFeed';

--- a/src/renderer/features/assistant/canvas-command-handler.ts
+++ b/src/renderer/features/assistant/canvas-command-handler.ts
@@ -623,7 +623,6 @@ const handlers: Record<string, (args: Record<string, unknown>) => CanvasCommandR
     const idMap: Record<string, string> = {};
 
     // Phase 1: Create zones first (they must exist before cards reference them)
-    const prevActive = store.activeCanvasId;
     store.setActiveCanvas(canvasId);
 
     for (const zone of blueprint.zones || []) {

--- a/src/renderer/features/assistant/strip-ansi.test.ts
+++ b/src/renderer/features/assistant/strip-ansi.test.ts
@@ -4,12 +4,11 @@ import { describe, it, expect } from 'vitest';
 function stripAnsi(text: string): string {
   return text
     // eslint-disable-next-line no-control-regex
-    .replace(/\x1b\[[\?]?[0-9;]*[a-zA-Z~]/g, '')
+    .replace(/\x1b\[[?]?[0-9;]*[a-zA-Z~]/g, '')
     // eslint-disable-next-line no-control-regex
     .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
     // eslint-disable-next-line no-control-regex
     .replace(/\x1b[^[\]]/g, '')
-    // eslint-disable-next-line no-control-regex
     .replace(/\r/g, '')
     .replace(/^quote> /gm, '');
 }

--- a/src/renderer/plugins/builtin/canvas/canvas-blueprint.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-blueprint.test.ts
@@ -5,7 +5,7 @@ import {
   validateBlueprint,
   BLUEPRINT_VERSION,
 } from './canvas-blueprint';
-import type { CanvasBlueprint, BlueprintView } from './canvas-blueprint';
+import type { CanvasBlueprint } from './canvas-blueprint';
 import type {
   CanvasInstance,
   AgentCanvasView,


### PR DESCRIPTION
## Summary
- Cleans up 22 lint errors + 1 warning surfaced by `npm run lint`
- No behavioral changes — all fixes are unused-symbol removals, type tightening, and a regex cleanup
- `npm run lint`, `npm run typecheck`, and the full `npm test` (11657 tests) all pass after these changes

## Changes
**Unused imports / vars / dead code (17 errors)**
- `e2e/assistant/builder-persona.spec.ts` — drop unused `openAssistantPanel` import
- `src/main/ipc/mcp-binding-handlers.ts` — remove unreferenced `assertAgentRegistered` helper
- `src/main/orchestrators/base-provider.ts` — drop unused `import * as fs from 'fs'` (only `fsp` is used)
- `src/main/orchestrators/instructions-paths.test.ts` — remove unused `projectDir` constant
- `src/main/services/agent-config.ts` — remove unused `prevIds` Set in `writeAgents`
- `src/main/services/clubhouse-mcp/tools/browser-tools.ts` — drop unused `optionalString` import
- `src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts` — drop unused `r1` assignment
- `src/main/services/config-pipeline.test.ts` — remove unused `absPath` constant
- `src/main/services/group-project-bulletin.test.ts` — drop unused `msg1` assignment
- `src/renderer/features/agents/AgentSettingsView.tsx` — remove unused `colorInfo`
- `src/renderer/features/agents/AgentTerminal.batching.test.tsx` — prefix unused `cb` arg with `_`
- `src/renderer/features/annex/SatelliteDashboard.tsx` — drop unused `useState` import
- `src/renderer/features/assistant/action-card.test.ts` — drop unused `ActionCardStatus` import
- `src/renderer/features/assistant/assistant-ui.test.ts` — drop unused `beforeEach` import
- `src/renderer/features/assistant/canvas-command-handler.ts` — remove unused `prevActive` (active canvas is intentionally not restored after blueprint import)
- `src/renderer/plugins/builtin/canvas/canvas-blueprint.test.ts` — drop unused `BlueprintView` import

**Unsafe `Function` types (4 errors)**
- `src/main/window-security-guards.test.ts` — replace 4 `Function` annotations with explicit `Listener = (...args: unknown[]) => unknown` and `WindowOpenHandler = (details: { url: string }) => unknown` types; also drop the now-unused `appLog` import

**Other**
- `src/renderer/features/assistant/strip-ansi.test.ts` — replace `[\?]` with `[?]` (escape inside char class is unnecessary) and remove an `eslint-disable-next-line no-control-regex` directive that was guarding a regex with no control chars

## Test Plan
- [x] `npm run lint` is clean (was 22 errors + 1 warning, now 0)
- [x] `npm run typecheck` is clean
- [x] `npm test` — 11657 passed, 4 skipped (no regressions)

## Manual Validation
None required — this PR only removes dead symbols, tightens loose `Function` types in a test file, and cleans up regex/lint directives. No runtime code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)