### PR TITLE
feat(ui): add confirm dialogs for Remove Wrapper and Kill Agent (VQ-DA-CRIT-01, VQ-AT-CRIT-02)

### DIFF
--- a/src/renderer/components/ConfirmDestructiveAction.tsx
+++ b/src/renderer/components/ConfirmDestructiveAction.tsx
@@ -1,0 +1,43 @@
+import { Modal } from './Modal';
+
+interface Props {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDestructiveAction({
+  open,
+  title,
+  description,
+  confirmLabel = 'Remove',
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <Modal open={open} onClose={onCancel} title={title}>
+      <p className="text-sm text-ctp-subtext1 mb-5">{description}</p>
+      <div className="flex items-center justify-end gap-2">
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 text-xs rounded-lg text-ctp-subtext0 hover:text-ctp-text
+            hover:bg-surface-0 cursor-pointer transition-colors"
+          data-testid="confirm-destructive-cancel"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          className="px-4 py-1.5 text-xs rounded-lg bg-ctp-error text-ctp-base hover:opacity-90
+            cursor-pointer transition-colors font-medium"
+          data-testid="confirm-destructive-confirm"
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/renderer/features/agents/HeadlessAgentView.test.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HeadlessAgentView, MAX_FEED_ITEMS } from './HeadlessAgentView';
 import { useAgentStore } from '../../stores/agentStore';
@@ -417,5 +417,32 @@ describe('HeadlessAgentView', () => {
     // Advance time — should NOT change because agent is stopped
     act(() => { vi.advanceTimersByTime(5000); });
     expect(screen.getByText('1m 0s')).toBeInTheDocument();
+  });
+
+  it('clicking Stop Agent shows confirm dialog without calling killAgent', () => {
+    const mockKillAgent = vi.fn();
+    useAgentStore.setState({ killAgent: mockKillAgent });
+    render(<HeadlessAgentView agent={headlessAgent} />);
+    fireEvent.click(screen.getByTestId('stop-agent-button'));
+    expect(screen.getByText(`Kill ${headlessAgent.name}?`)).toBeInTheDocument();
+    expect(mockKillAgent).not.toHaveBeenCalled();
+  });
+
+  it('cancelling kill confirm dialog does not call killAgent', () => {
+    const mockKillAgent = vi.fn();
+    useAgentStore.setState({ killAgent: mockKillAgent });
+    render(<HeadlessAgentView agent={headlessAgent} />);
+    fireEvent.click(screen.getByTestId('stop-agent-button'));
+    fireEvent.click(screen.getByTestId('confirm-destructive-cancel'));
+    expect(mockKillAgent).not.toHaveBeenCalled();
+  });
+
+  it('confirming kill dialog calls killAgent with agent id', () => {
+    const mockKillAgent = vi.fn();
+    useAgentStore.setState({ killAgent: mockKillAgent });
+    render(<HeadlessAgentView agent={headlessAgent} />);
+    fireEvent.click(screen.getByTestId('stop-agent-button'));
+    fireEvent.click(screen.getByTestId('confirm-destructive-confirm'));
+    expect(mockKillAgent).toHaveBeenCalledWith(headlessAgent.id);
   });
 });

--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Agent, AgentHookEvent } from '../../../shared/types';
 import { useAgentStore } from '../../stores/agentStore';
+import { ConfirmDestructiveAction } from '../../components/ConfirmDestructiveAction';
 
 export const MAX_FEED_ITEMS = 200;
 const TRANSCRIPT_PAGE_SIZE = 100;
