### PR TITLE
feat(theme-e): canonical UI primitives — Modal, Spinner, EmptyState + hooks

### DIFF
--- a/src/renderer/components/EmptyState.tsx
+++ b/src/renderer/components/EmptyState.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  compact?: boolean;
+}
+
+export function EmptyState({ icon, title, description, action, compact = false }: Props) {
+  return (
+    <div className={`flex flex-col items-center justify-center text-center ${compact ? 'py-4 gap-1' : 'py-8 gap-2'}`}>
+      {icon && (
+        <div className="text-ctp-overlay0 mb-1">
+          {icon}
+        </div>
+      )}
+      <span className={`font-medium text-ctp-subtext1 ${compact ? 'text-xs' : 'text-sm'}`}>{title}</span>
+      {description && (
+        <p className="text-xs text-ctp-overlay0 max-w-[240px] leading-relaxed">{description}</p>
+      )}
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}

--- a/src/renderer/components/Modal.test.tsx
+++ b/src/renderer/components/Modal.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Modal } from './Modal';
+
+describe('Modal', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <Modal open={false} onClose={vi.fn()}>
+        <span>content</span>
+      </Modal>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders children when open=true', () => {
+    render(
+      <Modal open={true} onClose={vi.fn()}>
+        <span>hello modal</span>
+      </Modal>
+    );
+    expect(screen.getByText('hello modal')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose}>
+        <span>content</span>
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register Escape handler when open=false', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={false} onClose={onClose}>
+        <span>content</span>
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose}>
+        <span>content</span>
+      </Modal>
+    );
+    // Click the outermost fixed backdrop div (data-testid via aria or first child)
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when the inner panel is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose}>
+        <span data-testid="inner">inner content</span>
+      </Modal>
+    );
+    fireEvent.click(screen.getByTestId('inner'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/Modal.tsx
+++ b/src/renderer/components/Modal.tsx
@@ -1,0 +1,54 @@
+import { ReactNode, useEffect } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** When provided, renders a header row with title and close (×) button. */
+  title?: string;
+  /** Max-width class — defaults to w-[360px]. */
+  width?: string;
+  /** Darker backdrop for image/media dialogs. */
+  backdrop?: 'default' | 'heavy';
+  children: ReactNode;
+}
+
+export function Modal({ open, onClose, title, width = 'w-[360px]', backdrop = 'default', children }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 z-modal flex items-center justify-center ${backdrop === 'heavy' ? 'bg-black/70' : 'bg-black/50'}`}
+      onClick={onClose}
+    >
+      <div
+        className={`bg-ctp-mantle border border-surface-0 rounded-xl shadow-2xl ${width}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && (
+          <div className="flex items-center justify-between px-5 pt-5 pb-0">
+            <h2 className="text-base font-semibold text-ctp-text">{title}</h2>
+            <button
+              onClick={onClose}
+              className="w-6 h-6 flex items-center justify-center rounded text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-0 transition-colors"
+              aria-label="Close"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        )}
+        <div className="p-5">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/Spinner.tsx
+++ b/src/renderer/components/Spinner.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const SIZE_MAP = {
+  xs: 'w-3 h-3 border',
+  sm: 'w-4 h-4 border-2',
+  md: 'w-5 h-5 border-2',
+  lg: 'w-6 h-6 border-2',
+} as const;
+
+export function Spinner({ size = 'md', className = '' }: Props) {
+  return (
+    <span
+      className={`inline-block rounded-full border-ctp-subtext0 border-t-transparent animate-spin flex-shrink-0 ${SIZE_MAP[size]} ${className}`}
+      role="status"
+      aria-label="Loading"
+    />
+  );
+}

--- a/src/renderer/features/agents/QuickAgentDialog.tsx
+++ b/src/renderer/features/agents/QuickAgentDialog.tsx
@@ -4,6 +4,7 @@ import { useAgentStore } from '../../stores/agentStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useModelOptions } from '../../hooks/useModelOptions';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
+import { Modal } from '../../components/Modal';
 
 export function QuickAgentDialog() {
   const isOpen = useUIStore((s) => s.quickAgentDialogOpen);
@@ -45,8 +46,6 @@ export function QuickAgentDialog() {
       setTimeout(() => inputRef.current?.focus(), 50);
     }
   }, [isOpen]);
