### PR TITLE
refactor(orchestrators): extract shared NDJSON/hook/session helpers (M-ORCH-01..05)

### DIFF
--- a/src/main/orchestrators/adapters/acp-client.ts
+++ b/src/main/orchestrators/adapters/acp-client.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'child_process';
+import { NdjsonRpcBase, DEFAULT_RPC_TIMEOUT_MS, type BaseRpcOpts } from './ndjson-rpc-base';
 
 /** Rich RPC error that preserves error code and optional data from the JSON-RPC response. */
 export class RpcError extends Error {
@@ -47,25 +47,8 @@ export type JsonRpcMessage =
   | JsonRpcNotification
   | JsonRpcServerRequest;
 
-/** Default timeout for RPC requests (ms). Prevents indefinite hangs on init failures. */
-const DEFAULT_RPC_TIMEOUT_MS = 30_000;
-
-export interface AcpClientOpts {
-  binary: string;
-  args: string[];
-  cwd?: string;
-  env?: Record<string, string>;
+export interface AcpClientOpts extends BaseRpcOpts {
   clientInfo?: { name: string; version: string };
-  /** RPC request timeout in milliseconds (default: 30000) */
-  rpcTimeoutMs?: number;
-  /** Called for notifications (method, no id) */
-  onNotification?: (method: string, params: unknown) => void;
-  /** Called for server-initiated requests (method + id) */
-  onServerRequest?: (id: number | string, method: string, params: unknown) => void;
-  /** Called when the process exits */
-  onExit?: (code: number | null, signal: string | null) => void;
-  /** Optional logger for diagnostic messages */
-  onLog?: (level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>) => void;
 }
 
 /**
@@ -75,25 +58,10 @@ export interface AcpClientOpts {
  * NDJSON responses from stdout. Uses a callback-based JSONL parser inline
  * (same buffering pattern as JsonlParser but without EventEmitter).
  */
-export class AcpClient {
-  private proc: ChildProcess | null = null;
-  private nextId = 1;
-  private pending = new Map<
-    number | string,
-    { resolve: (result: unknown) => void; reject: (err: Error) => void }
-  >();
-  private chunks: string[] = [];
-  private opts: AcpClientOpts;
-  private killed = false;
-  private stderrBuffer: string[] = [];
-
-  constructor(opts: AcpClientOpts) {
-    this.opts = opts;
-  }
-
-  private log(level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>): void {
-    this.opts.onLog?.(level, message, meta);
-  }
+export class AcpClient extends NdjsonRpcBase<AcpClientOpts> {
+  protected readonly processLabel = 'ACP process';
+  protected readonly exitLabel = 'ACP process';
+  protected readonly malformedLabel = 'ACP';
 
   /** Spawn the child process, begin parsing stdout, and complete the ACP init handshake. */
   async start(): Promise<void> {
@@ -103,30 +71,7 @@ export class AcpClient {
       cwd: this.opts.cwd,
     });
 
-    this.proc = spawn(this.opts.binary, this.opts.args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: this.opts.cwd,
-      env: this.opts.env,
-    });
-
-    this.proc.stdout?.setEncoding('utf8');
-    this.proc.stdout?.on('data', (chunk: string) => this.feed(chunk));
-
-    this.proc.stderr?.setEncoding('utf8');
-    this.proc.stderr?.on('data', (chunk: string) => {
-      this.stderrBuffer.push(chunk);
-      this.log('warn', 'ACP process stderr', { text: chunk.trim() });
-    });
-
-    this.proc.on('exit', (code, signal) => {
-      this.handleProcessExit(code, signal);
-    });
-
-    this.proc.on('error', (err) => {
-      this.log('error', 'ACP process spawn error', { error: err.message });
-      this.rejectAllPending(err);
-      this.opts.onExit?.(null, null);
-    });
+    this.spawnProcess();
 
     // Perform ACP initialization handshake
     this.log('info', 'Starting ACP init handshake');
@@ -137,11 +82,6 @@ export class AcpClient {
     });
     this.notify('initialized');
     this.log('info', 'ACP init handshake complete');
-  }
-
-  /** Return collected stderr output. */
-  getStderr(): string {
-    return this.stderrBuffer.join('');
   }
 
   /** Send a JSON-RPC request and wait for the response. Rejects after the configured timeout. */
@@ -166,7 +106,7 @@ export class AcpClient {
         resolve: (result) => { clearTimeout(timer); resolve(result); },
         reject: (err) => { clearTimeout(timer); reject(err); },
       });
-      this.send(msg);
+      this.send(msg as unknown as Record<string, unknown>);
     });
   }
 
