### PR TITLE
fix(wave2): NF-001 sessionEnd hook + P-C-2 O(1) agent Map index

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -478,7 +478,18 @@ describe('CopilotCliProvider', () => {
       expect(written.hooks.userPromptSubmitted).toBeDefined();
     });
 
-    it('writes all 6 hook events', async () => {
+    // NF-001 regression: sessionEnd must be registered so GHCP agents signal "stopped"
+    it('NF-001: includes sessionEnd hook with 5s timeout', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      await provider.writeHooksConfig('/project', 'http://127.0.0.1:9999/hook');
+
+      const written = JSON.parse(vi.mocked(fsp.writeFile).mock.calls[0][1] as string);
+      expect(written.hooks.sessionEnd).toBeDefined();
+      expect(written.hooks.sessionEnd[0].type).toBe('command');
+      expect(written.hooks.sessionEnd[0].timeoutSec).toBe(5);
+    });
+
+    it('writes all 7 hook events', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       await provider.writeHooksConfig('/project', 'http://127.0.0.1:9999/hook');
 
@@ -489,8 +500,9 @@ describe('CopilotCliProvider', () => {
       expect(hookKeys).toContain('errorOccurred');
       expect(hookKeys).toContain('permissionRequest');
       expect(hookKeys).toContain('sessionStart');
+      expect(hookKeys).toContain('sessionEnd');
       expect(hookKeys).toContain('userPromptSubmitted');
-      expect(hookKeys).toHaveLength(6);
+      expect(hookKeys).toHaveLength(7);
     });
   });
 

--- a/src/main/orchestrators/copilot-cli-provider.ts
+++ b/src/main/orchestrators/copilot-cli-provider.ts
@@ -243,6 +243,7 @@ export class CopilotCliProvider extends BaseProvider implements HookCapable, Hea
       // PermissionRequest uses a long timeout to allow for remote approval via Annex
       permissionRequest: [{ type: 'command', bash: makeCurl('permissionRequest'), timeoutSec: 120 }],
       sessionStart: [{ type: 'command', bash: makeCurl('sessionStart'), timeoutSec: 5 }],
+      sessionEnd: [{ type: 'command', bash: makeCurl('sessionEnd'), timeoutSec: 5 }],
       userPromptSubmitted: [{ type: 'command', bash: makeCurl('userPromptSubmitted'), timeoutSec: 5 }],
     };
 

--- a/src/main/services/agent-config.test.ts
+++ b/src/main/services/agent-config.test.ts
@@ -1936,4 +1936,42 @@ describe('backup and recovery', () => {
       expect(result.restoredCount).toBe(0);
     });
   });
