### PR TITLE
fix(security): LB-IPC-2026-05-01 + CQ-EH-01 + LB-PS-2026-05-01 — window open + auto-update safety

### DIFF
--- a/src/main/services/auto-update-download.test.ts
+++ b/src/main/services/auto-update-download.test.ts
@@ -2,6 +2,9 @@
  * LB-SP-001: downloadFile must reject when fewer bytes are received than
  * the Content-Length header indicates (partial/truncated downloads).
  *
+ * LB-PS-2026-05-01: downloadFile must limit redirect hops and reject
+ * redirects to disallowed hosts (SSRF / DoS prevention).
+ *
  * Kept in a separate file because mocking the ESM `http` module requires
  * vi.mock() hoisting, which would interfere with the real-fs tests in
  * auto-update-service.test.ts (e.g. verifySHA256 writes real temp files).
@@ -120,5 +123,78 @@ describe('LB-SP-001: downloadFile partial-download detection', () => {
     fakeFile.emit('finish');
 
     await expect(promise).rejects.toThrow('Partial download: expected 100 bytes, received 70');
+  });
+});
+
+describe('LB-PS-2026-05-01: downloadFile redirect safety', () => {
+  function makeRedirectRes(location: string): FakeRes {
+    return Object.assign(new EventEmitter(), {
+      statusCode: 302,
+      headers: { location } as Record<string, string>,
+      pipe: vi.fn(),
+      resume: vi.fn(),
+    }) as FakeRes;
+  }
+
+  beforeEach(() => {
+    vi.mocked(http.get).mockReset();
+    vi.mocked(fs.createWriteStream).mockReset();
+    vi.mocked(fs.unlink).mockReset();
+  });
+
+  it('rejects after exceeding 5 redirect hops', async () => {
+    const fakeReq = Object.assign(new EventEmitter(), { destroy: vi.fn() }) as FakeReq;
+    // Every call returns a 302 redirect back to the same allowed host
+    vi.mocked(http.get).mockImplementation((_url: any, _opts: any, callback: any) => {
+      callback(makeRedirectRes('http://stclubhousereleases.blob.core.windows.net/file'));
+      return fakeReq as any;
+    });
+
+    await expect(
+      downloadFile('http://stclubhousereleases.blob.core.windows.net/file', '/tmp/out', undefined, vi.fn()),
+    ).rejects.toThrow('Too many redirects');
+  });
+
+  it('rejects on redirect to a disallowed host', async () => {
+    const fakeReq = Object.assign(new EventEmitter(), { destroy: vi.fn() }) as FakeReq;
+    vi.mocked(http.get).mockImplementationOnce((_url: any, _opts: any, callback: any) => {
+      callback(makeRedirectRes('http://evil.attacker.com/malware'));
+      return fakeReq as any;
+    });
+
+    await expect(
+      downloadFile('http://stclubhousereleases.blob.core.windows.net/file', '/tmp/out', undefined, vi.fn()),
+    ).rejects.toThrow('Redirect to disallowed host: evil.attacker.com');
+  });
+
+  it('follows up to 5 redirects to allowed hosts before resolving', async () => {
+    const fakeReq = Object.assign(new EventEmitter(), { destroy: vi.fn() }) as FakeReq;
+    const fakeFile = Object.assign(new EventEmitter(), { close: vi.fn() }) as FakeFile;
+    const finalRes = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      pipe: vi.fn(),
+      resume: vi.fn(),
+    }) as FakeRes;
+
+    let callCount = 0;
+    vi.mocked(http.get).mockImplementation((_url: any, _opts: any, callback: any) => {
+      callCount++;
+      if (callCount <= 3) {
+        callback(makeRedirectRes('http://stclubhousereleases.blob.core.windows.net/file'));
+      } else {
+        callback(finalRes);
+      }
+      return fakeReq as any;
+    });
+
+    vi.mocked(fs.createWriteStream).mockReturnValue(fakeFile as any);
+
+    const promise = downloadFile('http://stclubhousereleases.blob.core.windows.net/file', '/tmp/out', undefined, vi.fn());
+    finalRes.emit('finish');
+    fakeFile.emit('finish');
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(callCount).toBe(4); // 3 redirects + 1 final
   });
 });

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -323,6 +323,13 @@ function fetchJSON<T = UpdateManifest>(url: string): Promise<T> {
   });
 }
 
