### PR TITLE
fix(perf/theme): O(n²) HTTP body accumulation + launch wrapper theme tokens (P-C-1, VQ-TR-01)

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -2420,4 +2420,56 @@ describe('annex-server', () => {
       expect(_testing.isValidToken('nonexistent')).toBe(false);
     });
   });
+
+  describe('readBody — chunked accumulation (P-C-1)', () => {
+    it('correctly assembles a body delivered in many small chunks', async () => {
+      const { _testing } = await import('./annex-server');
+      const { EventEmitter } = await import('events');
+
+      const mockReq = new EventEmitter() as any;
+      const resultPromise = _testing.readBody(mockReq);
+
+      // 900 chunks × 1 KB = ~900 KB (well under the 1 MB limit)
+      const chunkCount = 900;
+      const chunkSize = 1024;
+      const chunk = Buffer.alloc(chunkSize, 'x');
+      for (let i = 0; i < chunkCount; i++) {
+        mockReq.emit('data', chunk);
+      }
+      mockReq.emit('end');
+
+      const result = await resultPromise;
+      expect(result).toBe('x'.repeat(chunkCount * chunkSize));
+      expect(result.length).toBe(chunkCount * chunkSize);
+    });
+
+    it('rejects when body exceeds MAX_BODY_SIZE', async () => {
+      const { _testing } = await import('./annex-server');
+      const { EventEmitter } = await import('events');
+
+      const mockReq = new EventEmitter() as any;
+      mockReq.destroy = vi.fn();
+      const resultPromise = _testing.readBody(mockReq);
+
+      // Send chunks exceeding 1 MB
+      const bigChunk = Buffer.alloc(600 * 1024, 'y'); // 600 KB
+      mockReq.emit('data', bigChunk);
+      mockReq.emit('data', bigChunk); // total 1200 KB > 1 MB limit
+
+      await expect(resultPromise).rejects.toThrow('Body exceeded maximum allowed size');
+      expect(mockReq.destroy).toHaveBeenCalled();
+    });
+
+    it('rejects on stream error', async () => {
+      const { _testing } = await import('./annex-server');
+      const { EventEmitter } = await import('events');
+
+      const mockReq = new EventEmitter() as any;
+      const resultPromise = _testing.readBody(mockReq);
+
+      mockReq.emit('error', new Error('connection reset'));
+
+      await expect(resultPromise).rejects.toThrow('connection reset');
+    });
+  });
 });

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -335,16 +335,18 @@ const MAX_BODY_SIZE = 1024 * 1024; // 1 MB
 
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
-    let body = '';
+    const chunks: Buffer[] = [];
+    let totalSize = 0;
     req.on('data', (chunk: Buffer) => {
-      if (body.length + chunk.length > MAX_BODY_SIZE) {
+      if (totalSize + chunk.length > MAX_BODY_SIZE) {
         req.destroy();
         reject(new Error('Body exceeded maximum allowed size'));
         return;
       }
-      body += chunk;
+      totalSize += chunk.length;
+      chunks.push(chunk);
     });
-    req.on('end', () => resolve(body));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString()));
     req.on('error', (err) => reject(err));
   });
 }
