### PR TITLE
fix(copilot-cli): pass --allow-all-tools when permissionMode is skip-all

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -224,6 +224,38 @@ describe('CopilotCliProvider', () => {
       expect(result.args[promptIdx + 1]).toContain('Fix the bug');
     });
 
+    it('adds --allow-all-tools when permissionMode is skip-all', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        permissionMode: 'skip-all',
+      });
+      expect(result.args).toContain('--allow-all-tools');
+    });
+
+    it('does not add --allow-all-tools when permissionMode is undefined', async () => {
+      const result = await provider.buildSpawnCommand({ cwd: '/project' });
+      expect(result.args).not.toContain('--allow-all-tools');
+    });
+
+    it('does not add --allow-all-tools for other permissionMode values', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        permissionMode: 'prompt' as any,
+      });
+      expect(result.args).not.toContain('--allow-all-tools');
+    });
+
+    it('combines freeAgentMode and permissionMode skip-all', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        freeAgentMode: true,
+        permissionMode: 'skip-all',
+      });
+      expect(result.args).toContain('--yolo');
+      expect(result.args).toContain('--autopilot');
+      expect(result.args).toContain('--allow-all-tools');
+    });
+
     it('adds --allow-tool flags for allowed tools', async () => {
       const result = await provider.buildSpawnCommand({
         cwd: '/project',

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -155,6 +155,9 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
     if (opts.freeAgentMode) {
       args.push('--yolo', '--autopilot');
     }
+    if (opts.permissionMode === 'skip-all') {
+      args.push('--allow-all-tools');
+    }
 
     if (opts.model && opts.model !== 'default') {
       args.push('--model', opts.model);


### PR DESCRIPTION
## Summary

When a spawned agent has \permissionMode\ set to \'skip-all'\, forward the \--allow-all-tools\ flag to the Copilot CLI binary. This prevents the permission hook from blocking tool calls for sub-agents.

## Changes

- **copilot-cli-provider.ts**: Added conditional to append \--allow-all-tools\ when \opts.permissionMode === 'skip-all'\
- **copilot-cli-provider.test.ts**: Added 4 tests covering the new behavior (happy path, undefined, non-matching value, combination with freeAgentMode)

## Testing

All 69 tests pass in \copilot-cli-provider.test.ts\.

ran `npm run make` and running the produced exe and my setup works as expected. Agents can run powershell script, etc. Had one make this pr and link the issue which was not possible after the most recent update but before this fix.

Fixes #1425