### PR TITLE
fix(themes): guard hexToRgbChannels against undefined color slots

### DIFF
--- a/src/renderer/themes/apply-theme.test.ts
+++ b/src/renderer/themes/apply-theme.test.ts
@@ -27,7 +27,7 @@ Object.defineProperty(globalThis, 'localStorage', {
   writable: true,
 });
 
-import { applyTheme } from './apply-theme';
+import { applyTheme, hexToRgbChannels, themeToStyleVars } from './apply-theme';
 
 function makeTheme(overrides?: Partial<ThemeDefinition>): ThemeDefinition {
   return {
@@ -98,6 +98,34 @@ function makeTheme(overrides?: Partial<ThemeDefinition>): ThemeDefinition {
     ...overrides,
   };
 }
+
+describe('hexToRgbChannels', () => {
+  it('converts a hex color to space-separated RGB channels', () => {
+    expect(hexToRgbChannels('#1e1e2e')).toBe('30 30 46');
+    expect(hexToRgbChannels('#ffffff')).toBe('255 255 255');
+    expect(hexToRgbChannels('#000000')).toBe('0 0 0');
+  });
+
+  it('returns "0 0 0" for an undefined color (plugin-contributed theme missing a slot)', () => {
+    expect(hexToRgbChannels(undefined as unknown as string)).toBe('0 0 0');
+  });
+
+  it('returns "0 0 0" for an empty string', () => {
+    expect(hexToRgbChannels('')).toBe('0 0 0');
+  });
+});
+
+describe('themeToStyleVars', () => {
+  it('skips undefined color slots without throwing (plugin theme missing accent2)', () => {
+    const theme = makeTheme();
+    delete (theme.colors as any).accent2;
+
+    let result: Record<string, string> | undefined;
+    expect(() => { result = themeToStyleVars(theme); }).not.toThrow();
+    expect(result!['--ctp-accent2']).toBeUndefined();
+    expect(result!['--ctp-base']).toBe('30 30 46');
+  });
+});
 
 describe('applyTheme', () => {
   beforeEach(() => {
@@ -220,6 +248,29 @@ describe('applyTheme', () => {
     it('sets exactly 36 CSS variables for a plain theme (17 colors + 16 hljs + 3 shadows)', () => {
       applyTheme(makeTheme());
       expect(mockSetProperty).toHaveBeenCalledTimes(36);
+    });
+  });
+
+  describe('missing color slots (plugin-contributed themes)', () => {
+    it('does not throw when accent2 is undefined', () => {
+      const theme = makeTheme();
+      delete (theme.colors as any).accent2;
+      expect(() => applyTheme(theme)).not.toThrow();
+    });
+
+    it('skips setting the CSS variable for any undefined color slot', () => {
+      const theme = makeTheme();
+      delete (theme.colors as any).accent2;
+      applyTheme(theme);
+      expect(mockSetProperty).not.toHaveBeenCalledWith('--ctp-accent2', expect.anything());
+    });
+
+    it('still sets all other color variables when one is missing', () => {
+      const theme = makeTheme();
+      delete (theme.colors as any).accent2;
+      applyTheme(theme);
+      expect(mockSetProperty).toHaveBeenCalledWith('--ctp-accent', '203 166 247');
+      expect(mockSetProperty).toHaveBeenCalledWith('--ctp-base', '30 30 46');
     });
   });
 

--- a/src/renderer/themes/apply-theme.ts
+++ b/src/renderer/themes/apply-theme.ts
@@ -1,6 +1,7 @@
 import { ThemeDefinition } from '../../shared/types';
 
 export function hexToRgbChannels(hex: string): string {
+  if (!hex) return '0 0 0';
   const h = hex.replace('#', '');
   const r = parseInt(h.substring(0, 2), 16);
   const g = parseInt(h.substring(2, 4), 16);
@@ -40,6 +41,7 @@ export function applyTheme(theme: ThemeDefinition, options?: ApplyThemeOptions):
   };
 
   for (const [varName, hex] of Object.entries(colorMap)) {
+    if (hex === undefined) continue;
     const rgb = hexToRgbChannels(hex);
     s.setProperty(varName, rgb);
     cache[varName] = rgb;
@@ -183,7 +185,7 @@ export function themeToStyleVars(theme: ThemeDefinition): Record<string, string>
   };
 
   for (const [varName, hex] of Object.entries(colorMap)) {
-    vars[varName] = hexToRgbChannels(hex);
+    if (hex !== undefined) vars[varName] = hexToRgbChannels(hex);
   }
 
   return vars;


### PR DESCRIPTION
## Summary
- Fixes a Canvas plugin crash (`Render error: Cannot read properties of undefined (reading 'replace')`) triggered when any canvas zone uses a plugin-contributed theme that was registered without all required color slots
- Guards `hexToRgbChannels` to return `'0 0 0'` instead of throwing when passed `undefined` or empty string
- Both `applyTheme` and `themeToStyleVars` now skip CSS variable assignment for any undefined color slot, so the zone renders with a fallback color rather than crashing the entire Canvas plugin

## Root Cause
`accent2` and `overlay` were added to `ThemeColors` in a recent commit. The plugin theme registration path (`registerPackThemes`) uses a type cast (`as ThemeColors`) with no runtime validation, so a plugin-contributed theme written before these slots were added will have `undefined` for those fields. When a canvas zone renders with such a theme, `ZoneThemeProvider` → `themeToStyleVars` → `hexToRgbChannels(undefined)` throws `Cannot read properties of undefined (reading 'replace')`, which is caught by the Canvas plugin's `PluginErrorBoundary` and marks the entire Canvas as errored.

## Changes
- `src/renderer/themes/apply-theme.ts`
  - `hexToRgbChannels`: early return `'0 0 0'` when `hex` is falsy
  - `applyTheme` color loop: skip slots where `hex === undefined`
  - `themeToStyleVars` color loop: skip slots where `hex !== undefined`
- `src/renderer/themes/apply-theme.test.ts`
  - New `hexToRgbChannels` describe block with 3 tests (normal conversion, undefined input, empty string)
  - New `themeToStyleVars` describe block testing that undefined slots are skipped without throwing
  - New `applyTheme > missing color slots` block with 3 tests for the plugin-theme scenario

## Test Plan
- [x] 30/30 tests pass in `apply-theme.test.ts`
- [x] `hexToRgbChannels(undefined)` returns `'0 0 0'`
- [x] `applyTheme` with `accent2` deleted does not throw and does not call `setProperty` for `--ctp-accent2`
- [x] All other color variables still set correctly when one slot is missing

## Manual Validation
Open the app with a canvas that has a zone with any theme applied — the Canvas plugin should load normally. If you have a plugin installed that contributes a theme without `accent2`/`overlay`, the zone will render using a black (`0 0 0`) fallback for those tokens rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)