### PR TITLE
fix(hooks): resolve GHCP permission timeout race + add observability + escape-hatch toggle

### DIFF
--- a/docs/hook-investigation-2026-05-05.md
+++ b/docs/hook-investigation-2026-05-05.md
@@ -1,0 +1,199 @@
+# Hook Integration Investigation — Claude Code vs Copilot CLI vs Codex CLI
+
+**Date:** 2026-05-05
+**Author:** faithful-urchin
+**Context:** Triggered by a stuck-state bug on a local GHCP agent (`lucky-mantis`) where the `permissionRequest` hook timed out after 120s and the agent stalled. Root cause and fixes shipped in PR `faithful-urchin/hook-resilience`. This report covers the gap analysis the user asked for, separately from the code changes — to inform follow-up work as GitHub Copilot CLI moves from beta to GA and a large user base migrates from Claude Code → GHCP.
+
+---
+
+## 1. Root cause recap
+
+**Symmetric 120s timeout race.** GHCP's `permissionRequest` hook config had `timeoutSec: 120` (set in `copilot-cli-provider.ts:244`). Our permission queue also resolved at exactly `120_000` ms (`hook-server.ts:115`). Both expired at the same instant — GHCP killed the curl child *before* our `decision.then(...)` callback wrote the `'ask'` fallback response. From GHCP's POV the hook returned nothing → fell through to its own TUI prompt UI in a hidden PTY → agent stalled with no human watching.
+
+**Fixed in this PR** by:
+- Plumbing a shared `PERMISSION_HOOK_TIMEOUT_SEC = 120` constant through all three providers and deriving `PERMISSION_QUEUE_TIMEOUT_MS = 110_000` (10s safety margin) for the queue. Queue now resolves before the orchestrator times out.
+- Adding `core:hook-server` and `core:permission-queue` lifecycle logging at INFO/WARN (the bug was effectively invisible in logs before).
+- Adding a settings toggle to disable the hook server entirely as a durable escape hatch.
+
+The `'timeout' → 'ask'` fallback semantic was kept per user direction — interactive PTYs can still recover by responding to the prompt.
+
+---
+
+## 2. Hook event coverage — provider matrix
+
+| Normalized kind     | Claude Code event           | Copilot CLI event       | Codex CLI event             |
+|---------------------|-----------------------------|-------------------------|-----------------------------|
+| `pre_tool`          | `PreToolUse`                | `preToolUse`            | `PreToolUse`                |
+| `post_tool`         | `PostToolUse`               | `postToolUse`           | `PostToolUse`               |
+| `tool_error`        | `PostToolUseFailure`        | `errorOccurred`         | `PostToolUseFailure`        |
+| `stop`              | `Stop`                      | — (no equivalent)       | `Stop`                      |
+| `notification`      | `Notification`              | `sessionStart`, `userPromptSubmitted` (both mapped → notification) | `Notification` |
+| `permission_request`| `PermissionRequest`         | `permissionRequest`     | `PermissionRequest`         |
+
+**Observations:**
+
+1. **GHCP has no `Stop` equivalent.** Claude Code and Codex emit a `Stop` hook when the model finishes its response cycle; GHCP does not. We currently lose the per-cycle "agent went idle" signal for GHCP. Two GHCP events (`sessionStart`, `userPromptSubmitted`) are crammed into our `notification` bucket — they're roughly informational but the loss of cycle-end is real.
+
+2. **GHCP event-name casing differs.** All three CLIs use snake_case for `hook_event_name` in stdin payloads, but **GHCP uses camelCase event names** (`preToolUse` not `PreToolUse`). The hook config writers and `EVENT_NAME_MAP` per provider already handle this; just calling it out for future event additions.
+
+3. **GHCP doesn't include `hook_event_name` in stdin** for some hooks — our hook server compensates by injecting from the URL path (`/hook/{agentId}/{eventHint}`). This mismatch is documented in `hook-server.ts:171-174`.
+
+4. **All three use 5s timeout for non-permission hooks**, 120s for `permissionRequest`. After this PR, the 120s value is shared via `PERMISSION_HOOK_TIMEOUT_SEC`; the 5s values remain hardcoded per-provider (low risk — no permission queue race for those).
+
+---
+
+## 3. Hook lifecycle differences
+
+### Claude Code
+- Reads `.claude/settings.local.json` at session start.
+- Session resume (`--resume`) re-reads the file.
+- No internal "workspace recycling" inside a single CLI process — process lifecycle is 1:1 with hook config reload.
+
+### GHCP (Copilot CLI)
+- Reads `.github/hooks/hooks.json` at session start.
+- **Internal workspace recycling**: a single CLI process can close and re-init workspaces (we observed it in `lucky-mantis`'s log: `Closing session c1b73d32...` → `Workspace initialized: 137768d6...` 2.5 days later, same process). Whether the hook config is re-read at workspace re-init is **undocumented** and a meaningful unknown for long-running agents. See draft upstream issue below.
+- `--continue` resumes the most recent session. Hook config behavior on `--continue` is the same — but if Clubhouse code changed between sessions, the on-disk hook config might be different than what GHCP cached in memory.
+
+**Mitigation already in place**: `agent-system.ts:337` calls `provider.writeHooksConfig()` on every spawn, and each provider's writeHooksConfig strips and replaces stale Clubhouse entries via `isClubhouseHookEntry`. So the on-disk config is always fresh on spawn. The risk window is purely *during* a long-running CLI session that internally re-uses without a process restart — which is more theoretical than observed for now.
+
+### Codex CLI
+- Reads `.codex/hooks.json` at session start. Same shape as Claude Code. No known internal workspace recycling concern.
+
+---
+
+## 4. `permissionDecision` semantics
+
+Per [GitHub Copilot CLI hooks reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference), valid values are `"allow"`, `"deny"`, and `"ask"`. The docs define:
+- `"allow"` — short-circuits permission flow, tool runs.
+- `"deny"` — short-circuits, tool is rejected with "Permission Denied" feedback.
+- `"ask"` — falls through to interactive user prompt in the PTY.
+
+**Edge cases the public docs do not address:**
+- What happens on hook timeout? Documented behavior for non-permission hooks is "fire-and-forget; never blocks." For `permissionRequest`, undocumented. Empirically (per `lucky-mantis` log) GHCP records `Hook execution failed: Error: Hook command timed out after 120 seconds` and falls through to its own UI — same path as `"ask"`.
+- What happens on unrecognized values? Undocumented. We were not testing this; safe to assume unrecognized → falls through to default behavior.
+
+**Claude Code** uses identical semantics for the three values per its docs.
+
+**Codex CLI** is undocumented at this level; the EVENT_NAME_MAP and hook shape mirror Claude Code so we assume parity.
+
+---
+
+## 5. Known upstream issues we're exposed to
+
+### `github/copilot-cli` #2586 — "Notification hook fires for already-approved tools in interactive mode"
+The Notification hook fires asynchronously and does NOT correspond 1:1 to actual permission state. Our renderer uses Notification events for status-tracking heuristics — there's a soft risk of UI showing "needs permission" when the tool is actually already approved. Low impact today (we don't auto-act on those), but worth tracking if we expand.
+
+### `github/copilot-cli` #1651 — "Add hook for permission prompt"
+Already resolved — the `permissionRequest` hook this PR depends on. Mentioned for breadcrumb context.
+
+---
+
+## 6. Draft follow-up issues (Clubhouse repo)
+
+The user asked us to draft these but NOT to file them. Bodies below for review.
+
+---
+
+### Draft issue 1: Add agent-restart UX for the hook server toggle
+
+**Title**: `Wire renderer notice for AGENTS_NEED_RESTART after hook server toggle`
+
+**Body**:
+
+The new `IPC.HOOK_SERVER.AGENTS_NEED_RESTART` event (added in #PR_NUMBER) is broadcast to all renderer windows when the user toggles the global hook server enable setting. The preload bridge exposes a subscription via `window.clubhouse.hookServer.onAgentsNeedRestart`. Today nothing in the renderer subscribes to it, so users don't see a notice and may not know to restart affected agents.
+
+**Proposal**:
+- Subscribe in a new top-level effect (e.g. inside the agent hub layout).
+- On event, show a non-blocking toast / status pill near each affected agent: "Hook server toggled — restart this agent for changes to take effect."
+- Offer a per-agent restart button on the toast.
+- **Do NOT auto-restart** — same constraint as the original design: killing PTYs mid-task loses work.
+
+Acceptance:
+- [ ] Toggling the hook server off with running agents surfaces a visible notice.
+- [ ] The notice shows the count and (optionally) names of affected agents.
+- [ ] Restart is gated on user click.
+
+---
+
+### Draft issue 2: GHCP `--continue` hook config reload is unverified
+
+**Title**: `Verify GHCP --continue picks up new hook config after Clubhouse upgrade`
+
+**Body**:
+
+`agent-system.ts:337` calls `provider.writeHooksConfig()` on every spawn, so the on-disk hook config is fresh after a Clubhouse upgrade. But within a long-running GHCP CLI process, workspace recycling can re-init internal session state without re-reading the hook config (observed in `lucky-mantis`: 2.5-day idle → workspace re-init in same process). Whether GHCP re-reads `.github/hooks/hooks.json` on workspace re-init is **undocumented**.
+
+Risk window: a Clubhouse upgrade that changes hook timeouts (e.g. the `PERMISSION_HOOK_TIMEOUT_SEC` constant added in #PR_NUMBER) would not take effect for an agent whose CLI process survives the upgrade. Today this is theoretical — Electron app restart kills child processes — but it's worth confirming.
+
+**Proposal**:
+1. Set up a repro: spawn a GHCP agent, wait for workspace re-init (or force it), modify hook config on disk, fire a permission request, observe whether the new value is honored.
+2. If the answer is "GHCP caches in memory and ignores disk changes mid-process," consider a heartbeat that re-issues `writeHooksConfig` periodically, OR fail closed on workspace re-init.
+3. File an upstream issue if GHCP behavior is surprising — see draft below.
+
+Acceptance:
+- [ ] Documented behavior in the orchestrator notes.
+- [ ] Test (manual or automated) confirming the contract.
+
+---
+
+### Draft issue 3: Hook server load test + stuck-permission alerting
+
+**Title**: `Stress test the permission queue with concurrent + duplicate requests`
+
+**Body**:
+
+The current permission queue (`annex-permission-queue.ts`) has no deduplication or per-agent rate limiting. Tests confirm multiple permission entries from the same agent are stored independently. The queue test only covers happy paths — we have no regression coverage for:
+
+1. **Burst scenarios**: 50+ concurrent permissions from a single agent. Memory + listener storm risk.
+2. **Duplicate request behavior**: GHCP issue #2586 (notification hook firing for already-approved tools) suggests upstream may send duplicates. We treat each as a fresh request → independent timeouts → potential UI confusion.
+3. **Stuck-permission alerting**: This PR added a 30s scanner that logs WARN for pending permissions older than 30s. There's no UI surface — would be useful as a status pill on the agent or in a hub-level notification.
+
+**Proposal**:
+- Add a vitest stress test with 100 concurrent `createPermission` calls; assert no memory leak, all resolve cleanly on `clearForAgent`.
+- Add deduplication keyed on `(agentId, toolName, JSON.stringify(toolInput))` with a configurable window — return the existing `requestId` instead of creating a new entry.
+- Surface stuck-permission warnings to the renderer (toast or status pill).
+
+Acceptance:
+- [ ] Stress test in CI.
+- [ ] Dedup design + implementation.
+- [ ] Renderer surface for the stuck-permission warning.
+
+---
+
+## 7. Draft upstream issue (`github/copilot-cli`)
+
+The user said to write the body but not file it.
+
+---
+
+### Draft upstream issue: Document `permissionRequest` hook timeout behavior
+
+**Title**: `[docs] Clarify what happens when a permissionRequest hook times out`
+
+**Body**:
+
+The [hooks reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference) describes `permissionRequest` as accepting `permissionDecision` values of `"allow"`, `"deny"`, or `"ask"`. The reference also says hook failures "are logged and skipped — they never block agent execution."
+
+What's *not* documented:
+
+1. **Timeout fallthrough**: When `timeoutSec` elapses and the hook command is killed, what happens? Does the CLI fall through to interactive prompt (same as `"ask"`)? Treat as `"deny"`? Hard-fail the tool call?
+2. **Empty / unrecognized output**: If the hook returns no `permissionDecision` field, is that the same as `"ask"`?
+3. **Race window**: If a hook process exits at the exact moment of timeout, is its output read?
+
+We hit a real bug in our integration ([Clubhouse PR](https://github.com/anthropics/clubhouse-clubhouse/pull/PR_NUMBER)) caused by a symmetric 120s timeout race — our server held the response open for 120s, GHCP also waited 120s, and both expired at the same instant. We worked around it by resolving server-side at 110s. Documenting the timeout fallthrough behavior would help other integrators avoid the same trap.
+
+**Suggested addition** to the docs:
+- A short section under `permissionRequest` titled "Hook failure / timeout behavior" stating which fallthrough path applies.
+- A recommendation: integrators that hold the response open for remote approval should resolve at `timeoutSec - safety_margin` to avoid races.
+
+---
+
+## 8. Other observations worth recording
+
+- **Hook server only logs on failure today** — this PR fixes that with comprehensive INFO/WARN logging in `hook-server.ts` and a new `core:permission-queue` namespace. Future bugs in this area should be visible in logs.
+
+- **No periodic snapshot of pending permissions** — added in this PR. Every 30s, any pending permission older than 30s logs WARN with `requestId`, `agentId`, `toolName`, `ageMs`, `remainingMs`. Bridges the gap between "queue silently stuck" and "user reports symptom."
+
+- **Settings toggle is the durable escape hatch** — added in this PR. Disabling strips Clubhouse hooks from running agents and short-circuits the hook server. Users who get stuck (in any future bug we don't anticipate) can recover by toggling off.
+
+- **All three providers share the timeout constant now** — `PERMISSION_HOOK_TIMEOUT_SEC` in `orchestrators/types.ts`. If we ever need different per-provider values, the right move is an optional method on `HookCapable`. Not needed today.

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -15,7 +15,7 @@ import { registerAgentQueueHandlers } from './agent-queue-handlers';
 import { registerAnnexClientHandlers } from './annex-client-handlers';
 import { registerMarketplaceHandlers } from './marketplace-handlers';
 import { registerProfileHandlers } from './profile-handlers';
-import { registerSettingsHandlers } from './settings-handlers';
+import { registerSettingsHandlers, hookServerSettings } from './settings-handlers';
 import { registerAssistantHandlers } from './assistant-handlers';
 import { registerBlueprintHandlers } from './blueprint-handlers';
 import * as hookServer from '../services/hook-server';
@@ -66,8 +66,14 @@ export function registerAllHandlers(): void {
   registerAssistantHandlers();
   registerBlueprintHandlers();
 
-  // Start the hook server for agent status events
-  hookServer.start().catch((err) => {
+  // Start the hook server for agent status events.  The persisted toggle
+  // (HOOK_SERVER_SETTINGS) is honoured at startup so a previously-disabled
+  // server stays disabled across restarts — this is the durable escape hatch
+  // for users whose orchestrator hook integration gets stuck.
+  hookServer.start().then(() => {
+    const persisted = hookServerSettings.getSettings();
+    if (!persisted.enabled) hookServer.setEnabled(false);
+  }).catch((err) => {
     logService.appLog('core:hook-server', 'error', 'Failed to start hook server', {
       meta: { error: err?.message ?? String(err), stack: err?.stack },
     });

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -13,10 +13,12 @@
  * That's it — no IPC channels, handler registration, or preload changes needed.
  */
 import { createManagedSettings } from '../services/managed-settings';
-import { CLIPBOARD_SETTINGS, EDITOR_SETTINGS, MCP_SETTINGS, SECURITY_SETTINGS } from '../../shared/settings-definitions';
+import { CLIPBOARD_SETTINGS, EDITOR_SETTINGS, HOOK_SERVER_SETTINGS, MCP_SETTINGS, SECURITY_SETTINGS } from '../../shared/settings-definitions';
 import { onMcpSettingsChanged } from './mcp-binding-handlers';
+import { onHookServerSettingsChanged } from '../services/hook-server-toggle';
+import type { HookServerSettings } from '../../shared/types';
 
-export { CLIPBOARD_SETTINGS, EDITOR_SETTINGS, MCP_SETTINGS, SECURITY_SETTINGS };
+export { CLIPBOARD_SETTINGS, EDITOR_SETTINGS, HOOK_SERVER_SETTINGS, MCP_SETTINGS, SECURITY_SETTINGS };
 
 export const clipboardSettings = createManagedSettings(CLIPBOARD_SETTINGS, {
   defaultsOverride: {
@@ -31,6 +33,12 @@ export const mcpSettings = createManagedSettings(MCP_SETTINGS, {
 });
 
 export const securitySettings = createManagedSettings(SECURITY_SETTINGS);
+
+export const hookServerSettings = createManagedSettings(HOOK_SERVER_SETTINGS, {
+  onSave: (settings: HookServerSettings) => {
+    void onHookServerSettingsChanged(settings);
+  },
+});
 
 // ---------------------------------------------------------------------------
 // To migrate more settings, add them here following the same pattern.
@@ -48,4 +56,5 @@ export function registerSettingsHandlers(): void {
   editorSettings.register();
   mcpSettings.register();
   securitySettings.register();
+  hookServerSettings.register();
 }

--- a/src/main/orchestrators/claude-code-provider.ts
+++ b/src/main/orchestrators/claude-code-provider.ts
@@ -14,6 +14,7 @@ import {
   HeadlessCapable,
   SessionCapable,
   StructuredCapable,
+  PERMISSION_HOOK_TIMEOUT_SEC,
 } from './types';
 import { BaseProvider } from './base-provider';
 import { StreamJsonAdapter } from './adapters/stream-json-adapter';
@@ -177,10 +178,10 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
       PostToolUseFailure: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
       Stop: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
       Notification: [{ matcher: '', hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
-      // PermissionRequest uses a longer timeout (120s) so that the hook server
-      // can hold the response while waiting for a remote approval decision
-      // from the Annex iOS client.
-      PermissionRequest: [{ hooks: [{ type: 'command', command: curl, timeout: 120 }] }],
+      // PermissionRequest uses a longer timeout so that the hook server can
+      // hold the response while waiting for a remote approval decision from
+      // the Annex iOS client.
+      PermissionRequest: [{ hooks: [{ type: 'command', command: curl, timeout: PERMISSION_HOOK_TIMEOUT_SEC }] }],
     };
 
     const claudeDir = path.join(cwd, '.claude');

--- a/src/main/orchestrators/codex-cli-provider.ts
+++ b/src/main/orchestrators/codex-cli-provider.ts
@@ -15,6 +15,7 @@ import {
   HookCapable,
   SessionCapable,
   NormalizedHookEvent,
+  PERMISSION_HOOK_TIMEOUT_SEC,
 } from './types';
 import type { McpServerDef } from '../../shared/types';
 import type { StreamJsonEvent } from '../services/jsonl-parser';
@@ -272,7 +273,7 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable, S
       PostToolUseFailure: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
       Stop: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
       Notification: [{ matcher: '', hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
-      PermissionRequest: [{ hooks: [{ type: 'command', command: curl, timeout: 120 }] }],
+      PermissionRequest: [{ hooks: [{ type: 'command', command: curl, timeout: PERMISSION_HOOK_TIMEOUT_SEC }] }],
     };
 
     const codexDir = path.join(cwd, '.codex');

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -16,6 +16,7 @@ import {
   SessionCapable,
   StructuredCapable,
   AgentFileCapable,
+  PERMISSION_HOOK_TIMEOUT_SEC,
 } from './types';
 import type { McpServerDef } from '../../shared/types';
 import { BaseProvider } from './base-provider';
@@ -241,7 +242,7 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
       postToolUse: [{ type: 'command', bash: makeCurl('postToolUse'), timeoutSec: 5 }],
       errorOccurred: [{ type: 'command', bash: makeCurl('errorOccurred'), timeoutSec: 5 }],
       // PermissionRequest uses a long timeout to allow for remote approval via Annex
-      permissionRequest: [{ type: 'command', bash: makeCurl('permissionRequest'), timeoutSec: 120 }],
+      permissionRequest: [{ type: 'command', bash: makeCurl('permissionRequest'), timeoutSec: PERMISSION_HOOK_TIMEOUT_SEC }],
       sessionStart: [{ type: 'command', bash: makeCurl('sessionStart'), timeoutSec: 5 }],
       userPromptSubmitted: [{ type: 'command', bash: makeCurl('userPromptSubmitted'), timeoutSec: 5 }],
     };

--- a/src/main/orchestrators/types.ts
+++ b/src/main/orchestrators/types.ts
@@ -53,6 +53,18 @@ export interface NormalizedHookEvent {
   message?: string;
 }
 
+/**
+ * Hook timeout (seconds) the orchestrator's permissionRequest hook is configured
+ * with — the maximum time the orchestrator will wait for our hook server to
+ * respond before killing the curl child and falling through to its own UI.
+ *
+ * Our permission queue MUST resolve before this elapses (see
+ * PERMISSION_QUEUE_TIMEOUT_MS in annex-permission-queue.ts), otherwise the
+ * orchestrator records "Hook execution failed: timed out" and the agent stalls
+ * waiting for a TUI prompt that no human is watching.
+ */
+export const PERMISSION_HOOK_TIMEOUT_SEC = 120;
+
 export interface OrchestratorConventions {
   /** Directory name under the project root for agent config (e.g. '.claude') */
   configDir: string;

--- a/src/main/services/agent-registry.ts
+++ b/src/main/services/agent-registry.ts
@@ -9,6 +9,8 @@ export type AgentRuntime = 'pty' | 'headless' | 'structured';
 
 export interface AgentRegistration {
   projectPath: string;
+  /** Worktree path for the agent — where hook/MCP configs are written. */
+  cwd?: string;
   orchestrator: OrchestratorId;
   runtime: AgentRuntime;
   nonce?: string;
@@ -58,6 +60,10 @@ export function getAgentOrchestrator(agentId: string): OrchestratorId | undefine
 
 export function getAgentNonce(agentId: string): string | undefined {
   return agentRegistry.get(agentId)?.nonce;
+}
+
+export function getAgentCwd(agentId: string): string | undefined {
+  return agentRegistry.get(agentId)?.cwd;
 }
 
 export function untrackAgent(agentId: string): void {

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -102,6 +102,7 @@ export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
 
   agentRegistry.register(params.agentId, {
     projectPath: params.projectPath,
+    cwd: params.cwd,
     orchestrator: provider.id as OrchestratorId,
     runtime: 'pty',
   });

--- a/src/main/services/annex-permission-queue.test.ts
+++ b/src/main/services/annex-permission-queue.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+}));
+
 import * as queue from './annex-permission-queue';
 
 describe('annex-permission-queue', () => {
@@ -108,5 +113,36 @@ describe('annex-permission-queue', () => {
 
     await expect(decision).resolves.toBe('timeout');
     expect(queue.listPending().length).toBe(0);
+  });
+
+  describe('race-fix invariants', () => {
+    it('PERMISSION_QUEUE_TIMEOUT_MS is strictly less than the orchestrator hook timeout', async () => {
+      // The whole point of the race fix: our queue must resolve before the
+      // orchestrator's permissionRequest hook timeout fires, so the
+      // orchestrator actually receives our 'ask' fallback decision instead
+      // of killing the curl child and stalling.
+      const { PERMISSION_HOOK_TIMEOUT_SEC } = await import('../orchestrators/types');
+      expect(queue.PERMISSION_QUEUE_TIMEOUT_MS).toBeLessThan(PERMISSION_HOOK_TIMEOUT_SEC * 1000);
+      expect(queue.PERMISSION_QUEUE_SAFETY_MARGIN_MS).toBeGreaterThan(0);
+    });
+
+    it('createPermission defaults to PERMISSION_QUEUE_TIMEOUT_MS when no timeout is passed', async () => {
+      vi.useFakeTimers();
+      const { decision } = queue.createPermission('agent1', 'Bash');
+
+      // Advance just past the orchestrator hook timeout — by then our queue
+      // must already have resolved (otherwise the race is lost).
+      vi.advanceTimersByTime(queue.PERMISSION_QUEUE_TIMEOUT_MS + 1);
+      await expect(decision).resolves.toBe('timeout');
+      vi.useRealTimers();
+    });
+
+    it('an explicit timeoutMs overrides the default', async () => {
+      vi.useFakeTimers();
+      const { decision } = queue.createPermission('agent1', 'Bash', undefined, undefined, 50);
+      vi.advanceTimersByTime(51);
+      await expect(decision).resolves.toBe('timeout');
+      vi.useRealTimers();
+    });
   });
 });

--- a/src/main/services/annex-permission-queue.ts
+++ b/src/main/services/annex-permission-queue.ts
@@ -1,15 +1,44 @@
 /**
  * Pending permission approval queue for Annex.
  *
- * When a Claude Code agent fires a PermissionRequest hook, the hook server
- * creates a pending permission entry. The Annex server broadcasts it to
- * connected iOS clients. When a client responds (allow/deny), the decision
- * is relayed back to the waiting hook script via the resolved promise.
+ * When a Claude Code / Copilot CLI / Codex CLI agent fires a PermissionRequest
+ * hook, the hook server creates a pending permission entry. The Annex server
+ * broadcasts it to connected iOS clients. When a client responds (allow/deny),
+ * the decision is relayed back to the waiting hook script via the resolved
+ * promise.
+ *
+ * ## Timeout race
+ *
+ * The orchestrator's hook config has its own timeout (PERMISSION_HOOK_TIMEOUT_SEC,
+ * 120s today).  If both the orchestrator and our queue expire at the same instant
+ * the orchestrator kills the curl child *before* we write the response, the agent
+ * stalls.  We resolve PERMISSION_QUEUE_SAFETY_MARGIN_MS *earlier* so the queue
+ * always wins the race and the orchestrator actually receives our `'ask'`
+ * fallback decision.
  */
 
 import { randomUUID } from 'crypto';
+import { appLog } from './log-service';
+import { PERMISSION_HOOK_TIMEOUT_SEC } from '../orchestrators/types';
 
 export type PermissionDecision = 'allow' | 'deny';
+
+/**
+ * Safety margin ensuring the queue always resolves before the orchestrator's
+ * hook timeout fires.  10s gives the network round-trip + response write
+ * comfortable headroom even on slow systems.
+ */
+export const PERMISSION_QUEUE_SAFETY_MARGIN_MS = 10_000;
+
+/**
+ * Default queue timeout, derived from the orchestrator hook timeout minus the
+ * safety margin.  Callers may override via the timeoutMs argument to
+ * createPermission().
+ */
+export const PERMISSION_QUEUE_TIMEOUT_MS =
+  PERMISSION_HOOK_TIMEOUT_SEC * 1000 - PERMISSION_QUEUE_SAFETY_MARGIN_MS;
+
+const NS = 'core:permission-queue';
 
 export interface PendingPermission {
   requestId: string;
@@ -41,7 +70,7 @@ export function createPermission(
   toolName: string,
   toolInput?: Record<string, unknown>,
   message?: string,
-  timeoutMs: number = 120_000,
+  timeoutMs: number = PERMISSION_QUEUE_TIMEOUT_MS,
 ): { requestId: string; decision: Promise<PermissionDecision | 'timeout'> } {
   const requestId = randomUUID();
   const createdAt = Date.now();
@@ -49,6 +78,9 @@ export function createPermission(
   const decision = new Promise<PermissionDecision | 'timeout'>((resolve) => {
     const timer = setTimeout(() => {
       pending.delete(requestId);
+      appLog(NS, 'warn', 'Permission timed out', {
+        meta: { requestId, agentId, toolName, timeoutMs },
+      });
       resolve('timeout');
     }, timeoutMs);
 
@@ -66,6 +98,18 @@ export function createPermission(
     pending.set(requestId, entry);
   });
 
+  appLog(NS, 'info', 'Permission requested', {
+    meta: {
+      requestId,
+      agentId,
+      toolName,
+      timeoutMs,
+      deadline: createdAt + timeoutMs,
+      hasInput: toolInput !== undefined,
+      hasMessage: message !== undefined,
+    },
+  });
+
   // Notify listeners
   const info: PendingPermission = { requestId, agentId, toolName, toolInput, message, createdAt, timeoutMs };
   for (const fn of listeners) fn(info);
@@ -79,9 +123,24 @@ export function createPermission(
  */
 export function resolvePermission(requestId: string, decision: PermissionDecision): boolean {
   const entry = pending.get(requestId);
-  if (!entry) return false;
+  if (!entry) {
+    appLog(NS, 'warn', 'Permission resolve no-op (unknown or already resolved)', {
+      meta: { requestId, decision },
+    });
+    return false;
+  }
   clearTimeout(entry.timer);
   pending.delete(requestId);
+  const elapsedMs = Date.now() - entry.createdAt;
+  appLog(NS, 'info', 'Permission resolved', {
+    meta: {
+      requestId,
+      agentId: entry.agentId,
+      toolName: entry.toolName,
+      decision,
+      elapsedMs,
+    },
+  });
   entry.resolve(decision);
   return true;
 }
@@ -104,21 +163,32 @@ export function onPermissionRequest(fn: PermissionRequestListener): () => void {
 
 /** Clear all pending permissions for an agent (e.g., when agent stops). */
 export function clearForAgent(agentId: string): void {
+  let count = 0;
   for (const [id, entry] of pending) {
     if (entry.agentId === agentId) {
       clearTimeout(entry.timer);
       pending.delete(id);
       entry.resolve('timeout');
+      count += 1;
     }
+  }
+  if (count > 0) {
+    appLog(NS, 'info', 'Permissions cleared on agent stop', {
+      meta: { agentId, count },
+    });
   }
 }
 
 /** Reset all state. Used during shutdown. */
 export function reset(): void {
+  const count = pending.size;
   for (const entry of pending.values()) {
     clearTimeout(entry.timer);
     entry.resolve('timeout');
   }
   pending.clear();
   listeners.clear();
+  if (count > 0) {
+    appLog(NS, 'debug', 'Permission queue reset', { meta: { count } });
+  }
 }

--- a/src/main/services/hook-server-toggle.test.ts
+++ b/src/main/services/hook-server-toggle.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./log-service', () => ({
+  appLog: vi.fn(),
+}));
+
+const mockBroadcastToAllWindows = vi.fn();
+vi.mock('../util/ipc-broadcast', () => ({
+  broadcastToAllWindows: (...args: unknown[]) => mockBroadcastToAllWindows(...args),
+}));
+
+vi.mock('../../shared/ipc-channels', () => ({
+  IPC: {
+    HOOK_SERVER: {
+      AGENTS_NEED_RESTART: 'hook-server:agents-need-restart',
+    },
+  },
+}));
+
+const mockGetAllRegistrations = vi.fn();
+vi.mock('./agent-registry', () => ({
+  agentRegistry: {
+    getAllRegistrations: () => mockGetAllRegistrations(),
+  },
+}));
+
+const mockGetProvider = vi.fn();
+const mockIsHookCapable = vi.fn();
+vi.mock('../orchestrators', () => ({
+  getProvider: (...args: unknown[]) => mockGetProvider(...args),
+  isHookCapable: (...args: unknown[]) => mockIsHookCapable(...args),
+}));
+
+const mockSnapshotFile = vi.fn(() => Promise.resolve());
+const mockRestoreForAgent = vi.fn(() => Promise.resolve());
+const mockGetHooksConfigPath = vi.fn();
+vi.mock('./config-pipeline', () => ({
+  snapshotFile: (...args: unknown[]) => mockSnapshotFile(...args),
+  restoreForAgent: (...args: unknown[]) => mockRestoreForAgent(...args),
+  getHooksConfigPath: (...args: unknown[]) => mockGetHooksConfigPath(...args),
+}));
+
+const mockListPending = vi.fn(() => []);
+const mockReset = vi.fn();
+vi.mock('./annex-permission-queue', () => ({
+  listPending: () => mockListPending(),
+  reset: () => mockReset(),
+}));
+
+const mockSetEnabled = vi.fn();
+const mockGetPort = vi.fn(() => 12345);
+vi.mock('./hook-server', () => ({
+  setEnabled: (v: boolean) => mockSetEnabled(v),
+  getPort: () => mockGetPort(),
+}));
+
+import { applyDisabled, applyEnabled, onHookServerSettingsChanged } from './hook-server-toggle';
+
+describe('hook-server-toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('applyDisabled', () => {
+    it('flips the hook server off', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      await applyDisabled();
+      expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('resolves any in-flight permissions before stripping hooks', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      // Two pending permissions in flight
+      mockListPending.mockReturnValue([
+        { requestId: 'r1', agentId: 'a1', toolName: 'Bash', createdAt: 0, timeoutMs: 110_000 },
+        { requestId: 'r2', agentId: 'a2', toolName: 'Edit', createdAt: 0, timeoutMs: 110_000 },
+      ] as any);
+      await applyDisabled();
+      expect(mockReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call queue.reset when no permissions are pending', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      mockListPending.mockReturnValue([]);
+      await applyDisabled();
+      expect(mockReset).not.toHaveBeenCalled();
+    });
+
+    it('strips Clubhouse hooks from every running agent and reports their ids', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+        ['agent-b', { projectPath: '/p', cwd: '/p/b', orchestrator: 'copilot-cli', runtime: 'pty' }],
+      ]));
+      const affected = await applyDisabled();
+      expect(mockRestoreForAgent).toHaveBeenCalledWith('agent-a');
+      expect(mockRestoreForAgent).toHaveBeenCalledWith('agent-b');
+      expect(affected).toEqual(['agent-a', 'agent-b']);
+    });
+
+    it('broadcasts agents-need-restart with the affected agentIds', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      await applyDisabled();
+      expect(mockBroadcastToAllWindows).toHaveBeenCalledWith(
+        'hook-server:agents-need-restart',
+        { reason: 'disabled', agentIds: ['agent-a'] },
+      );
+    });
+
+    it('does not broadcast when no agents were affected', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      await applyDisabled();
+      expect(mockBroadcastToAllWindows).not.toHaveBeenCalled();
+    });
+
+    it('continues processing remaining agents when one strip fails', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+        ['agent-b', { projectPath: '/p', cwd: '/p/b', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      mockRestoreForAgent.mockImplementationOnce(() => Promise.reject(new Error('disk failure')));
+      const affected = await applyDisabled();
+      // First failed, second succeeded — only the second is reported
+      expect(affected).toEqual(['agent-b']);
+    });
+  });
+
+  describe('applyEnabled', () => {
+    const mockProvider = {
+      id: 'claude-code',
+      writeHooksConfig: vi.fn(() => Promise.resolve()),
+    };
+
+    beforeEach(() => {
+      mockProvider.writeHooksConfig.mockClear();
+      mockGetProvider.mockReturnValue(mockProvider);
+      mockIsHookCapable.mockReturnValue(true);
+      mockGetHooksConfigPath.mockReturnValue('/p/a/.claude/settings.local.json');
+    });
+
+    it('flips the hook server on', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      await applyEnabled();
+      expect(mockSetEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('skips re-injection when the server port is 0 (server not started)', async () => {
+      mockGetPort.mockReturnValueOnce(0);
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      const affected = await applyEnabled();
+      expect(affected).toEqual([]);
+      expect(mockProvider.writeHooksConfig).not.toHaveBeenCalled();
+    });
+
+    it('re-injects hooks for each running agent with a known cwd', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+        ['agent-b', { projectPath: '/p', cwd: '/p/b', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      const affected = await applyEnabled();
+      expect(mockProvider.writeHooksConfig).toHaveBeenCalledWith('/p/a', 'http://127.0.0.1:12345/hook');
+      expect(mockProvider.writeHooksConfig).toHaveBeenCalledWith('/p/b', 'http://127.0.0.1:12345/hook');
+      expect(affected).toEqual(['agent-a', 'agent-b']);
+    });
+
+    it('skips agents with unknown cwd (legacy registrations)', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-legacy', { projectPath: '/p', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      const affected = await applyEnabled();
+      expect(mockProvider.writeHooksConfig).not.toHaveBeenCalled();
+      expect(affected).toEqual([]);
+    });
+
+    it('snapshots the hook config file before re-injecting (so future disable can restore)', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      await applyEnabled();
+      expect(mockSnapshotFile).toHaveBeenCalledWith('agent-a', '/p/a/.claude/settings.local.json');
+    });
+
+    it('broadcasts agents-need-restart with the affected agentIds', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      await applyEnabled();
+      expect(mockBroadcastToAllWindows).toHaveBeenCalledWith(
+        'hook-server:agents-need-restart',
+        { reason: 'enabled', agentIds: ['agent-a'] },
+      );
+    });
+
+    it('skips providers that are not hook-capable', async () => {
+      mockIsHookCapable.mockReturnValue(false);
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      const affected = await applyEnabled();
+      expect(mockProvider.writeHooksConfig).not.toHaveBeenCalled();
+      expect(affected).toEqual([]);
+    });
+  });
+
+  describe('onHookServerSettingsChanged', () => {
+    it('routes enabled=true to applyEnabled', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      await onHookServerSettingsChanged({ enabled: true });
+      expect(mockSetEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('routes enabled=false to applyDisabled', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      await onHookServerSettingsChanged({ enabled: false });
+      expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/main/services/hook-server-toggle.ts
+++ b/src/main/services/hook-server-toggle.ts
@@ -1,0 +1,151 @@
+/**
+ * Hook server toggle — applies the side effects when the user flips the
+ * global hook server enable setting.
+ *
+ * **Disable**:  resolve all in-flight permissions as 'timeout' (so the
+ * orchestrator's curl child returns), then strip Clubhouse-injected hook
+ * entries from each running agent's hook config file.  The agent's CLI
+ * process keeps running but its in-memory hook config may still reference
+ * Clubhouse — surface a "needs restart" notice for each affected agent.
+ *
+ * **Enable**:  re-inject hook entries into each running agent's hook config
+ * file, snapshot them again so a future disable can restore the original.
+ * Same "needs restart" notice — the agent's CLI process won't pick up the
+ * new entries until it next reads its hook config.
+ *
+ * Auto-restart of agents is intentionally NOT performed: killing PTYs
+ * mid-task would lose work.  Restart is the user's call.
+ */
+
+import { agentRegistry } from './agent-registry';
+import { getProvider } from '../orchestrators';
+import { isHookCapable } from '../orchestrators';
+import { appLog } from './log-service';
+import * as configPipeline from './config-pipeline';
+import * as permissionQueue from './annex-permission-queue';
+import * as hookServer from './hook-server';
+import { broadcastToAllWindows } from '../util/ipc-broadcast';
+import { IPC } from '../../shared/ipc-channels';
+import type { HookServerSettings } from '../../shared/types';
+
+const NS = 'core:hook-server-toggle';
+
+/**
+ * Apply the disabled state: resolve pending permissions, strip injected
+ * hooks from each running agent's config, broadcast restart-needed.
+ */
+export async function applyDisabled(): Promise<string[]> {
+  const registrations = agentRegistry.getAllRegistrations();
+  const affectedAgentIds: string[] = [];
+
+  // 1. Stop the server from processing new requests.
+  hookServer.setEnabled(false);
+
+  // 2. Resolve any in-flight permissions so curls return immediately.
+  //    `permissionQueue.reset()` resolves every pending entry as 'timeout',
+  //    which the hook server maps to 'ask' on its way back to the orchestrator.
+  const pendingCount = permissionQueue.listPending().length;
+  if (pendingCount > 0) {
+    permissionQueue.reset();
+    appLog(NS, 'info', 'Released in-flight permissions on disable', {
+      meta: { count: pendingCount },
+    });
+  }
+
+  // 3. Strip Clubhouse-injected hooks from every running agent's config.
+  for (const [agentId] of registrations) {
+    try {
+      await configPipeline.restoreForAgent(agentId);
+      affectedAgentIds.push(agentId);
+    } catch (err) {
+      appLog(NS, 'error', 'Failed to strip hooks for agent', {
+        meta: { agentId, error: err instanceof Error ? err.message : String(err) },
+      });
+    }
+  }
+
+  appLog(NS, 'info', 'Hook server disabled — agents stripped of injected hooks', {
+    meta: { affectedAgentIds, agentCount: affectedAgentIds.length },
+  });
+
+  if (affectedAgentIds.length > 0) {
+    broadcastToAllWindows(IPC.HOOK_SERVER.AGENTS_NEED_RESTART, {
+      reason: 'disabled',
+      agentIds: affectedAgentIds,
+    });
+  }
+
+  return affectedAgentIds;
+}
+
+/**
+ * Apply the enabled state: re-inject hook entries into each running agent's
+ * config, broadcast restart-needed.
+ */
+export async function applyEnabled(): Promise<string[]> {
+  const registrations = agentRegistry.getAllRegistrations();
+  const affectedAgentIds: string[] = [];
+
+  hookServer.setEnabled(true);
+
+  const port = hookServer.getPort();
+  if (port === 0) {
+    appLog(NS, 'warn', 'Hook server enabled but server port is 0 — re-injection skipped', {
+      meta: {},
+    });
+    return affectedAgentIds;
+  }
+  const hookUrl = `http://127.0.0.1:${port}/hook`;
+
+  for (const [agentId, registration] of registrations) {
+    if (!registration.cwd) {
+      appLog(NS, 'warn', 'Cannot re-inject hooks for agent — cwd unknown', {
+        meta: { agentId, orchestrator: registration.orchestrator },
+      });
+      continue;
+    }
+
+    try {
+      const provider = getProvider(registration.orchestrator);
+      if (!provider || !isHookCapable(provider)) continue;
+
+      // Snapshot the (possibly user-edited) current state before we re-inject,
+      // so a future disable can restore it cleanly.
+      const hookConfigPath = configPipeline.getHooksConfigPath(provider, registration.cwd);
+      if (hookConfigPath) {
+        await configPipeline.snapshotFile(agentId, hookConfigPath);
+      }
+      await provider.writeHooksConfig(registration.cwd, hookUrl);
+      affectedAgentIds.push(agentId);
+    } catch (err) {
+      appLog(NS, 'error', 'Failed to re-inject hooks for agent', {
+        meta: { agentId, error: err instanceof Error ? err.message : String(err) },
+      });
+    }
+  }
+
+  appLog(NS, 'info', 'Hook server enabled — agents re-injected with hooks', {
+    meta: { affectedAgentIds, agentCount: affectedAgentIds.length },
+  });
+
+  if (affectedAgentIds.length > 0) {
+    broadcastToAllWindows(IPC.HOOK_SERVER.AGENTS_NEED_RESTART, {
+      reason: 'enabled',
+      agentIds: affectedAgentIds,
+    });
+  }
+
+  return affectedAgentIds;
+}
+
+/**
+ * onSave hook for the HOOK_SERVER_SETTINGS managed setting.  Applies the
+ * appropriate side effect when the user flips the toggle.
+ */
+export async function onHookServerSettingsChanged(settings: HookServerSettings): Promise<void> {
+  if (settings.enabled) {
+    await applyEnabled();
+  } else {
+    await applyDisabled();
+  }
+}

--- a/src/main/services/hook-server.test.ts
+++ b/src/main/services/hook-server.test.ts
@@ -61,7 +61,7 @@ vi.mock('./annex-event-bus', () => ({
   emitHookEvent: (...args: unknown[]) => mockEmitHookEvent(...args),
 }));
 
-import { start, stop, getPort, waitReady } from './hook-server';
+import { start, stop, getPort, waitReady, setEnabled, isEnabled } from './hook-server';
 
 function postToServer(port: number, path: string, body: unknown, extraHeaders?: Record<string, string>): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -924,6 +924,78 @@ describe('hook-server', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('disabled mode (escape hatch)', () => {
+    const VALID_NONCE = 'disabled-nonce';
+
+    beforeEach(() => {
+      mockGetAgentProjectPath.mockReturnValue('/my/project');
+      mockGetAgentOrchestrator.mockReturnValue('claude-code');
+      mockGetAgentNonce.mockReturnValue(VALID_NONCE);
+      mockResolveOrchestrator.mockResolvedValue({
+        id: 'claude-code',
+        parseHookEvent: vi.fn(() => ({ kind: 'pre_tool', toolName: 'Bash' })),
+        toolVerb: vi.fn(() => 'Running command'),
+      });
+    });
+
+    afterEach(() => {
+      // Re-enable so other test groups aren't affected by ordering
+      setEnabled(true);
+    });
+
+    it('isEnabled defaults to true', () => {
+      expect(isEnabled()).toBe(true);
+    });
+
+    it('setEnabled(false) makes /hook routes return 200 immediately without dispatching', async () => {
+      setEnabled(false);
+      const status = await postToServer(port, '/hook/agent-1', {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+      await new Promise(r => setTimeout(r, 50));
+      expect(status).toBe(200);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockResolveOrchestrator).not.toHaveBeenCalled();
+      expect(mockCreatePermission).not.toHaveBeenCalled();
+    });
+
+    it('setEnabled(false) short-circuits permission_request hooks too', async () => {
+      setEnabled(false);
+      const response = await postToServerWithBody(port, '/hook/agent-1', {
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+      expect(response.status).toBe(200);
+      // Empty body — no permissionDecision, no holding response open
+      expect(mockCreatePermission).not.toHaveBeenCalled();
+    });
+
+    it('setEnabled(true) restores normal processing', async () => {
+      setEnabled(false);
+      setEnabled(true);
+      await postToServer(port, '/hook/agent-1', {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockSend).toHaveBeenCalled();
+    });
+
+    it('setEnabled is idempotent and only logs on actual transitions', () => {
+      setEnabled(true); // already enabled — no-op
+      setEnabled(false); // transition: enabled → disabled
+      setEnabled(false); // already disabled — no-op
+      const transitions = mockAppLog.mock.calls.filter(
+        (c: unknown[]) => c[2] === 'Hook server enabled' || c[2] === 'Hook server disabled',
+      );
+      // One transition log: 'Hook server disabled'.  No log for the no-op
+      // calls before/after.
+      expect(transitions).toHaveLength(1);
+      expect(transitions[0][2]).toBe('Hook server disabled');
     });
   });
 

--- a/src/main/services/hook-server.test.ts
+++ b/src/main/services/hook-server.test.ts
@@ -485,7 +485,6 @@ describe('hook-server', () => {
         'Bash',
         { command: 'rm -rf /' },
         'Allow dangerous command?',
-        120_000,
       );
 
       // Resolve the decision
@@ -567,7 +566,6 @@ describe('hook-server', () => {
         'unknown',
         undefined,
         undefined,
-        120_000,
       );
     });
 
@@ -723,7 +721,7 @@ describe('hook-server', () => {
       await new Promise(r => setTimeout(r, 50));
 
       expect(mockAppLog).toHaveBeenCalledWith(
-        'core:hook-server', 'error', 'Failed to send permission response',
+        'core:hook-server', 'error', 'Permission decision promise rejected',
         expect.objectContaining({
           meta: expect.objectContaining({ agentId: 'agent-1', error: 'connection closed' }),
         }),
@@ -779,6 +777,153 @@ describe('hook-server', () => {
       // The server was stopped in this test, so waitReady should reject
       // after stop() sets readyPromise to null
       await expect(waitReady()).rejects.toThrow('Hook server not started');
+    });
+  });
+
+  describe('hook event observability', () => {
+    const VALID_NONCE = 'log-nonce';
+
+    beforeEach(() => {
+      mockGetAgentProjectPath.mockReturnValue('/my/project');
+      mockGetAgentOrchestrator.mockReturnValue('claude-code');
+      mockGetAgentNonce.mockReturnValue(VALID_NONCE);
+    });
+
+    it('logs INFO when a hook event is received and successfully normalized', async () => {
+      mockResolveOrchestrator.mockResolvedValue({
+        id: 'claude-code',
+        parseHookEvent: vi.fn(() => ({
+          kind: 'pre_tool',
+          toolName: 'Bash',
+          toolInput: { command: 'ls' },
+          message: undefined,
+        })),
+        toolVerb: vi.fn(() => 'Running command'),
+      });
+
+      await postToServer(port, '/hook/agent-1', {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockAppLog).toHaveBeenCalledWith(
+        'core:hook-server', 'info', 'Hook event received',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            agentId: 'agent-1',
+            kind: 'pre_tool',
+            toolName: 'Bash',
+            orchestrator: 'claude-code',
+          }),
+        }),
+      );
+    });
+
+    it('logs WARN when parseHookEvent returns null (unknown event)', async () => {
+      mockResolveOrchestrator.mockResolvedValue({
+        id: 'claude-code',
+        parseHookEvent: vi.fn(() => null),
+        toolVerb: vi.fn(),
+      });
+
+      await postToServer(port, '/hook/agent-1/UnknownEvent', {
+        hook_event_name: 'UnknownEvent',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockAppLog).toHaveBeenCalledWith(
+        'core:hook-server', 'warn', 'Hook event ignored (unknown event for orchestrator)',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            agentId: 'agent-1',
+            rawEventName: 'UnknownEvent',
+          }),
+        }),
+      );
+    });
+
+    it('logs WARN when agent has no project path registered', async () => {
+      mockGetAgentProjectPath.mockReturnValue(undefined);
+
+      await postToServer(port, '/hook/orphan-agent/preToolUse', {
+        tool_name: 'Bash',
+      });
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockAppLog).toHaveBeenCalledWith(
+        'core:hook-server', 'warn', 'Hook event ignored (no project path for agent)',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            agentId: 'orphan-agent',
+            eventHint: 'preToolUse',
+          }),
+        }),
+      );
+    });
+
+    it('logs INFO when permission decision is sent back to the orchestrator', async () => {
+      mockCreatePermission.mockReturnValue({
+        requestId: 'req-log-1',
+        decision: Promise.resolve('allow'),
+      });
+      mockResolveOrchestrator.mockResolvedValue({
+        id: 'claude-code',
+        parseHookEvent: vi.fn(() => ({
+          kind: 'permission_request',
+          toolName: 'Bash',
+          toolInput: undefined,
+          message: undefined,
+        })),
+        toolVerb: vi.fn(() => 'Running command'),
+      });
+
+      await postToServerWithBody(port, '/hook/agent-1', {
+        hook_event_name: 'PermissionRequest',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+
+      expect(mockAppLog).toHaveBeenCalledWith(
+        'core:hook-server', 'info', 'Permission hook decision sent to orchestrator',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            agentId: 'agent-1',
+            requestId: 'req-log-1',
+            decision: 'allow',
+            queueResult: 'allow',
+          }),
+        }),
+      );
+    });
+
+    it('maps queue timeout to ask in the decision-sent log', async () => {
+      mockCreatePermission.mockReturnValue({
+        requestId: 'req-log-2',
+        decision: Promise.resolve('timeout'),
+      });
+      mockResolveOrchestrator.mockResolvedValue({
+        id: 'claude-code',
+        parseHookEvent: vi.fn(() => ({
+          kind: 'permission_request',
+          toolName: 'Write',
+          toolInput: undefined,
+          message: undefined,
+        })),
+        toolVerb: vi.fn(() => 'Writing file'),
+      });
+
+      await postToServerWithBody(port, '/hook/agent-1', {
+        hook_event_name: 'PermissionRequest',
+      }, { 'X-Clubhouse-Nonce': VALID_NONCE });
+
+      expect(mockAppLog).toHaveBeenCalledWith(
+        'core:hook-server', 'info', 'Permission hook decision sent to orchestrator',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            decision: 'ask',
+            queueResult: 'timeout',
+          }),
+        }),
+      );
     });
   });
 

--- a/src/main/services/hook-server.ts
+++ b/src/main/services/hook-server.ts
@@ -22,6 +22,28 @@ let server: any = null;
 let serverPort = 0;
 let readyPromise: Promise<number> | null = null;
 let stuckScanTimer: ReturnType<typeof setInterval> | null = null;
+let enabled = true;
+
+/**
+ * Toggle whether the hook server processes incoming hook callbacks.  When
+ * disabled, the server keeps listening (so existing curls don't dangle on
+ * connection refused) but returns 200 immediately for every `/hook/*` route.
+ *
+ * The toggle is the durable escape hatch for users whose orchestrator hook
+ * integration gets stuck.  See hook-server-toggle.ts for the side effects
+ * (stripping injected hooks from running agents' configs).
+ */
+export function setEnabled(value: boolean): void {
+  if (enabled === value) return;
+  enabled = value;
+  appLog('core:hook-server', 'info', `Hook server ${value ? 'enabled' : 'disabled'}`, {
+    meta: { enabled: value },
+  });
+}
+
+export function isEnabled(): boolean {
+  return enabled;
+}
 
 export function getPort(): number {
   return serverPort;
@@ -179,6 +201,17 @@ function handlePermissionRequest(
 async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   if (req.method !== 'POST' || !req.url?.startsWith('/hook/')) {
     res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  // When disabled, short-circuit every hook route with a fast 200.  The
+  // orchestrator's curl child returns immediately and the orchestrator
+  // falls through to its own permission UI.  We deliberately don't drain
+  // the body — saves time, and the orchestrator doesn't care about response
+  // body content for non-permission hooks.
+  if (!enabled) {
+    res.writeHead(200);
     res.end();
     return;
   }

--- a/src/main/services/hook-server.ts
+++ b/src/main/services/hook-server.ts
@@ -9,9 +9,19 @@ import * as permissionQueue from './annex-permission-queue';
 
 const MAX_BODY_SIZE = 1024 * 1024; // 1MB
 
+/**
+ * Interval at which we scan for pending permissions older than
+ * STUCK_PERMISSION_AGE_MS and log them at WARN.  Helps diagnose stuck-state
+ * bugs (the kind that motivated this whole logging pass) by surfacing the
+ * stuck queue state instead of leaving it invisible until a user reports it.
+ */
+const STUCK_PERMISSION_SCAN_INTERVAL_MS = 30_000;
+const STUCK_PERMISSION_AGE_MS = 30_000;
+
 let server: any = null;
 let serverPort = 0;
 let readyPromise: Promise<number> | null = null;
+let stuckScanTimer: ReturnType<typeof setInterval> | null = null;
 
 export function getPort(): number {
   return serverPort;
@@ -99,7 +109,9 @@ function buildHookEvent(
 
 /**
  * Handle permission request lifecycle — holds the HTTP response open
- * until the Annex client sends a decision (allow/deny) or the request times out.
+ * until the Annex client sends a decision (allow/deny) or the request times
+ * out.  Queue timeout < orchestrator hook timeout (see PERMISSION_QUEUE_TIMEOUT_MS)
+ * so we always respond before the orchestrator kills the curl child.
  */
 function handlePermissionRequest(
   agentId: string,
@@ -107,12 +119,12 @@ function handlePermissionRequest(
   res: http.ServerResponse,
 ): void {
   const toolName = normalized.toolName || 'unknown';
-  const { decision } = permissionQueue.createPermission(
+  const startedAt = Date.now();
+  const { requestId, decision } = permissionQueue.createPermission(
     agentId,
     toolName,
     normalized.toolInput,
     normalized.message,
-    120_000, // 120 second timeout
   );
 
   decision.then((result) => {
@@ -120,11 +132,29 @@ function handlePermissionRequest(
     const responseBody = JSON.stringify({
       hookSpecificOutput: { permissionDecision },
     });
-    res.writeHead(200, {
-      'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(responseBody),
-    });
-    res.end(responseBody);
+    const elapsedMs = Date.now() - startedAt;
+    try {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(responseBody),
+      });
+      res.end(responseBody);
+      appLog('core:hook-server', 'info', 'Permission hook decision sent to orchestrator', {
+        meta: { agentId, requestId, toolName, decision: permissionDecision, queueResult: result, elapsedMs },
+      });
+    } catch (err) {
+      appLog('core:hook-server', 'error', 'Failed to write permission response', {
+        meta: {
+          agentId,
+          requestId,
+          toolName,
+          decision: permissionDecision,
+          elapsedMs,
+          error: err instanceof Error ? err.message : String(err),
+          writableEnded: res.writableEnded,
+        },
+      });
+    }
 
     // Broadcast permission_resolved so the renderer clears the
     // needs_permission status.  Without this, denied / timed-out
@@ -138,8 +168,8 @@ function handlePermissionRequest(
     broadcastToAllWindows(IPC.AGENT.HOOK_EVENT, agentId, resolvedEvent);
     annexEventBus.emitHookEvent(agentId, resolvedEvent as any);
   }).catch((err) => {
-    appLog('core:hook-server', 'error', 'Failed to send permission response', {
-      meta: { agentId, error: err instanceof Error ? err.message : String(err) },
+    appLog('core:hook-server', 'error', 'Permission decision promise rejected', {
+      meta: { agentId, requestId, toolName, error: err instanceof Error ? err.message : String(err) },
     });
     try { if (!res.writableEnded) res.end(); } catch { /* response already closed */ }
   });
@@ -164,6 +194,7 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
   if (body === null) return; // size limit exceeded, response already sent
 
   const { agentId, eventHint } = route;
+  const bodyBytes = Buffer.byteLength(body);
 
   try {
     const raw = JSON.parse(body);
@@ -175,41 +206,101 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
     const projectPath = getAgentProjectPath(agentId);
     const orchestrator = getAgentOrchestrator(agentId);
 
-    if (projectPath) {
-      if (!validateNonce(agentId, req)) {
-        res.writeHead(200);
-        res.end();
-        return;
-      }
+    if (!projectPath) {
+      appLog('core:hook-server', 'warn', 'Hook event ignored (no project path for agent)', {
+        meta: { agentId, eventHint, orchestrator, bodyBytes },
+      });
+      res.writeHead(200);
+      res.end();
+      return;
+    }
 
-      const provider = await resolveOrchestrator(projectPath, orchestrator);
-      if (!isHookCapable(provider)) {
-        res.writeHead(200);
-        res.end();
-        return;
-      }
-      const normalized = provider.parseHookEvent(raw);
+    if (!validateNonce(agentId, req)) {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
 
-      if (normalized) {
-        const hookEvent = buildHookEvent(provider, normalized);
-        broadcastToAllWindows(IPC.AGENT.HOOK_EVENT, agentId, hookEvent);
-        annexEventBus.emitHookEvent(agentId, hookEvent as any);
+    const provider = await resolveOrchestrator(projectPath, orchestrator);
+    if (!isHookCapable(provider)) {
+      appLog('core:hook-server', 'warn', 'Hook event ignored (provider not hook-capable)', {
+        meta: { agentId, eventHint, orchestrator: provider?.id, bodyBytes },
+      });
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    const normalized = provider.parseHookEvent(raw);
 
-        if (normalized.kind === 'permission_request') {
-          handlePermissionRequest(agentId, normalized, res);
-          return; // Don't respond yet — the promise will handle it
-        }
-      }
+    if (!normalized) {
+      appLog('core:hook-server', 'warn', 'Hook event ignored (unknown event for orchestrator)', {
+        meta: {
+          agentId,
+          eventHint,
+          orchestrator: provider.id,
+          rawEventName: raw?.hook_event_name,
+          bodyBytes,
+        },
+      });
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+
+    appLog('core:hook-server', 'info', 'Hook event received', {
+      meta: {
+        agentId,
+        eventHint,
+        orchestrator: provider.id,
+        kind: normalized.kind,
+        toolName: normalized.toolName,
+        bodyBytes,
+      },
+    });
+
+    const hookEvent = buildHookEvent(provider, normalized);
+    broadcastToAllWindows(IPC.AGENT.HOOK_EVENT, agentId, hookEvent);
+    annexEventBus.emitHookEvent(agentId, hookEvent as any);
+
+    if (normalized.kind === 'permission_request') {
+      handlePermissionRequest(agentId, normalized, res);
+      return; // Don't respond yet — the promise will handle it
     }
   } catch (err) {
     appLog('core:hook-server', 'error', 'Failed to parse hook event', {
-      meta: { agentId, error: err instanceof Error ? err.message : String(err) },
+      meta: { agentId, eventHint, bodyBytes, error: err instanceof Error ? err.message : String(err) },
     });
   }
 
   // For non-permission events, respond immediately
   res.writeHead(200);
   res.end();
+}
+
+/**
+ * Periodic scan for stuck pending permissions.  Logs a WARN line for any
+ * permission that has been pending longer than STUCK_PERMISSION_AGE_MS.
+ * Without this, a stuck queue is silent until a user reports the symptom.
+ */
+function scanForStuckPermissions(): void {
+  const now = Date.now();
+  const pending = permissionQueue.listPending();
+  for (const p of pending) {
+    const ageMs = now - p.createdAt;
+    if (ageMs >= STUCK_PERMISSION_AGE_MS) {
+      const remainingMs = (p.createdAt + p.timeoutMs) - now;
+      appLog('core:permission-queue', 'warn', 'Stuck pending permission', {
+        meta: {
+          requestId: p.requestId,
+          agentId: p.agentId,
+          toolName: p.toolName,
+          ageMs,
+          timeoutMs: p.timeoutMs,
+          remainingMs,
+        },
+      });
+    }
+  }
 }
 
 export function start(): Promise<number> {
@@ -223,6 +314,11 @@ export function start(): Promise<number> {
         appLog('core:hook-server', 'info', `Hook server listening on 127.0.0.1:${serverPort}`, {
           meta: { port: serverPort },
         });
+        if (!stuckScanTimer) {
+          stuckScanTimer = setInterval(scanForStuckPermissions, STUCK_PERMISSION_SCAN_INTERVAL_MS);
+          // Don't keep the event loop alive on the scan timer alone
+          if (typeof stuckScanTimer.unref === 'function') stuckScanTimer.unref();
+        }
         resolve(serverPort);
       } else {
         const err = new Error('Failed to get hook server address');
@@ -243,6 +339,10 @@ export function start(): Promise<number> {
 }
 
 export function stop(): void {
+  if (stuckScanTimer) {
+    clearInterval(stuckScanTimer);
+    stuckScanTimer = null;
+  }
   if (server) {
     server.close();
     server = null;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1419,6 +1419,21 @@ const api = {
       ipcRenderer.send(IPC.CMD_PALETTE.RESULT, { callId, result });
     },
   },
+  hookServer: {
+    /**
+     * Listen for "agents need restart" events broadcast when the user toggles
+     * the hook server enable setting.  Payload includes the affected agentIds
+     * and whether the toggle went to enabled or disabled.  Renderer should
+     * surface a non-blocking notice and offer per-agent restart — do NOT
+     * auto-restart, which would lose mid-task work.
+     */
+    onAgentsNeedRestart: (callback: (payload: { reason: 'enabled' | 'disabled'; agentIds: string[] }) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload: { reason: 'enabled' | 'disabled'; agentIds: string[] }) =>
+        callback(payload);
+      ipcRenderer.on(IPC.HOOK_SERVER.AGENTS_NEED_RESTART, listener);
+      return () => { ipcRenderer.removeListener(IPC.HOOK_SERVER.AGENTS_NEED_RESTART, listener); };
+    },
+  },
 };
 
 export type ClubhouseAPI = typeof api;

--- a/src/renderer/features/settings/ExperimentalSettingsView.test.tsx
+++ b/src/renderer/features/settings/ExperimentalSettingsView.test.tsx
@@ -1,15 +1,24 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ExperimentalSettingsView } from './ExperimentalSettingsView';
+import { useHookServerSettingsStore } from '../../stores/hookServerSettingsStore';
 
 const mockGetExperimentalSettings = vi.fn();
 const mockSaveExperimentalSettings = vi.fn();
 const mockRestart = vi.fn();
+const mockSettingsGet = vi.fn();
+const mockSettingsSave = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetExperimentalSettings.mockResolvedValue({});
   mockSaveExperimentalSettings.mockResolvedValue(undefined);
   mockRestart.mockResolvedValue(undefined);
+  mockSettingsGet.mockResolvedValue({ enabled: true });
+  mockSettingsSave.mockResolvedValue(undefined);
+
+  // Reset the Zustand store to a fresh state — it's module-level and
+  // persists across tests otherwise.
+  useHookServerSettingsStore.setState({ enabled: true, loaded: false });
 
   (window as any).clubhouse = {
     ...(window as any).clubhouse,
@@ -18,6 +27,11 @@ beforeEach(() => {
       getExperimentalSettings: mockGetExperimentalSettings,
       saveExperimentalSettings: mockSaveExperimentalSettings,
       restart: mockRestart,
+    },
+    settings: {
+      ...(window as any).clubhouse?.settings,
+      get: mockSettingsGet,
+      save: mockSettingsSave,
     },
   };
 });
@@ -97,6 +111,43 @@ describe('ExperimentalSettingsView', () => {
     render(<ExperimentalSettingsView />);
     await waitFor(() => {
       expect(screen.getByText(/Restart Clubhouse to apply/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Diagnostics — hook server toggle', () => {
+    it('renders the Diagnostics section with the Hook server toggle', async () => {
+      render(<ExperimentalSettingsView />);
+      await waitFor(() => {
+        expect(screen.getByText('Diagnostics')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Hook server')).toBeInTheDocument();
+      expect(screen.getByText(/escape hatch/)).toBeInTheDocument();
+    });
+
+    it('loads hook server settings on mount', async () => {
+      render(<ExperimentalSettingsView />);
+      await waitFor(() => {
+        expect(mockSettingsGet).toHaveBeenCalledWith('hook-server');
+      });
+    });
+
+    it('saves the toggle change to the hook-server settings key', async () => {
+      mockSettingsGet.mockResolvedValue({ enabled: true });
+      render(<ExperimentalSettingsView />);
+      await waitFor(() => {
+        expect(screen.getByText('Hook server')).toBeInTheDocument();
+      });
+
+      // Click the toggle next to "Hook server".  All toggles render as
+      // `button.rounded-full`; the Diagnostics one is the last (after the
+      // experimental feature toggles).
+      const toggles = document.querySelectorAll('button.rounded-full');
+      const hookToggle = toggles[toggles.length - 1] as HTMLElement;
+      fireEvent.click(hookToggle);
+
+      await waitFor(() => {
+        expect(mockSettingsSave).toHaveBeenCalledWith('hook-server', { enabled: false });
+      });
     });
   });
 });

--- a/src/renderer/features/settings/ExperimentalSettingsView.tsx
+++ b/src/renderer/features/settings/ExperimentalSettingsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Toggle } from '../../components/Toggle';
+import { useHookServerSettingsStore } from '../../stores/hookServerSettingsStore';
 
 /** Feature definitions for the experimental settings page. */
 const EXPERIMENTAL_FEATURES: Array<{
@@ -38,17 +39,27 @@ export function ExperimentalSettingsView() {
   const [settings, setSettings] = useState<Record<string, boolean>>({});
   const [loaded, setLoaded] = useState(false);
 
+  const hookServerEnabled = useHookServerSettingsStore((s) => s.enabled);
+  const hookServerLoaded = useHookServerSettingsStore((s) => s.loaded);
+  const loadHookServerSettings = useHookServerSettingsStore((s) => s.loadSettings);
+  const saveHookServerSettings = useHookServerSettingsStore((s) => s.saveSettings);
+
   useEffect(() => {
     window.clubhouse.app.getExperimentalSettings().then((s) => {
       setSettings(s);
       setLoaded(true);
     });
-  }, []);
+    if (!hookServerLoaded) void loadHookServerSettings();
+  }, [hookServerLoaded, loadHookServerSettings]);
 
   const handleToggle = async (id: string, enabled: boolean) => {
     const updated = { ...settings, [id]: enabled };
     setSettings(updated);
     await window.clubhouse.app.saveExperimentalSettings(updated);
+  };
+
+  const handleHookServerToggle = (enabled: boolean) => {
+    void saveHookServerSettings({ enabled });
   };
 
   const handleRestart = () => {
@@ -89,6 +100,31 @@ export function ExperimentalSettingsView() {
               />
             </div>
           ))}
+        </div>
+
+        {/* Diagnostics — escape hatches for stuck states.  Not experimental
+            in the "may be removed" sense, but lives here because the user
+            audience overlaps and the section is already labelled advanced. */}
+        <div className="space-y-3 mb-6 border-t border-surface-0 pt-4">
+          <h3 className="text-xs text-ctp-subtext0 uppercase tracking-wider">Diagnostics</h3>
+          <div className="flex items-center justify-between py-2">
+            <div className="pr-4">
+              <div className="text-sm text-ctp-text font-medium">Hook server</div>
+              <div className="text-xs text-ctp-subtext0 mt-0.5">
+                Receives orchestrator hook callbacks (permission requests, tool
+                events). Disabling is the durable escape hatch when an
+                orchestrator's hook integration gets stuck — Clubhouse-injected
+                hooks are stripped from running agents and the server returns
+                fast 200s. Running agents need to be restarted before changes
+                take full effect; permission request and observability features
+                are unavailable while disabled.
+              </div>
+            </div>
+            <Toggle
+              checked={hookServerEnabled}
+              onChange={handleHookServerToggle}
+            />
+          </div>
         </div>
 
         {/* Restart button */}

--- a/src/renderer/stores/hookServerSettingsStore.ts
+++ b/src/renderer/stores/hookServerSettingsStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import type { HookServerSettings } from '../../shared/types';
+import { HOOK_SERVER_SETTINGS } from '../../shared/settings-definitions';
+
+interface HookServerSettingsState {
+  enabled: boolean;
+  loaded: boolean;
+  loadSettings: () => Promise<void>;
+  saveSettings: (settings: Partial<HookServerSettings>) => Promise<void>;
+}
+
+export const useHookServerSettingsStore = create<HookServerSettingsState>((set, get) => ({
+  enabled: HOOK_SERVER_SETTINGS.defaults.enabled,
+  loaded: false,
+
+  loadSettings: async () => {
+    try {
+      const settings = await window.clubhouse.settings.get(HOOK_SERVER_SETTINGS.key) as HookServerSettings | null;
+      set({ enabled: settings?.enabled ?? HOOK_SERVER_SETTINGS.defaults.enabled, loaded: true });
+    } catch {
+      set({ loaded: true });
+    }
+  },
+
+  saveSettings: async (partial: Partial<HookServerSettings>) => {
+    const prev = get().enabled;
+    const next = partial.enabled ?? prev;
+    set({ enabled: next });
+    try {
+      await window.clubhouse.settings.save(HOOK_SERVER_SETTINGS.key, { enabled: next });
+    } catch {
+      set({ enabled: prev });
+    }
+  },
+}));

--- a/src/shared/ipc-channel-sync.test.ts
+++ b/src/shared/ipc-channel-sync.test.ts
@@ -99,6 +99,9 @@ const MAIN_TO_RENDERER_ONLY_CHANNELS = new Set([
   // Command palette bridge: REQUEST is main→renderer push, RESULT is handled in command-palette-bridge.ts
   'IPC.CMD_PALETTE.REQUEST',
   'IPC.CMD_PALETTE.RESULT',
+  // Hook server toggle: AGENTS_NEED_RESTART is broadcast main→renderer when
+  // the user flips the global hook server toggle (see hook-server-toggle.ts).
+  'IPC.HOOK_SERVER.AGENTS_NEED_RESTART',
   'IPC.WINDOW.NAVIGATE_TO_AGENT',
   'IPC.WINDOW.NAVIGATE_TO_PLUGIN_SETTINGS',
   'IPC.WINDOW.REQUEST_AGENT_STATE',

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -466,6 +466,10 @@ export const IPC = {
      */
     OPEN_AND_READ: 'blueprint:open-and-read',
   },
+  HOOK_SERVER: {
+    /** Main → renderer: a list of agentIds whose hook config was changed and need restart for the change to take full effect. */
+    AGENTS_NEED_RESTART: 'hook-server:agents-need-restart',
+  },
   AGENT_QUEUE: {
     CREATE: 'agent-queue:create',
     GET: 'agent-queue:get',

--- a/src/shared/settings-definitions.ts
+++ b/src/shared/settings-definitions.ts
@@ -38,7 +38,7 @@ export function settingsChannels(key: string) {
 // Concrete definitions — importable from both main and renderer
 // ---------------------------------------------------------------------------
 
-import type { ClipboardSettings, EditorSettings, McpSettings, SecuritySettings } from './types';
+import type { ClipboardSettings, EditorSettings, HookServerSettings, McpSettings, SecuritySettings } from './types';
 
 export const CLIPBOARD_SETTINGS: SettingsDefinition<ClipboardSettings> = {
   key: 'clipboard',
@@ -62,4 +62,10 @@ export const SECURITY_SETTINGS: SettingsDefinition<SecuritySettings> = {
   key: 'security',
   filename: 'security-settings.json',
   defaults: { allowLocalFileWebviews: false },
+};
+
+export const HOOK_SERVER_SETTINGS: SettingsDefinition<HookServerSettings> = {
+  key: 'hook-server',
+  filename: 'hook-server-settings.json',
+  defaults: { enabled: true },
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -518,6 +518,21 @@ export interface EditorSettings {
   editorName: string;
 }
 
+/**
+ * Hook server settings — global toggle for the in-process HTTP server that
+ * receives orchestrator hook callbacks (preToolUse, permissionRequest, etc.).
+ *
+ * Disabling is the durable escape hatch when an orchestrator's hook integration
+ * gets stuck.  Disabled means: hook-server short-circuits all `/hook/*`
+ * requests with an immediate 200, AND Clubhouse-injected hook entries are
+ * stripped from each running agent's hook config file.  Running agents
+ * continue executing but lose remote-permission/observability features until
+ * their next restart.
+ */
+export interface HookServerSettings {
+  enabled: boolean;
+}
+
 // --- Experimental settings ---
 
 export interface ExperimentalSettings {

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -461,6 +461,9 @@ vi.stubGlobal('clubhouse', {
     onRequest: () => noop,
     sendResult: noop,
   },
+  hookServer: {
+    onAgentsNeedRestart: () => noop,
+  },
   window: {
     createPopout: asyncNoop,
     closePopout: asyncNoop,


### PR DESCRIPTION
## Summary
- **Fix the GHCP permission stuck-state bug**: symmetric 120s timeout race between the orchestrator's `permissionRequest` hook and our permission queue meant both expired at the same instant — the orchestrator killed the curl child before our server wrote the `'ask'` fallback, agents stalled in a hidden TUI prompt UI.
- **Make hooks observable**: hook server previously only logged failures (the bug was effectively invisible until users reported it). Now logs every receipt, permission lifecycle event, and decision write-back, plus a periodic stuck-permission scanner.
- **Durable escape hatch**: a global Diagnostics → Hook server toggle that lets stuck users unstick themselves — strips Clubhouse-injected hooks from running agents and short-circuits the server to a fast 200, without killing PTYs.

Companion deliverable: [`docs/hook-investigation-2026-05-05.md`](docs/hook-investigation-2026-05-05.md) — gap analysis of CC vs GHCP vs Codex hooks, lifecycle differences, and draft follow-up issues (3 internal, 1 upstream — bodies drafted, not filed).

## Background

GHCP is moving from beta to GA and a large user base is migrating from Claude Code → GHCP, so this stuck state is blocking adoption. Reproduced locally on agent `lucky-mantis`. Smoking gun in GHCP's own log:
```
2026-05-05T00:52:20.731Z [ERROR] Hook execution failed: Error: Hook command timed out after 120 seconds
```

## Changes

### (A) Race fix
- New shared `PERMISSION_HOOK_TIMEOUT_SEC = 120` constant in `orchestrators/types.ts`. All three providers (Claude Code, Copilot CLI, Codex CLI) reference it for their `permissionRequest` hook config.
- `annex-permission-queue.ts` exports `PERMISSION_QUEUE_TIMEOUT_MS = 110_000` derived as `(PERMISSION_HOOK_TIMEOUT_SEC × 1000) - 10_000` safety margin. Queue's default timeout uses the new value, so the orchestrator's hook always receives our `'ask'` response before its own timeout fires.
- The `'timeout' → 'ask'` fallback in `hook-server.ts` is intentionally **kept** — interactive PTYs can still recover via the orchestrator's user-prompt UI.

### (A) Observability
- `hook-server.ts`: INFO log on every received event (agentId, eventHint, kind, toolName, orchestrator, body bytes). WARN on unknown events (with raw `hook_event_name`), missing project path, or non-hook-capable provider. INFO on permission decision write-back with elapsedMs and the original queue result so `'timeout → ask'` mappings are traceable.
- `annex-permission-queue.ts` (new `core:permission-queue` namespace): lifecycle logging for requested / resolved / no-op resolves / timeout / per-agent clears / reset.
- New 30-second stuck-permission scanner in `hook-server.ts` — WARN logs any pending permission older than 30s with `requestId`, `agentId`, `toolName`, `ageMs`, `remainingMs`. Bridges the "queue silently stuck" → "user reports symptom" gap.

### (C) Settings toggle
- New `HOOK_SERVER_SETTINGS` (default `enabled: true`) wired through the standard `createManagedSettings` pattern.
- **Off path**: server short-circuits all `/hook/*` routes with a fast 200; `permissionQueue.reset()` releases any in-flight permissions; `configPipeline.restoreForAgent()` strips Clubhouse-injected hooks from each running agent's config; `IPC.HOOK_SERVER.AGENTS_NEED_RESTART` broadcasts the affected agentIds.
- **On path**: server resumes; for each running agent with a known `cwd`, the hook config is re-snapshotted and `provider.writeHooksConfig()` re-injects entries. Same `agents-need-restart` broadcast.
- **No auto-restart of PTYs** — restart is the user's call to avoid losing mid-task work.
- New Diagnostics section in `ExperimentalSettingsView.tsx` with the toggle.
- `AgentRegistration` grows a `cwd` field (passed at registration in `agent-system.ts`) so the toggle can re-inject without scanning for worktree paths.
- Persisted state honoured at startup: after `hookServer.start()` resolves, we re-apply the persisted `enabled` flag.

### (D) Investigation report
- `docs/hook-investigation-2026-05-05.md` covering the provider event matrix, lifecycle differences (notably GHCP's internal workspace recycling), `permissionDecision` semantics edge cases, exposure to upstream issues `github/copilot-cli` #2586 and #1651, and draft bodies for 3 internal follow-ups + 1 upstream docs request.

## Test Plan

### Automated
- [x] `annex-permission-queue.test.ts` — new race-fix invariants: `PERMISSION_QUEUE_TIMEOUT_MS < PERMISSION_HOOK_TIMEOUT_SEC × 1000`, queue defaults to derived value, explicit override still works.
- [x] `hook-server.test.ts` — new observability tests: INFO on receipt, WARN on unknown event / missing project path, INFO on decision write-back with `queueResult`, `'timeout → ask'` mapping traceability. New disabled-mode tests: short-circuit, idempotent transitions, restoration on re-enable.
- [x] `hook-server-toggle.test.ts` (new) — disable strips hooks for all running agents and broadcasts; in-flight permissions get released; failure on one agent doesn't block others; enable re-injects with snapshot before write; skips agents with unknown cwd; routing through `onHookServerSettingsChanged`.
- [x] `ExperimentalSettingsView.test.tsx` — Diagnostics section renders, loads from `hook-server` key, save persists.
- [x] `ipc-channel-sync.test.ts` — new channel registered as main→renderer broadcast and exposed in preload.
- [x] All 1653 tests in modified-area files pass; all 5224 main+shared unit tests pass; `tsc --noEmit` clean; `eslint .` clean.

### Manual Validation

**Repro the original bug + verify fix** (most important — needs another machine since `lucky-mantis` is the live repro):
- [ ] Spawn a GHCP agent. Trigger a tool call that requires permission. Verify the agent does NOT stall after 120s.
- [ ] Confirm the new INFO logs (\`core:hook-server\` and \`core:permission-queue\`) show up in `~/.clubhouse/logs/session-*.jsonl` for each permission lifecycle.
- [ ] Force a stuck state (e.g. ignore the iOS approval for >30s). Verify the periodic WARN scanner logs the stuck entry.

**Settings toggle**:
- [ ] Open Settings → Experimental → Diagnostics. Toggle Hook server off.
- [ ] Confirm the running agent's `.github/hooks/hooks.json` (GHCP) or `.claude/settings.local.json` (CC) no longer contains Clubhouse curl entries.
- [ ] Make a request from a running agent that fires a hook — confirm it returns immediately (no hanging).
- [ ] Toggle Hook server on. Confirm hook entries are re-injected into running agents' configs.
- [ ] Restart Clubhouse with the toggle off. Confirm it stays off (persistence).

**Existing flows still work**:
- [ ] Spawn a Claude Code agent, request permission via Annex iOS, approve → tool runs.
- [ ] Spawn a GHCP agent, same flow.
- [ ] Spawn a Codex CLI agent, same flow.

## Notes for reviewers
- The `'ask'` fallback semantic was kept per design — interactive PTYs can still recover. If you'd prefer `'deny'` for headless contexts later, the right place is per-runtime configuration, not the hook server.
- The investigation report at `docs/hook-investigation-2026-05-05.md` has draft GH issue bodies — review and file as you see fit. The renderer-side notice for `AGENTS_NEED_RESTART` is intentionally left as a follow-up issue since the wiring is small and the user's primary need (escape hatch + observability) ships now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)