### PR TITLE
fix(theme): named z-index scale + fix toast/modal stacking conflict (Track D, VQ O-1)

### DIFF
--- a/src/renderer/components/ImageCropDialog.tsx
+++ b/src/renderer/components/ImageCropDialog.tsx
@@ -217,7 +217,7 @@ export function ImageCropDialog({
   const canvasSize = CROP_AREA_SIZE + 80; // Extra padding around crop area
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70" onClick={onCancel}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/70" onClick={onCancel}>
       <div
         className="bg-ctp-base rounded-xl border border-surface-2 shadow-2xl p-5 flex flex-col items-center gap-4"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/components/ToastContainer.tsx
+++ b/src/renderer/components/ToastContainer.tsx
@@ -41,7 +41,7 @@ export function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2" data-testid="toast-container">
+    <div className="fixed bottom-4 right-4 z-toast flex flex-col gap-2" data-testid="toast-container">
       {toasts.map((t) => (
         <ToastItem key={t.id} toast={t} />
       ))}

--- a/src/renderer/features/agents/AddAgentDialog.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.tsx
@@ -65,7 +65,7 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={onClose}>
       <div
         className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[360px] shadow-2xl"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/agents/AgentGalleryDialog.tsx
+++ b/src/renderer/features/agents/AgentGalleryDialog.tsx
@@ -81,7 +81,7 @@ export function AgentGalleryDialog({ onClose, onCreate }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-modal flex items-center justify-center">
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
       <div className="relative bg-ctp-base border border-surface-0 rounded-xl shadow-2xl w-[520px] max-h-[80vh] flex flex-col">
         {/* Header */}

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -551,7 +551,7 @@ export function AgentList() {
             const rect = dropdownBtnRef.current?.getBoundingClientRect();
             return (
               <div
-                className="fixed bg-ctp-mantle border border-surface-0 rounded-lg shadow-xl py-1 z-50 min-w-[160px]"
+                className="fixed bg-ctp-mantle border border-surface-0 rounded-lg shadow-xl py-1 z-dropdown min-w-[160px]"
                 style={rect ? { top: rect.bottom + 4, right: window.innerWidth - rect.right } : undefined}
               >
                 <button
@@ -595,7 +595,7 @@ export function AgentList() {
 
       {/* Close dropdown on outside click */}
       {showDropdown && (
-        <div className="fixed inset-0 z-40" onClick={() => setShowDropdown(false)} />
+        <div className="fixed inset-0 z-dropdown-backdrop" onClick={() => setShowDropdown(false)} />
       )}
 
       <div className="flex-1 overflow-y-auto min-h-0" data-testid="agent-list-content">

--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -102,7 +102,7 @@ function ContextMenu({ actions, position, onClose }: {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
+      className="fixed z-dropdown min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
       style={style}
       data-testid="agent-context-menu"
     >

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -708,7 +708,7 @@ export function AgentSettingsView({ agent }: Props) {
                     </button>
                   )}
                   {showEmojiPicker && (
-                    <div className="absolute top-8 left-0 z-50">
+                    <div className="absolute top-8 left-0 z-dropdown">
                       <EmojiPicker
                         onSelect={handleEmojiSelect}
                         onClose={() => setShowEmojiPicker(false)}

--- a/src/renderer/features/agents/AgentTemplatesSection.tsx
+++ b/src/renderer/features/agents/AgentTemplatesSection.tsx
@@ -275,7 +275,7 @@ export function AgentTemplatesSection({ worktreePath, projectPath, disabled, ref
 
       {/* Delete confirmation dialog */}
       {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
           <div className="bg-ctp-base border border-surface-1 rounded-lg p-4 max-w-sm mx-4 shadow-xl">
             <h4 className="text-sm font-semibold text-ctp-text mb-2">Delete Agent Definition</h4>
             <p className="text-xs text-ctp-subtext0 mb-1">

--- a/src/renderer/features/agents/ConfigChangesDialog.tsx
+++ b/src/renderer/features/agents/ConfigChangesDialog.tsx
@@ -141,7 +141,7 @@ export function ConfigChangesDialog() {
     item.category === 'instructions' || item.category === 'skills' || item.category === 'agent-templates';
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeDialog}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={closeDialog}>
       <div
         className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[540px] shadow-2xl max-h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/agents/DeleteAgentDialog.tsx
+++ b/src/renderer/features/agents/DeleteAgentDialog.tsx
@@ -144,7 +144,7 @@ export function DeleteAgentDialog() {
   // Non-worktree agents get a simple unregister dialog
   if (!agent.worktreePath) {
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeDeleteDialog}>
+      <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={closeDeleteDialog}>
         <div
           className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[400px] shadow-2xl"
           onClick={(e) => e.stopPropagation()}
@@ -191,7 +191,7 @@ export function DeleteAgentDialog() {
   const handleLeaveFiles = () => handleExecute('unregister');
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeDeleteDialog}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={closeDeleteDialog}>
       <div
         className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[480px] shadow-2xl max-h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/agents/QuickAgentDialog.tsx
+++ b/src/renderer/features/agents/QuickAgentDialog.tsx
@@ -102,7 +102,7 @@ export function QuickAgentDialog() {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeDialog}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={closeDialog}>
       <div
         className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[420px] shadow-2xl"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/agents/SessionNamePromptDialog.tsx
+++ b/src/renderer/features/agents/SessionNamePromptDialog.tsx
@@ -51,7 +51,7 @@ export function SessionNamePromptDialog({ agentId, projectPath, onDone }: Sessio
   }, [onDone]);
 
   return createPortal(
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-modal">
       <div
         ref={dialogRef}
         data-testid="session-name-prompt-dialog"

--- a/src/renderer/features/agents/SessionPickerDialog.tsx
+++ b/src/renderer/features/agents/SessionPickerDialog.tsx
@@ -180,7 +180,7 @@ export function SessionPickerDialog({ agentId, projectPath, orchestrator, onResu
   }, []);
 
   return createPortal(
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-modal">
       <div
         ref={dialogRef}
         data-testid="session-picker-dialog"

--- a/src/renderer/features/agents/SkillsSection.tsx
+++ b/src/renderer/features/agents/SkillsSection.tsx
@@ -213,7 +213,7 @@ export function SkillsSection({ worktreePath, projectPath, disabled, refreshKey,
 
       {/* Delete confirmation dialog */}
       {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
           <div className="bg-ctp-base border border-surface-1 rounded-lg p-4 max-w-sm mx-4 shadow-xl">
             <h4 className="text-sm font-semibold text-ctp-text mb-2">Delete Skill</h4>
             <p className="text-xs text-ctp-subtext0 mb-1">

--- a/src/renderer/features/agents/SleepingAgent.tsx
+++ b/src/renderer/features/agents/SleepingAgent.tsx
@@ -146,7 +146,7 @@ export function SleepingAgent({ agent }: { agent: Agent }) {
               {dropdownOpen && (
                 <div
                   data-testid="wake-dropdown-menu"
-                  className="absolute top-full mt-1 left-0 right-0 min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle z-50"
+                  className="absolute top-full mt-1 left-0 right-0 min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle z-dropdown"
                 >
                   <button
                     onClick={handleWakeAndResume}

--- a/src/renderer/features/agents/TemplateConfigDialog.tsx
+++ b/src/renderer/features/agents/TemplateConfigDialog.tsx
@@ -87,7 +87,7 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={onClose}>
       <div
         className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[360px] shadow-2xl"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/annex/SatelliteLockOverlay.tsx
+++ b/src/renderer/features/annex/SatelliteLockOverlay.tsx
@@ -33,7 +33,7 @@ export const SatelliteLockOverlay = React.memo(function SatelliteLockOverlay({ l
 
   return (
     <div
-      className={`fixed inset-0 z-[9999] flex items-center justify-center transition-opacity ${
+      className={`fixed inset-0 z-canvas-overlay flex items-center justify-center transition-opacity ${
         lockState.paused ? 'bg-black/20 pointer-events-none' : 'bg-black/60'
       }`}
       style={{ backdropFilter: lockState.paused ? 'none' : 'blur(4px)' }}

--- a/src/renderer/features/app/UpdateGateModal.tsx
+++ b/src/renderer/features/app/UpdateGateModal.tsx
@@ -20,7 +20,7 @@ export function UpdateGateModal({ agents, onCancel, onConfirm, onResolveAgent }:
   const hasWorking = workingAgents.length > 0;
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center" onClick={onCancel}>
+    <div className="fixed inset-0 z-modal bg-black/50 flex items-center justify-center" onClick={onCancel}>
       <div
         className="bg-ctp-mantle border border-surface-0 rounded-xl shadow-2xl max-w-lg w-full mx-4 p-5"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/app/WhatsNewDialog.tsx
+++ b/src/renderer/features/app/WhatsNewDialog.tsx
@@ -32,7 +32,7 @@ export function WhatsNewDialog() {
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+      className="fixed inset-0 z-modal bg-black/50 flex items-center justify-center"
       data-testid="whats-new-backdrop"
       onClick={handleDismiss}
     >

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -213,7 +213,7 @@ export function BlueprintGallery() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-modal flex items-center justify-center bg-black/50"
       onClick={(e) => { if (e.target === e.currentTarget) close(); }}
       data-testid="blueprint-gallery-overlay"
     >
@@ -423,7 +423,7 @@ function BlueprintCard({
       {contextMenu && (
         <div
           ref={menuRef}
-          className="fixed z-50 bg-ctp-mantle border border-surface-0 rounded-lg shadow-2xl py-1 min-w-[140px] text-[11px]"
+          className="fixed z-dropdown bg-ctp-mantle border border-surface-0 rounded-lg shadow-2xl py-1 min-w-[140px] text-[11px]"
           style={{ left: contextMenu.x, top: contextMenu.y }}
           data-testid="blueprint-card-context-menu"
         >

--- a/src/renderer/features/blueprints/ExportBlueprintDialog.tsx
+++ b/src/renderer/features/blueprints/ExportBlueprintDialog.tsx
@@ -103,7 +103,7 @@ export function ExportBlueprintDialog({
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: 100000 }}
+      style={{ zIndex: "var(--z-top)" }}
       onClick={handleBackdropClick}
       data-testid="export-blueprint-dialog"
     >

--- a/src/renderer/features/blueprints/ExportBundleDialog.tsx
+++ b/src/renderer/features/blueprints/ExportBundleDialog.tsx
@@ -95,7 +95,7 @@ export function ExportBundleDialog({
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: 100000 }}
+      style={{ zIndex: "var(--z-top)" }}
       onClick={handleBackdropClick}
       data-testid="export-bundle-dialog"
     >

--- a/src/renderer/features/blueprints/ImportBundleDialog.tsx
+++ b/src/renderer/features/blueprints/ImportBundleDialog.tsx
@@ -55,7 +55,7 @@ export function ImportBundleDialog({ bundle, onImport, onClose }: ImportBundleDi
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: 100000 }}
+      style={{ zIndex: "var(--z-top)" }}
       onClick={handleBackdropClick}
       data-testid="import-bundle-dialog"
     >

--- a/src/renderer/features/command-palette/CommandPalette.tsx
+++ b/src/renderer/features/command-palette/CommandPalette.tsx
@@ -101,7 +101,7 @@ export function CommandPalette() {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50" data-testid="command-palette-overlay" onKeyDown={handleKeyDown}>
+    <div className="fixed inset-0 z-modal" data-testid="command-palette-overlay" onKeyDown={handleKeyDown}>
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/50" onClick={close} />
       {/* Palette */}

--- a/src/renderer/features/onboarding/OnboardingModal.tsx
+++ b/src/renderer/features/onboarding/OnboardingModal.tsx
@@ -55,7 +55,7 @@ export function OnboardingModal() {
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+      className="fixed inset-0 z-modal bg-black/50 flex items-center justify-center"
       data-testid="onboarding-backdrop"
       onClick={handleDismiss}
     >

--- a/src/renderer/features/projects/Dashboard.tsx
+++ b/src/renderer/features/projects/Dashboard.tsx
@@ -458,7 +458,7 @@ function AgentRowContextMenu({ actions, position, onClose }: {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
+      className="fixed z-dropdown min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
       style={style}
       data-testid="dashboard-agent-context-menu"
     >

--- a/src/renderer/features/settings/OrchestratorSettingsView.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.tsx
@@ -159,7 +159,7 @@ function AppAgentSettings() {
 
       {/* Confirmation dialog */}
       {showConfirm && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-modal">
           <div className="bg-ctp-base border border-surface-1 rounded-xl p-6 max-w-md mx-4 shadow-xl">
             <h3 className="text-sm font-semibold text-ctp-text mb-2">Enable Clubhouse Mode?</h3>
             <p className="text-xs text-ctp-subtext0 mb-4">

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -89,7 +89,7 @@ function PermissionInfoPopup({ entry }: { entry: PluginRegistryEntry }) {
       {open && (
         <div
           data-testid="permission-popup"
-          className="fixed z-50 w-72 p-3 rounded-lg bg-ctp-mantle border border-surface-1 shadow-lg"
+          className="fixed z-dropdown w-72 p-3 rounded-lg bg-ctp-mantle border border-surface-1 shadow-lg"
           style={popupStyle}
         >
           <p className="text-xs font-semibold text-ctp-subtext1 mb-2">Permissions</p>

--- a/src/renderer/features/settings/PluginMarketplaceDialog.tsx
+++ b/src/renderer/features/settings/PluginMarketplaceDialog.tsx
@@ -439,7 +439,7 @@ export function PluginMarketplaceDialog({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-modal flex items-center justify-center bg-black/60"
       onClick={onClose}
       data-testid="marketplace-overlay"
     >

--- a/src/renderer/features/settings/ProfilesSettingsView.tsx
+++ b/src/renderer/features/settings/ProfilesSettingsView.tsx
@@ -393,7 +393,7 @@ export function ProfilesSettingsView() {
 
         {/* Confirm delete dialog */}
         {showConfirmDelete && (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-modal">
             <div className="bg-ctp-base border border-surface-1 rounded-xl p-6 max-w-md mx-4 shadow-xl">
               <h3 className="text-sm font-semibold text-ctp-text mb-2">Delete Profile?</h3>
               <p className="text-xs text-ctp-subtext0 mb-4">

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -86,7 +86,7 @@ function ConfirmDialog({
   confirmingLabel?: string;
 }) {
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-modal">
       <div className="bg-ctp-base border border-surface-1 rounded-xl p-6 max-w-md mx-4 shadow-xl">
         <h3 className="text-sm font-semibold text-ctp-text mb-2">{title}</h3>
         <p className="text-xs text-ctp-subtext0 mb-4">{message}</p>

--- a/src/renderer/features/settings/ProjectSettings.tsx
+++ b/src/renderer/features/settings/ProjectSettings.tsx
@@ -152,7 +152,7 @@ function AppearanceSection({ projectId }: { projectId: string }) {
             </button>
           )}
           {showEmojiPicker && (
-            <div className="absolute top-12 left-0 z-50">
+            <div className="absolute top-12 left-0 z-dropdown">
               <EmojiPicker
                 onSelect={handleEmojiSelect}
                 onClose={() => setShowEmojiPicker(false)}

--- a/src/renderer/features/settings/ResetProjectDialog.tsx
+++ b/src/renderer/features/settings/ResetProjectDialog.tsx
@@ -22,7 +22,7 @@ export function ResetProjectDialog({ projectName, projectPath, onConfirm, onCanc
   const canConfirm = confirmText === projectName;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onCancel}>
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/60" onClick={onCancel}>
       <div
         className="bg-ctp-base border border-surface-2 rounded-xl shadow-2xl w-full max-w-md mx-4"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/features/settings/SourceAgentTemplatesSection.tsx
+++ b/src/renderer/features/settings/SourceAgentTemplatesSection.tsx
@@ -184,7 +184,7 @@ export function SourceAgentTemplatesSection({ projectPath }: Props) {
 
       {/* Delete confirmation dialog */}
       {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
           <div className="bg-ctp-base border border-surface-1 rounded-lg p-4 max-w-sm mx-4 shadow-xl">
             <h4 className="text-sm font-semibold text-ctp-text mb-2">Delete Agent Definition</h4>
             <p className="text-xs text-ctp-subtext0 mb-1">

--- a/src/renderer/features/settings/SourceSkillsSection.tsx
+++ b/src/renderer/features/settings/SourceSkillsSection.tsx
@@ -194,7 +194,7 @@ export function SourceSkillsSection({ projectPath }: Props) {
 
       {/* Delete confirmation dialog */}
       {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
           <div className="bg-ctp-base border border-surface-1 rounded-lg p-4 max-w-sm mx-4 shadow-xl">
             <h4 className="text-sm font-semibold text-ctp-text mb-2">Delete Skill</h4>
             <p className="text-xs text-ctp-subtext0 mb-1">

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -29,6 +29,16 @@
   --color-ctp-peach: rgb(var(--ctp-warning));
   --color-ctp-mauve: rgb(var(--ctp-accent2));
   --color-ctp-yellow: rgb(var(--ctp-warning));
+
+  /* Named z-index scale — use z-modal, z-toast, etc. instead of ad-hoc z-50/z-[9999] */
+  --z-raised: 10;
+  --z-dropdown-backdrop: 40;
+  --z-dropdown: 50;
+  --z-modal: 200;
+  --z-toast: 300;
+  --z-canvas-overlay: 9999;
+  --z-canvas-dialog: 10000;
+  --z-top: 100000;
 }
 
 @import '@xterm/xterm/css/xterm.css';

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -51,7 +51,7 @@ function ProjectContextMenu({ position, onClose, onSettings, onCloseProject }: {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
+      className="fixed z-dropdown min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle"
       style={style}
       data-testid="project-context-menu"
     >

--- a/src/renderer/plugins/PluginDialog.tsx
+++ b/src/renderer/plugins/PluginDialog.tsx
@@ -41,7 +41,7 @@ function InputDialog({ prompt, defaultValue, onResolve }: InputDialogProps) {
 
   return (
     <div
-      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-canvas-dialog flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onClick={() => resolve(null)}
       data-testid="plugin-dialog-overlay"
     >
@@ -122,7 +122,7 @@ function ConfirmDialog({ message, onResolve }: ConfirmDialogProps) {
 
   return (
     <div
-      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-canvas-dialog flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onClick={() => resolve(false)}
       data-testid="plugin-dialog-overlay"
     >
@@ -257,7 +257,7 @@ function ApprovalDialog({ options, onResolve }: ApprovalDialogProps) {
 
   return (
     <div
-      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-canvas-dialog flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onClick={() => resolve(null)}
       data-testid="plugin-dialog-overlay"
     >

--- a/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasContextMenu.tsx
@@ -76,7 +76,7 @@ export function CanvasContextMenu({ x, y, onSelect, onDismiss }: CanvasContextMe
     <MenuPortal>
       <div
         ref={menuRef}
-        className="fixed z-[9999] min-w-[180px] bg-ctp-mantle border border-surface-1 rounded-lg shadow-xl py-1 backdrop-blur-none"
+        className="fixed z-canvas-overlay min-w-[180px] bg-ctp-mantle border border-surface-1 rounded-lg shadow-xl py-1 backdrop-blur-none"
         style={{ left: x, top: y }}
         data-testid="canvas-context-menu"
       >

--- a/src/renderer/plugins/builtin/canvas/CanvasControls.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasControls.tsx
@@ -294,7 +294,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
           </button>
           {showLayoutMenu && (
             <div
-              className="absolute top-full right-0 mt-1 w-56 bg-ctp-mantle border border-surface-0 rounded-lg shadow-lg p-2 z-50"
+              className="absolute top-full right-0 mt-1 w-56 bg-ctp-mantle border border-surface-0 rounded-lg shadow-lg p-2 z-dropdown"
               data-testid="canvas-auto-layout-menu"
             >
               <div className="text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider mb-1.5 px-1">Auto Layout</div>

--- a/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
@@ -213,7 +213,7 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
 
       {/* Results dropdown */}
       <div
-        className="absolute top-8 right-0 w-64 max-h-64 overflow-y-auto bg-ctp-mantle border border-surface-1 rounded-lg shadow-lg z-50"
+        className="absolute top-8 right-0 w-64 max-h-64 overflow-y-auto bg-ctp-mantle border border-surface-1 rounded-lg shadow-lg z-dropdown"
         data-testid="canvas-search-results"
       >
         {filteredViews.length === 0 ? (

--- a/src/renderer/plugins/builtin/canvas/CanvasTabBar.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasTabBar.tsx
@@ -82,7 +82,7 @@ export function CanvasTabBar({
         </button>
         {addMenuOpen && (
           <div
-            className="absolute top-full right-0 mt-1 bg-ctp-base border border-surface-0 rounded-lg shadow-lg py-1 min-w-[160px] z-50"
+            className="absolute top-full right-0 mt-1 bg-ctp-base border border-surface-0 rounded-lg shadow-lg py-1 min-w-[160px] z-dropdown"
             data-testid="canvas-add-menu"
           >
             <button
@@ -149,7 +149,7 @@ function TabContextMenu({ x, y, onExportBlueprint, onClose }: TabContextMenuProp
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 bg-ctp-mantle border border-surface-0 rounded-lg shadow-2xl py-1 min-w-[180px] text-[11px]"
+      className="fixed z-dropdown bg-ctp-mantle border border-surface-0 rounded-lg shadow-2xl py-1 min-w-[180px] text-[11px]"
       style={{ left: x, top: y }}
       data-testid="canvas-tab-context-menu"
     >

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -1194,7 +1194,7 @@ export function CanvasWorkspace({
       {/* Blueprint error toast */}
       {blueprintError && (
         <div
-          className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[9999] px-4 py-2 bg-ctp-error text-ctp-text text-sm rounded-lg shadow-lg"
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 z-canvas-overlay px-4 py-2 bg-ctp-error text-ctp-text text-sm rounded-lg shadow-lg"
           data-testid="canvas-blueprint-error-toast"
         >
           {blueprintError}
@@ -1219,7 +1219,7 @@ export function CanvasWorkspace({
       {/* Zoomed view overlay */}
       {zoomedView && (
         <div
-          className="absolute inset-0 z-[9999] flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
+          className="absolute inset-0 z-canvas-overlay flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
           onClick={(e) => { if (e.target === e.currentTarget) onZoomView(null); }}
           data-testid="canvas-zoom-overlay"
         >
@@ -1448,7 +1448,7 @@ export function CanvasWorkspace({
         <MenuPortal>
           <div
             ref={viewMenuRef}
-            className="fixed z-[9999] min-w-[180px] bg-ctp-mantle border border-surface-1 rounded-lg shadow-xl py-1 backdrop-blur-none"
+            className="fixed z-canvas-overlay min-w-[180px] bg-ctp-mantle border border-surface-1 rounded-lg shadow-xl py-1 backdrop-blur-none"
             style={{ left: viewContextMenu.x, top: viewContextMenu.y }}
             data-testid="view-context-menu"
           >

--- a/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
@@ -91,7 +91,7 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: 100000 }}
+      style={{ zIndex: "var(--z-top)" }}
       onMouseDown={handleBackdropMouseDown}
       onClick={handleBackdropClick}
       data-testid="wire-instructions-dialog"

--- a/src/renderer/plugins/builtin/canvas/WireToolPermissionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireToolPermissionsDialog.tsx
@@ -123,7 +123,7 @@ export function WireToolPermissionsDialog({ binding, onSave, onClose }: WireTool
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: 100000 }}
+      style={{ zIndex: "var(--z-top)" }}
       onMouseDown={handleBackdropMouseDown}
       onClick={handleBackdropClick}
       data-testid="wire-tool-permissions-dialog"

--- a/src/renderer/plugins/builtin/canvas/ZoneDeleteDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoneDeleteDialog.tsx
@@ -14,7 +14,7 @@ interface ZoneDeleteDialogProps {
 
 export function ZoneDeleteDialog({ zoneName, containedCount, onConfirm, onCancel }: ZoneDeleteDialogProps) {
   return (
-    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm">
+    <div className="fixed inset-0 z-canvas-dialog flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div className="bg-ctp-base border border-surface-2 rounded-lg p-5 max-w-sm shadow-xl">
         <h3 className="text-sm font-semibold text-ctp-text mb-2">
           Delete Zone &ldquo;{zoneName}&rdquo;?

--- a/src/renderer/plugins/builtin/files/FileTree.ts
+++ b/src/renderer/plugins/builtin/files/FileTree.ts
@@ -479,7 +479,7 @@ function ContextMenu({ x, y, node: _node, multiSelectCount, onClose, onAction }:
 
   return React.createElement('div', {
     ref: menuRef,
-    className: 'fixed z-50 bg-ctp-mantle border border-surface-0 rounded shadow-lg py-1 min-w-[140px]',
+    className: 'fixed z-dropdown bg-ctp-mantle border border-surface-0 rounded shadow-lg py-1 min-w-[140px]',
     style,
   },
     ...items.map((item) =>

--- a/src/renderer/plugins/builtin/files/FileViewer.ts
+++ b/src/renderer/plugins/builtin/files/FileViewer.ts
@@ -53,7 +53,7 @@ interface UnsavedDialogProps {
 
 function UnsavedDialog({ fileName, onSave, onDiscard, onCancel }: UnsavedDialogProps) {
   return React.createElement('div', {
-    className: 'absolute inset-0 z-40 flex items-center justify-center bg-black/60 backdrop-blur-sm',
+    className: 'absolute inset-0 z-dropdown-backdrop flex items-center justify-center bg-black/60 backdrop-blur-sm',
   },
     React.createElement('div', {
       className: 'bg-ctp-mantle border border-surface-1 rounded-xl shadow-2xl w-[360px] flex flex-col',

--- a/src/renderer/plugins/builtin/files/TabBar.ts
+++ b/src/renderer/plugins/builtin/files/TabBar.ts
@@ -95,7 +95,7 @@ function TabContextMenu({ x, y, tab, onClose, onAction }: TabContextMenuProps) {
 
   return React.createElement('div', {
     ref: menuRef,
-    className: 'fixed z-50 bg-ctp-mantle border border-surface-0 rounded shadow-lg py-1 min-w-[170px]',
+    className: 'fixed z-dropdown bg-ctp-mantle border border-surface-0 rounded shadow-lg py-1 min-w-[170px]',
     style,
   },
     ...items.map((item) => {

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -1028,7 +1028,7 @@ function ShoulderTapModal({
 
   return (
     <div
-      className="absolute inset-0 bg-ctp-crust/80 flex items-center justify-center z-50"
+      className="absolute inset-0 bg-ctp-crust/80 flex items-center justify-center z-modal"
       onClick={onClose}
     >
       <div

--- a/src/renderer/plugins/builtin/hub/HubTabContextMenu.tsx
+++ b/src/renderer/plugins/builtin/hub/HubTabContextMenu.tsx
@@ -51,7 +51,7 @@ export function HubTabContextMenu({
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 bg-ctp-mantle border border-surface-0 rounded-lg shadow-2xl py-1 min-w-[180px] text-[11px]"
+      className="fixed z-dropdown bg-ctp-mantle border border-surface-0 rounded-lg shadow-2xl py-1 min-w-[180px] text-[11px]"
       style={{ left: x, top: y }}
       data-testid="hub-tab-context-menu"
     >

--- a/src/renderer/plugins/builtin/hub/MigrateAllHubsModal.tsx
+++ b/src/renderer/plugins/builtin/hub/MigrateAllHubsModal.tsx
@@ -18,7 +18,7 @@ export function MigrateAllHubsModal({ hubCount, onConfirm, onCancel }: MigrateAl
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-modal flex items-center justify-center bg-black/50"
       onClick={onCancel}
       data-testid="migrate-all-hubs-backdrop"
     >

--- a/src/renderer/plugins/builtin/hub/UpgradeToCanvasDialog.tsx
+++ b/src/renderer/plugins/builtin/hub/UpgradeToCanvasDialog.tsx
@@ -24,7 +24,7 @@ export function UpgradeToCanvasDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-modal flex items-center justify-center bg-black/50"
       onClick={onClose}
       data-testid="upgrade-to-canvas-backdrop"
     >

--- a/src/renderer/zIndex.ts
+++ b/src/renderer/zIndex.ts
@@ -1,0 +1,19 @@
+/**
+ * Named z-index scale — use these instead of ad-hoc numeric values.
+ *
+ * Tailwind utilities are also available (e.g. z-modal, z-toast) via @theme in index.css.
+ * Use the CSS custom property form (style={{ zIndex: 'var(--z-top)' }}) or these constants
+ * for inline styles where Tailwind classes aren't available.
+ */
+export const Z_INDEX = {
+  raised: 10,            // Local absolute elements (drag handles, status badges)
+  dropdownBackdrop: 40,  // Transparent backdrop for dismissing open dropdowns
+  dropdown: 50,          // Dropdown menus, context menus, search results
+  modal: 200,            // Modals and dialogs (full-screen fixed overlays)
+  toast: 300,            // Toast notifications — must render above modals
+  canvasOverlay: 9999,   // Canvas-specific overlays and critical app states
+  canvasDialog: 10000,   // Canvas-specific dialogs (zone delete, plugin)
+  top: 100000,           // Absolute top layer (blueprint/wire dialogs)
+} as const;
+
+export type ZIndexKey = keyof typeof Z_INDEX;


### PR DESCRIPTION
## Summary

- Creates `src/renderer/zIndex.ts` with named Z_INDEX constants
- Adds `--z-*` CSS custom properties to `@theme` in `index.css`, providing `z-modal`, `z-toast`, `z-dropdown`, etc. as Tailwind utilities
- **Fixes the toast/modal bug**: toasts (`z-toast = 300`) now render above modals (`z-modal = 200`)
- Replaces all ad-hoc z-index values with named scale entries across 54 files

## Scale

| Name | Value | Usage |
|---|---|---|
| `raised` / `z-raised` | 10 | Local absolute elements |
| `dropdownBackdrop` / `z-dropdown-backdrop` | 40 | Transparent backdrop for dropdown dismissal |
| `dropdown` / `z-dropdown` | 50 | Dropdown menus, context menus |
| `modal` / `z-modal` | 200 | Dialogs and full-screen modals |
| `toast` / `z-toast` | 300 | Toast notifications (above modals) |
| `canvasOverlay` / `z-canvas-overlay` | 9999 | Canvas-specific overlays |
| `canvasDialog` / `z-canvas-dialog` | 10000 | Canvas-specific dialogs |
| `top` | 100000 | Blueprint/wire import dialogs |

## Test plan

- [ ] Open a modal dialog, then trigger a toast — toast should appear above the modal
- [ ] Verify dropdown menus open correctly (agent list context menu, blueprint context menu)
- [ ] Verify SatelliteLockOverlay appears above all other UI
- [ ] Verify canvas overlays (CanvasWorkspace error state, CanvasContextMenu) appear correctly
- [ ] Verify blueprint import/export dialogs appear above everything

## Validation

- Lint: clean
- TypeCheck: 1 pre-existing MermaidDiagram error
- Tests: 11,501 passing, 10 pre-existing plugin/mermaid failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)