### PR TITLE
fix(canvas): A2A wire wake action + woken-agent canvas sync

### DIFF
--- a/src/renderer/app-event-bridge.test.ts
+++ b/src/renderer/app-event-bridge.test.ts
@@ -16,6 +16,7 @@ const mockRemovers = {
   onNavigateToAgent: vi.fn(),
   onNavigateToPluginSettings: vi.fn(),
   onExit: vi.fn(),
+  onData: vi.fn(),
   onHookEvent: vi.fn(),
   onAgentWaking: vi.fn(),
   onAgentWakeFailed: vi.fn(),
@@ -52,6 +53,7 @@ vi.stubGlobal('window', {
     },
     pty: {
       onExit: vi.fn(() => mockRemovers.onExit),
+      onData: vi.fn(() => mockRemovers.onData),
       kill: vi.fn(),
     },
     agent: {
@@ -427,6 +429,129 @@ describe('initAppEventBridge', () => {
     });
 
     expect(mockPlaySound).toHaveBeenCalledWith('permission-denied', 'proj-1');
+  });
+
+  it('registers a PTY data listener as a wake-detection fallback', () => {
+    expect(window.clubhouse.pty.onData).toHaveBeenCalled();
+  });
+
+  it('transitions a non-running agent to running on first PTY data', () => {
+    const setStateSpy = vi.mocked(useAgentStore.setState);
+    setStateSpy.mockClear();
+
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: { ...createAgent('a1', 'proj-1'), status: 'waking' } },
+      activeAgentId: null,
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const dataCallback = vi.mocked(window.clubhouse.pty.onData).mock.calls[0][0];
+    dataCallback('a1', 'output');
+
+    expect(setStateSpy).toHaveBeenCalledTimes(1);
+    const updater = setStateSpy.mock.calls[0][0] as (s: any) => any;
+    const next = updater({
+      agents: { a1: { ...createAgent('a1', 'proj-1'), status: 'waking' } },
+      agentSpawnedAt: {},
+    });
+    expect(next.agents.a1.status).toBe('running');
+    expect(next.agentSpawnedAt.a1).toBeTypeOf('number');
+  });
+
+  it('does not transition or re-fire on subsequent PTY data for the same agent', () => {
+    const setStateSpy = vi.mocked(useAgentStore.setState);
+    setStateSpy.mockClear();
+
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: { ...createAgent('a1', 'proj-1'), status: 'waking' } },
+      activeAgentId: null,
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const dataCallback = vi.mocked(window.clubhouse.pty.onData).mock.calls[0][0];
+    dataCallback('a1', 'first');
+    dataCallback('a1', 'second');
+    dataCallback('a1', 'third');
+
+    expect(setStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not transition an already-running agent', () => {
+    const setStateSpy = vi.mocked(useAgentStore.setState);
+    setStateSpy.mockClear();
+
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: { ...createAgent('a1', 'proj-1'), status: 'running' } },
+      activeAgentId: null,
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const dataCallback = vi.mocked(window.clubhouse.pty.onData).mock.calls[0][0];
+    dataCallback('a1', 'output');
+
+    expect(setStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears wake dedupe on PTY exit so the next wake is detected', () => {
+    const setStateSpy = vi.mocked(useAgentStore.setState);
+    setStateSpy.mockClear();
+
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: { ...createAgent('a1', 'proj-1'), status: 'waking' } },
+      activeAgentId: null,
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const dataCallback = vi.mocked(window.clubhouse.pty.onData).mock.calls[0][0];
+    dataCallback('a1', 'first');
+    expect(setStateSpy).toHaveBeenCalledTimes(1);
+
+    // Find the exit listener registered by the PTY data wake listener (not the
+    // earlier exit listener for status-to-sleeping). The latest call is ours.
+    const exitCalls = vi.mocked(window.clubhouse.pty.onExit).mock.calls;
+    const wakeExitCallback = exitCalls[exitCalls.length - 1][0];
+    wakeExitCallback('a1', 0);
+
+    setStateSpy.mockClear();
+    // Status is still 'waking' in the mock; second wake cycle should re-fire.
+    dataCallback('a1', 'second-wake');
+    expect(setStateSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does not play agent-focus when the active agent is unchanged or cleared', () => {

--- a/src/renderer/app-event-bridge.ts
+++ b/src/renderer/app-event-bridge.ts
@@ -341,6 +341,51 @@ function initAgentWakingListener(): () => void {
   };
 }
 
+/**
+ * Detect sleeping → running transitions via PTY data.
+ *
+ * When an agent is woken externally — e.g. via the group-project `wake_agent`
+ * MCP tool, or via annex sync — its status is set to `waking` (or stays
+ * `sleeping`) by the broadcast listeners above. The transition to `running`
+ * normally happens when a hook event arrives (see handleHookEvent), but if
+ * the woken agent sits idle at a prompt, no hook ever fires and the status
+ * is stuck. PTY data is a reliable signal that the process is alive.
+ *
+ * Mirrors the same logic in PopoutWindow.tsx for popout windows.
+ */
+function initPtyDataWakeListener(): () => void {
+  const awokenAgents = new Set<string>();
+
+  const removeDataListener = window.clubhouse.pty.onData((agentId: string) => {
+    if (awokenAgents.has(agentId)) return;
+    const agent = useAgentStore.getState().agents[agentId];
+    if (!agent) return;
+    awokenAgents.add(agentId);
+    if (agent.status === 'running') return;
+    useAgentStore.setState((s) => {
+      const a = s.agents[agentId];
+      if (!a || a.status === 'running') return s;
+      return {
+        agents: {
+          ...s.agents,
+          [agentId]: { ...a, status: 'running', exitCode: undefined, errorMessage: undefined },
+        },
+        agentSpawnedAt: { ...s.agentSpawnedAt, [agentId]: Date.now() },
+      };
+    });
+  });
+
+  // Allow re-detection on the next wake by clearing the dedupe set on exit.
+  const removeExitListener = window.clubhouse.pty.onExit((agentId: string) => {
+    awokenAgents.delete(agentId);
+  });
+
+  return () => {
+    removeDataListener();
+    removeExitListener();
+  };
+}
+
 function initHookEventListener(): () => void {
   const removeHookListener = window.clubhouse.agent.onHookEvent(
     (agentId: string, event: { kind: string; toolName?: string; toolInput?: Record<string, unknown>; message?: string; toolVerb?: string; timestamp: number }) => {
@@ -637,6 +682,7 @@ export function initAppEventBridge(): () => void {
   cleanups.push(...initWindowListeners());
   cleanups.push(initPtyExitListener());
   cleanups.push(initAgentWakingListener());
+  cleanups.push(initPtyDataWakeListener());
   cleanups.push(initHookEventListener());
   cleanups.push(initAnnexSpawnListener());
   cleanups.push(initAgentStateBroadcast());

--- a/src/renderer/plugins/builtin/canvas/WireConfigPopover.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireConfigPopover.test.tsx
@@ -4,6 +4,7 @@ import { WireConfigPopover } from './WireConfigPopover';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
 import { useAgentStore } from '../../../stores/agentStore';
+import { useProjectStore } from '../../../stores/projectStore';
 
 describe('WireConfigPopover', () => {
   const browserBinding: McpBindingEntry = {
@@ -73,19 +74,114 @@ describe('WireConfigPopover', () => {
     expect(getByTestId('wire-instructions-button').textContent).toContain('Set Instructions');
   });
 
-  it('does not expose a wire-level wake action for sleeping agent targets', () => {
+  it('exposes a wake action for sleeping agent targets on A2A wires', () => {
     useAgentStore.setState({
       agents: {
         'agent-2': { id: 'agent-2', name: 'Agent 2', kind: 'durable', status: 'sleeping', projectId: 'project-1' } as any,
       },
     });
 
-    const { queryByTestId, queryByText } = render(
+    const { getByTestId } = render(
+      <WireConfigPopover binding={agentBinding} x={100} y={200} onClose={vi.fn()} />,
+    );
+
+    expect(getByTestId('wire-wake-agent')).toBeTruthy();
+    expect(getByTestId('wire-wake-agent').textContent).toContain('Wake Agent');
+  });
+
+  it('shows "Retry Agent" for errored target agents', () => {
+    useAgentStore.setState({
+      agents: {
+        'agent-2': { id: 'agent-2', name: 'Agent 2', kind: 'durable', status: 'error', projectId: 'project-1' } as any,
+      },
+    });
+
+    const { getByTestId } = render(
+      <WireConfigPopover binding={agentBinding} x={100} y={200} onClose={vi.fn()} />,
+    );
+
+    expect(getByTestId('wire-wake-agent').textContent).toContain('Retry');
+  });
+
+  it('does not expose a wake action when target agent is running', () => {
+    useAgentStore.setState({
+      agents: {
+        'agent-2': { id: 'agent-2', name: 'Agent 2', kind: 'durable', status: 'running', projectId: 'project-1' } as any,
+      },
+    });
+
+    const { queryByTestId } = render(
       <WireConfigPopover binding={agentBinding} x={100} y={200} onClose={vi.fn()} />,
     );
 
     expect(queryByTestId('wire-wake-agent')).toBeNull();
-    expect(queryByText('Wake Agent')).toBeNull();
+  });
+
+  it('does not expose a wake action for non-agent targets even when binding label matches', () => {
+    useAgentStore.setState({
+      agents: {
+        'browser-1': { id: 'browser-1', name: 'Browser', kind: 'durable', status: 'sleeping', projectId: 'project-1' } as any,
+      },
+    });
+
+    const { queryByTestId } = render(
+      <WireConfigPopover binding={browserBinding} x={100} y={200} onClose={vi.fn()} />,
+    );
+
+    expect(queryByTestId('wire-wake-agent')).toBeNull();
+  });
+
+  it('does not expose a wake action for quick-kind agent targets', () => {
+    useAgentStore.setState({
+      agents: {
+        'agent-2': { id: 'agent-2', name: 'Agent 2', kind: 'quick', status: 'sleeping', projectId: 'project-1' } as any,
+      },
+    });
+
+    const { queryByTestId } = render(
+      <WireConfigPopover binding={agentBinding} x={100} y={200} onClose={vi.fn()} />,
+    );
+
+    expect(queryByTestId('wire-wake-agent')).toBeNull();
+  });
+
+  it('clicking wake on a local sleeping target spawns the durable agent and closes the popover', async () => {
+    const onClose = vi.fn();
+    const spawnDurableAgent = vi.fn().mockResolvedValue('agent-2');
+    useAgentStore.setState({
+      agents: {
+        'agent-2': { id: 'agent-2', name: 'Agent 2', kind: 'durable', status: 'sleeping', projectId: 'project-1' } as any,
+      },
+      spawnDurableAgent,
+    } as any);
+
+    useProjectStore.setState({
+      projects: [{ id: 'project-1', name: 'Proj', path: '/path/to/proj' } as any],
+    } as any);
+
+    (window as any).clubhouse = {
+      agent: {
+        listDurable: vi.fn().mockResolvedValue([
+          { id: 'agent-2', name: 'Agent 2', color: 'red' },
+        ]),
+      },
+    };
+
+    const { getByTestId } = render(
+      <WireConfigPopover binding={agentBinding} x={100} y={200} onClose={onClose} />,
+    );
+
+    fireEvent.click(getByTestId('wire-wake-agent'));
+
+    await waitFor(() => {
+      expect(spawnDurableAgent).toHaveBeenCalledWith(
+        'project-1',
+        '/path/to/proj',
+        expect.objectContaining({ id: 'agent-2' }),
+        false,
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 
   it('shows Edit Instructions when instructions are set', () => {

--- a/src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx
@@ -3,9 +3,13 @@
  * disconnect, bidirectional toggle, and custom instructions controls.
  */
 
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
+import { useAgentStore } from '../../../stores/agentStore';
+import { useProjectStore } from '../../../stores/projectStore';
+import { useAnnexClientStore } from '../../../stores/annexClientStore';
+import { useRemoteProjectStore, parseNamespacedId, isRemoteAgentId } from '../../../stores/remoteProjectStore';
 import { Toggle } from '../../../components/Toggle';
 import { WireInstructionsDialog } from './WireInstructionsDialog';
 import { WireToolPermissionsDialog } from './WireToolPermissionsDialog';
@@ -37,6 +41,7 @@ export function WireConfigPopover({ binding, x, y, onClose, onAddWireDefinition,
   const [bidirectional, setBidirectional] = useState(false);
   const [showInstructions, setShowInstructions] = useState(false);
   const [showPermissions, setShowPermissions] = useState(false);
+  const [waking, setWaking] = useState(false);
 
   // Keep binding in sync with store (instructions may change)
   const liveBinding = bindings.find(
@@ -45,6 +50,44 @@ export function WireConfigPopover({ binding, x, y, onClose, onAddWireDefinition,
 
   // Check if reverse binding exists (agent-to-agent only)
   const isAgentToAgent = binding.targetKind === 'agent';
+
+  // ── Wake action for sleeping agent targets ──────────────────────────
+  // For A2A wires, expose a wake action on the popover when the target
+  // agent is sleeping or in an error state. Mirrors SleepingAgent.tsx.
+  const targetAgentLocal = useAgentStore((s) => isAgentToAgent ? s.agents[binding.targetId] : undefined);
+  const targetAgentRemote = useRemoteProjectStore((s) => isAgentToAgent ? s.remoteAgents[binding.targetId] : undefined);
+  const targetAgent = targetAgentLocal || targetAgentRemote;
+  const projects = useProjectStore((s) => s.projects);
+  const spawnDurableAgent = useAgentStore((s) => s.spawnDurableAgent);
+  const sendAgentWake = useAnnexClientStore((s) => s.sendAgentWake);
+
+  const isTargetSleeping = !!targetAgent
+    && (targetAgent.status === 'sleeping' || targetAgent.status === 'error')
+    && targetAgent.kind === 'durable';
+
+  const targetIsRemote = useMemo(() => isAgentToAgent && isRemoteAgentId(binding.targetId), [isAgentToAgent, binding.targetId]);
+  const remoteParts = useMemo(() => targetIsRemote ? parseNamespacedId(binding.targetId) : null, [targetIsRemote, binding.targetId]);
+
+  const handleWakeTarget = useCallback(async () => {
+    if (!targetAgent || waking) return;
+    setWaking(true);
+    try {
+      if (targetIsRemote && remoteParts) {
+        await sendAgentWake(remoteParts.satelliteId, remoteParts.agentId);
+      } else {
+        const project = projects.find((p) => p.id === targetAgent.projectId);
+        if (!project) return;
+        const configs = await window.clubhouse.agent.listDurable(project.path);
+        const config = configs.find((c: { id: string }) => c.id === targetAgent.id);
+        if (config) {
+          await spawnDurableAgent(project.id, project.path, config, false);
+        }
+      }
+      onClose();
+    } finally {
+      setWaking(false);
+    }
+  }, [targetAgent, waking, targetIsRemote, remoteParts, sendAgentWake, projects, spawnDurableAgent, onClose]);
   useEffect(() => {
     if (isAgentToAgent) {
       const reverse = bindings.some(
@@ -133,6 +176,31 @@ export function WireConfigPopover({ binding, x, y, onClose, onAddWireDefinition,
 
         {/* Actions */}
         <div className="p-2 space-y-1">
+          {/* Wake target agent (agent-to-agent + sleeping/errored target) */}
+          {isAgentToAgent && isTargetSleeping && (
+            <button
+              className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-ctp-accent hover:bg-ctp-accent/10 rounded transition-colors disabled:opacity-50"
+              onClick={handleWakeTarget}
+              disabled={waking}
+              data-testid="wire-wake-agent"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0">
+                <circle cx="12" cy="12" r="5" />
+                <line x1="12" y1="1" x2="12" y2="3" />
+                <line x1="12" y1="21" x2="12" y2="23" />
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                <line x1="1" y1="12" x2="3" y2="12" />
+                <line x1="21" y1="12" x2="23" y2="12" />
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+              </svg>
+              <span className="flex-1 text-left">
+                {waking ? 'Waking...' : (targetAgent?.status === 'error' ? 'Retry Agent' : 'Wake Agent')}
+              </span>
+            </button>
+          )}
+
           {/* Bidirectional toggle (agent-to-agent only) */}
           {isAgentToAgent && (
             <div


### PR DESCRIPTION
## Summary
- A2A wires now expose a wake action when the target agent is sleeping/errored — previously you could only wake from the agent direct view
- Canvas card no longer gets stuck on the SleepingAgent placeholder after a wake-via-`wake_agent`-MCP-tool — first PTY data now reliably promotes the agent to `running`
- Bug #3 (What's New for preview builds) was deferred to issue #1421 because it requires CI workflow changes; not in this PR

## Changes

### `src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx`
- Added a wake button at the top of the wire popover for agent-to-agent wires whose target is a sleeping or errored durable agent
- Mirrors the wake logic in `SleepingAgent.tsx`: local agents go through `spawnDurableAgent`, remote agents go through `useAnnexClientStore.sendAgentWake`
- Label is \`Retry Agent\` when the target is in error state, \`Wake Agent\` otherwise; closes the popover on success

### `src/renderer/app-event-bridge.ts`
- Added \`initPtyDataWakeListener()\` — when first PTY data arrives for an agent whose status is not \`running\`, transitions it to \`running\`
- Mirrors the same listener already present in \`PopoutWindow.tsx\` for popout windows. The main window was missing it, so a group-project \`wake_agent\` (which broadcasts \`AGENT_WAKING\` → status \`waking\`) would stay stuck on \`waking\` whenever the woken agent sat idle at a prompt and never fired a hook event
- Dedupe set is reset on PTY exit so subsequent wake cycles re-detect

## Test Plan
- [x] \`WireConfigPopover.test.tsx\` — replaced the \"does not expose wake\" assertion with positive coverage; added cases for sleeping/error/running/quick/non-agent targets and a click-to-wake assertion (20 tests total, all passing)
- [x] \`app-event-bridge.test.ts\` — added 4 cases for the new PTY data wake listener: registration, transition-on-first-data, dedupe across repeated data events, no-op when already running, dedupe-clears-on-exit (17 tests total, all passing)
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 11,693 passed, 4 skipped (pre-existing skips)
- [x] \`npm run lint\` — clean

## Manual Validation
- [ ] Two-instance Claude Code setup: open a group-project canvas with both members visible. Have one agent invoke its \`wake_agent\` tool on the sleeping peer. Verify the canvas card transitions to the live PTY view (previously it stayed on the SleepingAgent placeholder)
- [ ] On any A2A wire whose target is sleeping, right-click the wire and confirm a \"Wake Agent\" button appears at the top of the popover. Click it and verify the target agent boots
- [ ] On an A2A wire to an *errored* agent, confirm the button reads \"Retry Agent\"
- [ ] On an A2A wire to a *running* agent, confirm no wake button appears
- [ ] Browser/group-project wires never show the wake button regardless of state

## Related
- Issue #1421 tracks the deferred What's New / preview-builds bug