+const MAX_REDIRECTS = 5;
+
+// Hosts that downloadFile is permitted to follow redirects to.
+const ALLOWED_DOWNLOAD_HOSTS = new Set([
+  'stclubhousereleases.blob.core.windows.net',
+]);
+
 export function downloadFile(
   url: string,
   destPath: string,
@@ -330,51 +337,76 @@ export function downloadFile(
   onProgress: (percent: number) => void,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const mod = url.startsWith('https') ? https : http;
-    const req = mod.get(url, { timeout: 300_000 }, (res) => {
-      // Follow redirects (Azure CDN may redirect)
-      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        downloadFile(res.headers.location, destPath, expectedSize, onProgress)
-          .then(resolve)
-          .catch(reject);
-        res.resume();
-        return;
-      }
-      if (res.statusCode !== 200) {
-        reject(new Error(`Download failed: HTTP ${res.statusCode}`));
-        res.resume();
-        return;
-      }
+    let hopsLeft = MAX_REDIRECTS;
 
-      const totalSize = expectedSize || parseInt(res.headers['content-length'] || '0', 10);
-      let downloadedBytes = 0;
-      const file = fs.createWriteStream(destPath);
+    function attempt(currentUrl: string): void {
+      const mod = currentUrl.startsWith('https') ? https : http;
+      const req = mod.get(currentUrl, { timeout: 300_000 }, (res) => {
+        // Follow redirects (Azure CDN may redirect)
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
 
-      res.on('data', (chunk: Buffer) => {
-        downloadedBytes += chunk.length;
-        if (totalSize > 0) {
-          onProgress(Math.min(99, Math.round((downloadedBytes / totalSize) * 100)));
-        }
-      });
+          if (hopsLeft <= 0) {
+            reject(new Error('Too many redirects'));
+            return;
+          }
 
-      res.pipe(file);
-      file.on('finish', () => {
-        file.close();
-        if (totalSize > 0 && downloadedBytes !== totalSize) {
-          fs.unlink(destPath, () => {});
-          reject(new Error(`Partial download: expected ${totalSize} bytes, received ${downloadedBytes}`));
+          let redirectUrl: URL;
+          try {
+            redirectUrl = new URL(res.headers.location, currentUrl);
+          } catch {
+            reject(new Error(`Invalid redirect URL: ${res.headers.location}`));
+            return;
+          }
+
+          if (!ALLOWED_DOWNLOAD_HOSTS.has(redirectUrl.hostname)) {
+            reject(new Error(`Redirect to disallowed host: ${redirectUrl.hostname}`));
+            return;
+          }
+
+          hopsLeft--;
+          attempt(redirectUrl.href);
           return;
         }
-        onProgress(100);
-        resolve();
+
+        if (res.statusCode !== 200) {
+          reject(new Error(`Download failed: HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+
+        const totalSize = expectedSize || parseInt(res.headers['content-length'] || '0', 10);
+        let downloadedBytes = 0;
+        const file = fs.createWriteStream(destPath);
+
+        res.on('data', (chunk: Buffer) => {
+          downloadedBytes += chunk.length;
+          if (totalSize > 0) {
+            onProgress(Math.min(99, Math.round((downloadedBytes / totalSize) * 100)));
+          }
+        });
+
+        res.pipe(file);
+        file.on('finish', () => {
+          file.close();
+          if (totalSize > 0 && downloadedBytes !== totalSize) {
+            fs.unlink(destPath, () => {});
+            reject(new Error(`Partial download: expected ${totalSize} bytes, received ${downloadedBytes}`));
+            return;
+          }
+          onProgress(100);
+          resolve();
+        });
+        file.on('error', (err) => {
+          fs.unlink(destPath, () => {});
+          reject(err);
+        });
       });
-      file.on('error', (err) => {
-        fs.unlink(destPath, () => {});
-        reject(err);
-      });
-    });
-    req.on('error', reject);
-    req.on('timeout', () => { req.destroy(); reject(new Error('Download timed out')); });
+      req.on('error', reject);
+      req.on('timeout', () => { req.destroy(); reject(new Error('Download timed out')); });
+    }
+
+    attempt(url);
   });
 }
 
@@ -1233,14 +1265,18 @@ export async function startPeriodicChecks(): Promise<void> {
 
   // Check on startup (delayed to let the app settle)
   setTimeout(() => {
-    checkForUpdates().catch(() => {});
+    checkForUpdates().catch((err: unknown) => {
+      appLog('update:check', 'error', `Startup update check failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
   }, 30_000); // 30 second delay after startup
 
   // Periodic checks
   checkTimer = setInterval(() => {
     const currentSettings = getSettings();
     if (currentSettings.autoUpdate) {
-      checkForUpdates().catch(() => {});
+      checkForUpdates().catch((err: unknown) => {
+        appLog('update:check', 'error', `Periodic update check failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
     }
   }, CHECK_INTERVAL_MS);
 }

--- a/src/main/window-security-guards.test.ts
+++ b/src/main/window-security-guards.test.ts
@@ -78,6 +78,16 @@ describe('applyWindowSecurityGuards', () => {
       const result = mockWin._triggerWindowOpen({ url: 'https://evil.com' });
       expect(result).toEqual({ action: 'deny' });
     });
+
+    it('allows allowed URLs (LB-IPC-2026-05-01)', () => {
+      const result = mockWin._triggerWindowOpen({ url: 'file:///app/index.html' });
+      expect(result).toEqual({ action: 'allow' });
+    });
+
+    it('allows localhost URLs', () => {
+      const result = mockWin._triggerWindowOpen({ url: 'http://localhost:3000/page' });
+      expect(result).toEqual({ action: 'allow' });
+    });
   });
 
   describe('will-attach-webview', () => {

--- a/src/main/window-security-guards.ts
+++ b/src/main/window-security-guards.ts
@@ -25,7 +25,7 @@ export function applyWindowSecurityGuards(win: BrowserWindow): void {
       appLog('core:security', 'warn', `Blocked window.open to external URL: ${url}`);
       return { action: 'deny' };
     }
-    return { action: 'deny' };
+    return { action: 'allow' };
   });
 
   // Restrict webview creation to safe URL schemes


### PR DESCRIPTION
## Summary

Three related window/auto-update security fixes from the 2026-05-17 Quality Sprint Wave 1.

### LB-IPC-2026-05-01 — setWindowOpenHandler Denies ALL URLs (HIGH)
**File:** `src/main/window-security-guards.ts`

Both branches of `setWindowOpenHandler` returned `{ action: 'deny' }`, silently blocking all `window.open()` and `target="_blank"` clicks — including internal app URLs (file://, localhost). Fixed the allow-branch to return `{ action: 'allow' }`.

### CQ-EH-01 — Auto-Update Silent Failure (CRITICAL)
**File:** `src/main/services/auto-update-service.ts`

`startPeriodicChecks` called `checkForUpdates().catch(() => {})` twice — swallowing all errors. Users had no way to know update checks were failing. Replaced with `appLog('update:check', 'error', ...)` so failures appear in logs.

### LB-PS-2026-05-01 — downloadFile Unbounded Redirects (CRITICAL — SSRF/DoS)
**File:** `src/main/services/auto-update-service.ts`

`downloadFile` recursively followed HTTP redirects with no depth limit and no host validation. An attacker controlling the update server or CDN could redirect to arbitrary hosts, and infinite loops could cause stack exhaustion. Fixed by:
- Replacing recursion with an iterative `attempt()` inner function
- Capping at `MAX_REDIRECTS = 5` hops
- Rejecting redirects to hosts not in `ALLOWED_DOWNLOAD_HOSTS` (currently `stclubhousereleases.blob.core.windows.net`)

## Tests

- Added 2 tests to `window-security-guards.test.ts` covering the allow-branch for file:// and localhost URLs
- Added `LB-PS-2026-05-01` describe block in `auto-update-download.test.ts` with 3 new tests:
  - Rejects after exceeding 5 hops
  - Rejects redirect to disallowed host
  - Follows up to 5 allowed-host redirects before resolving

All 19 targeted tests pass. The 9 renderer/plugin test failures in the full suite are pre-existing and unrelated to these changes.

## Pre-existing failures (not introduced here)
The following 9 renderer test files were already failing on main before this branch:
- `PluginContentView.test.tsx`, `builtin-canvas-widgets.test.ts`, `PluginListSettings.test.tsx`, `PluginMarketplaceDialog.test.tsx`, `PluginPermissions.test.tsx`, `builtin-plugin-testing.test.ts`, `MermaidDiagram.test.tsx`, `MarkdownPreview.test.tsx`, `feature-gating.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)