### PR TITLE
fix(agent): Track C latent bugs — queue concurrency, canvas sort, async rejection (LB-AG-001..004)

### DIFF
--- a/src/main/services/agent-queue-runner.test.ts
+++ b/src/main/services/agent-queue-runner.test.ts
@@ -20,6 +20,7 @@ vi.mock('./agent-queue-task-store', () => ({
     listTasks: vi.fn(),
     getTask: vi.fn(),
     cancelTask: vi.fn(),
+    tryClaim: vi.fn().mockReturnValue(true),
   },
 }));
 
@@ -126,6 +127,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   capturedExitCb = undefined;
   _resetForTesting();
+  // Re-default tryClaim to true — some tests override it to false and vi.clearAllMocks
+  // only clears recordings, not implementations.
+  vi.mocked(agentQueueTaskStore.tryClaim).mockReturnValue(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -181,9 +185,10 @@ describe('happy path: enqueue -> drain -> spawn -> exit(0) -> task completed', (
     await enqueueTask('q1', 'do something');
     await flushPromises();
 
-    // Verify task was marked running
+    // Verify tryClaim was called to atomically set status to running
+    expect(agentQueueTaskStore.tryClaim).toHaveBeenCalledWith('q1', 'task1');
+    // updateTask sets agent details (status was already set by tryClaim)
     expect(agentQueueTaskStore.updateTask).toHaveBeenCalledWith('q1', 'task1', expect.objectContaining({
-      status: 'running',
       agentId: 'quick_test_abc',
       agentName: 'brave-owl',
     }));
@@ -364,6 +369,27 @@ describe('concurrency limit enforcement', () => {
   });
 });
 
+describe('atomic claim prevents concurrent double-start (LB-AG-001)', () => {
+  it('does not spawn when tryClaim returns false', async () => {
+    const queue = makeQueue({ concurrency: 2 });
+    const task = makeTask();
+
+    vi.mocked(agentQueueTaskStore.createTask).mockResolvedValue(task);
+    vi.mocked(agentQueueRegistry.get).mockResolvedValue(queue);
+    vi.mocked(agentQueueTaskStore.listTasks).mockResolvedValue([task]);
+    vi.mocked(agentQueueTaskStore.updateTask).mockResolvedValue(task);
+    vi.mocked(spawnAgent).mockResolvedValue(undefined);
+    // tryClaim returns false — task already claimed by a concurrent drain
+    vi.mocked(agentQueueTaskStore.tryClaim).mockReturnValue(false);
+
+    await enqueueTask('q1', 'do something');
+    await flushPromises();
+
+    // spawnAgent should NOT be called since tryClaim rejected the claim
+    expect(spawnAgent).not.toHaveBeenCalled();
+  });
+});
+
 describe('re-entrancy prevention', () => {
   it('skips drain when already draining the same queue', async () => {
     const queue = makeQueue();
@@ -480,10 +506,8 @@ describe('spawn failure', () => {
     await enqueueTask('q1', 'do something');
     await flushPromises();
 
-    // Task should be marked running first, then failed after spawn error
-    expect(agentQueueTaskStore.updateTask).toHaveBeenCalledWith('q1', 'task1', expect.objectContaining({
-      status: 'running',
-    }));
+    // tryClaim atomically set status to running; then updateTask commits agent details
+    expect(agentQueueTaskStore.tryClaim).toHaveBeenCalledWith('q1', 'task1');
     expect(agentQueueTaskStore.updateTask).toHaveBeenCalledWith('q1', 'task1', expect.objectContaining({
       status: 'failed',
       errorMessage: 'spawn failed',

--- a/src/main/services/agent-queue-runner.ts
+++ b/src/main/services/agent-queue-runner.ts
@@ -120,6 +120,11 @@ async function drainQueue(queueId: string): Promise<void> {
 
 /** Start a single task — spawn a quick agent for it. */
 async function startTask(queueId: string, task: AgentQueueTask): Promise<void> {
+  // Atomically claim the task before any await — prevents a concurrent drainQueue
+  // call from starting the same task a second time if it reads the status before
+  // this call's updateTask has committed to the in-memory store.
+  if (!agentQueueTaskStore.tryClaim(queueId, task.id)) return;
+
   const queue = await agentQueueRegistry.get(queueId);
   if (!queue) {
     await agentQueueTaskStore.updateTask(queueId, task.id, {
@@ -147,9 +152,8 @@ async function startTask(queueId: string, task: AgentQueueTask): Promise<void> {
   // Track the agent -> task mapping
   agentTaskMap.set(agentId, { queueId, taskId: task.id });
 
-  // Update task to running
+  // Update task with agent details — status was already set to 'running' by tryClaim
   await agentQueueTaskStore.updateTask(queueId, task.id, {
-    status: 'running',
     agentId,
     agentName,
     startedAt: new Date().toISOString(),

--- a/src/main/services/agent-queue-task-store.test.ts
+++ b/src/main/services/agent-queue-task-store.test.ts
@@ -152,3 +152,79 @@ describe('AgentQueueTaskStore', () => {
     unsub();
   });
 });
+
+describe('AgentQueueTaskStore.tryClaim (LB-AG-001)', () => {
+  beforeEach(() => {
+    store.clear();
+    dirs.clear();
+    agentQueueTaskStore._resetForTesting();
+  });
+
+  it('claims a pending task — returns true and sets status to running', async () => {
+    const task = await agentQueueTaskStore.createTask('aq_1', 'Claimable');
+    expect(task.status).toBe('pending');
+
+    const claimed = agentQueueTaskStore.tryClaim('aq_1', task.id);
+
+    expect(claimed).toBe(true);
+    const updated = await agentQueueTaskStore.getTask('aq_1', task.id);
+    expect(updated!.status).toBe('running');
+  });
+
+  it('returns false when task is already running (prevents double-start)', async () => {
+    const task = await agentQueueTaskStore.createTask('aq_1', 'Already running');
+    agentQueueTaskStore.tryClaim('aq_1', task.id); // first claim
+
+    const secondClaim = agentQueueTaskStore.tryClaim('aq_1', task.id);
+
+    expect(secondClaim).toBe(false);
+  });
+
+  it('returns false for non-existent task', () => {
+    const claimed = agentQueueTaskStore.tryClaim('aq_1', 'aqt_nonexistent');
+    expect(claimed).toBe(false);
+  });
+
+  it('returns false for cancelled task', async () => {
+    const task = await agentQueueTaskStore.createTask('aq_1', 'Cancelled');
+    await agentQueueTaskStore.cancelTask('aq_1', task.id);
+
+    const claimed = agentQueueTaskStore.tryClaim('aq_1', task.id);
+
+    expect(claimed).toBe(false);
+  });
+
+  it('returns false for completed task', async () => {
+    const task = await agentQueueTaskStore.createTask('aq_1', 'Completed');
+    agentQueueTaskStore.tryClaim('aq_1', task.id); // pending → running
+    await agentQueueTaskStore.updateTask('aq_1', task.id, { status: 'completed' });
+
+    const secondClaim = agentQueueTaskStore.tryClaim('aq_1', task.id);
+
+    expect(secondClaim).toBe(false);
+  });
+
+  it('notifies onChange listeners when claim succeeds', async () => {
+    const task = await agentQueueTaskStore.createTask('aq_1', 'Notify on claim');
+    const listener = vi.fn();
+    const unsub = agentQueueTaskStore.onChange(listener);
+    listener.mockClear();
+
+    agentQueueTaskStore.tryClaim('aq_1', task.id);
+
+    expect(listener).toHaveBeenCalledWith('aq_1', task.id);
+    unsub();
+  });
+
+  it('concurrent claims: only first returns true (no double-start)', async () => {
+    const task = await agentQueueTaskStore.createTask('aq_1', 'Race');
+
+    // Simulate two concurrent drainQueue calls both trying to claim the same task.
+    // In Node.js single-threaded model, these run synchronously in order.
+    const first = agentQueueTaskStore.tryClaim('aq_1', task.id);
+    const second = agentQueueTaskStore.tryClaim('aq_1', task.id);
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+});

--- a/src/main/services/agent-queue-task-store.ts
+++ b/src/main/services/agent-queue-task-store.ts
@@ -232,6 +232,27 @@ class AgentQueueTaskStore {
     this.tasks.set(queueId, queueTasks);
   }
 
+  /**
+   * Atomically claim a pending task by transitioning its status from 'pending'
+   * to 'running' in the in-memory cache (synchronous in Node.js single-threaded model).
+   * Returns true if the claim succeeded; false if the task is not pending or not found.
+   *
+   * Callers must call this before any await to guarantee no other concurrent
+   * drainQueue can claim the same task.
+   */
+  tryClaim(queueId: string, taskId: string): boolean {
+    const task = this.tasks.get(queueId)?.get(taskId);
+    if (!task || task.status !== 'pending') return false;
+    task.status = 'running';
+    this.persistTask(task).catch((err) => {
+      appLog('core:agent-queue', 'warn', 'Failed to persist task claim', {
+        meta: { queueId, taskId, error: err instanceof Error ? err.message : String(err) },
+      });
+    });
+    this.notifyListeners(queueId, taskId);
+    return true;
+  }
+
   /** For testing: reset all state. */
   _resetForTesting(): void {
     this.tasks.clear();

--- a/src/renderer/features/assistant/assistant-agent.ts
+++ b/src/renderer/features/assistant/assistant-agent.ts
@@ -610,10 +610,14 @@ export function approveAction(actionId: string): void {
   if (item?.action && item.action.status === 'pending_approval') {
     item.action.status = 'running';
     notifyFeedListeners();
-    // Notify the orchestrator that the tool execution is approved
-    // The IPC method may not exist yet — guarded by optional chaining on the untyped cast
+    // Notify the orchestrator that the tool execution is approved.
+    // Use Promise.resolve() to safely handle both Promise and non-Promise returns —
+    // the ?.catch?.() pattern silently drops rejections when the return is not a
+    // Promise, leaving the agent hung waiting for approval that never completes.
     if (state.agentId && state.mode === 'structured') {
-      (window.clubhouse.agent as any).approveToolExecution?.(state.agentId, actionId)?.catch?.((err: unknown) => {
+      void Promise.resolve(
+        (window.clubhouse.agent as any).approveToolExecution?.(state.agentId, actionId)
+      ).catch((err: unknown) => {
         console.error('Failed to approve action:', err);
         if (item.action) {
           item.action.status = 'error';
@@ -630,10 +634,13 @@ export function skipAction(actionId: string): void {
   if (item?.action && item.action.status === 'pending_approval') {
     item.action.status = 'skipped';
     notifyFeedListeners();
-    // Notify the orchestrator to skip this tool execution
-    // The IPC method may not exist yet — guarded by optional chaining on the untyped cast
+    // Notify the orchestrator to skip this tool execution.
+    // Use Promise.resolve() to safely handle both Promise and non-Promise returns —
+    // the ?.catch?.() pattern silently drops rejections when the return is not a Promise.
     if (state.agentId && state.mode === 'structured') {
-      (window.clubhouse.agent as any).skipToolExecution?.(state.agentId, actionId)?.catch?.((err: unknown) => {
+      void Promise.resolve(
+        (window.clubhouse.agent as any).skipToolExecution?.(state.agentId, actionId)
+      ).catch((err: unknown) => {
         console.error('Failed to skip action:', err);
         if (item.action) {
           item.action.status = 'error';

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
@@ -169,10 +169,12 @@ describe('GroupProjectCanvasWidget — include instructions checkbox', () => {
 
 describe('GroupProjectCanvasWidget — message ordering', () => {
   it('sorts messages newest-first in expanded view using sortedMessages', () => {
-    // The expanded view should sort messages by timestamp descending
+    // The expanded view should sort messages by numeric message ID descending
+    // (LB-AG-002: localeCompare on timestamps gives wrong order for same-second messages)
     expect(source).toContain('sortedMessages');
     expect(source).toMatch(/\[\.\.\.messages\]\.sort\(/);
-    expect(source).toMatch(/b\.timestamp\.localeCompare\(a\.timestamp\)/);
+    // Sort uses numeric ID extraction (id format: prefix_<timestamp>)
+    expect(source).toMatch(/parseInt.*split.*\[1\]/);
   });
 
   it('renders sortedMessages instead of raw messages in the list', () => {
@@ -246,7 +248,9 @@ describe('GroupProjectCanvasWidget — orchestrator-aware polling', () => {
     expect(source).toContain('useAgentStore.getState().agents');
     expect(source).toContain('useRemoteProjectStore.getState().remoteAgents');
     expect(source).toContain('const allAgents = { ...localAgents, ...remoteAgents }');
-    expect(source).toContain('allAgents[member.agentId]?.orchestrator');
+    // LB-AG-004: guard against undefined agent before accessing orchestrator
+    expect(source).toContain('allAgents[member.agentId]');
+    expect(source).toContain('agent.orchestrator');
   });
 
   it('passes orchestrator to pollingStartMsg and pollingStopMsg', () => {

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -242,7 +242,9 @@ function ProjectCard({
     const remoteAgents = useRemoteProjectStore.getState().remoteAgents;
     const allAgents = { ...localAgents, ...remoteAgents };
     for (const member of members) {
-      const orchestrator = allAgents[member.agentId]?.orchestrator;
+      const agent = allAgents[member.agentId];
+      if (!agent) continue;
+      const orchestrator = agent.orchestrator;
       const msg = newVal ? pollingStartMsg(name, orchestrator) : pollingStopMsg(name, orchestrator);
       void injectMessage(member.agentId, msg);
     }
@@ -488,9 +490,15 @@ function ExpandedProjectView({
     return () => { cancelled = true; clearInterval(interval); };
   }, [groupProjectId, selectedTopic, fetchDigest, fetchAllMessages, fetchTopicMessages]);
 
-  // Sort messages newest-first so the feed shows latest on top
+  // Sort messages newest-first by the numeric timestamp embedded in the message ID
+  // (msg_<epoch_ms>_<random>) to match the backend's numeric sort order and avoid
+  // localeCompare producing wrong results for same-millisecond messages.
   const sortedMessages = useMemo(
-    () => [...messages].sort((a, b) => b.timestamp.localeCompare(a.timestamp)),
+    () => [...messages].sort((a, b) => {
+      const tsA = parseInt(a.id.split('_')[1] || '0', 10);
+      const tsB = parseInt(b.id.split('_')[1] || '0', 10);
+      return tsB - tsA;
+    }),
     [messages],
   );
 
@@ -514,7 +522,9 @@ function ExpandedProjectView({
     const remoteAgents = useRemoteProjectStore.getState().remoteAgents;
     const allAgents = { ...localAgents, ...remoteAgents };
     for (const member of members) {
-      const orchestrator = allAgents[member.agentId]?.orchestrator;
+      const agent = allAgents[member.agentId];
+      if (!agent) continue;
+      const orchestrator = agent.orchestrator;
       const msg = newVal ? pollingStartMsg(name, orchestrator) : pollingStopMsg(name, orchestrator);
       void injectMessage(member.agentId, msg);
     }


### PR DESCRIPTION
## Summary

- **LB-AG-001**: Add `tryClaim()` to `AgentQueueTaskStore` for atomic `pending→running` transition — prevents concurrent `drainQueue` calls from double-starting the same task
- **LB-AG-002**: Sort canvas messages by numeric message ID instead of `localeCompare` on timestamp strings (same-second messages got wrong order)
- **LB-AG-003**: Replace `?.()?.catch?.()` chains on IPC calls in `assistant-agent.ts` with `Promise.resolve().catch()` — the optional-chain form swallows rejections when the function is undefined
- **LB-AG-004**: Guard against undefined agent entry in `handleTogglePolling` before accessing `orchestrator` — missing agent caused malformed polling message templates

## Changes

**`src/main/services/agent-queue-task-store.ts`**
- Added `tryClaim(queueId, taskId): boolean` — synchronous atomic status transition that exploits Node.js single-threaded guarantee; must be called before any `await` in `startTask`

**`src/main/services/agent-queue-runner.ts`**
- `startTask` now calls `tryClaim()` before any await; if it returns false (task already claimed), returns immediately
- `updateTask` after claim no longer redundantly sets `status: 'running'` (already set by `tryClaim`)

**`src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx`**
- Sort changed from `b.timestamp.localeCompare(a.timestamp)` to numeric ID extraction `parseInt(id.split('_')[1])`
- Both occurrences of the member loop in `handleTogglePolling` guarded with `if (!agent) continue`

**`src/renderer/features/assistant/assistant-agent.ts`**
- `approveAction` (L616) and `skipAction` (L640): both changed from `?.()?.catch?.()` to `void Promise.resolve(...).catch(err => { ... })`

## Test Plan

- [x] `agent-queue-task-store.test.ts` — 7 new tests for `tryClaim`: pending→running, double-claim guard, cancelled/completed rejection, concurrent claim returns false once
- [x] `agent-queue-runner.test.ts` — new test: `tryClaim` returning false prevents spawn; updated mock to include `tryClaim`; fixed `updateTask` expectation (no longer expects `status: 'running'`)
- [x] `GroupProjectCanvasWidget.test.ts` — updated source-inspection tests to match new sort pattern and guard pattern
- [x] All 11505 main-process + renderer tests pass (10 pre-existing renderer plugin failures unrelated to this PR)

## Manual Validation

- Validated via `npm test` + `npm run lint`; no new failures introduced