@@ -273,6 +274,7 @@ export function HeadlessAgentView({ agent }: Props) {
   const feedBufferRef = useRef<FeedItem[]>([]);
   const killAgent = useAgentStore((s) => s.killAgent);
   const spawnedAt = useAgentStore((s) => s.agentSpawnedAt[agent.id]);
+  const [confirmKill, setConfirmKill] = useState(false);
 
   // Batch feed-item state updates: push to buffer ref (O(1)), flush to state
   // once per animation frame to avoid copying the full array on every event.
@@ -459,12 +461,21 @@ export function HeadlessAgentView({ agent }: Props) {
 
         {/* Stop button */}
         <button
-          onClick={() => killAgent(agent.id)}
+          onClick={() => setConfirmKill(true)}
           className="px-4 py-1.5 text-xs rounded-lg border border-ctp-error/30
             hover:bg-ctp-error/20 transition-colors cursor-pointer text-ctp-error"
+          data-testid="stop-agent-button"
         >
           Stop Agent
         </button>
+        <ConfirmDestructiveAction
+          open={confirmKill}
+          title={`Kill ${agent.name}?`}
+          description="This will immediately end the current session. Work in progress may be lost."
+          confirmLabel="Kill Agent"
+          onConfirm={() => { setConfirmKill(false); killAgent(agent.id); }}
+          onCancel={() => setConfirmKill(false)}
+        />
       </div>
     </div>
   );

--- a/src/renderer/features/settings/ProjectSettings.test.tsx
+++ b/src/renderer/features/settings/ProjectSettings.test.tsx
@@ -680,7 +680,33 @@ describe('ProjectSettings', () => {
       });
     });
 