-
-  if (!isOpen) return null;
 
   // Durable agents for the selected project
   const durableAgents = Object.values(agents).filter(
@@ -96,20 +95,11 @@ export function QuickAgentDialog() {
       e.preventDefault();
       handleSubmit();
     }
-    if (e.key === 'Escape') {
-      closeDialog();
-    }
   };
 
   return (
-    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50" onClick={closeDialog}>
-      <div
-        className="bg-ctp-mantle border border-surface-0 rounded-xl p-5 w-[420px] shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        <h2 className="text-base font-semibold text-ctp-text mb-4">New Quick Agent</h2>
-
+    <Modal open={isOpen} onClose={closeDialog} title="New Quick Agent" width="w-[420px]">
+      <div onKeyDown={handleKeyDown}>
         {/* Project */}
         <label className="block mb-3">
           <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Project</span>
@@ -195,7 +185,7 @@ export function QuickAgentDialog() {
             checked={freeAgentMode}
             onChange={(e) => setFreeAgentMode(e.target.checked)}
             disabled={!supportsPermissions}
-            className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-red-500 focus:ring-ctp-error accent-red-500"
+            className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
           />
           <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Free Agent Mode</span>
           <span className="text-[10px] text-ctp-subtext0/70 ml-1">
@@ -243,6 +233,6 @@ export function QuickAgentDialog() {
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/renderer/features/agents/SessionNamePromptDialog.test.tsx
+++ b/src/renderer/features/agents/SessionNamePromptDialog.test.tsx
@@ -30,12 +30,9 @@ describe('SessionNamePromptDialog', () => {
     expect(screen.getByText('Name This Session')).toBeInTheDocument();
   });
 
-  it('renders into document.body via portal, not inside parent container', () => {
-    const { container } = renderDialog();
+  it('renders into the document', () => {
+    renderDialog();
     expect(screen.getByTestId('session-name-prompt-dialog')).toBeInTheDocument();
-    // Dialog should NOT be inside the render container (it's portaled to document.body)
-    expect(container.querySelector('[data-testid="session-name-prompt-dialog"]')).toBeNull();
-    // But it should be in document.body
     expect(document.body.querySelector('[data-testid="session-name-prompt-dialog"]')).not.toBeNull();
   });
 

--- a/src/renderer/features/agents/SessionNamePromptDialog.tsx
+++ b/src/renderer/features/agents/SessionNamePromptDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { createPortal } from 'react-dom';
+import { Modal } from '../../components/Modal';
 
 interface SessionNamePromptDialogProps {
   agentId: string;
@@ -12,7 +12,6 @@ export function SessionNamePromptDialog({ agentId, projectPath, onDone }: Sessio
   const [saving, setSaving] = useState(false);
   const [lastSessionId, setLastSessionId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const dialogRef = useRef<HTMLDivElement>(null);
 
   // Fetch the last session ID on mount
   useEffect(() => {
@@ -50,61 +49,45 @@ export function SessionNamePromptDialog({ agentId, projectPath, onDone }: Sessio
     onDone();
   }, [onDone]);
 
-  return createPortal(
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-modal">
-      <div
-        ref={dialogRef}
-        data-testid="session-name-prompt-dialog"
-        className="bg-ctp-mantle border border-surface-1 rounded-xl shadow-2xl w-[400px] flex flex-col"
-      >
-        {/* Header */}
-        <div className="px-4 py-3 border-b border-surface-1">
-          <h3 className="text-sm font-semibold text-ctp-text">Name This Session</h3>
-          <p className="text-xs text-ctp-subtext0 mt-1">
-            Give this session a friendly name for easy identification later.
-          </p>
-        </div>
-
-        {/* Input */}
-        <div className="px-4 py-4">
-          <input
-            ref={inputRef}
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. Bug fix for login flow"
-            data-testid="session-name-input"
-            className="w-full bg-surface-1 border border-surface-2 rounded-lg px-3 py-2 text-sm text-ctp-text
-              placeholder:text-ctp-subtext0 focus-ring"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSave();
-              if (e.key === 'Escape') handleSkip();
-            }}
-          />
-        </div>
-
-        {/* Actions */}
-        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-surface-1">
-          <button
-            onClick={handleSkip}
-            data-testid="session-name-skip"
-            className="px-3 py-1.5 text-xs rounded-lg text-ctp-subtext0 hover:text-ctp-text
-              hover:bg-surface-1 cursor-pointer transition-colors"
-          >
-            Skip
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={saving || !name.trim()}
-            data-testid="session-name-save"
-            className="px-4 py-1.5 text-xs rounded-lg bg-ctp-accent text-white hover:bg-ctp-accent/80
-              cursor-pointer transition-colors font-medium disabled:opacity-40 disabled:cursor-default"
-          >
-            Save
-          </button>
-        </div>
+  return (
+    <Modal open={true} onClose={handleSkip} title="Name This Session" width="w-[400px]">
+      <div data-testid="session-name-prompt-dialog">
+      <p className="text-xs text-ctp-subtext0 mb-3">
+        Give this session a friendly name for easy identification later.
+      </p>
+      <input
+        ref={inputRef}
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="e.g. Bug fix for login flow"
+        data-testid="session-name-input"
+        className="w-full bg-surface-1 border border-surface-2 rounded-lg px-3 py-2 text-sm text-ctp-text
+          placeholder:text-ctp-subtext0 focus-ring mb-4"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSave();
+        }}
+      />
+      <div className="flex items-center justify-end gap-2">
+        <button
+          onClick={handleSkip}
+          data-testid="session-name-skip"
+          className="px-3 py-1.5 text-xs rounded-lg text-ctp-subtext0 hover:text-ctp-text
+            hover:bg-surface-1 cursor-pointer transition-colors"
+        >
+          Skip
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={saving || !name.trim()}
+          data-testid="session-name-save"
+          className="px-4 py-1.5 text-xs rounded-lg bg-ctp-accent text-white hover:bg-ctp-accent/80
+            cursor-pointer transition-colors font-medium disabled:opacity-40 disabled:cursor-default"
+        >
+          Save
+        </button>
       </div>
-    </div>,
-    document.body
+      </div>
+    </Modal>
   );
 }

--- a/src/renderer/hooks/useAsyncAction.ts
+++ b/src/renderer/hooks/useAsyncAction.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+
+interface State<T> {
+  loading: boolean;
+  error: string | null;
+  result: T | null;
+}
+
+interface Return<T> extends State<T> {
+  run: (...args: Parameters<(...a: unknown[]) => Promise<T>>) => Promise<void>;
+  reset: () => void;
+}
+
+export function useAsyncAction<T>(
+  fn: (...args: unknown[]) => Promise<T>,
+): Return<T> {
+  const [state, setState] = useState<State<T>>({ loading: false, error: null, result: null });
+
+  const run = useCallback(async (...args: unknown[]) => {
+    setState({ loading: true, error: null, result: null });
+    try {
+      const result = await fn(...args);
+      setState({ loading: false, error: null, result });
+    } catch (err) {
+      setState({ loading: false, error: err instanceof Error ? err.message : String(err), result: null });
+    }
+  }, [fn]);
+
+  const reset = useCallback(() => setState({ loading: false, error: null, result: null }), []);
+
+  return { ...state, run, reset };
+}

--- a/src/renderer/hooks/useClickOutside.ts
+++ b/src/renderer/hooks/useClickOutside.ts
@@ -1,0 +1,17 @@
+import { useEffect, RefObject } from 'react';
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: (e: MouseEvent) => void,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const listener = (e: MouseEvent) => {
+      if (!ref.current || ref.current.contains(e.target as Node)) return;
+      handler(e);
+    };
+    document.addEventListener('mousedown', listener);
+    return () => document.removeEventListener('mousedown', listener);
+  }, [ref, handler, enabled]);
+}

--- a/src/renderer/hooks/useContextMenu.ts
+++ b/src/renderer/hooks/useContextMenu.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+
+interface Position { x: number; y: number }
+
+interface Return {
+  open: boolean;
+  position: Position;
+  onContextMenu: (e: React.MouseEvent) => void;
+  close: () => void;
+}
+
+export function useContextMenu(): Return {
+  const [state, setState] = useState<{ open: boolean; position: Position }>({
+    open: false,
+    position: { x: 0, y: 0 },
+  });
+
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setState({ open: true, position: { x: e.clientX, y: e.clientY } });
+  }, []);
+
+  const close = useCallback(() => setState((s) => ({ ...s, open: false })), []);
+
+  return { open: state.open, position: state.position, onContextMenu, close };
+}

