### PR TITLE
fix(persistence): LB-PS-2026-05-02 + LB-PS-2026-05-03 — settings TOCTOU + blueprint version check

### DIFF
--- a/src/main/services/settings-store.test.ts
+++ b/src/main/services/settings-store.test.ts
@@ -308,6 +308,21 @@ describe('settings-store', () => {
       expect(result.name).toBe('default');
     });
 
+    it('concurrent updates both apply without losing either write (LB-PS-2026-05-02)', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ name: 'initial', count: 0, nested: { flag: false } }));
+
+      const store = createSettingsStore<TestSettings>('test.json', DEFAULTS);
+
+      await Promise.all([
+        store.update((current) => ({ ...current, name: 'from-update-1' })),
+        store.update((current) => ({ ...current, count: 99 })),
+      ]);
+
+      const final = store.get();
+      expect(final.name).toBe('from-update-1');
+      expect(final.count).toBe(99);
+    });
+
     it('sequential updates each see the result of the previous update', async () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ name: 'v1', count: 1, nested: { flag: false } }));
 

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -46,6 +46,8 @@ export function createSettingsStore<T>(
   let cachedSettings: T | null = null;
   let cacheLoaded = false;
   let pendingWrite: Promise<void> = Promise.resolve();
+  // Serializes concurrent update() calls so each read sees the prior write's result.
+  let updateLock: Promise<unknown> = Promise.resolve();
 
   function parseSettings(raw: string): T {
     const merged = {
@@ -106,9 +108,13 @@ export function createSettingsStore<T>(
       return queueWrite(cachedSettings);
     },
     update(fn: (current: T) => T): Promise<T> {
-      const current = store.get();
-      const updated = fn(current);
-      return store.save(updated).then(() => cloneSettings(updated));
+      const result = updateLock.catch(() => {}).then((): Promise<T> => {
+        const current = store.get();
+        const updated = fn(current);
+        return store.save(updated).then(() => cloneSettings(updated));
+      });
+      updateLock = result;
+      return result;
     },
   };
 
@@ -116,6 +122,7 @@ export function createSettingsStore<T>(
     cachedSettings = null;
     cacheLoaded = false;
     pendingWrite = Promise.resolve();
+    updateLock = Promise.resolve();
   });
 
   return store;

--- a/src/shared/blueprint-serialization.test.ts
+++ b/src/shared/blueprint-serialization.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   serializeBlueprint,
   deserializeBlueprint,
   generateBlueprintId,
+  BLUEPRINT_SCHEMA_VERSION,
 } from './blueprint-serialization';
 import type { BlueprintManifest } from './blueprint-types';
 
@@ -118,11 +119,21 @@ describe('deserializeBlueprint', () => {
     expect(() => deserializeBlueprint('{}')).toThrow('Invalid blueprint');
   });
 
