### PR TITLE
fix(ipc): type preload bridge, remove as-any casts, add runtime guards (CQ-23/24, M-IPC-02/05/06, M-STATE-07)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ export default tseslint.config(
       'import-x': importX,
     },
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-unused-vars': ['error', {

--- a/src/main/ipc/app-handlers.ts
+++ b/src/main/ipc/app-handlers.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
-import { ArchInfo, BadgeSettings, LogEntry, LoggingSettings, NotificationSettings } from '../../shared/types';
+import { ArchInfo, BadgeSettings, LogEntry, LoggingSettings, NotificationSettings, ThemeId } from '../../shared/types';
 import * as notificationService from '../services/notification-service';
 import * as themeService from '../services/theme-service';
 import * as orchestratorSettings from '../services/orchestrator-settings';
@@ -100,13 +100,13 @@ export function registerAppHandlers(): void {
   });
 
   ipcMain.handle(IPC.APP.SAVE_THEME, withValidatedArgs(
-    [objectArg<{ themeId: string }>({
+    [objectArg<{ themeId: ThemeId }>({
       validate: (v, name) => {
         if (typeof v.themeId !== 'string' || !v.themeId) throw new Error(`${name}.themeId must be a non-empty string`);
       },
     })],
     async (_event, settings) => {
-      await themeService.saveSettings(settings as any);
+      await themeService.saveSettings(settings);
       annexServer.broadcastThemeChanged();
     },
   ));

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,8 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/ipc-channels';
 import { settingsChannels } from '../shared/settings-definitions';
-import { AgentHookEvent } from '../shared/types';
+import { AgentHookEvent, LaunchWrapperConfig, McpCatalogEntry, DurableConfigUpdates, NotificationSettings, BadgeSettings } from '../shared/types';
+import type { PluginUpdatesStatus } from '../shared/marketplace-types';
 
 const api = {
   platform: process.platform as 'darwin' | 'win32' | 'linux',
@@ -70,11 +71,11 @@ const api = {
       ipcRenderer.invoke(IPC.PROJECT.RESET_PROJECT, projectPath),
     readLaunchWrapper: (projectPath: string) =>
       ipcRenderer.invoke(IPC.PROJECT.READ_LAUNCH_WRAPPER, projectPath),
-    writeLaunchWrapper: (projectPath: string, wrapper: any) =>
+    writeLaunchWrapper: (projectPath: string, wrapper: LaunchWrapperConfig) =>
       ipcRenderer.invoke(IPC.PROJECT.WRITE_LAUNCH_WRAPPER, projectPath, wrapper),
     readMcpCatalog: (projectPath: string) =>
       ipcRenderer.invoke(IPC.PROJECT.READ_MCP_CATALOG, projectPath),
-    writeMcpCatalog: (projectPath: string, catalog: any[]) =>
+    writeMcpCatalog: (projectPath: string, catalog: McpCatalogEntry[]) =>
       ipcRenderer.invoke(IPC.PROJECT.WRITE_MCP_CATALOG, projectPath, catalog),
     readDefaultMcps: (projectPath: string) =>
       ipcRenderer.invoke(IPC.PROJECT.READ_DEFAULT_MCPS, projectPath),
@@ -118,7 +119,7 @@ const api = {
       ipcRenderer.invoke(IPC.AGENT.READ_QUICK_SUMMARY, agentId, projectPath),
     getDurableConfig: (projectPath: string, agentId: string) =>
       ipcRenderer.invoke(IPC.AGENT.GET_DURABLE_CONFIG, projectPath, agentId),
-    updateDurableConfig: (projectPath: string, agentId: string, updates: any) =>
+    updateDurableConfig: (projectPath: string, agentId: string, updates: DurableConfigUpdates) =>
       ipcRenderer.invoke(IPC.AGENT.UPDATE_DURABLE_CONFIG, projectPath, agentId, updates),
 
     // New orchestrator-based methods
@@ -311,7 +312,7 @@ const api = {
       timestamp: number;
       data: unknown;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, agentId: string, structuredEvent: any) =>
+      const listener = (_event: Electron.IpcRendererEvent, agentId: string, structuredEvent: Parameters<typeof callback>[1]) =>
         callback(agentId, structuredEvent);
       ipcRenderer.on(IPC.AGENT.STRUCTURED_EVENT, listener);
       return () => { ipcRenderer.removeListener(IPC.AGENT.STRUCTURED_EVENT, listener); };
@@ -608,7 +609,7 @@ const api = {
       ipcRenderer.invoke(IPC.MARKETPLACE.CHECK_PLUGIN_UPDATES),
     updatePlugin: (req: { pluginId: string }) =>
       ipcRenderer.invoke(IPC.MARKETPLACE.UPDATE_PLUGIN, req),
-    getPluginUpdatesStatus: (): { updates: any[]; incompatibleUpdates: any[]; checking: boolean; lastCheck: string | null; updating: Record<string, string>; error: string | null } => ({
+    getPluginUpdatesStatus: (): PluginUpdatesStatus => ({
       updates: [],
       incompatibleUpdates: [],
       checking: false,
@@ -616,15 +617,8 @@ const api = {
       updating: {},
       error: null,
     }),
-    onPluginUpdatesChanged: (callback: (status: {
-      updates: any[];
-      incompatibleUpdates: any[];
-      checking: boolean;
-      lastCheck: string | null;
-      updating: Record<string, string>;
-      error: string | null;
-    }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, s: any) => callback(s);
+    onPluginUpdatesChanged: (callback: (status: PluginUpdatesStatus) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, s: PluginUpdatesStatus) => callback(s);
       ipcRenderer.on(IPC.MARKETPLACE.PLUGIN_UPDATES_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.MARKETPLACE.PLUGIN_UPDATES_CHANGED, listener); };
     },
@@ -684,7 +678,7 @@ const api = {
       ipcRenderer.invoke(IPC.APP.OPEN_EXTERNAL_URL, url),
     getNotificationSettings: () =>
       ipcRenderer.invoke(IPC.APP.GET_NOTIFICATION_SETTINGS),
-    saveNotificationSettings: (settings: any) =>
+    saveNotificationSettings: (settings: NotificationSettings) =>
       ipcRenderer.invoke(IPC.APP.SAVE_NOTIFICATION_SETTINGS, settings),
     sendNotification: (title: string, body: string, silent: boolean, agentId?: string, projectId?: string) =>
       ipcRenderer.invoke(IPC.APP.SEND_NOTIFICATION, title, body, silent, agentId, projectId),
@@ -742,7 +736,7 @@ const api = {
       ipcRenderer.invoke(IPC.APP.SET_DOCK_BADGE, count),
     getBadgeSettings: () =>
       ipcRenderer.invoke(IPC.APP.GET_BADGE_SETTINGS),
-    saveBadgeSettings: (settings: any) =>
+    saveBadgeSettings: (settings: BadgeSettings) =>
       ipcRenderer.invoke(IPC.APP.SAVE_BADGE_SETTINGS, settings),
     getUpdateSettings: () =>
       ipcRenderer.invoke(IPC.APP.GET_UPDATE_SETTINGS),
@@ -838,7 +832,7 @@ const api = {
       artifactUrl: string | null;
       applyAttempted: boolean;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, s: any) => callback(s);
+      const listener = (_event: Electron.IpcRendererEvent, s: Parameters<typeof callback>[0]) => callback(s);
       ipcRenderer.on(IPC.APP.UPDATE_STATUS_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.APP.UPDATE_STATUS_CHANGED, listener); };
     },
@@ -888,7 +882,7 @@ const api = {
       icon: string;
       color: string;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, s: any) => callback(s);
+      const listener = (_event: Electron.IpcRendererEvent, s: Parameters<typeof callback>[0]) => callback(s);
       ipcRenderer.on(IPC.ANNEX.STATUS_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX.STATUS_CHANGED, listener); };
     },
@@ -905,7 +899,7 @@ const api = {
       projectId: string;
       headless: boolean;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, agent: any) => callback(agent);
+      const listener = (_event: Electron.IpcRendererEvent, agent: Parameters<typeof callback>[0]) => callback(agent);
       ipcRenderer.on(IPC.ANNEX.AGENT_SPAWNED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX.AGENT_SPAWNED, listener); };
     },
@@ -926,17 +920,17 @@ const api = {
       pairedAt: string;
       lastSeen: string;
     }>) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, peers: any) => callback(peers);
+      const listener = (_event: Electron.IpcRendererEvent, peers: Parameters<typeof callback>[0]) => callback(peers);
       ipcRenderer.on(IPC.ANNEX.PEERS_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX.PEERS_CHANGED, listener); };
     },
     onPairingLocked: (callback: (locked: boolean) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, locked: any) => callback(locked);
+      const listener = (_event: Electron.IpcRendererEvent, locked: boolean) => callback(locked);
       ipcRenderer.on(IPC.ANNEX.PAIRING_LOCKED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX.PAIRING_LOCKED, listener); };
     },
     onLockStateChanged: (callback: (state: { locked: boolean; remainingMs: number }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, state: any) => callback(state);
+      const listener = (_event: Electron.IpcRendererEvent, state: Parameters<typeof callback>[0]) => callback(state);
       ipcRenderer.on(IPC.ANNEX.LOCK_STATE_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX.LOCK_STATE_CHANGED, listener); };
     },
