### PR TITLE
fix(theme): migrate border-red-* to border-ctp-error/* + hljs CSS var fallbacks (VQ T-1, HC-1..HC-10)

### DIFF
--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -702,7 +702,7 @@ export function AgentSettingsView({ agent }: Props) {
                   {((agent.icon && iconDataUrl) || agent.emoji) && !isRunning && (
                     <button
                       onClick={agent.emoji ? handleRemoveEmoji : handleRemoveIcon}
-                      className="text-xs px-2 py-1 rounded bg-surface-1 text-ctp-subtext0 hover:text-ctp-error hover:border-red-400/50 cursor-pointer transition-colors"
+                      className="text-xs px-2 py-1 rounded bg-surface-1 text-ctp-subtext0 hover:text-ctp-error hover:border-ctp-error/50 cursor-pointer transition-colors"
                     >
                       Remove
                     </button>

--- a/src/renderer/features/agents/AgentTemplatesSection.tsx
+++ b/src/renderer/features/agents/AgentTemplatesSection.tsx
@@ -293,7 +293,7 @@ export function AgentTemplatesSection({ worktreePath, projectPath, disabled, ref
               </button>
               <button
                 onClick={() => handleDelete(deleteTarget)}
-                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-red-500/30"
+                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-ctp-error/30"
               >
                 Delete
               </button>

--- a/src/renderer/features/agents/DeleteAgentDialog.tsx
+++ b/src/renderer/features/agents/DeleteAgentDialog.tsx
@@ -313,7 +313,7 @@ export function DeleteAgentDialog() {
                     disabled={executing}
                     className={`w-full text-left px-3 py-2.5 rounded-lg border transition-colors cursor-pointer disabled:opacity-50 flex items-start gap-3 ${
                       opt.destructive
-                        ? 'border-red-500/20 hover:border-red-500/40 hover:bg-ctp-error/5'
+                        ? 'border-ctp-error/20 hover:border-ctp-error/40 hover:bg-ctp-error/5'
                         : 'border-surface-0 hover:border-surface-2 hover:bg-surface-0'
                     }`}
                   >

--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -460,7 +460,7 @@ export function HeadlessAgentView({ agent }: Props) {
         {/* Stop button */}
         <button
           onClick={() => killAgent(agent.id)}
-          className="px-4 py-1.5 text-xs rounded-lg border border-red-500/30
+          className="px-4 py-1.5 text-xs rounded-lg border border-ctp-error/30
             hover:bg-ctp-error/20 transition-colors cursor-pointer text-ctp-error"
         >
           Stop Agent

