### PR TITLE
fix(stores): renderer store latent bugs — LB-SP-004/006, LB-SM-006/007

### DIFF
--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -29,7 +29,9 @@ function loadTabOrder(projectId: string): string[] | null {
 function saveTabOrder(projectId: string, order: string[]): void {
   try {
     localStorage.setItem(TAB_ORDER_KEY_PREFIX + projectId, JSON.stringify(order));
-  } catch { /* quota exceeded – silently ignore */ }
+  } catch (err) {
+    console.warn('[ExplorerRail] Failed to persist tab order to localStorage (quota?):', err instanceof Error ? err.message : err);
+  }
 }
 
 const CORE_TABS: TabEntry[] = [

--- a/src/renderer/stores/annexClientStore.test.ts
+++ b/src/renderer/stores/annexClientStore.test.ts
@@ -491,6 +491,70 @@ describe('annexClientStore', () => {
     });
   });
 
+    // -------------------------------------------------------------------------
+    // LB-SM-007: cleanup discards buffered PTY data — no stale emit on reconnect
+    // -------------------------------------------------------------------------
+
+    it('cleanup discards buffered pty:data — no emission after cleanup', async () => {
+      const { satellitePtyDataBus } = await import('./annexClientStore');
+      let eventCallback: ((event: any) => void) | undefined;
+      mockAnnexClient.onSatelliteEvent.mockImplementationOnce((cb: any) => {
+        eventCallback = cb;
+        return vi.fn();
+      });
+
+      const cleanup = initAnnexClientListener();
+
+      const received: any[] = [];
+      const unsub = satellitePtyDataBus.on((satId, agentId, data) => {
+        received.push({ satId, agentId, data });
+      });
+
+      vi.useFakeTimers();
+      // Enqueue PTY data into the buffer (timer has NOT fired yet)
+      eventCallback!({ satelliteId: 'sat-1', type: 'pty:data', payload: { agentId: 'agent-1', data: 'stale data' } });
+
+      // Cleanup before the 100ms flush timer fires — buffer should be discarded
+      cleanup();
+
+      // Advance past the flush window — should not emit
+      vi.advanceTimersByTime(200);
+
+      expect(received).toHaveLength(0);
+      unsub();
+      vi.useRealTimers();
+    });
+
+    it('cleanup allows a fresh listener session to start clean', async () => {
+      const { satellitePtyDataBus } = await import('./annexClientStore');
+      let eventCb1: ((event: any) => void) | undefined;
+
+      mockAnnexClient.onSatelliteEvent
+        .mockImplementationOnce((cb: any) => { eventCb1 = cb; return vi.fn(); })
+        .mockImplementationOnce((_cb: any) => vi.fn());
+
+      // First session: enqueue data and clean up before flush
+      vi.useFakeTimers();
+      const cleanup1 = initAnnexClientListener();
+      eventCb1!({ satelliteId: 'sat-1', type: 'pty:data', payload: { agentId: 'agent-1', data: 'session1' } });
+      cleanup1();
+
+      // Second session: start fresh
+      const cleanup2 = initAnnexClientListener();
+      const received: any[] = [];
+      const unsub = satellitePtyDataBus.on((satId, agentId, data) => {
+        received.push({ satId, agentId, data });
+      });
+
+      // Advance — only second session data (none queued) should fire
+      vi.advanceTimersByTime(200);
+
+      expect(received).toHaveLength(0); // no stale data from session 1
+      cleanup2();
+      unsub();
+      vi.useRealTimers();
+    });
+
   // -------------------------------------------------------------------------
   // satellitePtyDataBus
   // -------------------------------------------------------------------------

