### PR TITLE
fix(wave1): quick-agent timer race (CQ-RC-01) + plugin settings type safety (CQ-TS-01)

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -186,6 +186,11 @@ vi.mock('../../shared/name-generator', () => ({
   generateQuickName: vi.fn().mockReturnValue('swift-fox'),
 }));
 
+// Mock agent-id (generateQuickAgentId) — default returns a stable unique value per call
+vi.mock('../../shared/agent-id', () => ({
+  generateQuickAgentId: vi.fn().mockImplementation(() => `quick_${Date.now()}_test`),
+}));
+
 // Mock ipc-broadcast (used for notifying renderer of annex-spawned agents)
 const mockBroadcastToAllWindows = vi.fn();
 vi.mock('../util/ipc-broadcast', () => ({
@@ -209,6 +214,7 @@ import * as pluginManifestRegistry from './plugin-manifest-registry';
 import * as pluginStorage from './plugin-storage';
 import * as fileServiceModule from './file-service';
 import { generateQuickName } from '../../shared/name-generator';
+import * as agentIdModule from '../../shared/agent-id';
 import { appLog } from './log-service';
 import Bonjour from 'bonjour-service';
 
@@ -684,6 +690,60 @@ describe('annex-server', () => {
       expect(res.status).toBe(404);
       expect(JSON.parse(res.body)).toEqual({ error: 'agent_not_found' });
     });
+
+    // CQ-RC-01: regression — same-ID re-spawn within the 60s cleanup window must not
+    // delete the new entry when the stale timer fires.
+    it('CQ-RC-01: re-spawning with the same agentId within 60s cancels the stale cleanup timer', async () => {
+      const FIXED_ID = 'quick_race_regression_test';
+      vi.mocked(projectStore.list).mockReturnValue([
+        { id: 'proj_1', name: 'test', path: '/tmp/test' },
+      ]);
+      vi.mocked(agentIdModule.generateQuickAgentId).mockReturnValue(FIXED_ID);
+      vi.mocked(annexEventBus.onPtyExit).mockClear();
+
+      // Start with real timers so startAndPair() works
+      const { port, token } = await startAndPair();
+
+      // Capture the onPtyExit callback registered during start()
+      const ptyExitCb = vi.mocked(annexEventBus.onPtyExit).mock.calls[0][0] as (
+        agentId: string, exitCode: number,
+      ) => void;
+
+      // Switch to fake timers — only timers created from this point are synthetic
+      vi.useFakeTimers({ shouldAdvanceTime: false });
+      try {
+        // (a) Insert first entry via HTTP spawn
+        const res1 = await request(
+          port, 'POST', '/api/v1/projects/proj_1/agents/quick',
+          { prompt: 'First task' },
+          authHeaders(token),
+        );
+        expect(res1.status).toBe(201);
+
+        // Simulate PTY exit — starts the 60s cleanup timer bound to entry1
+        ptyExitCb(FIXED_ID, 0);
+
+        const { trackedQuickAgents } = annexServer._testing;
+        expect(trackedQuickAgents.has(FIXED_ID)).toBe(true);
+        expect(trackedQuickAgents.get(FIXED_ID)?.timerId).toBeDefined();
+
+        // (b) Insert second entry with the same ID — should cancel entry1's timer
+        const res2 = await request(
+          port, 'POST', '/api/v1/projects/proj_1/agents/quick',
+          { prompt: 'Second task' },
+          authHeaders(token),
+        );
+        expect(res2.status).toBe(201);
+
+        // (c) Advance past original 60s window — stale timer must NOT fire
+        vi.advanceTimersByTime(65_000);
+
+        expect(trackedQuickAgents.has(FIXED_ID)).toBe(true);
+        expect(trackedQuickAgents.get(FIXED_ID)?.prompt).toBe('Second task');
+      } finally {
+        vi.useRealTimers();
+      }
+    }, 15_000);
   });
 
   // -------------------------------------------------------------------------

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -291,9 +291,16 @@ interface TrackedQuickAgent {
   parentAgentId: string | null;
   projectId: string;
   spawnedAt: number;
+  timerId?: ReturnType<typeof setTimeout>;
 }
 
 const trackedQuickAgents = new Map<string, TrackedQuickAgent>();
+
+function setTrackedQuickAgent(agentId: string, entry: TrackedQuickAgent): void {
+  const existing = trackedQuickAgents.get(agentId);
+  if (existing?.timerId !== undefined) clearTimeout(existing.timerId);
+  trackedQuickAgents.set(agentId, entry);
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -819,7 +826,7 @@ async function handleSpawnQuickAgent(
     projectId,
     spawnedAt: Date.now(),
   };
-  trackedQuickAgents.set(agentId, tracked);
+  setTrackedQuickAgent(agentId, tracked);
 
   // Broadcast agent:spawned
   broadcastAndBuffer('agent:spawned', {
@@ -2351,7 +2358,7 @@ async function handleSpawnQuickAgentWs(
     model: model || null, orchestrator, freeAgentMode,
     parentAgentId: parentAgentId || null, projectId: project.id, spawnedAt: Date.now(),
   };
-  trackedQuickAgents.set(agentId, tracked);
+  setTrackedQuickAgent(agentId, tracked);
 
   broadcastAndBuffer('agent:spawned', {
     id: agentId, name, kind: 'quick', status: 'starting', prompt,
@@ -2680,7 +2687,7 @@ export function start(): void {
         projectId: tracked.projectId,
         parentAgentId: tracked.parentAgentId,
       });
-      setTimeout(() => { trackedQuickAgents.delete(agentId); }, 60_000);
+      tracked.timerId = setTimeout(() => { trackedQuickAgents.delete(agentId); }, 60_000);
     }
   });
 
@@ -3260,4 +3267,5 @@ export const _testing = {
   SERVER_HEARTBEAT_INTERVAL_MS,
   wsAlive,
   get heartbeatInterval() { return heartbeatInterval; },
+  get trackedQuickAgents() { return trackedQuickAgents; },
 };

--- a/src/renderer/plugins/plugin-api-factory.test.ts
+++ b/src/renderer/plugins/plugin-api-factory.test.ts
@@ -595,6 +595,45 @@ describe('plugin-api-factory', () => {
 
       expect(cb).toHaveBeenCalledWith('color', 'red');
     });
+
+    // CQ-TS-01: settings.get with type guard validation
+    describe('CQ-TS-01: get with type guard', () => {
+      it('returns value when no guard is provided (backward-compatible)', () => {
+        usePluginStore.setState({
+          pluginSettings: { 'proj-1:test-plugin': { count: 42 } },
+        });
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        expect(api.settings.get('count')).toBe(42);
+      });
+
+      it('returns value when guard passes', () => {
+        usePluginStore.setState({
+          pluginSettings: { 'proj-1:test-plugin': { config: { enabled: true } } },
+        });
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        const isObj = (v: unknown): v is { enabled: boolean } =>
+          typeof v === 'object' && v !== null && 'enabled' in v;
+        expect(api.settings.get('config', isObj)).toEqual({ enabled: true });
+      });
+
+      it('CQ-TS-01 regression: throws with plugin name when guard fails instead of returning mistyped value', () => {
+        usePluginStore.setState({
+          pluginSettings: { 'proj-1:test-plugin': { config: 'not-an-object' } },
+        });
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        const isObj = (v: unknown): v is { enabled: boolean } =>
+          typeof v === 'object' && v !== null;
+        expect(() => api.settings.get('config', isObj)).toThrow(
+          '[plugin:test-plugin] settings.get("config"): stored value failed type validation',
+        );
+      });
+
+      it('returns undefined without throwing when value is absent, even with a guard', () => {
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        const isObj = (v: unknown): v is object => typeof v === 'object' && v !== null;
+        expect(api.settings.get('missing', isObj)).toBeUndefined();
+      });
+    });
   });
 
   // ── UIAPI ─────────────────────────────────────────────────────────────