--- a/src/renderer/features/agents/QuickAgentGhost.tsx
+++ b/src/renderer/features/agents/QuickAgentGhost.tsx
@@ -202,7 +202,7 @@ export function QuickAgentGhost({ completed, onDismiss, onDelete }: Props) {
           {onDelete && (
             <button
               onClick={onDelete}
-              className="flex-1 px-3 py-1.5 text-xs rounded-lg border border-red-500/30
+              className="flex-1 px-3 py-1.5 text-xs rounded-lg border border-ctp-error/30
                 hover:bg-ctp-error/20 transition-colors cursor-pointer
                 text-ctp-error"
             >

--- a/src/renderer/features/agents/SkillsSection.tsx
+++ b/src/renderer/features/agents/SkillsSection.tsx
@@ -231,7 +231,7 @@ export function SkillsSection({ worktreePath, projectPath, disabled, refreshKey,
               </button>
               <button
                 onClick={() => handleDelete(deleteTarget)}
-                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-red-500/30"
+                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-ctp-error/30"
               >
                 Delete
               </button>

--- a/src/renderer/features/assistant/AssistantActionCard.tsx
+++ b/src/renderer/features/assistant/AssistantActionCard.tsx
@@ -198,7 +198,7 @@ function formatInput(input: Record<string, unknown>): string {
 
 function statusBorderClass(status: ActionCardStatus): string {
   switch (status) {
-    case 'error': return 'border-red-500/40 bg-ctp-error/5';
+    case 'error': return 'border-ctp-error/40 bg-ctp-error/5';
     case 'pending_approval': return 'border-ctp-accent/40 bg-ctp-accent/5';
     case 'skipped': return 'border-surface-0 bg-ctp-mantle opacity-60';
     case 'running': return 'border-ctp-accent/20 bg-ctp-mantle';

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -250,7 +250,7 @@ function OrphanInjectionsBanner({
                 <button
                   onClick={() => handleClean(id)}
                   disabled={cleaning !== null}
-                  className="text-[10px] px-1.5 py-0.5 rounded border border-red-500/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
+                  className="text-[10px] px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
                   data-testid={`clean-orphan-btn-${id}`}
                 >
                   {cleaning === id ? 'Cleaning…' : 'Clean up'}
@@ -263,7 +263,7 @@ function OrphanInjectionsBanner({
           <button
             onClick={handleCleanAll}
             disabled={cleaning !== null}
-            className="shrink-0 text-[11px] px-2 py-1 rounded border border-red-500/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
+            className="shrink-0 text-[11px] px-2 py-1 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
             data-testid="clean-all-orphans-btn"
           >
             {cleaning ? 'Cleaning…' : 'Clean all'}
@@ -326,7 +326,7 @@ function PluginInjectionsPanel({
         <button
           onClick={handleClean}
           disabled={cleaning}
-          className="text-[10px] px-1.5 py-0.5 rounded border border-red-500/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
+          className="text-[10px] px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
           data-testid={`clean-injections-btn-${pluginId}`}
         >
           {cleaning ? 'Cleaning...' : 'Remove all'}
@@ -1207,7 +1207,7 @@ export function PluginListSettings() {
                 {externalPlugins.length > 0 && (
                   <button
                     onClick={handleUninstallAll}
-                    className="text-[11px] px-2 py-1 rounded border border-red-500/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer"
+                    className="text-[11px] px-2 py-1 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer"
                   >
                     Uninstall All
                   </button>

--- a/src/renderer/features/settings/PluginMarketplaceDialog.tsx
+++ b/src/renderer/features/settings/PluginMarketplaceDialog.tsx
@@ -472,7 +472,7 @@ export function PluginMarketplaceDialog({ onClose }: { onClose: () => void }) {
           )}
 
           {customErrorEntries.length > 0 && (
-            <div className="mb-3 p-2 rounded bg-ctp-error/10 border border-red-500/30 text-xs text-ctp-error">
+            <div className="mb-3 p-2 rounded bg-ctp-error/10 border border-ctp-error/30 text-xs text-ctp-error">
               {customErrorEntries.map(([id, err]) => {
                 const mkt = customMarketplaces.find((m) => m.id === id);
                 return (

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -163,7 +163,7 @@ function OrphanBanner({
                 <button
                   onClick={() => handleClean(id)}
                   disabled={cleaning !== null}
-                  className="text-[10px] px-1.5 py-0.5 rounded border border-red-500/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
+                  className="text-[10px] px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
                 >
                   {cleaning === id ? 'Cleaning...' : 'Clean up'}
                 </button>
@@ -175,7 +175,7 @@ function OrphanBanner({
           <button
             onClick={handleCleanAll}
             disabled={cleaning !== null}
-            className="shrink-0 text-[10px] px-2 py-1 rounded border border-red-500/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
+            className="shrink-0 text-[10px] px-2 py-1 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
           >
             {cleaning ? 'Cleaning...' : 'Clean all'}
           </button>

--- a/src/renderer/features/settings/ProjectSettings.tsx
+++ b/src/renderer/features/settings/ProjectSettings.tsx
@@ -146,7 +146,7 @@ function AppearanceSection({ projectId }: { projectId: string }) {
             <button
               onClick={handleRemoveIcon}
               className="px-3 py-1.5 text-xs rounded-lg bg-surface-0 border border-surface-2
-                text-ctp-subtext0 hover:text-ctp-error hover:border-red-400/50 cursor-pointer transition-colors"
+                text-ctp-subtext0 hover:text-ctp-error hover:border-ctp-error/50 cursor-pointer transition-colors"
             >
               Remove
             </button>
@@ -402,19 +402,19 @@ function DangerZone({ projectId, projectPath, projectName }: { projectId: string
 
   return (
     <>
-      <div className="rounded-lg border border-red-500/30 p-4 space-y-3">
+      <div className="rounded-lg border border-ctp-error/30 p-4 space-y-3">
         <h3 className="text-xs text-ctp-error uppercase tracking-wider">Danger Zone</h3>
         <div className="flex items-center gap-3">
           <button
             onClick={handleClose}
-            className="px-4 py-2 text-sm rounded-lg bg-ctp-error/10 border border-red-500/30
+            className="px-4 py-2 text-sm rounded-lg bg-ctp-error/10 border border-ctp-error/30
               text-ctp-error hover:bg-ctp-error/20 cursor-pointer transition-colors"
           >
             Close Project
           </button>
           <button
             onClick={() => setShowResetDialog(true)}
-            className="px-4 py-2 text-sm rounded-lg bg-ctp-error/10 border border-red-500/30
+            className="px-4 py-2 text-sm rounded-lg bg-ctp-error/10 border border-ctp-error/30
               text-ctp-error hover:bg-ctp-error/20 cursor-pointer transition-colors"
           >
             Reset Project

--- a/src/renderer/features/settings/ResetProjectDialog.tsx
+++ b/src/renderer/features/settings/ResetProjectDialog.tsx
@@ -85,7 +85,7 @@ export function ResetProjectDialog({ projectName, projectPath, onConfirm, onCanc
             disabled={!canConfirm}
             className={`px-4 py-2 text-sm rounded-lg border cursor-pointer transition-colors ${
               canConfirm
-                ? 'bg-ctp-error/20 border-red-500/40 text-ctp-error hover:bg-ctp-error/30'
+                ? 'bg-ctp-error/20 border-ctp-error/40 text-ctp-error hover:bg-ctp-error/30'
                 : 'bg-surface-0 border-surface-2 text-ctp-subtext0 opacity-50 cursor-not-allowed'
             }`}
           >

--- a/src/renderer/features/settings/SourceAgentTemplatesSection.tsx
+++ b/src/renderer/features/settings/SourceAgentTemplatesSection.tsx
@@ -202,7 +202,7 @@ export function SourceAgentTemplatesSection({ projectPath }: Props) {
               </button>
               <button
                 onClick={() => handleDelete(deleteTarget)}
-                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-red-500/30"
+                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-ctp-error/30"
               >
                 Delete
               </button>

--- a/src/renderer/features/settings/SourceSkillsSection.tsx
+++ b/src/renderer/features/settings/SourceSkillsSection.tsx
@@ -212,7 +212,7 @@ export function SourceSkillsSection({ projectPath }: Props) {
               </button>
               <button
                 onClick={() => handleDelete(deleteTarget)}
-                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-red-500/30"
+                className="text-xs px-3 py-1.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30 cursor-pointer transition-colors border border-ctp-error/30"
               >
                 Delete
               </button>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -76,23 +76,23 @@
   --ctp-badge-indigo: 99 102 241;
   --ctp-badge-sky: 14 165 233;
 
-  /* highlight.js token colors */
-  --hljs-keyword: #cba6f7;
-  --hljs-string: #a6e3a1;
+  /* highlight.js token colors — use CSS vars where a theme token maps cleanly */
+  --hljs-keyword: rgb(var(--ctp-accent2));
+  --hljs-string: rgb(var(--ctp-success));
   --hljs-number: #fab387;
-  --hljs-comment: #6c7086;
-  --hljs-function: #89b4fa;
-  --hljs-type: #f9e2af;
-  --hljs-variable: #f38ba8;
+  --hljs-comment: rgb(var(--ctp-overlay0));
+  --hljs-function: rgb(var(--ctp-accent));
+  --hljs-type: rgb(var(--ctp-warning));
+  --hljs-variable: rgb(var(--ctp-error));
   --hljs-regexp: #f5c2e7;
-  --hljs-tag: #89b4fa;
-  --hljs-attribute: #f9e2af;
-  --hljs-symbol: #f38ba8;
+  --hljs-tag: rgb(var(--ctp-accent));
+  --hljs-attribute: rgb(var(--ctp-warning));
+  --hljs-symbol: rgb(var(--ctp-error));
   --hljs-meta: #fab387;
-  --hljs-addition: #a6e3a1;
-  --hljs-deletion: #f38ba8;
+  --hljs-addition: rgb(var(--ctp-success));
+  --hljs-deletion: rgb(var(--ctp-error));
   --hljs-property: #94e2d5;
-  --hljs-punctuation: #9399b2;
+  --hljs-punctuation: rgb(var(--ctp-overlay1));
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

- Replaces ~21 hardcoded `border-red-500/*` / `border-red-400/*` Tailwind classes with theme-aware `border-ctp-error/*` equivalents across 14 production files — error borders now respond correctly on non-Mocha themes (Latte, Dracula, etc.) instead of always rendering Tailwind `red-500`
- Replaces 10 hardcoded Mocha hex fallbacks in `index.css` `:root` hljs vars with `rgb(var(--ctp-*))` references so syntax highlighting tokens are theme-responsive even before `applyTheme()` runs
- Keeps `#fab387` (peach), `#f5c2e7` (pink), `#94e2d5` (teal) as-is — no direct `--ctp-*` token mapping exists for these

## Files Changed

14 production component files + `src/renderer/index.css`

Pattern replaced: `border-red-500/30` → `border-ctp-error/30` (and `/20`, `/40`, `border-red-400/50` → `/50`)

`border-ctp-error` is already used in other production files (MermaidDiagram, StickyNote, PermissionViolationBanner) — confirmed Tailwind v4 resolves `--color-ctp-error` with opacity modifiers correctly.

## Test plan

- [ ] QA: verify error states (delete dialogs, plugin/agent remove buttons, reset project) render correct theme color across Mocha (default), Latte (light), and one additional theme
- [ ] CI typecheck + unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)