@@ -174,154 +114,41 @@ export class AcpClient {
   notify(method: string, params?: unknown): void {
     const msg: Record<string, unknown> = { jsonrpc: '2.0', method };
     if (params !== undefined) msg.params = params;
-    this.send(msg as unknown as JsonRpcRequest);
+    this.send(msg);
   }
 
   /** Send a JSON-RPC response back to the server (e.g. for permission approvals). */
   respond(id: number | string, result: unknown): void {
     const msg: JsonRpcResponse = { jsonrpc: '2.0', id, result };
-    this.send(msg);
+    this.send(msg as unknown as Record<string, unknown>);
   }
 
-  /** Terminate the child process. */
-  kill(): void {
-    if (this.killed) return;
-    this.killed = true;
-    this.flush();
-    this.proc?.kill('SIGTERM');
-  }
-
-  /** Whether the process is still alive. */
-  get alive(): boolean {
-    return this.proc !== null && !this.killed && this.proc.exitCode === null;
-  }
-
-  // --- Private ---
-
-  private send(msg: JsonRpcRequest | JsonRpcResponse): void {
-    if (!this.proc?.stdin?.writable) return;
-    this.proc.stdin.write(JSON.stringify(msg) + '\n');
-  }
-
-  /**
-   * NDJSON line-buffered parser (callback-based, same pattern as JsonlParser).
-   * Accumulates chunks, scans for newlines, and dispatches complete JSON objects.
-   */
-  private feed(chunk: string): void {
-    this.chunks.push(chunk);
-
-    if (chunk.indexOf('\n') === -1) return;
-
-    const buffer = this.chunks.join('');
-    let start = 0;
-    let idx: number;
-
-    while ((idx = buffer.indexOf('\n', start)) !== -1) {
-      const line = buffer.substring(start, idx).trim();
-      start = idx + 1;
-      if (!line) continue;
-      try {
-        const parsed = JSON.parse(line);
-        this.dispatch(parsed);
-      } catch {
-        this.log('warn', 'Malformed JSON line from ACP stdout', {
-          line: line.length > 500 ? line.substring(0, 500) + '…' : line,
-        });
-      }
-    }
-
-    const remainder = start < buffer.length ? buffer.substring(start) : '';
-    this.chunks = remainder ? [remainder] : [];
-  }
-
-  private flush(): void {
-    const buffer = this.chunks.join('').trim();
-    if (buffer) {
-      try {
-        const parsed = JSON.parse(buffer);
-        this.dispatch(parsed);
-      } catch {
-        // Skip
-      }
-    }
-    this.chunks = [];
-  }
-
-  private dispatch(msg: Record<string, unknown>): void {
-    const hasId = 'id' in msg && msg.id !== undefined;
-    const hasMethod = 'method' in msg && typeof msg.method === 'string';
-
-    if (hasId && !hasMethod) {
-      // Response to our request
-      this.handleResponse(msg as unknown as JsonRpcResponse);
-    } else if (hasId && hasMethod) {
-      // Server-initiated request (e.g. permission_request)
-      this.opts.onServerRequest?.(
-        msg.id as number | string,
-        msg.method as string,
-        msg.params,
-      );
-    } else if (hasMethod) {
-      // Notification
-      this.opts.onNotification?.(msg.method as string, msg.params);
-    } else {
-      // Messages with neither id nor method are logged and ignored
-      this.log('warn', 'ACP message with neither id nor method', {
-        keys: Object.keys(msg),
-      });
-    }
-  }
-
-  private handleResponse(msg: JsonRpcResponse): void {
-    const pending = this.pending.get(msg.id);
+  protected handleResponse(msg: Record<string, unknown>): void {
+    const response = msg as unknown as JsonRpcResponse;
+    const pending = this.pending.get(response.id);
     if (!pending) {
-      this.log('warn', 'RPC response for unknown request', { id: msg.id });
+      this.log('warn', 'RPC response for unknown request', { id: response.id });
       return;
     }
-    this.pending.delete(msg.id);
+    this.pending.delete(response.id);
 
-    if (msg.error) {
-      this.log('error', `RPC error ← id=${msg.id}`, {
-        code: msg.error.code,
-        message: msg.error.message,
-        data: msg.error.data,
+    if (response.error) {
+      this.log('error', `RPC error ← id=${response.id}`, {
+        code: response.error.code,
+        message: response.error.message,
+        data: response.error.data,
       });
       const rpcError = new RpcError(
-        msg.error.code,
-        msg.error.message,
-        msg.error.data,
+        response.error.code,
+        response.error.message,
+        response.error.data,
       );
       pending.reject(rpcError);
     } else {
-      this.log('info', `RPC response ← id=${msg.id}`, {
-        resultType: typeof msg.result,
+      this.log('info', `RPC response ← id=${response.id}`, {
+        resultType: typeof response.result,
       });
-      pending.resolve(msg.result);
+      pending.resolve(response.result);
     }
-  }
-
-  private handleProcessExit(
-    code: number | null,
-    signal: string | null,
-  ): void {
-    const stderr = this.getStderr().trim();
-    this.log(code === 0 ? 'info' : 'error', 'ACP process exited', {
-      code,
-      signal,
-      pendingRequests: this.pending.size,
-      ...(stderr ? { stderr: stderr.length > 2000 ? stderr.substring(0, 2000) + '…' : stderr } : {}),
-    });
-    this.flush();
-    this.rejectAllPending(
-      new Error(`Process exited with code ${code}, signal ${signal}`),
-    );
-    this.opts.onExit?.(code, signal);
-  }
-
-  private rejectAllPending(err: Error): void {
-    for (const [, { reject }] of this.pending) {
-      reject(err);
-    }
-    this.pending.clear();
   }
 }

--- a/src/main/orchestrators/adapters/codex-app-server-client.ts
+++ b/src/main/orchestrators/adapters/codex-app-server-client.ts
@@ -1,24 +1,7 @@
-import { spawn, type ChildProcess } from 'child_process';
+import { NdjsonRpcBase, DEFAULT_RPC_TIMEOUT_MS, type BaseRpcOpts } from './ndjson-rpc-base';
 
-/** Default timeout for RPC requests (ms). Prevents indefinite hangs on init failures. */
-const DEFAULT_RPC_TIMEOUT_MS = 30_000;
-
-export interface CodexAppServerClientOpts {
-  binary: string;
-  args: string[];
-  cwd?: string;
-  env?: Record<string, string>;
+export interface CodexAppServerClientOpts extends BaseRpcOpts {
   clientInfo?: { name: string; title: string; version: string };
-  /** RPC request timeout in milliseconds (default: 30000) */
-  rpcTimeoutMs?: number;
-  /** Called for notifications (method, no id) */
-  onNotification?: (method: string, params: unknown) => void;
-  /** Called for server-initiated requests (method + id) */
-  onServerRequest?: (id: number | string, method: string, params: unknown) => void;
-  /** Called when the process exits */
-  onExit?: (code: number | null, signal: string | null) => void;
-  /** Optional logger for diagnostic messages */
-  onLog?: (level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>) => void;
 }
 
 /**
@@ -30,27 +13,17 @@ export interface CodexAppServerClientOpts {
  *
  * Key differences from AcpClient:
  * - Omits `jsonrpc: '2.0'` from outgoing messages (Codex convention)
- * - Supports sending notifications (fire-and-forget, no id/response)
  * - Performs initialization handshake in start()
  */
-export class CodexAppServerClient {
-  private proc: ChildProcess | null = null;
-  private nextId = 1;
-  private pending = new Map<
-    number | string,
-    { resolve: (result: unknown) => void; reject: (err: Error) => void }
-  >();
-  private chunks: string[] = [];
-  private opts: CodexAppServerClientOpts;
-  private killed = false;
-  private stderrBuffer: string[] = [];
+export class CodexAppServerClient extends NdjsonRpcBase<CodexAppServerClientOpts> {
+  protected readonly processLabel = 'Codex app-server';
+  protected readonly exitLabel = 'Codex app-server process';
+  protected readonly malformedLabel = 'Codex';
 
-  constructor(opts: CodexAppServerClientOpts) {
-    this.opts = opts;
-  }
-
-  private log(level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>): void {
-    this.opts.onLog?.(level, message, meta);
+  protected override handleUnknownMessage(msg: Record<string, unknown>): void {
+    this.log('info', 'Codex message with neither id nor method (ignored)', {
+      keys: Object.keys(msg),
+    });
   }
 
   /** Spawn the child process, begin parsing stdout, and complete the init handshake. */
@@ -61,30 +34,7 @@ export class CodexAppServerClient {
       cwd: this.opts.cwd,
     });
 
-    this.proc = spawn(this.opts.binary, this.opts.args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: this.opts.cwd,
-      env: this.opts.env,
-    });
-
-    this.proc.stdout?.setEncoding('utf8');
-    this.proc.stdout?.on('data', (chunk: string) => this.feed(chunk));
-
-    this.proc.stderr?.setEncoding('utf8');
-    this.proc.stderr?.on('data', (chunk: string) => {
-      this.stderrBuffer.push(chunk);
-      this.log('warn', 'Codex app-server stderr', { text: chunk.trim() });
-    });
-
-    this.proc.on('exit', (code, signal) => {
-      this.handleProcessExit(code, signal);
-    });
-
-    this.proc.on('error', (err) => {
-      this.log('error', 'Codex app-server spawn error', { error: err.message });
-      this.rejectAllPending(err);
-      this.opts.onExit?.(null, null);
-    });
+    this.spawnProcess();
 
     // Perform initialization handshake
     this.log('info', 'Starting Codex init handshake');
@@ -98,11 +48,6 @@ export class CodexAppServerClient {
     });
     this.notify('initialized');
     this.log('info', 'Codex init handshake complete');
-  }
-
-  /** Return collected stderr output. */
-  getStderr(): string {
-    return this.stderrBuffer.join('');
   }
 
   /** Send a JSON-RPC request and wait for the response. Rejects after the configured timeout. */
@@ -144,96 +89,7 @@ export class CodexAppServerClient {
     this.send({ id, result });
   }
 
-  /** Terminate the child process. */
-  kill(): void {
-    if (this.killed) return;
-    this.killed = true;
-    this.flush();
-    this.proc?.kill('SIGTERM');
-  }
-
-  /** Whether the process is still alive. */
-  get alive(): boolean {
-    return this.proc !== null && !this.killed && this.proc.exitCode === null;
-  }
-
-  // --- Private ---
-
-  private send(msg: Record<string, unknown>): void {
-    if (!this.proc?.stdin?.writable) return;
-    this.proc.stdin.write(JSON.stringify(msg) + '\n');
-  }
-
-  /**
-   * NDJSON line-buffered parser (callback-based, same pattern as AcpClient).
-   * Accumulates chunks, scans for newlines, and dispatches complete JSON objects.
-   */
-  private feed(chunk: string): void {
-    this.chunks.push(chunk);
-
-    if (chunk.indexOf('\n') === -1) return;
-
-    const buffer = this.chunks.join('');
-    let start = 0;
-    let idx: number;
-
-    while ((idx = buffer.indexOf('\n', start)) !== -1) {
-      const line = buffer.substring(start, idx).trim();
-      start = idx + 1;
-      if (!line) continue;
-      try {
-        const parsed = JSON.parse(line);
-        this.dispatch(parsed);
-      } catch {
-        this.log('warn', 'Malformed JSON line from Codex stdout', {
-          line: line.length > 500 ? line.substring(0, 500) + '…' : line,
-        });
-      }
-    }
-
-    const remainder = start < buffer.length ? buffer.substring(start) : '';
-    this.chunks = remainder ? [remainder] : [];
-  }
-
-  private flush(): void {
-    const buffer = this.chunks.join('').trim();
-    if (buffer) {
-      try {
-        const parsed = JSON.parse(buffer);
-        this.dispatch(parsed);
-      } catch {
-        // Skip
-      }
-    }
-    this.chunks = [];
-  }
-
-  private dispatch(msg: Record<string, unknown>): void {
-    const hasId = 'id' in msg && msg.id !== undefined;
-    const hasMethod = 'method' in msg && typeof msg.method === 'string';
-
-    if (hasId && !hasMethod) {
-      // Response to our request
-      this.handleResponse(msg);
-    } else if (hasId && hasMethod) {
-      // Server-initiated request (e.g. approval request)
-      this.opts.onServerRequest?.(
-        msg.id as number | string,
-        msg.method as string,
-        msg.params,
-      );
-    } else if (hasMethod) {
-      // Notification
-      this.opts.onNotification?.(msg.method as string, msg.params);
-    } else {
-      // Messages with neither id nor method — log at debug level and ignore
-      this.log('info', 'Codex message with neither id nor method (ignored)', {
-        keys: Object.keys(msg),
-      });
-    }
-  }
-
-  private handleResponse(msg: Record<string, unknown>): void {
+  protected handleResponse(msg: Record<string, unknown>): void {
     const id = msg.id as number | string;
     const pending = this.pending.get(id);
     if (!pending) {
@@ -258,30 +114,5 @@ export class CodexAppServerClient {
       });
       pending.resolve(msg.result);
     }
-  }
-
-  private handleProcessExit(
-    code: number | null,
-    signal: string | null,
-  ): void {
-    const stderr = this.getStderr().trim();
-    this.log(code === 0 ? 'info' : 'error', 'Codex app-server process exited', {
-      code,
-      signal,
-      pendingRequests: this.pending.size,
-      ...(stderr ? { stderr: stderr.length > 2000 ? stderr.substring(0, 2000) + '…' : stderr } : {}),
-    });
-    this.flush();
-    this.rejectAllPending(
-      new Error(`Process exited with code ${code}, signal ${signal}`),
-    );
-    this.opts.onExit?.(code, signal);
-  }
-
-  private rejectAllPending(err: Error): void {
-    for (const [, { reject }] of this.pending) {
-      reject(err);
-    }
-    this.pending.clear();
   }
 }

--- a/src/main/orchestrators/adapters/ndjson-rpc-base.ts
+++ b/src/main/orchestrators/adapters/ndjson-rpc-base.ts
@@ -1,0 +1,207 @@
+import { spawn, type ChildProcess } from 'child_process';
+
+/** Default RPC request timeout (ms). Prevents indefinite hangs on init failures. */
+export const DEFAULT_RPC_TIMEOUT_MS = 30_000;
+
+export interface BaseRpcOpts {
+  binary: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  /** RPC request timeout in milliseconds (default: 30000) */
+  rpcTimeoutMs?: number;
+  /** Called for notifications (method, no id) */
+  onNotification?: (method: string, params: unknown) => void;
+  /** Called for server-initiated requests (method + id) */
+  onServerRequest?: (id: number | string, method: string, params: unknown) => void;
+  /** Called when the process exits */
+  onExit?: (code: number | null, signal: string | null) => void;
+  /** Optional logger for diagnostic messages */
+  onLog?: (level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>) => void;
+}
+
+/**
+ * Shared base for JSON-RPC-over-stdio clients that communicate via NDJSON.
+ *
+ * Provides: process lifecycle, NDJSON line-buffered parsing, request/response
+ * dispatching, pending-map management, and cleanup. Subclasses supply the
+ * protocol-specific message formatting and initialization handshake.
+ *
+ * Log strings are parameterized via three abstract label properties so that
+ * each subclass can preserve its exact existing log output.
+ */
+export abstract class NdjsonRpcBase<TOpts extends BaseRpcOpts> {
+  protected proc: ChildProcess | null = null;
+  protected nextId = 1;
+  protected pending = new Map<
+    number | string,
+    { resolve: (result: unknown) => void; reject: (err: Error) => void }
+  >();
+  protected opts: TOpts;
+  protected killed = false;
+  protected stderrBuffer: string[] = [];
+  private chunks: string[] = [];
+
+  /**
+   * Label used in stderr and spawn-error log messages.
+   * e.g. 'ACP process' → "ACP process stderr"
+   */
+  protected abstract readonly processLabel: string;
+
+  /**
+   * Label used in process-exit log messages.
+   * e.g. 'ACP process' → "ACP process exited"
+   */
+  protected abstract readonly exitLabel: string;
+
+  /**
+   * Label used in malformed-JSON log messages.
+   * e.g. 'ACP' → "Malformed JSON line from ACP stdout"
+   */
+  protected abstract readonly malformedLabel: string;
+
+  constructor(opts: TOpts) {
+    this.opts = opts;
+  }
+
+  protected log(level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>): void {
+    this.opts.onLog?.(level, message, meta);
+  }
+
+  getStderr(): string {
+    return this.stderrBuffer.join('');
+  }
+
+  kill(): void {
+    if (this.killed) return;
+    this.killed = true;
+    this.flush();
+    this.proc?.kill('SIGTERM');
+  }
+
+  get alive(): boolean {
+    return this.proc !== null && !this.killed && this.proc.exitCode === null;
+  }
+
+  protected spawnProcess(): void {
+    this.proc = spawn(this.opts.binary, this.opts.args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: this.opts.cwd,
+      env: this.opts.env,
+    });
+
+    this.proc.stdout?.setEncoding('utf8');
+    this.proc.stdout?.on('data', (chunk: string) => this.feed(chunk));
+
+    this.proc.stderr?.setEncoding('utf8');
+    this.proc.stderr?.on('data', (chunk: string) => {
+      this.stderrBuffer.push(chunk);
+      this.log('warn', `${this.processLabel} stderr`, { text: chunk.trim() });
+    });
+
+    this.proc.on('exit', (code, signal) => this.handleProcessExit(code, signal));
+    this.proc.on('error', (err) => {
+      this.log('error', `${this.processLabel} spawn error`, { error: err.message });
+      this.rejectAllPending(err);
+      this.opts.onExit?.(null, null);
+    });
+  }
+
+  protected send(msg: Record<string, unknown>): void {
+    if (!this.proc?.stdin?.writable) return;
+    this.proc.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  private feed(chunk: string): void {
+    this.chunks.push(chunk);
+
+    if (chunk.indexOf('\n') === -1) return;
+
+    const buffer = this.chunks.join('');
+    let start = 0;
+    let idx: number;
+
+    while ((idx = buffer.indexOf('\n', start)) !== -1) {
+      const line = buffer.substring(start, idx).trim();
+      start = idx + 1;
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line);
+        this.dispatch(parsed);
+      } catch {
+        this.log('warn', `Malformed JSON line from ${this.malformedLabel} stdout`, {
+          line: line.length > 500 ? line.substring(0, 500) + '…' : line,
+        });
+      }
+    }
+
+    const remainder = start < buffer.length ? buffer.substring(start) : '';
+    this.chunks = remainder ? [remainder] : [];
+  }
+
+  protected flush(): void {
+    const buffer = this.chunks.join('').trim();
+    if (buffer) {
+      try {
+        const parsed = JSON.parse(buffer);
+        this.dispatch(parsed);
+      } catch {
+        // Skip
+      }
+    }
+    this.chunks = [];
+  }
+
+  protected dispatch(msg: Record<string, unknown>): void {
+    const hasId = 'id' in msg && msg.id !== undefined;
+    const hasMethod = 'method' in msg && typeof msg.method === 'string';
+
+    if (hasId && !hasMethod) {
+      this.handleResponse(msg);
+    } else if (hasId && hasMethod) {
+      this.opts.onServerRequest?.(
+        msg.id as number | string,
+        msg.method as string,
+        msg.params,
+      );
+    } else if (hasMethod) {
+      this.opts.onNotification?.(msg.method as string, msg.params);
+    } else {
+      this.handleUnknownMessage(msg);
+    }
+  }
+
+  /** Called for messages that have neither an `id` nor a `method`. Override to customize. */
+  protected handleUnknownMessage(msg: Record<string, unknown>): void {
+    this.log('warn', `${this.processLabel} message with neither id nor method`, {
+      keys: Object.keys(msg),
+    });
+  }
+
+  protected abstract handleResponse(msg: Record<string, unknown>): void;
+
+  protected handleProcessExit(code: number | null, signal: string | null): void {
+    const stderr = this.getStderr().trim();
+    this.log(code === 0 ? 'info' : 'error', `${this.exitLabel} exited`, {
+      code,
+      signal,
+      pendingRequests: this.pending.size,
+      ...(stderr ? { stderr: stderr.length > 2000 ? stderr.substring(0, 2000) + '…' : stderr } : {}),
+    });
+    this.flush();
+    this.rejectAllPending(new Error(`Process exited with code ${code}, signal ${signal}`));
+    this.opts.onExit?.(code, signal);
+  }
+
+  protected rejectAllPending(err: Error): void {
+    for (const [, { reject }] of this.pending) {
+      reject(err);
+    }
+    this.pending.clear();
+  }
+
+  abstract request(method: string, params?: unknown): Promise<unknown>;
+  abstract notify(method: string, params?: unknown): void;
+  abstract respond(id: number | string, result: unknown): void;
+  abstract start(): Promise<void>;
+}

--- a/src/main/orchestrators/claude-code-provider.ts
+++ b/src/main/orchestrators/claude-code-provider.ts
@@ -17,7 +17,7 @@ import {
 } from './types';
 import { BaseProvider } from './base-provider';
 import { StreamJsonAdapter } from './adapters/stream-json-adapter';
-import { homePath, validateHookUrl } from './shared';
+import { homePath, validateHookUrl, buildHookCurlCommand, mergeHookEntries, resolveEncodedPathDir, parseJsonlFile } from './shared';
 import { isClubhouseHookEntry } from '../services/config-pipeline';
 import { appLog } from '../services/log-service';
 
@@ -169,20 +169,18 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
 
   async writeHooksConfig(cwd: string, hookUrl: string): Promise<void> {
     const safeUrl = validateHookUrl(hookUrl);
-    const curlBase = process.platform === 'win32'
-      ? `curl -s -X POST ${safeUrl}/%CLUBHOUSE_AGENT_ID% -H "Content-Type: application/json" -H "X-Clubhouse-Nonce: %CLUBHOUSE_HOOK_NONCE%" -d @- || (exit /b 0)`
-      : `cat | curl -s -X POST ${safeUrl}/\${CLUBHOUSE_AGENT_ID} -H 'Content-Type: application/json' -H "X-Clubhouse-Nonce: \${CLUBHOUSE_HOOK_NONCE}" --data-binary @- || true`;
+    const curl = buildHookCurlCommand(safeUrl);
 
     const hooks: Record<string, unknown[]> = {
-      PreToolUse: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      PostToolUse: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      PostToolUseFailure: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      Stop: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      Notification: [{ matcher: '', hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
+      PreToolUse: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      PostToolUse: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      PostToolUseFailure: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      Stop: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      Notification: [{ matcher: '', hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
       // PermissionRequest uses a longer timeout (120s) so that the hook server
       // can hold the response while waiting for a remote approval decision
       // from the Annex iOS client.
-      PermissionRequest: [{ hooks: [{ type: 'command', command: curlBase, timeout: 120 }] }],
+      PermissionRequest: [{ hooks: [{ type: 'command', command: curl, timeout: 120 }] }],
     };
 
     const claudeDir = path.join(cwd, '.claude');
@@ -197,18 +195,8 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
       // No existing file — expected on first run
     }
 
-    // Merge per-event key: preserve user hooks, replace stale Clubhouse entries
-    const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>;
-    const mergedHooks: Record<string, unknown[]> = { ...existingHooks };
-
-    for (const [eventKey, ourEntries] of Object.entries(hooks)) {
-      const current = mergedHooks[eventKey] || [];
-      const userEntries = current.filter(e => !isClubhouseHookEntry(e));
-      mergedHooks[eventKey] = [...userEntries, ...ourEntries];
-    }
-
-    const merged: Record<string, unknown> = { ...existing, hooks: mergedHooks };
-    await fsp.writeFile(settingsPath, JSON.stringify(merged, null, 2), 'utf-8');
+    const mergedHooks = mergeHookEntries(existing, hooks, isClubhouseHookEntry);
+    await fsp.writeFile(settingsPath, JSON.stringify({ ...existing, hooks: mergedHooks }, null, 2), 'utf-8');
   }
 
   parseHookEvent(raw: unknown): NormalizedHookEvent | null {
@@ -291,30 +279,11 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
    * Resolve the Claude Code project directory for a given working directory.
    *
    * Claude Code stores sessions under ~/.claude/projects/<encoded-path>/.
-   * The encoded path replaces path separators with dashes. This method
-   * handles the ambiguity of whether the leading dash is present.
+   * The encoded path replaces path separators with dashes.
    */
   private resolveProjectDir(cwd: string, profileEnv?: Record<string, string>): string | null {
     const configDir = profileEnv?.CLAUDE_CONFIG_DIR || homePath('.claude');
-    const projectsDir = path.join(configDir, 'projects');
-
-    if (!fs.existsSync(projectsDir)) return null;
-
-    // Claude Code encodes project path by replacing separators with dashes
-    const absCwd = path.resolve(cwd);
-    const encodedPath = absCwd.replace(/[/\\]/g, '-');
-
-    // Try candidate directory names (with and without leading dash)
-    const candidates = [encodedPath, encodedPath.replace(/^-/, '')];
-
-    for (const candidate of candidates) {
-      const dir = path.join(projectsDir, candidate);
-      if (fs.existsSync(dir)) {
-        return dir;
-      }
-    }
-
-    return null;
+    return resolveEncodedPathDir(path.join(configDir, 'projects'), cwd);
   }
 
   /**
@@ -426,26 +395,13 @@ export class ClaudeCodeProvider extends BaseProvider implements HookCapable, Hea
 
     if (!jsonlPath) return null;
 
-    // Parse JSONL line-by-line
-    try {
-      const content = await fsp.readFile(jsonlPath, 'utf-8');
-      const events: import('../services/jsonl-parser').StreamJsonEvent[] = [];
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          events.push(JSON.parse(trimmed));
-        } catch {
-          // Skip malformed JSONL lines — expected in truncated sessions
-        }
-      }
-      return events.length > 0 ? events : null;
-    } catch (err) {
+    const events = await parseJsonlFile(jsonlPath);
+    if (!events) {
       appLog('core:orchestrator', 'warn', 'Failed to read session transcript', {
-        meta: { jsonlPath, error: err instanceof Error ? err.message : String(err) },
+        meta: { jsonlPath },
       });
-      return null;
     }
+    return events;
   }
 
   /**

--- a/src/main/orchestrators/codex-cli-provider.ts
+++ b/src/main/orchestrators/codex-cli-provider.ts
@@ -20,7 +20,7 @@ import type { McpServerDef } from '../../shared/types';
 import type { StreamJsonEvent } from '../services/jsonl-parser';
 import { BaseProvider } from './base-provider';
 import { CodexAppServerAdapter } from './adapters';
-import { homePath, parseModelChoicesFromHelp, validateHookUrl } from './shared';
+import { homePath, parseModelChoicesFromHelp, validateHookUrl, buildHookCurlCommand, mergeHookEntries, parseJsonlFile } from './shared';
 import { getShellEnvironment, invalidateShellEnvironmentCache } from '../util/shell';
 import { isClubhouseHookEntry } from '../services/config-pipeline';
 import { appLog } from '../services/log-service';
@@ -264,17 +264,15 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable, S
 
   async writeHooksConfig(cwd: string, hookUrl: string): Promise<void> {
     const safeUrl = validateHookUrl(hookUrl);
-    const curlBase = process.platform === 'win32'
-      ? `curl -s -X POST ${safeUrl}/%CLUBHOUSE_AGENT_ID% -H "Content-Type: application/json" -H "X-Clubhouse-Nonce: %CLUBHOUSE_HOOK_NONCE%" -d @- || (exit /b 0)`
-      : `cat | curl -s -X POST ${safeUrl}/\${CLUBHOUSE_AGENT_ID} -H 'Content-Type: application/json' -H "X-Clubhouse-Nonce: \${CLUBHOUSE_HOOK_NONCE}" --data-binary @- || true`;
+    const curl = buildHookCurlCommand(safeUrl);
 
     const hooks: Record<string, unknown[]> = {
-      PreToolUse: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      PostToolUse: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      PostToolUseFailure: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      Stop: [{ hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      Notification: [{ matcher: '', hooks: [{ type: 'command', command: curlBase, async: true, timeout: 5 }] }],
-      PermissionRequest: [{ hooks: [{ type: 'command', command: curlBase, timeout: 120 }] }],
+      PreToolUse: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      PostToolUse: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      PostToolUseFailure: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      Stop: [{ hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      Notification: [{ matcher: '', hooks: [{ type: 'command', command: curl, async: true, timeout: 5 }] }],
+      PermissionRequest: [{ hooks: [{ type: 'command', command: curl, timeout: 120 }] }],
     };
 
     const codexDir = path.join(cwd, '.codex');
@@ -289,16 +287,7 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable, S
       // No existing file — expected on first run
     }
 
-    // Merge per-event key: preserve user hooks, replace stale Clubhouse entries
-    const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>;
-    const mergedHooks: Record<string, unknown[]> = { ...existingHooks };
-
-    for (const [eventKey, ourEntries] of Object.entries(hooks)) {
-      const current = mergedHooks[eventKey] || [];
-      const userEntries = current.filter(e => !isClubhouseHookEntry(e));
-      mergedHooks[eventKey] = [...userEntries, ...ourEntries];
-    }
-
+    const mergedHooks = mergeHookEntries(existing, hooks, isClubhouseHookEntry);
     await fsp.writeFile(hooksPath, JSON.stringify({ ...existing, hooks: mergedHooks }, null, 2), 'utf-8');
   }
 
@@ -429,25 +418,13 @@ export class CodexCliProvider extends BaseProvider implements HeadlessCapable, S
 
     if (!filePath) return null;
 
-    try {
-      const content = await fsp.readFile(filePath, 'utf-8');
-      const events: StreamJsonEvent[] = [];
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          events.push(JSON.parse(trimmed));
-        } catch {
-          // Skip malformed JSONL lines
-        }
-      }
-      return events.length > 0 ? events : null;
-    } catch (err) {
+    const events = await parseJsonlFile(filePath);
+    if (!events) {
       appLog('core:orchestrator', 'warn', 'Failed to read session transcript', {
-        meta: { filePath, error: err instanceof Error ? err.message : String(err) },
+        meta: { filePath },
       });
-      return null;
     }
+    return events;
   }
 
   extractSessionId(ptyBuffer: string): string | null {

--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -31,13 +31,19 @@ vi.mock('util', () => ({
   promisify: vi.fn((fn: any) => vi.fn(async (...args: any[]) => fn(...args))),
 }));
 
-vi.mock('./shared', () => ({
-  findBinaryInPath: vi.fn(() => '/usr/local/bin/copilot'),
-  homePath: vi.fn((...segments: string[]) => `/home/user/${segments.join('/')}`),
-  humanizeModelId: vi.fn((id: string) => id),
-  validateHookUrl: vi.fn((url: string) => url),
-  parseModelChoicesFromHelp: vi.fn(() => null),
-}));
+vi.mock('./shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./shared')>();
+  return {
+    ...actual,
+    findBinaryInPath: vi.fn(() => '/usr/local/bin/copilot'),
+    homePath: vi.fn((...segments: string[]) => `/home/user/${segments.join('/')}`),
+    humanizeModelId: vi.fn((id: string) => id),
+    validateHookUrl: vi.fn((url: string) => url),
+    parseModelChoicesFromHelp: vi.fn(() => null),
+    resolveEncodedPathDir: vi.fn(() => null),
+    // buildHookCurlCommand, mergeHookEntries, and parseJsonlFile use real implementations
+  };
+});
 
 vi.mock('../services/config-pipeline', () => ({
   isClubhouseHookEntry: vi.fn(() => false),

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -20,7 +20,7 @@ import {
 import type { McpServerDef } from '../../shared/types';
 import { BaseProvider } from './base-provider';
 import { AcpAdapter } from './adapters';
-import { homePath, parseModelChoicesFromHelp, validateHookUrl } from './shared';
+import { homePath, parseModelChoicesFromHelp, validateHookUrl, buildHookCurlCommand, mergeHookEntries, resolveEncodedPathDir, parseJsonlFile } from './shared';
 import { isClubhouseHookEntry } from '../services/config-pipeline';
 import { appLog } from '../services/log-service';
 
@@ -231,10 +231,7 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
 
   async writeHooksConfig(cwd: string, hookUrl: string): Promise<void> {
     const safeUrl = validateHookUrl(hookUrl);
-    const makeCurl = (event: string) =>
-      process.platform === 'win32'
-        ? `curl -s -X POST ${safeUrl}/%CLUBHOUSE_AGENT_ID%/${event} -H "Content-Type: application/json" -H "X-Clubhouse-Nonce: %CLUBHOUSE_HOOK_NONCE%" -d @- || (exit /b 0)`
-        : `cat | curl -s -X POST ${safeUrl}/\${CLUBHOUSE_AGENT_ID}/${event} -H 'Content-Type: application/json' -H "X-Clubhouse-Nonce: \${CLUBHOUSE_HOOK_NONCE}" --data-binary @- || true`;
+    const makeCurl = (event: string) => buildHookCurlCommand(safeUrl, `/${event}`);
 
     const ourHooks: Record<string, unknown[]> = {
       preToolUse: [{ type: 'command', bash: makeCurl('preToolUse'), timeoutSec: 5 }],
@@ -259,16 +256,7 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
       // No existing file
     }
 
-    // Merge per-event key: preserve user hooks, replace stale Clubhouse entries
-    const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>;
-    const mergedHooks: Record<string, unknown[]> = { ...existingHooks };
-
-    for (const [eventKey, ourEntries] of Object.entries(ourHooks)) {
-      const current = mergedHooks[eventKey] || [];
-      const userEntries = current.filter(e => !isClubhouseHookEntry(e));
-      mergedHooks[eventKey] = [...userEntries, ...ourEntries];
-    }
-
+    const mergedHooks = mergeHookEntries(existing, ourHooks, isClubhouseHookEntry);
     await fsp.writeFile(settingsPath, JSON.stringify({ ...existing, hooks: mergedHooks }, null, 2), 'utf-8');
   }
 
@@ -318,28 +306,14 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
    * Resolve the Copilot CLI session directory for a given working directory.
    *
    * GitHub Copilot CLI stores session data under ~/.copilot/session-state/.
-   * Sessions may be organized by project path or stored flat.
+   * Falls back to the flat session-state directory when no project-scoped subdir exists.
    */
   private resolveSessionDir(cwd: string, profileEnv?: Record<string, string>): string | null {
     const configDir = profileEnv?.GH_COPILOT_CONFIG_DIR || homePath('.copilot');
     const sessionDir = path.join(configDir, 'session-state');
-
     if (!fs.existsSync(sessionDir)) return null;
-
-    // Check for project-scoped subdirectory (path encoded with dashes)
-    const absCwd = path.resolve(cwd);
-    const encodedPath = absCwd.replace(/[/\\]/g, '-');
-    const candidates = [encodedPath, encodedPath.replace(/^-/, '')];
-
-    for (const candidate of candidates) {
-      const dir = path.join(sessionDir, candidate);
-      if (fs.existsSync(dir)) {
-        return dir;
-      }
-    }
-
-    // Fall back to the flat session-state directory
-    return sessionDir;
+    // Return project-scoped subdir if found, else fall back to flat session-state dir
+    return resolveEncodedPathDir(sessionDir, cwd) ?? sessionDir;
   }
 
   /**
@@ -465,25 +439,13 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
 
     if (!filePath) return null;
 
-    try {
-      const content = await fsp.readFile(filePath, 'utf-8');
-      const events: import('../services/jsonl-parser').StreamJsonEvent[] = [];
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          events.push(JSON.parse(trimmed));
-        } catch {
-          // Skip malformed lines — expected in truncated sessions
-        }
-      }
-      return events.length > 0 ? events : null;
-    } catch (err) {
+    const events = await parseJsonlFile(filePath);
+    if (!events) {
       appLog('core:orchestrator', 'warn', 'Failed to read GHCP session transcript', {
-        meta: { filePath, error: err instanceof Error ? err.message : String(err) },
+        meta: { filePath },
       });
-      return null;
     }
+    return events;
   }
 
   /**

--- a/src/main/orchestrators/shared.test.ts
+++ b/src/main/orchestrators/shared.test.ts
@@ -515,8 +515,9 @@ Options:
         return p === '/base' || p === path.join('/base', encoded) || p === path.join('/base', encoded.replace(/^-/, ''));
       });
       const result = resolveEncodedPathDir('/base', '/some/project');
-      expect(result).toBeTruthy();
-      expect(result).toContain('/base');
+      const expectedVariant1 = path.join('/base', encoded);
+      const expectedVariant2 = path.join('/base', encoded.replace(/^-/, ''));
+      expect([expectedVariant1, expectedVariant2]).toContain(result);
     });
   });
 

--- a/src/main/orchestrators/shared.test.ts
+++ b/src/main/orchestrators/shared.test.ts
@@ -16,13 +16,18 @@ vi.mock('child_process', () => ({
   execFileSync: vi.fn(() => { throw new Error('not found'); }),
 }));
 
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); }),
+}));
+
 vi.mock('../util/shell', () => ({
   getShellEnvironment: vi.fn(() => ({ PATH: `/usr/local/bin${path.delimiter}/usr/bin` })),
 }));
 
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import { execSync, execFileSync } from 'child_process';
-import { findBinaryInPath, homePath, humanizeModelId, parseModelChoicesFromHelp, buildSummaryInstruction, readQuickSummary, applyLaunchWrapper, validateHookUrl } from './shared';
+import { findBinaryInPath, homePath, humanizeModelId, parseModelChoicesFromHelp, buildSummaryInstruction, readQuickSummary, applyLaunchWrapper, validateHookUrl, buildHookCurlCommand, mergeHookEntries, resolveEncodedPathDir, parseJsonlFile } from './shared';
 import type { LaunchWrapperConfig } from '../../shared/types';
 
 describe('shared orchestrator utilities', () => {
@@ -425,6 +430,124 @@ Options:
 
       const result = await readQuickSummary('agent-4');
       expect(result).toEqual({ summary: 'Done', filesModified: [] });
+    });
+  });
+
+  describe('buildHookCurlCommand', () => {
+    it('builds posix curl command without suffix', () => {
+      if (process.platform === 'win32') return;
+      const cmd = buildHookCurlCommand('http://localhost:3000/hooks');
+      expect(cmd).toContain('http://localhost:3000/hooks/${CLUBHOUSE_AGENT_ID}');
+      expect(cmd).toContain('--data-binary @-');
+      expect(cmd).toContain('X-Clubhouse-Nonce');
+    });
+
+    it('appends event suffix when provided', () => {
+      if (process.platform === 'win32') return;
+      const cmd = buildHookCurlCommand('http://localhost:3000/hooks', '/preToolUse');
+      expect(cmd).toContain('http://localhost:3000/hooks/${CLUBHOUSE_AGENT_ID}/preToolUse');
+    });
+
+    it('produces no suffix when omitted', () => {
+      const cmd = buildHookCurlCommand('http://localhost:3000/hooks');
+      expect(cmd).not.toContain('/preToolUse');
+    });
+  });
+
+  describe('mergeHookEntries', () => {
+    const isOwn = (e: unknown) => (e as Record<string, unknown>).clubhouse === true;
+
+    it('merges new hooks into empty existing config', () => {
+      const result = mergeHookEntries({}, { PreToolUse: [{ type: 'cmd', clubhouse: true }] }, isOwn);
+      expect(result).toEqual({ PreToolUse: [{ type: 'cmd', clubhouse: true }] });
+    });
+
+    it('preserves user entries and appends ours', () => {
+      const existing = { hooks: { PreToolUse: [{ type: 'user-hook' }] } };
+      const result = mergeHookEntries(existing, { PreToolUse: [{ type: 'cmd', clubhouse: true }] }, isOwn);
+      expect(result.PreToolUse).toEqual([
+        { type: 'user-hook' },
+        { type: 'cmd', clubhouse: true },
+      ]);
+    });
+
+    it('replaces stale Clubhouse entries (identified by isOwn)', () => {
+      const existing = {
+        hooks: { PreToolUse: [{ type: 'old-clubhouse', clubhouse: true }] },
+      };
+      const result = mergeHookEntries(existing, { PreToolUse: [{ type: 'new-clubhouse', clubhouse: true }] }, isOwn);
+      expect(result.PreToolUse).toEqual([{ type: 'new-clubhouse', clubhouse: true }]);
+    });
+
+    it('handles multiple event keys', () => {
+      const result = mergeHookEntries(
+        {},
+        {
+          PreToolUse: [{ a: 1, clubhouse: true }],
+          Stop: [{ b: 2, clubhouse: true }],
+        },
+        isOwn,
+      );
+      expect(Object.keys(result)).toEqual(expect.arrayContaining(['PreToolUse', 'Stop']));
+    });
+
+    it('does not mutate the existing object', () => {
+      const existing = { hooks: { PreToolUse: [{ type: 'user' }] } };
+      mergeHookEntries(existing, { PreToolUse: [{ type: 'ours', clubhouse: true }] }, isOwn);
+      expect((existing.hooks as Record<string, unknown[]>).PreToolUse).toEqual([{ type: 'user' }]);
+    });
+  });
+
+  describe('resolveEncodedPathDir', () => {
+    it('returns null when base directory does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(resolveEncodedPathDir('/nonexistent/base', '/some/cwd')).toBeNull();
+    });
+
+    it('returns null when no encoded subdir matches', () => {
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === '/base');
+      expect(resolveEncodedPathDir('/base', '/some/project')).toBeNull();
+    });
+
+    it('resolves encoded path variant', () => {
+      const encoded = path.resolve('/some/project').replace(/[/\\]/g, '-');
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        return p === '/base' || p === path.join('/base', encoded) || p === path.join('/base', encoded.replace(/^-/, ''));
+      });
+      const result = resolveEncodedPathDir('/base', '/some/project');
+      expect(result).toBeTruthy();
+      expect(result).toContain('/base');
+    });
+  });
+
+  describe('parseJsonlFile', () => {
+    it('returns null when file does not exist', async () => {
+      vi.mocked(fsp.readFile).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      expect(await parseJsonlFile('/no/such/file.jsonl')).toBeNull();
+    });
+
+    it('returns null for empty file', async () => {
+      vi.mocked(fsp.readFile).mockResolvedValue('');
+      expect(await parseJsonlFile('/empty.jsonl')).toBeNull();
+    });
+
+    it('parses valid JSONL lines into events', async () => {
+      vi.mocked(fsp.readFile).mockResolvedValue('{"type":"message","role":"user"}\n{"type":"message","role":"assistant"}\n');
+      const result = await parseJsonlFile('/session.jsonl');
+      expect(result).toHaveLength(2);
+      expect(result![0]).toEqual({ type: 'message', role: 'user' });
+      expect(result![1]).toEqual({ type: 'message', role: 'assistant' });
+    });
+
+    it('skips malformed JSONL lines and parses valid ones', async () => {
+      vi.mocked(fsp.readFile).mockResolvedValue('{"type":"ok"}\nnot-json\n{"type":"also-ok"}\n');
+      const result = await parseJsonlFile('/mixed.jsonl');
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns null when all lines are malformed', async () => {
+      vi.mocked(fsp.readFile).mockResolvedValue('not-json\nalso-not-json\n');
+      expect(await parseJsonlFile('/bad.jsonl')).toBeNull();
     });
   });
 });

--- a/src/main/orchestrators/shared.ts
+++ b/src/main/orchestrators/shared.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { execSync, execFileSync } from 'child_process';
 import { app } from 'electron';
 import { getShellEnvironment } from '../util/shell';
 import type { LaunchWrapperConfig } from '../../shared/types';
+import type { StreamJsonEvent } from '../services/jsonl-parser';
 
 /** Cached binary lookup results keyed by the first binary name */
 const binaryCache = new Map<string, { path: string; ts: number }>();
@@ -240,4 +242,87 @@ export async function readQuickSummary(agentId: string): Promise<{ summary: stri
   } catch {
     return null;
   }
+}
+
+/**
+ * Parse a JSONL file line-by-line, returning events or null if unreadable/empty.
+ * Used by all three provider SessionCapable implementations — identical across them.
+ */
+export async function parseJsonlFile(filePath: string): Promise<StreamJsonEvent[] | null> {
+  try {
+    const content = await fsp.readFile(filePath, 'utf-8');
+    const events: StreamJsonEvent[] = [];
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        events.push(JSON.parse(trimmed));
+      } catch {
+        // Skip malformed JSONL lines — expected in truncated sessions
+      }
+    }
+    return events.length > 0 ? events : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the platform-specific curl command for a Clubhouse hook endpoint.
+ *
+ * @param safeUrl   Already-validated hook base URL (no shell metacharacters).
+ * @param eventSuffix  Optional path suffix appended to the URL (e.g. '/preToolUse').
+ */
+export function buildHookCurlCommand(safeUrl: string, eventSuffix?: string): string {
+  const suffix = eventSuffix ?? '';
+  return process.platform === 'win32'
+    ? `curl -s -X POST ${safeUrl}/%CLUBHOUSE_AGENT_ID%${suffix} -H "Content-Type: application/json" -H "X-Clubhouse-Nonce: %CLUBHOUSE_HOOK_NONCE%" -d @- || (exit /b 0)`
+    : `cat | curl -s -X POST ${safeUrl}/\${CLUBHOUSE_AGENT_ID}${suffix} -H 'Content-Type: application/json' -H "X-Clubhouse-Nonce: \${CLUBHOUSE_HOOK_NONCE}" --data-binary @- || true`;
+}
+
+/**
+ * Merge provider-owned hook entries into an existing hooks config object.
+ *
+ * Preserves user-defined entries (those for which isOwnEntry returns false),
+ * replacing only Clubhouse-managed entries per event key.
+ */
+export function mergeHookEntries(
+  existing: Record<string, unknown>,
+  newHooks: Record<string, unknown[]>,
+  isOwnEntry: (entry: unknown) => boolean,
+): Record<string, unknown[]> {
+  const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>;
+  const merged: Record<string, unknown[]> = { ...existingHooks };
+
+  for (const [eventKey, ourEntries] of Object.entries(newHooks)) {
+    const current = merged[eventKey] || [];
+    const userEntries = current.filter(e => !isOwnEntry(e));
+    merged[eventKey] = [...userEntries, ...ourEntries];
+  }
+
+  return merged;
+}
+
+/**
+ * Resolve a session/project directory by scanning for a dash-encoded CWD path.
+ *
+ * Many CLI tools (Claude Code, Copilot) encode the project path by replacing
+ * path separators with dashes and storing sessions under that name. This helper
+ * checks both the raw encoded path and the variant with the leading dash stripped.
+ *
+ * Returns the matching directory, or null if none found.
+ */
+export function resolveEncodedPathDir(baseDir: string, cwd: string): string | null {
+  if (!fs.existsSync(baseDir)) return null;
+
+  const absCwd = path.resolve(cwd);
+  const encodedPath = absCwd.replace(/[/\\]/g, '-');
+  const candidates = [encodedPath, encodedPath.replace(/^-/, '')];
+
+  for (const candidate of candidates) {
+    const dir = path.join(baseDir, candidate);
+    if (fs.existsSync(dir)) return dir;
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary

- **NdjsonRpcBase** abstract class (~130 lines) extracts the duplicated process lifecycle, NDJSON line-buffered parsing, and request/response dispatch shared between `AcpClient` and `CodexAppServerClient`
- Four new helpers in `shared.ts` consolidate ~110 lines of copy-pasted code across all three CLI providers (`ClaudeCode`, `Copilot`, `Codex`):
  - `parseJsonlFile` — async JSONL reader used by all three `readSessionTranscript` implementations
  - `buildHookCurlCommand` — curl command builder with platform detection and env-var embedding
  - `mergeHookEntries` — hook config merge preserving user entries, replacing Clubhouse-owned ones
  - `resolveEncodedPathDir` — dash-encoded CWD path resolver used by ClaudeCode and Copilot providers
- `copilot-cli-provider.test.ts` updated to use `importOriginal` so real implementations of `buildHookCurlCommand`, `mergeHookEntries`, and `parseJsonlFile` run against already-mocked `fs/promises`

## Test plan

- [x] `shared.test.ts` — 67 tests pass including 5 new `parseJsonlFile` tests
- [x] `copilot-cli-provider.test.ts` — 104 tests pass (was 2 failures before `importOriginal` fix)
- [x] All orchestrator tests — 680 tests pass across 14 test files
- [x] `test:unit` — 5205 tests pass, 0 failures in main/shared projects
- [x] `typecheck` — no new errors (pre-existing `mermaid` module error only)
- [x] `lint` — no errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)