+
+  // P-C-2: O(1) Map index — behavioral correctness at scale
+  describe('P-C-2: getDurableConfig with 100-agent corpus', () => {
+    it('returns the correct agent from a 100-agent list without linear scan regression', async () => {
+      const AGENT_COUNT = 100;
+      const agents = Array.from({ length: AGENT_COUNT }, (_, i) => ({
+        id: `durable_${i + 1}_abc`,
+        name: `Agent ${i + 1}`,
+        color: 'indigo',
+        branch: `agent-${i + 1}/standby`,
+        worktreePath: `/test/agents/agent-${i + 1}`,
+        createdAt: '2024-01-01',
+      }));
+
+      mockAgentsFile(agents);
+
+      // Target agent is in the middle of the list — would require ~50 iterations with find()
+      const targetAgent = agents[49];
+      const result = await getDurableConfig(PROJECT_PATH, targetAgent.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(targetAgent.id);
+      expect(result!.name).toBe(targetAgent.name);
+    });
+
+    it('returns null for an unknown ID in a large corpus', async () => {
+      const agents = Array.from({ length: 100 }, (_, i) => ({
+        id: `durable_${i + 1}_abc`,
+        name: `Agent ${i + 1}`,
+        color: 'indigo',
+        createdAt: '2024-01-01',
+      }));
+      mockAgentsFile(agents);
+
+      const result = await getDurableConfig(PROJECT_PATH, 'durable_nonexistent_xyz');
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -86,9 +86,20 @@ export async function ensureGitignore(projectPath: string): Promise<void> {
 
 interface CacheEntry {
   agents: DurableAgentConfig[];
+  agentsById: Map<string, DurableAgentConfig>;
   dirty: boolean;
   flushTimer: ReturnType<typeof setTimeout> | null;
   pendingFlush: Promise<void> | null;
+}
+
+function buildAgentsById(agents: DurableAgentConfig[]): Map<string, DurableAgentConfig> {
+  return new Map(agents.map((a) => [a.id, a]));
+}
+
+/** Populate cache if needed, then return both the agents array and the O(1) ID index. */
+async function readAgentsEntry(projectPath: string): Promise<{ agents: DurableAgentConfig[]; agentsById: Map<string, DurableAgentConfig> }> {
+  const agents = await readAgents(projectPath);
+  return { agents, agentsById: configCache.get(projectPath)!.agentsById };
 }
 
 const configCache = new Map<string, CacheEntry>();
@@ -334,7 +345,7 @@ async function readAgents(projectPath: string): Promise<DurableAgentConfig[]> {
   let entry = configCache.get(projectPath);
   if (!entry) {
     const agents = await readAgentsFromDisk(projectPath);
-    entry = { agents, dirty: false, flushTimer: null, pendingFlush: null };
+    entry = { agents, agentsById: buildAgentsById(agents), dirty: false, flushTimer: null, pendingFlush: null };
     configCache.set(projectPath, entry);
     appLog('core:agent-config', 'info', `Cache initialized with ${agents.length} agent(s)`, {
       meta: { projectPath, agentIds: agents.map((a) => a.id) },
@@ -346,7 +357,7 @@ async function readAgents(projectPath: string): Promise<DurableAgentConfig[]> {
 async function writeAgents(projectPath: string, agents: DurableAgentConfig[]): Promise<void> {
   let entry = configCache.get(projectPath);
   if (!entry) {
-    entry = { agents, dirty: true, flushTimer: null, pendingFlush: null };
+    entry = { agents, agentsById: buildAgentsById(agents), dirty: true, flushTimer: null, pendingFlush: null };
     configCache.set(projectPath, entry);
   } else {
     // Log when agent count decreases — this is the signal for data loss
@@ -363,6 +374,7 @@ async function writeAgents(projectPath: string, agents: DurableAgentConfig[]): P
       });
     }
     entry.agents = agents;
+    entry.agentsById = buildAgentsById(agents);
   }
   entry.dirty = true;
   scheduleFlush(projectPath, entry);
@@ -465,8 +477,8 @@ export async function restoreFromBackup(projectPath: string): Promise<{ restored
 }
 
 export async function getDurableConfig(projectPath: string, agentId: string): Promise<DurableAgentConfig | null> {
-  const agents = await readAgents(projectPath);
-  return agents.find((a) => a.id === agentId) || null;
+  const { agentsById } = await readAgentsEntry(projectPath);
+  return agentsById.get(agentId) ?? null;
 }
 
 export async function updateDurableConfig(
@@ -474,8 +486,8 @@ export async function updateDurableConfig(
   agentId: string,
   updates: DurableConfigUpdates,
 ): Promise<void> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return;
   if (updates.quickAgentDefaults !== undefined) {
     agent.quickAgentDefaults = updates.quickAgentDefaults;
@@ -538,8 +550,8 @@ const MAX_SESSION_HISTORY = 50;
 
 /** Add or update a session entry in the agent's session history */
 export async function addSessionEntry(projectPath: string, agentId: string, entry: SessionInfo): Promise<void> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return;
 
   if (!agent.sessionHistory) {
@@ -575,8 +587,8 @@ export async function addSessionEntry(projectPath: string, agentId: string, entr
 
 /** Set or clear the friendly name for a session */
 export async function updateSessionName(projectPath: string, agentId: string, sessionId: string, friendlyName: string | null): Promise<void> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent?.sessionHistory) return;
 
   const session = agent.sessionHistory.find((s) => s.sessionId === sessionId);
@@ -750,8 +762,8 @@ export async function reorderDurable(projectPath: string, orderedIds: string[]):
 }
 
 export async function renameDurable(projectPath: string, agentId: string, newName: string): Promise<void> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return;
   agent.name = newName;
   await writeAgents(projectPath, agents);
@@ -762,8 +774,8 @@ export async function updateDurable(
   agentId: string,
   updates: { name?: string; color?: string; icon?: string | null; emoji?: string | null },
 ): Promise<void> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return;
   if (updates.name !== undefined) agent.name = updates.name;
   if (updates.color !== undefined) agent.color = updates.color;
@@ -787,8 +799,8 @@ export async function updateDurable(
 }
 
 export async function deleteDurable(projectPath: string, agentId: string): Promise<void> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return;
 
   // If no worktree, just unregister
@@ -867,8 +879,8 @@ function parseLogLine(line: string): GitLogEntry | null {
 }
 
 export async function getWorktreeStatus(projectPath: string, agentId: string): Promise<WorktreeStatus> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) {
     return { isValid: false, branch: '', uncommittedFiles: [], unpushedCommits: [], hasRemote: false };
   }
@@ -923,8 +935,8 @@ export async function getWorktreeStatus(projectPath: string, agentId: string): P
 }
 
 export async function deleteCommitAndPush(projectPath: string, agentId: string): Promise<DeleteResult> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return { ok: false, message: 'Agent not found' };
 
   const wt = agent.worktreePath;
@@ -965,8 +977,8 @@ export async function deleteCommitAndPush(projectPath: string, agentId: string):
 }
 
 export async function deleteWithCleanupBranch(projectPath: string, agentId: string): Promise<DeleteResult> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return { ok: false, message: 'Agent not found' };
 
   const wt = agent.worktreePath;
@@ -1017,8 +1029,8 @@ export async function deleteWithCleanupBranch(projectPath: string, agentId: stri
 }
 
 export async function deleteSaveAsPatch(projectPath: string, agentId: string, savePath: string): Promise<DeleteResult> {
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (!agent) return { ok: false, message: 'Agent not found' };
 
   const wt = agent.worktreePath;
@@ -1128,8 +1140,8 @@ export async function saveAgentIcon(projectPath: string, agentId: string, dataUr
   await fsp.writeFile(dest, Buffer.from(base64, 'base64'));
 
   // Update agents.json
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (agent) {
     agent.icon = filename;
     await writeAgents(projectPath, agents);
@@ -1164,8 +1176,8 @@ export async function removeAgentIconFile(agentId: string): Promise<void> {
 /** Remove agent icon metadata and file. */
 export async function removeAgentIcon(projectPath: string, agentId: string): Promise<void> {
   await removeAgentIconFile(agentId);
-  const agents = await readAgents(projectPath);
-  const agent = agents.find((a) => a.id === agentId);
+  const { agents, agentsById } = await readAgentsEntry(projectPath);
+  const agent = agentsById.get(agentId);
   if (agent) {
     delete agent.icon;
     await writeAgents(projectPath, agents);


### PR DESCRIPTION
## Summary
- **NF-001**: Register missing `sessionEnd` hook in GHCP `copilot-cli-provider.ts` — agents were never signaling stopped state
- **P-C-2**: Replace 13 O(n) `agents.find(a => a.id === agentId)` linear scans in `agent-config.ts` with O(1) Map lookups via a new `agentsById` Map maintained on `CacheEntry`

## Changes

### NF-001 — `src/main/orchestrators/copilot-cli-provider.ts`
- Added `sessionEnd` to `ourHooks` in `writeHooksConfig()` with `timeoutSec: 5`, matching the pattern of all other hook events
- Without this, GHCP agents never emitted a stop signal, leaving them permanently "running" in the agent lifecycle

### P-C-2 — `src/main/services/agent-config.ts`
- Added `agentsById: Map<string, DurableAgentConfig>` field to `CacheEntry` interface
- Added `buildAgentsById(agents)` pure helper that constructs the Map from an agents array
- Added `readAgentsEntry()` helper returning `{ agents, agentsById }` for callers that need both
- `readAgents()` now seeds the map on initial cache population
- `writeAgents()` rebuilds the map after every write, keeping it in sync
- Replaced all 13 `agents.find((a) => a.id === agentId)` calls across 8 functions with `agentsById.get(agentId) ?? null`

## Test Plan
- [x] **NF-001 regression** (`copilot-cli-provider.test.ts`): `NF-001: includes sessionEnd hook with 5s timeout` — verifies hook is present with correct timeout
- [x] **Hook count updated**: existing "writes all 6 hook events" test updated to assert 7 events including `sessionEnd`
- [x] **P-C-2 corpus test** (`agent-config.test.ts`): 100-agent corpus — returns correct agent at index 49 by ID
- [x] **P-C-2 corpus test**: 100-agent corpus — returns null for unknown ID (no false positives)
- [x] All 176 main+shared unit tests pass (`npm run test:unit`)
- [x] Lint: 0 errors

## Manual Validation
- No runtime behavior change for P-C-2 (pure performance optimization, same return values)
- NF-001: spawn a GHCP agent and confirm it transitions to stopped state when the session ends (previously it would remain "running" indefinitely)