--- a/src/renderer/stores/annexClientStore.ts
+++ b/src/renderer/stores/annexClientStore.ts
@@ -587,9 +587,9 @@ export function initAnnexClientListener(): () => void {
     unsubSatellites();
     unsubDiscovered();
     unsubEvents();
-    // Flush pending PTY data and clear throttle timers
+    // Discard buffered PTY data — do NOT emit into the next session on reconnect.
     if (ptyDataFlushTimer) { clearTimeout(ptyDataFlushTimer); ptyDataFlushTimer = null; }
-    flushPtyData();
+    ptyDataBuffer.splice(0);
     for (const timer of hookThrottleTimers.values()) clearTimeout(timer);
     hookThrottleTimers.clear();
     pendingHookPayloads.clear();

--- a/src/renderer/stores/panelStore.test.ts
+++ b/src/renderer/stores/panelStore.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { usePanelStore } from './panelStore';
+
+// Provide a spyable localStorage mock
+const storageMock: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((k: string) => storageMock[k] ?? null),
+  setItem: vi.fn((k: string, v: string) => { storageMock[k] = v; }),
+  removeItem: vi.fn((k: string) => { delete storageMock[k]; }),
+};
+vi.stubGlobal('localStorage', localStorageMock);
 
 describe('panelStore', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    for (const k of Object.keys(storageMock)) delete storageMock[k];
     usePanelStore.setState({
       explorerWidth: 200,
       explorerCollapsed: false,
@@ -11,7 +22,6 @@ describe('panelStore', () => {
       railPinned: false,
       railWidth: 200,
     });
-    vi.restoreAllMocks();
   });
 
   it('resizes explorer within bounds', () => {
@@ -153,6 +163,42 @@ describe('panelStore', () => {
     usePanelStore.getState().toggleExplorerCollapse();
     expect(usePanelStore.getState().railPinned).toBe(true);
     expect(usePanelStore.getState().explorerCollapsed).toBe(true);
+  });
+
+  // ── LB-SP-004: localStorage write errors are logged ──────────────────
+
+  describe('localStorage write error logging (LB-SP-004)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('logs console.warn when localStorage.setItem throws during persist debounce', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      localStorageMock.setItem.mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      vi.useFakeTimers();
+      usePanelStore.getState().resizeExplorer(10);
+      vi.advanceTimersByTime(400); // past 300ms debounce
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[store:panel]'),
+        expect.anything(),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('in-memory state still updates even when localStorage.setItem throws', () => {
+      localStorageMock.setItem.mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      vi.useFakeTimers();
+      usePanelStore.getState().resizeExplorer(20);
+      expect(usePanelStore.getState().explorerWidth).toBe(220);
+    });
   });
 
   // ── Debounced persist tests ──────────────────────────────────────────

--- a/src/renderer/stores/panelStore.ts
+++ b/src/renderer/stores/panelStore.ts
@@ -50,7 +50,9 @@ function persist(state: Pick<PanelState, 'explorerWidth' | 'explorerCollapsed' |
       railPinned: state.railPinned,
       railWidth: state.railWidth,
     }));
-  } catch { /* ignore */ }
+  } catch (err) {
+    console.warn('[store:panel] Failed to persist panel sizes to localStorage (quota?):', err instanceof Error ? err.message : err);
+  }
 }
 
 const PERSIST_DEBOUNCE_MS = 300;

--- a/src/renderer/stores/quickAgentStore.test.ts
+++ b/src/renderer/stores/quickAgentStore.test.ts
@@ -235,6 +235,53 @@ describe('quickAgentStore', () => {
     });
   });
 
