### PR TITLE
fix(theme): replace hardcoded rgba in stuck-pulse keyframe with ctp-error token (VQ T-2)

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -433,10 +433,10 @@
 
 @keyframes stuck-pulse {
   0%, 100% {
-    box-shadow: 0 0 6px 2px rgba(239, 68, 68, 0.3), 0 0 2px 1px rgba(239, 68, 68, 0.15);
+    box-shadow: 0 0 6px 2px rgb(var(--ctp-error) / 0.3), 0 0 2px 1px rgb(var(--ctp-error) / 0.15);
   }
   50% {
-    box-shadow: 0 0 14px 4px rgba(239, 68, 68, 0.5), 0 0 4px 2px rgba(239, 68, 68, 0.3);
+    box-shadow: 0 0 14px 4px rgb(var(--ctp-error) / 0.5), 0 0 4px 2px rgb(var(--ctp-error) / 0.3);
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `rgba(239, 68, 68, ...)` (hardcoded Tailwind red-500) in the `@keyframes stuck-pulse` block with `rgb(var(--ctp-error) / alpha)` CSS custom property references
- This was the only `@keyframes` block in `src/renderer/index.css` with hardcoded non-neutral color values; all others already use theme variables or neutral opacity/transform only

## What changed

`src/renderer/index.css`: The `stuck-pulse` animation (used on stuck/error agent cards) previously hardcoded `rgba(239, 68, 68)` (Tailwind red-500 / Mocha `red`), which rendered the wrong color on all non-default themes. Now uses `rgb(var(--ctp-error) / alpha)` to respect the active theme's error color.

## Test plan

- [ ] Verify animated stuck-pulse glow matches theme error color on default Mocha theme
- [ ] Verify animated stuck-pulse glow matches theme error color on Catppuccin Latte (light theme)
- [ ] Verify animated stuck-pulse glow matches theme error color on at least one other theme (e.g. Nord, Dracula)
- [ ] Confirm no visual regressions on non-stuck agent cards

## Validation

- Lint: clean
- Tests: 11,497 passing (10 pre-existing plugin/mermaid failures unrelated to this change)
- TypeCheck: 1 pre-existing MermaidDiagram module error (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)