@@ -3256,6 +3258,7 @@ export function getWsAuthType(ws: WebSocket): WsAuthType {
 export const _testing = {
   get sessionTokens() { return sessionTokens; },
   isValidToken,
+  readBody,
   TOKEN_TTL_MS,
   SERVER_HEARTBEAT_INTERVAL_MS,
   wsAlive,

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -60,18 +60,18 @@ function McpConfigRow({
             type="checkbox"
             checked={checked}
             onChange={onToggle}
-            className="w-3.5 h-3.5 rounded border-surface-2 bg-surface-0 text-indigo-500 focus:ring-indigo-500 shrink-0"
+            className="w-3.5 h-3.5 rounded border-surface-2 bg-surface-0 text-ctp-blue focus:ring-ctp-blue shrink-0"
           />
           <span className="text-xs text-ctp-text truncate flex items-center gap-1.5">
             {entry.name}
             {entry.state === 'new' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-300 uppercase tracking-wider">new</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-green/15 text-ctp-green uppercase tracking-wider">new</span>
             )}
             {entry.state === 'changed' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-300 uppercase tracking-wider">changed</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-yellow/15 text-ctp-yellow uppercase tracking-wider">changed</span>
             )}
             {entry.state === 'removed' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/15 text-red-300 uppercase tracking-wider">removed</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-red/15 text-ctp-red uppercase tracking-wider">removed</span>
             )}
           </span>
         </label>
@@ -91,7 +91,7 @@ function McpConfigRow({
           {textArgs.map((arg) => (
             <div key={arg.name} className="flex items-center gap-2">
               <span className="text-[10px] text-ctp-subtext0 font-mono w-28 text-right shrink-0 flex items-center justify-end gap-1">
-                {arg.required && <span className="w-1 h-1 rounded-full bg-amber-400 inline-block" title="Required" />}
+                {arg.required && <span className="w-1 h-1 rounded-full bg-ctp-yellow inline-block" title="Required" />}
                 {arg.name.replace(/^--/, '')}
               </span>
               <input
@@ -99,7 +99,7 @@ function McpConfigRow({
                 value={configs[arg.name] || ''}
                 onChange={(e) => onConfigChange(arg.name, e.target.value)}
                 placeholder={arg.description || ''}
-                className="flex-1 text-xs bg-surface-0 border border-surface-2 rounded px-2 py-1 text-ctp-text placeholder:text-ctp-subtext0/40 placeholder:italic focus:outline-none focus:border-indigo-500/50 transition-colors"
+                className="flex-1 text-xs bg-surface-0 border border-surface-2 rounded px-2 py-1 text-ctp-text placeholder:text-ctp-subtext0/40 placeholder:italic focus:outline-none focus:border-ctp-blue/50 transition-colors"
               />
             </div>
           ))}
@@ -115,7 +115,7 @@ function McpConfigRow({
                     title={arg.description || ''}
                     className={`text-[10px] px-2 py-0.5 rounded-full border transition-colors ${
                       active
-                        ? 'border-indigo-500/50 bg-indigo-500/15 text-indigo-300'
+                        ? 'border-ctp-blue/50 bg-ctp-blue/15 text-ctp-blue'
                         : 'border-surface-2 text-ctp-subtext0 hover:border-ctp-subtext0'
                     }`}
                   >

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -990,7 +990,7 @@ export function AgentSettingsView({ agent }: Props) {
                     checked={freeAgentMode}
                     onChange={(e) => handleFreeAgentModeChange(e.target.checked)}
                     disabled={isRunning || !(capabilities?.permissions ?? false)}
-                    className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
+                    className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-ctp-error"
                   />
                   <span className="text-sm text-ctp-text">Free Agent Mode</span>
                 </label>
@@ -1358,7 +1358,7 @@ export function AgentSettingsView({ agent }: Props) {
                       checked={qadFreeAgentMode}
                       onChange={(e) => { setQadFreeAgentMode(e.target.checked); setQadDirty(true); }}
                       disabled={isRunning || !(capabilities?.permissions ?? false)}
-                      className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
+                      className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-ctp-error"
                     />
                     <span className="text-xs text-ctp-subtext0">Free Agent Mode by default</span>
                   </label>

--- a/src/renderer/features/settings/ProjectSettings.tsx
+++ b/src/renderer/features/settings/ProjectSettings.tsx
@@ -364,7 +364,7 @@ function LaunchWrapperSection({ projectId, projectPath }: { projectId: string; p
           </button>
         </div>
         {hasDiff && (
-          <div className="flex items-center justify-between rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-300">
+          <div className="flex items-center justify-between rounded border border-ctp-yellow/30 bg-ctp-yellow/10 px-2 py-1.5 text-xs text-ctp-yellow">
             <span>
               {[
                 newCount && `${newCount} new`,
@@ -376,7 +376,7 @@ function LaunchWrapperSection({ projectId, projectPath }: { projectId: string; p
             </span>
             <button
               onClick={handleAcknowledge}
-              className="text-xs text-amber-300 hover:text-amber-200 cursor-pointer"
+              className="text-xs text-ctp-yellow hover:text-ctp-yellow/70 cursor-pointer"
             >
               Got it
             </button>
@@ -408,13 +408,13 @@ function LaunchWrapperSection({ projectId, projectPath }: { projectId: string; p
                     <span className="text-xs text-ctp-text truncate flex items-center gap-1.5">
                       {entry.name}
                       {entry.state === 'new' && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-300 uppercase tracking-wider">new</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-green/15 text-ctp-green uppercase tracking-wider">new</span>
                       )}
                       {entry.state === 'changed' && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-300 uppercase tracking-wider">changed</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-yellow/15 text-ctp-yellow uppercase tracking-wider">changed</span>
                       )}
                       {entry.state === 'removed' && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/15 text-red-300 uppercase tracking-wider">removed</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-red/15 text-ctp-red uppercase tracking-wider">removed</span>
                       )}
                     </span>
                   </label>


### PR DESCRIPTION
## Summary

- **P-C-1 (CRITICAL perf)**: `annex-server.ts:readBody()` accumulated HTTP body via `body += chunk` — O(n²) string allocations on every data event. Replaced with `Buffer[]` array accumulation + `Buffer.concat().toString()` at end. Size guard updated to use a separate `totalSize` counter so the 1 MB limit still works correctly. 3 new unit tests via `_testing.readBody` with a mock EventEmitter: 900-chunk assembly, over-limit rejection, stream error.

- **VQ-TR-01 (HIGH)**: Launch wrapper config UI introduced in PR #1450 used raw Tailwind palette colors (`bg-amber-500/10`, `bg-emerald-500/15`, `text-indigo-500`) in violation of semantic token conventions from the prior theme sprint. Migrated across `ProjectSettings.tsx` and `AgentSettingsView.tsx`:
  - `amber-500` → `ctp-yellow`
  - `emerald-500` → `ctp-green`
  - `indigo-500` → `ctp-blue`
  - `red-500` → `ctp-red` (removed badges, same pattern)

## Test plan

- [ ] POST request with a large chunked body assembles correctly (unit test: 900 × 1 KB chunks)
- [ ] Body over 1 MB is rejected with correct error
- [ ] Stream error propagates correctly
- [ ] Visual QA: launch wrapper config UI renders correctly with active theme (new/changed/removed badges, checkbox accent, toggle button active state, text field focus ring)
- [ ] Full suite: 474/474 test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)