### PR TITLE
chore: bump version to 0.39.0-beta.27 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.39.0-beta.26",
+  "version": "0.39.0-beta.27",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Wake Lifecycle & UI Polish Fixes

# Bug Fixes
- Fixed MCP-driven wake_agent leaving agent cards stuck on the sleeping mascot — agents now correctly transition to running
- File browser: New File/Folder targets the nav-selected folder, dragging a multi-selection moves the whole set, and creating a file in an empty/collapsed folder auto-expands it
- Wires: A2A wires pulse blue (green reserved for bidirectional non-agent wires), wire popover dismisses after manage-tools save, and disabled tool labels no longer use strike-through
- Group project UI: Clear All moved to its own row to prevent clipping, and Save now opens an approval dialog with scope (new vs all) instead of side-by-side buttons