-  it('throws on blueprint with wrong schemaVersion', () => {
+  it('warns on future schemaVersion instead of throwing (LB-PS-2026-05-03)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const bp = validBlueprint() as Record<string, unknown>;
-    bp.schemaVersion = 99;
-    const json = JSON.stringify(bp);
-    expect(() => deserializeBlueprint(json)).toThrow('schemaVersion must be 1');
+    bp.schemaVersion = 9999;
+    expect(() => deserializeBlueprint(JSON.stringify(bp))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('9999'));
+    warnSpy.mockRestore();
+  });
+
+  it('treats missing schemaVersion as version 1 (LB-PS-2026-05-03)', () => {
+    const bp = validBlueprint() as Record<string, unknown>;
+    delete bp.schemaVersion;
+    expect(() => deserializeBlueprint(JSON.stringify(bp))).not.toThrow();
+    const result = deserializeBlueprint(JSON.stringify(bp));
+    expect(result.schemaVersion).toBe(BLUEPRINT_SCHEMA_VERSION);
   });
 
   it('throws on blueprint with dangling wire refs', () => {

--- a/src/shared/blueprint-serialization.ts
+++ b/src/shared/blueprint-serialization.ts
@@ -7,6 +7,9 @@ import { validateBlueprint } from './blueprint-validation';
 // Public API
 // ---------------------------------------------------------------------------
 
+/** The highest schemaVersion this code fully understands. */
+export const BLUEPRINT_SCHEMA_VERSION = 1;
+
 /**
  * Serialize a BlueprintManifest to deterministic JSON (sorted keys, 2-space
  * indent). The output is stable across runs for the same input, which makes
@@ -20,6 +23,9 @@ export function serializeBlueprint(manifest: BlueprintManifest): string {
  * Parse a JSON string into a validated BlueprintManifest.
  *
  * Throws if the JSON is malformed or fails blueprint validation.
+ * Warns (does not throw) when schemaVersion is newer than BLUEPRINT_SCHEMA_VERSION
+ * so future blueprints degrade gracefully rather than crashing.
+ * A missing schemaVersion is treated as version 1 for backward compatibility.
  */
 export function deserializeBlueprint(json: string): BlueprintManifest {
   let parsed: unknown;
@@ -27,6 +33,18 @@ export function deserializeBlueprint(json: string): BlueprintManifest {
     parsed = JSON.parse(json);
   } catch (err) {
     throw new Error(`Invalid blueprint JSON: ${(err as Error).message}`);
+  }
+
+  if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const bp = parsed as Record<string, unknown>;
+    if (bp.schemaVersion === undefined || bp.schemaVersion === null) {
+      bp.schemaVersion = BLUEPRINT_SCHEMA_VERSION;
+    } else if (typeof bp.schemaVersion === 'number' && bp.schemaVersion > BLUEPRINT_SCHEMA_VERSION) {
+      console.warn(
+        `[blueprint-serialization] Blueprint schemaVersion ${bp.schemaVersion} is newer than supported version ${BLUEPRINT_SCHEMA_VERSION}. Some fields may be ignored.`,
+      );
+      bp.schemaVersion = BLUEPRINT_SCHEMA_VERSION;
+    }
   }
 
   const result = validateBlueprint(parsed);


### PR DESCRIPTION
## Summary

Two related persistence/data-safety fixes from the 2026-05-17 Quality Sprint Wave 2.

### LB-PS-2026-05-02 — settings-store.update TOCTOU (HIGH)
**File:** `src/main/services/settings-store.ts`

`update()` performed a read-modify-write with no serialization lock. Concurrent calls could interleave their reads before writes completed. Fixed by routing all `update()` calls through an `updateLock` Promise chain — each call waits for the previous one to fully resolve (including its disk write) before reading current state. The lock is included in `resetAllSettingsStoresForTests()` so tests remain isolated.

### LB-PS-2026-05-03 — Blueprint Deserialization Ignores Version Field (HIGH)
**File:** `src/shared/blueprint-serialization.ts`

`deserializeBlueprint` passed blueprints with unknown `schemaVersion` straight to `validateBlueprint` which threw. This means blueprints created by a newer app version would crash older clients rather than degrading gracefully. Fixed by:
- Adding `export const BLUEPRINT_SCHEMA_VERSION = 1` constant
- Before validation: if `schemaVersion > BLUEPRINT_SCHEMA_VERSION`, emit `console.warn` and treat as version 1 (graceful degradation)
- If `schemaVersion` is missing, default to 1 for backward compatibility

## Tests

**settings-store.test.ts** — 1 new test:
- `concurrent updates both apply without losing either write (LB-PS-2026-05-02)` — `Promise.all` with two independent field updates; asserts both fields survive

**blueprint-serialization.test.ts** — 2 new tests replacing the "throws on wrong schemaVersion" test:
- `warns on future schemaVersion instead of throwing (LB-PS-2026-05-03)` — schemaVersion 9999 → warn, no throw. Would fail on pre-fix code (no warn function existed)
- `treats missing schemaVersion as version 1 (LB-PS-2026-05-03)` — missing schemaVersion → defaults to BLUEPRINT_SCHEMA_VERSION. Would fail on pre-fix code (validateBlueprint would error on undefined schemaVersion)

57 targeted tests pass. Full suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)