@@ -1032,17 +1026,17 @@ const api = {
     pairWith: (fingerprint: string, pin: string) =>
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.PAIR_WITH, fingerprint, pin),
     onSatellitesChanged: (callback: (satellites: unknown[]) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, sats: any) => callback(sats);
+      const listener = (_event: Electron.IpcRendererEvent, sats: Parameters<typeof callback>[0]) => callback(sats);
       ipcRenderer.on(IPC.ANNEX_CLIENT.SATELLITES_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX_CLIENT.SATELLITES_CHANGED, listener); };
     },
     onDiscoveredChanged: (callback: (services: unknown[]) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: any) => callback(data);
+      const listener = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) => callback(data);
       ipcRenderer.on(IPC.ANNEX_CLIENT.DISCOVERED_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX_CLIENT.DISCOVERED_CHANGED, listener); };
     },
     onSatelliteEvent: (callback: (event: { satelliteId: string; type: string; payload: unknown }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: any) => callback(data);
+      const listener = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) => callback(data);
       ipcRenderer.on(IPC.ANNEX_CLIENT.SATELLITE_EVENT, listener);
       return () => { ipcRenderer.removeListener(IPC.ANNEX_CLIENT.SATELLITE_EVENT, listener); };
     },
@@ -1111,7 +1105,7 @@ const api = {
       agentDetailedStatus: Record<string, unknown>;
       agentIcons: Record<string, string>;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, state: any) => callback(state);