-    it('Remove clears wrapper, catalog, defaults, and snapshot', async () => {
+    it('clicking Remove Wrapper button shows confirm dialog without firing delete', async () => {
+      setupWrapperState({
+        wrapper: wrapperNoRefresh,
+        catalog: [],
+      });
+      resetStores();
+      render(<ProjectSettings />);
+      const removeBtn = await screen.findByTestId('remove-wrapper-button');
+      fireEvent.click(removeBtn);
+      expect(screen.getByText('Remove Launch Wrapper?')).toBeInTheDocument();
+      expect(window.clubhouse.project.writeLaunchWrapper).not.toHaveBeenCalled();
+    });
+
+    it('cancelling the confirm dialog does not remove wrapper', async () => {
+      setupWrapperState({
+        wrapper: wrapperNoRefresh,
+        catalog: [],
+      });
+      resetStores();
+      render(<ProjectSettings />);
+      const removeBtn = await screen.findByTestId('remove-wrapper-button');
+      fireEvent.click(removeBtn);
+      fireEvent.click(screen.getByTestId('confirm-destructive-cancel'));
+      expect(window.clubhouse.project.writeLaunchWrapper).not.toHaveBeenCalled();
+    });
+
+    it('confirming remove dialog clears wrapper, catalog, defaults, and snapshot', async () => {
       setupWrapperState({
         wrapper: wrapperNoRefresh,
         catalog: [{ id: 'a', name: 'A', description: 'a' }],
@@ -688,9 +714,11 @@ describe('ProjectSettings', () => {
       });
       resetStores();
       render(<ProjectSettings />);
-      // Two "Remove" buttons exist (one for icon if image set; here only the wrapper one).
-      const removeBtn = await screen.findByText('Remove');
+      const removeBtn = await screen.findByTestId('remove-wrapper-button');
       fireEvent.click(removeBtn);
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('confirm-destructive-confirm'));
+      });
       await waitFor(() => {
         expect(window.clubhouse.project.writeLaunchWrapper).toHaveBeenCalledWith(
           '/home/user/my-project',

--- a/src/renderer/features/settings/ProjectSettings.tsx
+++ b/src/renderer/features/settings/ProjectSettings.tsx
@@ -11,6 +11,7 @@ import { computeCatalogDiff } from '../../../shared/wrapper-diff';
 import { pluginCommandRegistry } from '../../plugins/plugin-commands';
 import type { LaunchWrapperConfig, McpCatalogEntry, WrapperCatalogSnapshot } from '../../../shared/types';
 import { showConfirmDialog } from '../../plugins/PluginDialog';
+import { ConfirmDestructiveAction } from '../../components/ConfirmDestructiveAction';
 
 function NameAndPathSection({ projectId }: { projectId: string }) {
   const { projects, updateProject } = useProjectStore();
@@ -218,6 +219,7 @@ function LaunchWrapperSection({ projectId, projectPath }: { projectId: string; p
   const [snapshot, setSnapshot] = useState<WrapperCatalogSnapshot | undefined>(undefined);
   const [loaded, setLoaded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
 
   const agents = useAgentStore((s) => s.agents);
   const addToast = useToastStore((s) => s.addToast);
@@ -357,12 +359,24 @@ function LaunchWrapperSection({ projectId, projectPath }: { projectId: string; p
             )}
           </div>
           <button
-            onClick={handleRemoveWrapper}
-            className="text-xs text-ctp-subtext0 hover:text-ctp-error cursor-pointer transition-colors"
+            onClick={() => setConfirmRemove(true)}
+            className="flex items-center gap-1 text-xs text-ctp-error/70 hover:text-ctp-error cursor-pointer transition-colors"
+            data-testid="remove-wrapper-button"
           >
-            Remove
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="3 6 5 6 21 6" /><path d="M19 6l-1 14H6L5 6" /><path d="M10 11v6" /><path d="M14 11v6" /><path d="M9 6V4h6v2" />
+            </svg>
+            Remove Wrapper
           </button>
         </div>
+        <ConfirmDestructiveAction
+          open={confirmRemove}
+          title="Remove Launch Wrapper?"
+          description="This will permanently remove: wrapper configuration, environment overrides, command arguments, and tool filters."
+          confirmLabel="Remove Wrapper"
+          onConfirm={() => { setConfirmRemove(false); void handleRemoveWrapper(); }}
+          onCancel={() => setConfirmRemove(false)}
+        />
         {hasDiff && (
           <div className="flex items-center justify-between rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-300">
             <span>


### PR DESCRIPTION
## Summary
- Adds a confirmation dialog before the \"Remove Wrapper\" action in LaunchWrapperSection — prevents silent destruction of 4 config objects (wrapper config, env overrides, command args, tool filters)
- Adds a confirmation dialog before the \"Kill Agent\" (Stop Agent) action in HeadlessAgentView — prevents accidental session termination
- Extracts a shared `ConfirmDestructiveAction` modal component used by both fixes

## Changes
- `src/renderer/components/ConfirmDestructiveAction.tsx` — new reusable confirm modal built on the existing `<Modal>` primitive; props: `open`, `title`, `description`, `confirmLabel`, `onConfirm`, `onCancel`
- `src/renderer/features/settings/ProjectSettings.tsx` — `LaunchWrapperSection`: gates `handleRemoveWrapper` behind confirm dialog; restyles trigger button as destructive (red text + trash icon)
- `src/renderer/features/agents/HeadlessAgentView.tsx` — gates `killAgent` behind confirm dialog showing the agent name
- `src/renderer/features/settings/ProjectSettings.test.tsx` — 3 new tests: confirm dialog appears on click, cancel does not fire delete, confirm fires all 4 write calls
- `src/renderer/features/agents/HeadlessAgentView.test.tsx` — 3 new tests: confirm dialog appears on click, cancel does not call killAgent, confirm calls killAgent with correct agent id

## Test Plan
- [x] Clicking \"Remove Wrapper\" opens confirm dialog — `writeLaunchWrapper` NOT called yet
- [x] Clicking Cancel in confirm dialog — no writes happen
- [x] Clicking \"Remove Wrapper\" in confirm dialog — all 4 writes fire (`writeLaunchWrapper`, `writeMcpCatalog`, `writeDefaultMcps`, `writeWrapperCatalogSnapshot`)
- [x] Clicking \"Stop Agent\" opens confirm dialog showing agent name — `killAgent` NOT called yet
- [x] Clicking Cancel in confirm dialog — `killAgent` not called
- [x] Clicking \"Kill Agent\" in confirm dialog — `killAgent(agent.id)` called
- [x] All 65 tests in affected files pass; pre-existing failures in unrelated files (missing `mermaid` pkg) unchanged

## Manual Validation
1. Open a project with a Launch Wrapper configured → click the red \"Remove Wrapper\" button → confirm dialog should appear listing what will be deleted → Cancel leaves wrapper intact → Confirm removes it
2. Open a headless agent → click \"Stop Agent\" → confirm dialog showing \"Kill [agent-name]?\" with session-loss warning → Cancel leaves agent running → \"Kill Agent\" terminates it