--- a/src/renderer/plugins/plugin-api-settings.ts
+++ b/src/renderer/plugins/plugin-api-settings.ts
@@ -26,9 +26,14 @@ export function createSettingsAPI(ctx: PluginContext): SettingsAPI {
   ctx.subscriptions.push({ dispose: unsub });
 
   return {
-    get<T = unknown>(key: string): T | undefined {
+    get<T = unknown>(key: string, guard?: (v: unknown) => v is T): T | undefined {
       const allSettings = usePluginStore.getState().pluginSettings[settingsKey];
-      return allSettings?.[key] as T | undefined;
+      const value = allSettings?.[key];
+      if (value === undefined) return undefined;
+      if (guard !== undefined && !guard(value)) {
+        throw new Error(`[plugin:${ctx.pluginId}] settings.get("${key}"): stored value failed type validation`);
+      }
+      return value as T | undefined;
     },
     getAll(): Record<string, unknown> {
       return usePluginStore.getState().pluginSettings[settingsKey] || {};

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -635,7 +635,7 @@ export interface EventsAPI {
 }
 
 export interface SettingsAPI {
-  get<T = unknown>(key: string): T | undefined;
+  get<T = unknown>(key: string, guard?: (v: unknown) => v is T): T | undefined;
   getAll(): Record<string, unknown>;
   set(key: string, value: unknown): void;
   onChange(callback: (key: string, value: unknown) => void): Disposable;


### PR DESCRIPTION
## Summary
- **CQ-RC-01**: Fix race condition in `trackedQuickAgents` where a stale 60s cleanup timer could delete a newly re-spawned agent with the same ID, making it invisible to the system with no error
- **CQ-TS-01**: Fix plugin settings `get<T>()` silently casting unknown storage data to `T` without validation — add an optional type guard parameter that throws a typed error (with plugin name) on shape mismatch

## Changes

### CQ-RC-01 — `src/main/services/annex-server.ts`
- Added `timerId?: ReturnType<typeof setTimeout>` field to `TrackedQuickAgent` interface
- Introduced `setTrackedQuickAgent(agentId, entry)` helper that clears any existing cleanup timer before overwriting a map entry
- Replaced both `trackedQuickAgents.set(agentId, tracked)` call sites (HTTP handler + WS handler) with the safe helper
- The `onPtyExit` handler now stores the timer handle: `tracked.timerId = setTimeout(...)`
- Exposed `trackedQuickAgents` via `_testing` accessor for regression tests

### CQ-TS-01 — `src/renderer/plugins/plugin-api-settings.ts` + `src/shared/plugin-types.ts`
- Updated `SettingsAPI.get<T>()` signature to accept an optional `guard?: (v: unknown) => v is T` parameter
- Implementation validates the stored value with the guard before returning; throws `[plugin:ID] settings.get("key"): stored value failed type validation` on mismatch
- Missing keys return `undefined` without invoking the guard (preserving existing behavior)
- Callers without a guard behave identically to before (backward-compatible)

### Tests
- `src/main/services/annex-server.test.ts`: Added `vi.mock('../../shared/agent-id')` + regression test that pins the agentId, fires `onPtyExit` to start the 60s timer, re-spawns with the same ID, advances fake timers 65s, and asserts the second entry is still present
- `src/renderer/plugins/plugin-api-factory.test.ts`: Added 4 tests — guard passes, guard fails (regression), missing key with guard, no-guard backward compat

## Test Plan
- [x] `npx vitest run src/main/services/annex-server.test.ts src/renderer/plugins/plugin-api-factory.test.ts` — 520 tests pass
- [x] `npm test` — all pre-existing failures only (9 renderer tests, pre-existing on main); no regressions introduced
- [x] `npm run lint` — 0 errors

## Manual Validation
- **CQ-RC-01**: Spawn a quick agent, let it complete, spawn another with a forced ID collision within 60s — the second agent should remain visible in the snapshot after 60s. (The race is covered by the regression test in annex-server.test.ts.)
- **CQ-TS-01**: Plugin calling `api.settings.get('key', myGuard)` with a stored value that fails the guard will now throw instead of silently returning a mistyped object.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)