+      const listener = (_event: Electron.IpcRendererEvent, state: Parameters<typeof callback>[0]) => callback(state);
       ipcRenderer.on(IPC.WINDOW.AGENT_STATE_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.WINDOW.AGENT_STATE_CHANGED, listener); };
     },
@@ -1143,7 +1137,7 @@ const api = {
       focusedPaneId: string;
       zoomedPaneId: string | null;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, state: any) => callback(state);
+      const listener = (_event: Electron.IpcRendererEvent, state: Parameters<typeof callback>[0]) => callback(state);
       ipcRenderer.on(IPC.WINDOW.HUB_STATE_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.WINDOW.HUB_STATE_CHANGED, listener); };
     },
@@ -1196,7 +1190,7 @@ const api = {
       nextZIndex: number;
       zoomedViewId: string | null;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, state: any) => callback(state);
+      const listener = (_event: Electron.IpcRendererEvent, state: Parameters<typeof callback>[0]) => callback(state);
       ipcRenderer.on(IPC.WINDOW.CANVAS_STATE_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.WINDOW.CANVAS_STATE_CHANGED, listener); };
     },
@@ -1249,7 +1243,7 @@ const api = {
       return () => { ipcRenderer.removeListener(IPC.AGENT_QUEUE.CHANGED, listener); };
     },
     onTaskChanged: (callback: (data: { queueId: string; taskId: string }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: any) => callback(data);
+      const listener = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) => callback(data);
       ipcRenderer.on(IPC.AGENT_QUEUE.TASK_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.AGENT_QUEUE.TASK_CHANGED, listener); };
     },