+  // ---- LB-SP-004: localStorage write errors are logged ----
+  describe('localStorage write error logging (LB-SP-004)', () => {
+    it('logs console.warn when setItem throws a quota error in addCompleted', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      getState().addCompleted(makeCompleted());
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[store:quick-agent]'),
+        expect.anything(),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('logs console.warn when setItem throws in dismissCompleted', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      useQuickAgentStore.setState({ completedAgents: { proj_1: [makeCompleted()] } });
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      getState().dismissCompleted('proj_1', 'agent_1');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[store:quick-agent]'),
+        expect.anything(),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('in-memory state still updates even when setItem throws', () => {
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const r = makeCompleted({ id: 'agent_quota' });
+      getState().addCompleted(r);
+
+      expect(getState().completedAgents['proj_1']).toHaveLength(1);
+      expect(getState().completedAgents['proj_1'][0].id).toBe('agent_quota');
+    });
+  });
+
   // ---- || [] fallback edge cases ----
   describe('|| [] fallback edge cases', () => {
     it('addCompleted with completely empty state does not throw', () => {

--- a/src/renderer/stores/quickAgentStore.ts
+++ b/src/renderer/stores/quickAgentStore.ts
@@ -20,8 +20,8 @@ function saveToStorage(projectId: string, records: CompletedQuickAgent[]): void 
   try {
     const capped = records.length > MAX_COMPLETED_AGENTS ? records.slice(0, MAX_COMPLETED_AGENTS) : records;
     localStorage.setItem(storageKey(projectId), JSON.stringify(capped));
-  } catch {
-    // Ignore quota errors
+  } catch (err) {
+    console.warn('[store:quick-agent] Failed to persist completed agents to localStorage (quota?):', err instanceof Error ? err.message : err);
   }
 }
 

--- a/src/renderer/stores/remoteProjectStore.test.ts
+++ b/src/renderer/stores/remoteProjectStore.test.ts
@@ -779,6 +779,85 @@ describe('remoteProjectStore', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // updateRemoteGroupProject — LB-SM-006: immutable update pattern
+  // -------------------------------------------------------------------------
+
+  describe('updateRemoteGroupProject (LB-SM-006)', () => {
+    type FakeGP = { id: string; name: string };
+
+    beforeEach(() => {
+      useRemoteProjectStore.setState({ remoteGroupProjects: {} });
+    });
+
+    it('creates: adds a new group project without mutating prior array', () => {
+      const gp: FakeGP = { id: 'gp-1', name: 'Sprint' };
+      useRemoteProjectStore.getState().updateRemoteGroupProject('sat-1', 'created', gp);
+
+      const projects = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      expect(projects).toHaveLength(1);
+      expect((projects[0] as FakeGP).id).toBe('gp-1');
+    });
+
+    it('updated: replaces matching entry by id, returning a new array reference', () => {
+      const gp1: FakeGP = { id: 'gp-1', name: 'Sprint' };
+      const gp2: FakeGP = { id: 'gp-2', name: 'Other' };
+      useRemoteProjectStore.setState({
+        remoteGroupProjects: { 'sat-1': [gp1, gp2] },
+      });
+
+      const prevRef = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      const updated: FakeGP = { id: 'gp-1', name: 'Sprint v2' };
+      useRemoteProjectStore.getState().updateRemoteGroupProject('sat-1', 'updated', updated);
+
+      const nextRef = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      expect(nextRef).not.toBe(prevRef); // new array reference
+      expect((nextRef[0] as FakeGP).name).toBe('Sprint v2');
+      expect((nextRef[1] as FakeGP).id).toBe('gp-2'); // unrelated entry preserved
+    });
+
+    it('deleted: filters out entry by id, returning a new array reference', () => {
+      const gp1: FakeGP = { id: 'gp-1', name: 'Sprint' };
+      const gp2: FakeGP = { id: 'gp-2', name: 'Other' };
+      useRemoteProjectStore.setState({
+        remoteGroupProjects: { 'sat-1': [gp1, gp2] },
+      });
+
+      const prevRef = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      useRemoteProjectStore.getState().updateRemoteGroupProject('sat-1', 'deleted', gp1);
+
+      const nextRef = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      expect(nextRef).not.toBe(prevRef);
+      expect(nextRef).toHaveLength(1);
+      expect((nextRef[0] as FakeGP).id).toBe('gp-2');
+    });
+
+    it('updated with unknown id: appends without mutation', () => {
+      const gp1: FakeGP = { id: 'gp-1', name: 'Sprint' };
+      useRemoteProjectStore.setState({ remoteGroupProjects: { 'sat-1': [gp1] } });
+
+      const newGP: FakeGP = { id: 'gp-new', name: 'New Sprint' };
+      useRemoteProjectStore.getState().updateRemoteGroupProject('sat-1', 'updated', newGP);
+
+      const next = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      expect(next).toHaveLength(2);
+      expect((next[1] as FakeGP).id).toBe('gp-new');
+    });
+
+    it('does not mutate the previous array directly', () => {
+      const gp: FakeGP = { id: 'gp-1', name: 'Sprint' };
+      useRemoteProjectStore.setState({ remoteGroupProjects: { 'sat-1': [gp] } });
+
+      const prevArray = useRemoteProjectStore.getState().remoteGroupProjects['sat-1'];
+      const prevLength = prevArray.length;
+
+      useRemoteProjectStore.getState().updateRemoteGroupProject('sat-1', 'created', { id: 'gp-2', name: 'Other' });
+
+      // The old array should not have been mutated (no splice/push)
+      expect(prevArray.length).toBe(prevLength);
+    });
+  });
+
   describe('upsertRemoteAgent', () => {
     it('uses canonical || namespace format for projectId', () => {
       const store = useRemoteProjectStore.getState();

--- a/src/renderer/stores/remoteProjectStore.ts
+++ b/src/renderer/stores/remoteProjectStore.ts
@@ -587,20 +587,23 @@ export const useRemoteProjectStore = create<RemoteProjectStoreState>((set, get) 
 
   updateRemoteGroupProject: (satelliteId, action, project) => {
     set((state) => {
-      const existing = [...(state.remoteGroupProjects[satelliteId] || [])];
+      const prev = state.remoteGroupProjects[satelliteId] || [];
       const gp = project as { id: string };
+      let next: unknown[];
       if (action === 'created') {
-        existing.push(project);
+        next = [...prev, project];
       } else if (action === 'updated') {
-        const idx = existing.findIndex((p: any) => p.id === gp.id);
-        if (idx >= 0) existing[idx] = project;
-        else existing.push(project);
+        const idx = prev.findIndex((p: any) => p.id === gp.id);
+        next = idx >= 0
+          ? [...prev.slice(0, idx), project, ...prev.slice(idx + 1)]
+          : [...prev, project];
       } else if (action === 'deleted') {
-        const idx = existing.findIndex((p: any) => p.id === gp.id);
-        if (idx >= 0) existing.splice(idx, 1);
+        next = prev.filter((p: any) => p.id !== gp.id);
+      } else {
+        next = prev;
       }
       return {
-        remoteGroupProjects: { ...state.remoteGroupProjects, [satelliteId]: existing },
+        remoteGroupProjects: { ...state.remoteGroupProjects, [satelliteId]: next },
       };
     });
   },

--- a/src/renderer/stores/themeStore.test.ts
+++ b/src/renderer/stores/themeStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { ThemeId } from '../../shared/types';
+import type { ThemeId, ThemeDefinition } from '../../shared/types';
 
 // ---------- mock applyTheme before importing store ----------
 vi.mock('../themes/apply-theme', () => ({
@@ -19,10 +19,18 @@ vi.stubGlobal('window', {
   clubhouse: { app: mockApp },
 });
 
+// localStorage mock for flash-prevention cache tests
+const localStorageStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((k: string) => localStorageStore[k] ?? null),
+  setItem: vi.fn((k: string, v: string) => { localStorageStore[k] = v; }),
+  removeItem: vi.fn((k: string) => { delete localStorageStore[k]; }),
+  clear: vi.fn(() => { for (const k of Object.keys(localStorageStore)) delete localStorageStore[k]; }),
+});
+
 import { useThemeStore } from './themeStore';
 import { THEMES, registerTheme, unregisterTheme } from '../themes';
 import { applyTheme } from '../themes/apply-theme';
-import type { ThemeDefinition } from '../../shared/types';
 
 // ---------- helpers ----------
 function getState() {
@@ -33,6 +41,7 @@ function getState() {
 describe('themeStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    for (const k of Object.keys(localStorageStore)) delete localStorageStore[k];
     mockApp.updateTitleBarOverlay.mockResolvedValue(undefined);
     mockApp.getExperimentalSettings.mockResolvedValue({} as Record<string, boolean>);
     useThemeStore.setState({
@@ -196,9 +205,11 @@ describe('themeStore', () => {
       expect(useThemeStore.getState().themeId).toBe(fakePluginTheme.id);
     });
 
-    it('does not re-apply when the active theme already matches themeId', () => {
-      // Both themeId and theme are already the plugin theme — registry fires for a
-      // different reason (another plugin registers), active state is untouched.
+    it('re-applies (for cache consistency) when registry fires and active theme is still valid', () => {
+      // Both themeId and theme are the plugin theme. Registry fires for another
+      // reason (different plugin registers/unregisters). The fix always re-applies
+      // to atomically regenerate the flash-prevention localStorage cache so it
+      // stays consistent with the CSS variables written to the document.
       registerTheme(fakePluginTheme);
       useThemeStore.setState({
         themeId: fakePluginTheme.id as ThemeId,
@@ -214,7 +225,8 @@ describe('themeStore', () => {
       registerTheme(otherTheme);
       unregisterTheme(otherTheme.id);
 
-      expect(applyTheme).not.toHaveBeenCalled();
+      // applyTheme is called to regenerate the flash-prevention cache atomically
+      expect(applyTheme).toHaveBeenCalledWith(fakePluginTheme, { experimentalGradients: false });
     });
 
     it('falls back to catppuccin-mocha when the active plugin theme is unregistered', async () => {
@@ -291,6 +303,80 @@ describe('themeStore', () => {
 
       unregisterTheme(fakePluginTheme.id);
       expect(getState().availableThemeIds).not.toContain('plugin:test:ocean');
+    });
+  });
+
+  // ── LB-SP-006: registry change — cache consistency ──────────────────
+
+  describe('flash-prevention cache consistency on registry change (LB-SP-006)', () => {
+    const pluginTheme: ThemeDefinition = {
+      id: 'plugin:test:cache-test',
+      name: 'Cache Test',
+      type: 'dark',
+      colors: THEMES['catppuccin-mocha'].colors,
+      hljs: THEMES['catppuccin-mocha'].hljs,
+      terminal: THEMES['catppuccin-mocha'].terminal,
+    };
+
+    afterEach(() => {
+      unregisterTheme(pluginTheme.id);
+    });
+
+    it('does NOT remove localStorage cache when active theme is still registered', () => {
+      registerTheme(pluginTheme);
+      useThemeStore.setState({
+        themeId: pluginTheme.id as ThemeId,
+        theme: pluginTheme,
+      });
+      vi.clearAllMocks();
+
+      // Trigger registry change by registering another theme
+      const other: ThemeDefinition = { ...pluginTheme, id: 'plugin:test:other2', name: 'Other' };
+      registerTheme(other);
+      unregisterTheme(other.id);
+
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith('clubhouse-theme-vars');
+    });
+
+    it('re-applies theme (regenerating cache) when registry fires with valid theme', () => {
+      registerTheme(pluginTheme);
+      useThemeStore.setState({
+        themeId: pluginTheme.id as ThemeId,
+        theme: pluginTheme,
+      });
+      vi.clearAllMocks();
+
+      const other: ThemeDefinition = { ...pluginTheme, id: 'plugin:test:other3', name: 'Other3' };
+      registerTheme(other);
+      unregisterTheme(other.id);
+
+      // applyTheme must be called to keep CSS vars and flash-prevention cache in sync
+      expect(applyTheme).toHaveBeenCalledWith(pluginTheme, { experimentalGradients: false });
+    });
+
+    it('removes localStorage cache when active plugin theme is unregistered', async () => {
+      registerTheme(pluginTheme);
+      await getState().setTheme(pluginTheme.id as ThemeId);
+      localStorageStore['clubhouse-theme-vars'] = 'stale-vars';
+      vi.clearAllMocks();
+
+      unregisterTheme(pluginTheme.id);
+
+      expect(localStorage.removeItem).toHaveBeenCalledWith('clubhouse-theme-vars');
+    });
+
+    it('falls back to catppuccin-mocha and does not leave stale cache when theme unregistered', async () => {
+      registerTheme(pluginTheme);
+      await getState().setTheme(pluginTheme.id as ThemeId);
+      localStorageStore['clubhouse-theme-vars'] = 'stale-vars';
+      vi.clearAllMocks();
+
+      unregisterTheme(pluginTheme.id);
+
+      expect(useThemeStore.getState().themeId).toBe('catppuccin-mocha');
+      expect(applyTheme).toHaveBeenCalledWith(THEMES['catppuccin-mocha'], { experimentalGradients: false });
+      // Cache was removed, not left stale
+      expect(localStorageStore['clubhouse-theme-vars']).toBeUndefined();
     });
   });
 });

--- a/src/renderer/stores/themeStore.ts
+++ b/src/renderer/stores/themeStore.ts
@@ -89,23 +89,26 @@ export const unsubscribeThemeRegistryListener = onRegistryChange(() => {
   const store = useThemeStore.getState();
   store.refreshAvailable();
 
-  // Invalidate flash-prevention cache — stale theme data causes flicker
-  // when plugin themes are added, removed, or updated
-  try { localStorage.removeItem('clubhouse-theme-vars'); } catch { /* ignore */ }
-
-  // If the active theme was unregistered, fall back to default
   const currentTheme = getTheme(store.themeId);
   if (!currentTheme) {
+    // Active theme was unregistered — clear stale flash-prevention cache and fall back.
+    // The cache is only removed here, atomically with applying the fallback that replaces it,
+    // so we never leave the cache in a state that doesn't match the applied CSS.
+    try { localStorage.removeItem('clubhouse-theme-vars'); } catch { /* ignore */ }
     const fallback = BUILTIN_THEMES['catppuccin-mocha'];
     applyTheme(fallback, { experimentalGradients: store.experimentalGradients });
     syncTitleBarOverlay(fallback);
     useThemeStore.setState({ themeId: 'catppuccin-mocha', theme: fallback });
-  } else if (currentTheme.id !== store.theme.id) {
-    // The preferred theme was previously unavailable (loaded with fallback) and is now registered.
-    // Re-apply so CSS variables reflect the correct theme.
+  } else {
+    // Theme is still registered — re-apply to pick up any variable changes from updated
+    // plugin themes. applyTheme atomically re-writes the flash-prevention cache so it stays
+    // consistent with the CSS variables that were just written to the document.
     applyTheme(currentTheme, { experimentalGradients: store.experimentalGradients });
     syncTitleBarOverlay(currentTheme);
-    useThemeStore.setState({ theme: currentTheme });
+    if (currentTheme.id !== store.theme.id) {
+      // Previously unavailable theme is now registered — update state to match CSS.
+      useThemeStore.setState({ theme: currentTheme });
+    }
   }
 
   // Sync plugin themes to main process for MCP tool visibility

--- a/src/renderer/stores/uiStore.test.ts
+++ b/src/renderer/stores/uiStore.test.ts
@@ -215,6 +215,58 @@ describe('uiStore', () => {
     });
   });
 
+  describe('localStorage write error logging (LB-SP-004)', () => {
+    it('logs via rendererLog when setItem throws in setShowHome', () => {
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      getState().setShowHome(false);
+
+      expect(mockRendererLog).toHaveBeenCalledWith(
+        'store:ui',
+        'warn',
+        expect.stringContaining('Failed to persist view prefs'),
+        expect.objectContaining({ meta: expect.objectContaining({ key: 'clubhouse_view_prefs' }) }),
+      );
+    });
+
+    it('in-memory state still updates even when setItem throws in setShowHome', () => {
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      getState().setShowHome(false);
+
+      expect(getState().showHome).toBe(false);
+    });
+
+    it('logs via rendererLog when setItem throws in setActiveHost', () => {
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      getState().setActiveHost('sat-1');
+
+      expect(mockRendererLog).toHaveBeenCalledWith(
+        'store:ui',
+        'warn',
+        expect.stringContaining('Failed to persist active host'),
+        expect.objectContaining({ meta: expect.objectContaining({ key: 'clubhouse_active_host' }) }),
+      );
+    });
+
+    it('in-memory state still updates even when setItem throws in setActiveHost', () => {
+      vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      getState().setActiveHost('sat-1');
+
+      expect(getState().activeHostId).toBe('sat-1');
+    });
+  });
+
   describe('corrupt localStorage', () => {
     it('logs a warning when view prefs data is corrupt', async () => {
       localStorage.setItem('clubhouse_view_prefs', '{not valid json');

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -24,7 +24,11 @@ function loadViewPrefs(): ViewPrefs {
 function saveViewPrefs(prefs: ViewPrefs): void {
   try {
     localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify(prefs));
-  } catch { /* ignore */ }
+  } catch (err) {
+    rendererLog('store:ui', 'warn', 'Failed to persist view prefs to localStorage (quota?)', {
+      meta: { key: VIEW_PREFS_KEY, error: err instanceof Error ? err.message : String(err) },
+    });
+  }
 }
 
 interface UIState {
@@ -94,7 +98,11 @@ export const useUIStore = create<UIState>((set, get) => ({
       } else {
         localStorage.removeItem(ACTIVE_HOST_KEY);
       }
-    } catch { /* ignore */ }
+    } catch (err) {
+      rendererLog('store:ui', 'warn', 'Failed to persist active host to localStorage (quota?)', {
+        meta: { key: ACTIVE_HOST_KEY, error: err instanceof Error ? err.message : String(err) },
+      });
+    }
   },
 
   setExplorerTab: (tab, projectId?) => {


### PR DESCRIPTION
## Summary
- **LB-SP-004**: Silent `localStorage.setItem` failures in 4 renderer stores now log warnings (rendererLog / console.warn) instead of being swallowed; in-memory state still updates
- **LB-SP-006**: Theme registry change listener now atomically re-applies the active theme on every registry event to keep CSS variables and the flash-prevention localStorage cache consistent; only removes the cache when the active plugin theme is actually unregistered
- **LB-SM-006 / LB-SM-007**: `updateRemoteGroupProject` uses a fully immutable array pattern; `annexClientStore` cleanup discards the ptyDataBuffer instead of flushing it (preventing stale terminal data from leaking into new sessions)

## Changes

### LB-SP-004 — localStorage write errors logged (not silently swallowed)
- `src/renderer/stores/uiStore.ts`: `saveViewPrefs` and `setActiveHost` catch blocks now log via `rendererLog('store:ui', 'warn', ...)`
- `src/renderer/stores/panelStore.ts`: `persist()` catch block now logs via `console.warn('[store:panel] ...')`
- `src/renderer/stores/quickAgentStore.ts`: `saveToStorage` catch block now logs via `console.warn('[store:quick-agent] ...')`
- `src/renderer/panels/ExplorerRail.tsx`: `saveTabOrder` catch block now logs via `console.warn('[ExplorerRail] ...')`

### LB-SP-006 — Theme flash-prevention cache consistency
- `src/renderer/stores/themeStore.ts`: Registry change listener refactored — always calls `applyTheme` in the valid-theme branch (atomically regenerating the cache), only calls `localStorage.removeItem('clubhouse-theme-vars')` when the active theme is actually unregistered and a fallback is applied

### LB-SM-006 — Immutable update pattern in remoteProjectStore
- `src/renderer/stores/remoteProjectStore.ts`: `updateRemoteGroupProject` replaced direct index-assign (`prev[idx] = project`) on a spread copy with `[...prev.slice(0, idx), project, ...prev.slice(idx + 1)]` — safe under future Zustand batching

### LB-SM-007 — ptyDataBuffer discarded on cleanup
- `src/renderer/stores/annexClientStore.ts`: Cleanup now calls `ptyDataBuffer.splice(0)` (discard) instead of `flushPtyData()` (emit) — prevents buffered terminal output from session N leaking into session N+1 on reconnect

## Test Plan
- [x] `uiStore.test.ts` — LB-SP-004: `setShowHome` and `setActiveHost` quota errors log via rendererLog; in-memory state still updates
- [x] `panelStore.test.ts` — LB-SP-004: `setItem` throws after 300ms debounce logs via console.warn; in-memory state still updates
- [x] `quickAgentStore.test.ts` — LB-SP-004: `setItem` throws in `addCompleted`/`dismissCompleted` logs via console.warn; in-memory state still updates
- [x] `themeStore.test.ts` — LB-SP-006: registry change with valid theme re-applies (does NOT remove cache); registry change unregistering active theme removes cache and falls back to mocha
- [x] `remoteProjectStore.test.ts` — LB-SM-006: `created`/`updated`/`deleted` return new array references; previous array is not mutated
- [x] `annexClientStore.test.ts` — LB-SM-007: cleanup discards buffer, no pty:data emitted after cleanup fires; fresh session starts clean

## Manual Validation
- Trigger a localStorage quota error (e.g. fill storage in devtools) and verify the warning appears in the renderer console without crashing
- Register then unregister a plugin theme while it's active — UI should fall back to catppuccin-mocha with no visual flash
- Connect a remote satellite, send PTY data, disconnect, reconnect — verify no stale terminal output appears in the new session