--- a/src/renderer/hooks/useFormDirtyState.ts
+++ b/src/renderer/hooks/useFormDirtyState.ts
@@ -1,0 +1,16 @@
+import { useState, useCallback, useRef } from 'react';
+
+export function useFormDirtyState<T>(initialValue: T) {
+  const original = useRef(JSON.stringify(initialValue));
+  const [current, setCurrent] = useState(initialValue);
+
+  const isDirty = JSON.stringify(current) !== original.current;
+
+  const reset = useCallback((newValue?: T) => {
+    const v = newValue ?? initialValue;
+    original.current = JSON.stringify(v);
+    setCurrent(v);
+  }, [initialValue]);
+
+  return { value: current, setValue: setCurrent, isDirty, reset };
+}


### PR DESCRIPTION
## Summary

Track E of the theme system sprint: establishes a set of canonical shared UI primitives so modal dialogs, loading indicators, and form state no longer need to be hand-rolled per feature.

**New primitives**

| Path | What it provides |
|------|-----------------|
| `src/renderer/components/Modal.tsx` | Backdrop overlay with Escape/click-outside close, optional title+× row, `z-modal` layer (200) |
| `src/renderer/components/Spinner.tsx` | 4-size (`xs`/`sm`/`md`/`lg`) loading indicator using `ctp-subtext0` theme token |
| `src/renderer/components/EmptyState.tsx` | Icon + title + description + action slot, compact/normal variants |
| `src/renderer/hooks/useAsyncAction.ts` | `loading / error / result` state wrapper for any async fn |
| `src/renderer/hooks/useFormDirtyState.ts` | JSON-serialization dirty tracking with reset |
| `src/renderer/hooks/useClickOutside.ts` | `mousedown` listener scoped to a ref, enabled flag |
| `src/renderer/hooks/useContextMenu.ts` | Right-click `x/y` position + open state manager |

**Migrations**

- `QuickAgentDialog` — replaces inline `fixed inset-0 z-50 bg-black/50` boilerplate with `<Modal open={isOpen} onClose={closeDialog} title="New Quick Agent" width="w-[420px]">`
- `SessionNamePromptDialog` — replaces `createPortal` + inline backdrop with Modal; Escape and backdrop click both map to skip; test updated to reflect inline (non-portal) rendering

**Validation**

- `npm run typecheck` — one pre-existing error in MermaidDiagram.ts (missing `mermaid` package, unrelated to this track)
- `npm test` — 11501 passed, 0 failed; 10 pre-existing mermaid test-file failures unchanged
- `npm run lint` — clean

## Test plan

- [ ] Open Quick Agent dialog (keyboard shortcut or button) — renders with title bar, × button, Escape closes it, clicking backdrop closes it
- [ ] Open session name prompt after a session ends — renders with "Name This Session" title, Skip/Save work, Escape skips
- [ ] No regressions in other dialogs
- [ ] `Spinner`, `EmptyState` render correctly when imported (visual smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)