@@ -1322,7 +1316,7 @@ const api = {
       targetKind: 'browser' | 'agent' | 'terminal' | 'group-project' | 'agent-queue';
       label: string;
     }>) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, bindings: any) => callback(bindings);
+      const listener = (_event: Electron.IpcRendererEvent, bindings: Parameters<typeof callback>[0]) => callback(bindings);
       ipcRenderer.on(IPC.MCP_BINDING.BINDINGS_CHANGED, listener);
       return () => { ipcRenderer.removeListener(IPC.MCP_BINDING.BINDINGS_CHANGED, listener); };
     },
@@ -1333,7 +1327,7 @@ const api = {
       toolSuffix: string;
       timestamp: number;
     }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, activity: any) => callback(activity);
+      const listener = (_event: Electron.IpcRendererEvent, activity: Parameters<typeof callback>[0]) => callback(activity);
       ipcRenderer.on(IPC.MCP_BINDING.TOOL_ACTIVITY, listener);
       return () => { ipcRenderer.removeListener(IPC.MCP_BINDING.TOOL_ACTIVITY, listener); };
     },
@@ -1362,7 +1356,7 @@ const api = {
       ipcRenderer.invoke(IPC.ASSISTANT.SEND_STRUCTURED_FOLLOWUP, params),
     /** Listen for headless agent completion events. */
     onResult: (callback: (result: { agentId: string; exitCode: number }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, result: any) => callback(result);
+      const listener = (_event: Electron.IpcRendererEvent, result: Parameters<typeof callback>[0]) => callback(result);
       ipcRenderer.on(IPC.ASSISTANT.RESULT, listener);
       return () => { ipcRenderer.removeListener(IPC.ASSISTANT.RESULT, listener); };
     },
@@ -1370,16 +1364,16 @@ const api = {
     reset: (agentId: string) =>
       ipcRenderer.invoke(IPC.ASSISTANT.RESET, agentId),
     /** Save chat history to disk for session persistence. */
-    saveHistory: (items: any[]) =>
+    saveHistory: (items: unknown[]) =>
       ipcRenderer.invoke(IPC.ASSISTANT.SAVE_HISTORY, { items }),
     /** Load chat history from disk. */
     loadHistory: () =>
-      ipcRenderer.invoke(IPC.ASSISTANT.LOAD_HISTORY) as Promise<any[] | null>,
+      ipcRenderer.invoke(IPC.ASSISTANT.LOAD_HISTORY) as Promise<unknown[] | null>,
   },
   canvas: {
     /** Listen for canvas commands from the main process (assistant). */
     onCommand: (callback: (request: { callId: string; command: string; args: Record<string, unknown> }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, request: any) => callback(request);
+      const listener = (_event: Electron.IpcRendererEvent, request: Parameters<typeof callback>[0]) => callback(request);
       ipcRenderer.on(IPC.CANVAS_CMD.REQUEST, listener);
       return () => { ipcRenderer.removeListener(IPC.CANVAS_CMD.REQUEST, listener); };
     },
@@ -1401,7 +1395,7 @@ const api = {
   commandPalette: {
     /** Listen for command palette operations from the main process. */
     onRequest: (callback: (request: { callId: string; operation: string; args: Record<string, unknown> }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, request: any) => callback(request);
+      const listener = (_event: Electron.IpcRendererEvent, request: Parameters<typeof callback>[0]) => callback(request);
       ipcRenderer.on(IPC.CMD_PALETTE.REQUEST, listener);
       return () => { ipcRenderer.removeListener(IPC.CMD_PALETTE.REQUEST, listener); };
     },

--- a/src/renderer/features/assistant/assistant-agent.ts
+++ b/src/renderer/features/assistant/assistant-agent.ts
@@ -1,6 +1,10 @@
 import { buildAssistantInstructions } from './system-prompt';
 import type { FeedItem } from './types';
 
+function isFeedItem(v: unknown): v is FeedItem {
+  return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).type === 'string';
+}
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 export type AssistantStatus = 'idle' | 'starting' | 'active' | 'responding' | 'error';
@@ -546,7 +550,8 @@ export async function loadHistory(): Promise<void> {
     const items = await window.clubhouse.assistant.loadHistory();
     if (items && Array.isArray(items) && items.length > 0) {
       pendingItems.length = 0;
-      const capped = items.length > MAX_FEED_ITEMS ? items.slice(-MAX_FEED_ITEMS) : items;
+      const valid = items.filter(isFeedItem);
+      const capped = valid.length > MAX_FEED_ITEMS ? valid.slice(-MAX_FEED_ITEMS) : valid;
       for (const item of capped) {
         pendingItems.push(item);
       }

--- a/src/renderer/stores/agentQueueStore.ts
+++ b/src/renderer/stores/agentQueueStore.ts
@@ -1,6 +1,18 @@
 import { create } from 'zustand';
 import type { AgentQueue, AgentQueueTaskSummary, AgentQueueTask } from '../../shared/agent-queue-types';
 
+function isAgentQueue(v: unknown): v is AgentQueue {
+  return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).id === 'string';
+}
+
+function isAgentQueueTaskSummary(v: unknown): v is AgentQueueTaskSummary {
+  return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).id === 'string' && typeof (v as Record<string, unknown>).queueId === 'string';
+}
+
+function isAgentQueueTask(v: unknown): v is AgentQueueTask {
+  return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).id === 'string' && typeof (v as Record<string, unknown>).status === 'string';
+}
+
 interface AgentQueueStoreState {
   queues: AgentQueue[];
   loaded: boolean;
@@ -18,17 +30,19 @@ export const useAgentQueueStore = create<AgentQueueStoreState>((set) => ({
 
   loadQueues: async () => {
     try {
-      const queues = await window.clubhouse.agentQueue.list() as AgentQueue[];
-      set({ queues: queues || [], loaded: true });
+      const raw = await window.clubhouse.agentQueue.list() as unknown[];
+      const queues = Array.isArray(raw) ? raw.filter(isAgentQueue) : [];
+      set({ queues, loaded: true });
     } catch {
       set({ loaded: true });
     }
   },
 
   create: async (name) => {
-    const queue = await window.clubhouse.agentQueue.create(name) as AgentQueue;
-    set((state) => ({ queues: [...state.queues, queue] }));
-    return queue;
+    const raw = await window.clubhouse.agentQueue.create(name);
+    if (!isAgentQueue(raw)) throw new Error('create returned invalid AgentQueue');
+    set((state) => ({ queues: [...state.queues, raw] }));
+    return raw;
   },
 
   update: async (id, fields) => {
@@ -53,19 +67,20 @@ export const useAgentQueueStore = create<AgentQueueStoreState>((set) => ({
   },
 
   listTasks: async (queueId) => {
-    return await window.clubhouse.agentQueue.listTasks(queueId) as AgentQueueTaskSummary[];
+    const raw = await window.clubhouse.agentQueue.listTasks(queueId) as unknown[];
+    return Array.isArray(raw) ? raw.filter(isAgentQueueTaskSummary) : [];
   },
 
   getTask: async (queueId, taskId) => {
-    return await window.clubhouse.agentQueue.getTask(queueId, taskId) as AgentQueueTask | null;
+    const raw = await window.clubhouse.agentQueue.getTask(queueId, taskId);
+    return isAgentQueueTask(raw) ? raw : null;
   },
 }));
 
 /** Initialize listener for agent queue changes from main process. */
 export function initAgentQueueListener(): () => void {
   return window.clubhouse.agentQueue.onChanged((queues) => {
-    useAgentQueueStore.setState({
-      queues: (queues || []) as AgentQueue[],
-    });
+    const valid = Array.isArray(queues) ? (queues as unknown[]).filter(isAgentQueue) : [];
+    useAgentQueueStore.setState({ queues: valid });
   });
 }

--- a/src/renderer/stores/groupProjectStore.ts
+++ b/src/renderer/stores/groupProjectStore.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
 import type { GroupProject } from '../../shared/group-project-types';
 
+function isGroupProject(v: unknown): v is GroupProject {
+  return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).id === 'string' && typeof (v as Record<string, unknown>).name === 'string';
+}
+
 interface GroupProjectStoreState {
   projects: GroupProject[];
   loaded: boolean;
@@ -27,8 +31,9 @@ export const useGroupProjectStore = create<GroupProjectStoreState>((set) => ({
 
   loadProjects: async () => {
     try {
-      const projects = await window.clubhouse.groupProject.list() as GroupProject[];
-      set({ projects: projects || [], loaded: true, loadError: null });
+      const raw = await window.clubhouse.groupProject.list() as unknown[];
+      const projects = Array.isArray(raw) ? raw.filter(isGroupProject) : [];
+      set({ projects, loaded: true, loadError: null });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error('[group-project] loadProjects failed:', message);
@@ -37,9 +42,10 @@ export const useGroupProjectStore = create<GroupProjectStoreState>((set) => ({
   },
 
   create: async (name) => {
-    const project = await window.clubhouse.groupProject.create(name) as GroupProject;
-    set((state) => ({ projects: [...state.projects, project] }));
-    return project;
+    const raw = await window.clubhouse.groupProject.create(name);
+    if (!isGroupProject(raw)) throw new Error('create returned invalid GroupProject');
+    set((state) => ({ projects: [...state.projects, raw] }));
+    return raw;
   },
 
   update: async (id, fields) => {
@@ -104,8 +110,7 @@ export const useGroupProjectStore = create<GroupProjectStoreState>((set) => ({
 /** Initialize listener for group project changes from main process. */
 export function initGroupProjectListener(): () => void {
   return window.clubhouse.groupProject.onChanged((projects) => {
-    useGroupProjectStore.setState({
-      projects: (projects || []) as GroupProject[],
-    });
+    const valid = Array.isArray(projects) ? (projects as unknown[]).filter(isGroupProject) : [];
+    useGroupProjectStore.setState({ projects: valid });
   });
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -244,6 +244,17 @@ export interface McpCatalogEntry {
   description: string;
 }
 
+export interface DurableConfigUpdates {
+  quickAgentDefaults?: QuickAgentDefaults;
+  orchestrator?: OrchestratorId;
+  model?: string;
+  freeAgentMode?: boolean;
+  clubhouseModeOverride?: boolean;
+  lastSessionId?: string | null;
+  structuredMode?: boolean;
+  persona?: string;
+}
+
 export interface ClubhouseModeSettings {
   enabled: boolean;
   projectOverrides?: Record<string, boolean>;


### PR DESCRIPTION
## Summary

- **CQ-23 / M-IPC-02**: Replace 29 `any` types in `src/preload/index.ts` with concrete types — imported from `shared/types.ts` and `marketplace-types.ts`, or derived via `Parameters<typeof callback>[N]` for pass-through listeners
- **M-IPC-06**: Remove `settings as any` cast in `app-handlers.ts` SAVE_THEME handler; change `objectArg<{themeId:string}>` → `objectArg<{themeId:ThemeId}>` so TypeScript infers the correct type without casting
- **M-STATE-07**: Add `isAgentQueue`, `isAgentQueueTaskSummary`, `isAgentQueueTask`, and `isGroupProject` runtime guard functions; replace raw `as Type` casts at all IPC return sites in `agentQueueStore` and `groupProjectStore` with filtered/checked results
- **CQ-24**: Re-enable `@typescript-eslint/no-explicit-any` as `warn` in ESLint config — surfaces remaining `any` usage as warnings across the codebase

**New shared type:** `DurableConfigUpdates` exported from `src/shared/types.ts` (includes all fields `updateDurableConfig` accepts, including `structuredMode` and `persona`)

## Test plan

- [x] `typecheck` — 0 new errors (pre-existing `mermaid` module error only)
- [x] `test:unit` — 5198 tests pass, 0 failures
- [x] `lint` — 0 errors in changed files; `no-explicit-any` warnings are pre-existing usages now surfaced (expected, intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)