### PR TITLE
chore: bump version to 0.39.0-beta.26 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.39.0-beta.25",
+  "version": "0.39.0-beta.26",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Canvas Theme Stability Fix

# Bug Fixes
- Fixed canvas zone crash when a plugin-contributed theme is missing color slots introduced in a later SDK version