### PR TITLE
fix(quality): TC-CRIT-03 ESLint no-readFileSync-in-tests + LB-CB-2026-05-02 mutation race guard

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,6 +65,24 @@ export default tseslint.config(
     },
   },
   {
+    files: [
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+      'test/**/*.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.object.name="fs"][callee.property.name="readFileSync"]',
+          message: 'Use behavioral tests (spies, output assertions) instead of reading source files in tests.',
+        },
+      ],
+    },
+  },
+  {
     ignores: [
       '.webpack/**',
       'out/**',

--- a/src/main/forge-plist-entries.test.ts
+++ b/src/main/forge-plist-entries.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -1734,6 +1734,7 @@ describe('annex-server', () => {
     it('notifySessionPause tracks sessionPaused state (structural)', () => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -1750,6 +1751,7 @@ describe('annex-server', () => {
     it('buildSnapshot includes sessionPaused in payload (structural)', () => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -1766,6 +1768,7 @@ describe('annex-server', () => {
     it('resets sessionPaused when last mTLS controller disconnects (structural)', () => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -1788,6 +1791,7 @@ describe('annex-server', () => {
       // This structural test reads the source to confirm the fix is in place.
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -1813,6 +1817,7 @@ describe('annex-server', () => {
     it('canvas:mutation handler calls broadcastSnapshotRefresh on success (structural)', () => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -1843,6 +1848,7 @@ describe('annex-server', () => {
     beforeAll(() => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -1944,6 +1950,7 @@ describe('annex-server', () => {
 
   describe('theme broadcast includes terminal colors', () => {
     it('snapshot includes terminalColors field', async () => {
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = await import('fs').then(fs => fs.readFileSync(
         path.join(__dirname, 'annex-server.ts'), 'utf-8',
       ));
@@ -1952,6 +1959,7 @@ describe('annex-server', () => {
     });
 
     it('broadcastThemeChanged includes terminalColors', async () => {
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = await import('fs').then(fs => fs.readFileSync(
         path.join(__dirname, 'annex-server.ts'), 'utf-8',
       ));
@@ -1966,6 +1974,7 @@ describe('annex-server', () => {
 
     beforeAll(() => {
       const fs = require('fs');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -2088,6 +2097,7 @@ describe('annex-server', () => {
       // handles wireDefinitions. Full behavioral tests exist in
       // remote-canvas-wire-sync.test.ts (5 tests covering restore, non-overwrite,
       // and replacement). This ensures the contract is stable.
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = await import('fs').then(fs => fs.readFileSync(
         path.join(__dirname, '../../renderer/plugins/builtin/canvas/canvas-store.ts'), 'utf-8',
       ));
@@ -2188,6 +2198,7 @@ describe('annex-server', () => {
     beforeAll(() => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -2231,6 +2242,7 @@ describe('annex-server', () => {
     it('handleWakeAgentWs calls waitForAgentRunning before broadcastSnapshotRefresh', () => {
       const fs = require('fs');
       const path = require('path');
+      // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion
       const source = fs.readFileSync(
         path.resolve(__dirname, 'annex-server.ts'),
         'utf-8',
@@ -2347,47 +2359,83 @@ describe('annex-server', () => {
 
   // --- LB-AN-006: Lock overlay timing fix ---
   describe('mTLS lock state broadcast ordering', () => {
-    it('broadcasts LOCK_STATE_CHANGED before awaiting buildSnapshot in connection handler', () => {
-      const fs = require('fs');
-      const path = require('path');
-      const source = fs.readFileSync(
-        path.resolve(__dirname, 'annex-server.ts'),
-        'utf-8',
+    it('broadcasts LOCK_STATE_CHANGED before buildSnapshot resolves (LB-AN-006 behavioral)', async () => {
+      // Regression: LOCK_STATE_CHANGED must fire synchronously at connection start,
+      // before the async buildSnapshot() I/O completes, so the satellite UI locks
+      // immediately without waiting for snapshot data.
+      const { _testing } = await import('./annex-server');
+      await startAndPair();
+
+      // Stall buildSnapshot's first async step so we can observe the race window
+      let resolveProjectList!: (v: any[]) => void;
+      vi.mocked(projectStore.list).mockReturnValueOnce(
+        new Promise<any[]>((r) => { resolveProjectList = r; }),
       );
 
-      // Find the wss.on('connection', ...) handler body
-      const connStart = source.indexOf("wss.on('connection', async (ws) => {");
-      expect(connStart).toBeGreaterThan(-1);
+      const { EventEmitter } = await import('events');
+      const mockWs = Object.assign(new EventEmitter(), {
+        send: vi.fn(),
+        ping: vi.fn(),
+        readyState: 1, // WebSocket.OPEN
+      }) as any;
 
-      // Locate the positions of the critical operations within the handler
-      const lockBroadcastPos = source.indexOf('broadcastToAllWindows(IPC.ANNEX.LOCK_STATE_CHANGED, {', connStart);
-      const buildSnapshotPos = source.indexOf('await buildSnapshot()', connStart);
+      // Pre-mark this WS as mTLS-authenticated (normally done by handleUpgrade)
+      _testing.wsAuthTypes.set(mockWs, 'mtls');
+      _testing.wsPeerFingerprints.set(mockWs, 'aa:bb:cc:dd');
+      mockBroadcastToAllWindows.mockClear();
 
-      expect(lockBroadcastPos).toBeGreaterThan(-1);
-      expect(buildSnapshotPos).toBeGreaterThan(-1);
+      // Emit 'connection' — triggers the wss.on('connection', ...) handler
+      _testing.wss!.emit('connection', mockWs);
 
-      // LOCK_STATE_CHANGED must be broadcast BEFORE buildSnapshot is awaited
-      expect(lockBroadcastPos).toBeLessThan(buildSnapshotPos);
-    });
+      // LOCK_STATE_CHANGED fires synchronously (before any await in the handler)
+      expect(mockBroadcastToAllWindows).toHaveBeenCalledWith(
+        'annex:lock-state-changed',
+        expect.objectContaining({ locked: true }),
+      );
+      // buildSnapshot hasn't resolved yet — snapshot message not sent
+      expect(mockWs.send).not.toHaveBeenCalled();
 
-    it('registers ws.on(close) before awaiting buildSnapshot in connection handler', () => {
-      const fs = require('fs');
-      const path = require('path');
-      const source = fs.readFileSync(
-        path.resolve(__dirname, 'annex-server.ts'),
-        'utf-8',
+      // Let buildSnapshot complete (cleanup)
+      resolveProjectList([]);
+      await new Promise((r) => setTimeout(r, 20));
+    }, 10_000);
+
+    it('registers ws.on(close) before buildSnapshot resolves (LB-AN-006 behavioral)', async () => {
+      // Regression: the close handler must be registered synchronously (before any
+      // await) so a disconnect during buildSnapshot I/O still releases the lock.
+      const { _testing } = await import('./annex-server');
+      await startAndPair();
+
+      let resolveProjectList!: (v: any[]) => void;
+      vi.mocked(projectStore.list).mockReturnValueOnce(
+        new Promise<any[]>((r) => { resolveProjectList = r; }),
       );
 
-      const connStart = source.indexOf("wss.on('connection', async (ws) => {");
-      const closeHandlerPos = source.indexOf("ws.on('close',", connStart);
-      const buildSnapshotPos = source.indexOf('await buildSnapshot()', connStart);
+      const { EventEmitter } = await import('events');
+      const registeredEvents: string[] = [];
+      const base = new EventEmitter() as any;
+      const origOn = base.on.bind(base);
+      const mockWs = Object.assign(base, {
+        send: vi.fn(),
+        ping: vi.fn(),
+        readyState: 1,
+        on: vi.fn().mockImplementation((event: string, handler: (...args: any[]) => void) => {
+          registeredEvents.push(event);
+          origOn(event, handler);
+          return mockWs;
+        }),
+      });
 
-      expect(closeHandlerPos).toBeGreaterThan(-1);
-      expect(buildSnapshotPos).toBeGreaterThan(-1);
+      _testing.wsAuthTypes.set(mockWs, 'bearer');
+      _testing.wss!.emit('connection', mockWs);
 
-      // close handler must be registered BEFORE buildSnapshot is awaited
-      expect(closeHandlerPos).toBeLessThan(buildSnapshotPos);
-    });
+      // close handler registered synchronously — before buildSnapshot awaits
+      expect(registeredEvents).toContain('close');
+      expect(mockWs.send).not.toHaveBeenCalled(); // buildSnapshot still pending
+
+      resolveProjectList([]);
+      await new Promise((r) => setTimeout(r, 20));
+    }, 10_000);
   });
 
   // --- SEC-11: Session token expiry ---

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -3262,5 +3262,8 @@ export const _testing = {
   TOKEN_TTL_MS,
   SERVER_HEARTBEAT_INTERVAL_MS,
   wsAlive,
+  wsAuthTypes,
+  wsPeerFingerprints,
+  get wss() { return wss; },
   get heartbeatInterval() { return heartbeatInterval; },
 };

--- a/src/main/services/file-service.test.ts
+++ b/src/main/services/file-service.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/main/shutdown-guard.test.ts
+++ b/src/main/shutdown-guard.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/main/util/ipc-broadcast-audit.test.ts
+++ b/src/main/util/ipc-broadcast-audit.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/renderer/features/popout/PopoutCanvasView.test.tsx
+++ b/src/renderer/features/popout/PopoutCanvasView.test.tsx
@@ -250,6 +250,51 @@ describe('PopoutCanvasView', () => {
     });
   });
 
+  // ─── LB-CB-2026-05-02 — mutation race: no IPC before initial state resolves ──
+
+  it('suppresses sendCanvasMutation until the initial IPC snapshot resolves', async () => {
+    // Regression: mutations fired before getCanvasState resolved could reach the
+    // leader window before it had a chance to apply the initial state, causing
+    // out-of-order updates. sendMutation must be gated on initialization.
+    let resolveSnapshot!: (v: any) => void;
+    vi.mocked(window.clubhouse.window.getCanvasState).mockReturnValueOnce(
+      new Promise((r) => { resolveSnapshot = r; }),
+    );
+
+    render(<PopoutCanvasView canvasId="canvas-1" projectId="proj-1" />);
+
+    // Component is still loading — no snapshot yet, so sendMutation is suppressed
+    if (capturedProps) {
+      capturedProps.onMoveView('view-1', { x: 999, y: 999 });
+    }
+    expect(window.clubhouse.window.sendCanvasMutation).not.toHaveBeenCalled();
+
+    // Resolve the snapshot — initialization completes
+    resolveSnapshot({
+      canvasId: 'canvas-1',
+      name: 'main',
+      views: [
+        { id: 'view-1', type: 'agent', position: { x: 0, y: 0 }, size: { width: 200, height: 200 }, title: 'Card 1' },
+      ],
+      viewport: { panX: 0, panY: 0, zoom: 1 },
+      nextZIndex: 1,
+      zoomedViewId: null,
+      selectedViewId: null,
+    });
+
+    // Wait for the component to finish loading and re-render with new props
+    await waitFor(() => expect(capturedProps).not.toBeNull());
+    await waitFor(() => expect(screen.queryByText('Loading canvas...')).not.toBeInTheDocument());
+
+    // Now mutations should be forwarded
+    capturedProps.onMoveView('view-1', { x: 200, y: 300 });
+    expect(window.clubhouse.window.sendCanvasMutation).toHaveBeenCalledWith(
+      'canvas-1', 'project-local',
+      expect.objectContaining({ type: 'moveView', viewId: 'view-1' }),
+      'proj-1',
+    );
+  });
+
   // Avoid unused-var warning on imported helper
   void fireEvent;
 });

--- a/src/renderer/features/popout/PopoutCanvasView.tsx
+++ b/src/renderer/features/popout/PopoutCanvasView.tsx
@@ -9,7 +9,7 @@
  *   the main window via IPC — no local state modification.
  * - Periodic reconciliation (every 30 seconds) catches any missed events.
  */
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { CanvasWorkspace } from '../../plugins/builtin/canvas/CanvasWorkspace';
 import type { CanvasView, CanvasViewType, Viewport, Position, Size } from '../../plugins/builtin/canvas/canvas-types';
 import { clampViewport } from '../../plugins/builtin/canvas/canvas-operations';
@@ -188,6 +188,8 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
   const popoutWireDefinitions = useMcpBindingStore((s) => s.bindings);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Guard against mutations firing before the initial IPC snapshot resolves.
+  const initializedRef = useRef(false);
 
   const loadProjects = useProjectStore((s) => s.loadProjects);
   const loadDurableAgents = useAgentStore((s) => s.loadDurableAgents);
@@ -227,6 +229,7 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
       } else {
         setError(`Canvas "${canvasId}" not found`);
       }
+      initializedRef.current = true;
       setLoading(false);
     })().catch((err) => {
       if (!cancelled) {
@@ -270,7 +273,7 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
   // ── Mutation forwarding via IPC ───────────────────────────────────
 
   const sendMutation = useCallback((mutation: CanvasMutation) => {
-    if (!canvasId) return;
+    if (!canvasId || !initializedRef.current) return;
     window.clubhouse.window.sendCanvasMutation(canvasId, scope, mutation, projectId);
   }, [canvasId, scope, projectId]);
 

--- a/src/renderer/plugins/builtin-canvas-widgets.test.ts
+++ b/src/renderer/plugins/builtin-canvas-widgets.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Built-in Canvas Widget Registration Tests
  *

--- a/src/renderer/plugins/builtin/canvas/annex-ui-fixes.test.ts
+++ b/src/renderer/plugins/builtin/canvas/annex-ui-fixes.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';

--- a/src/renderer/plugins/builtin/canvas/canvas-paused-overlay.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-paused-overlay.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/renderer/plugins/builtin/canvas/canvas-sleeping-agent-selector.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-sleeping-agent-selector.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/renderer/plugins/builtin/canvas/canvas-ux-fixes.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-ux-fixes.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/renderer/plugins/builtin/canvas/canvas-widget-tweaks.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-widget-tweaks.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Feature 1: File viewer read-only toggle ─────────────────────────

--- a/src/renderer/plugins/builtin/canvas/canvas-workspace-decomp.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-workspace-decomp.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Tests for M-PLUG-01: CanvasWorkspace decomposition.
  *

--- a/src/renderer/plugins/builtin/canvas/feature-gating.test.ts
+++ b/src/renderer/plugins/builtin/canvas/feature-gating.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import { getBuiltinPlugins, getDefaultEnabledIds, CANVAS_SUB_PLUGIN_IDS } from '../index';
 

--- a/src/renderer/plugins/builtin/canvas/main.test.ts
+++ b/src/renderer/plugins/builtin/canvas/main.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect, vi } from 'vitest';
 import { validateBuiltinPlugin } from '../builtin-plugin-testing';
 import { manifest } from './manifest';

--- a/src/renderer/plugins/plugin-api-widgets-remote.test.ts
+++ b/src/renderer/plugins/plugin-api-widgets-remote.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Tests that widget adapters (SleepingAgent, AgentAvatar) resolve agents
  * from both local and remote agent stores — fixing the issue where

--- a/src/renderer/scrollbar-autohide.test.ts
+++ b/src/renderer/scrollbar-autohide.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/renderer/stores/__tests__/selector-safety.test.ts
+++ b/src/renderer/stores/__tests__/selector-safety.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Zustand Selector Safety Tests
  *

--- a/src/renderer/stores/canvas-annex-sync.test.ts
+++ b/src/renderer/stores/canvas-annex-sync.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Tests for canvas-over-annex state synchronization.
  *

--- a/src/shared/eslint-ignores.test.ts
+++ b/src/shared/eslint-ignores.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Validates that eslint.config.mjs ignores generated output directories,
  * including those inside agent worktrees (.clubhouse/agents/**).

--- a/src/shared/ipc-channel-sync.test.ts
+++ b/src/shared/ipc-channel-sync.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * IPC Channel Sync Test — structural test verifying that every channel defined
  * in ipc-channels.ts is wired up in both handler registration (main process)

--- a/test/preload-bridge-sync.test.ts
+++ b/test/preload-bridge-sync.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(TC-CRIT-03): structural readFileSync tests pending behavioral conversion */
 /**
  * Automated check that test/setup-renderer.ts stays in sync with src/preload/index.ts.
  *


### PR DESCRIPTION
## Summary
- **TC-CRIT-03**: Add ESLint rule banning `fs.readFileSync` in test files; rewrite the two highest-risk annex-server structural tests as behavioral spy-based tests
- **LB-CB-2026-05-02**: Guard `sendMutation` in `PopoutCanvasView` with `initializedRef` to prevent IPC mutations firing before the initial canvas snapshot resolves

## Changes

### TC-CRIT-03 — ESLint rule + behavioral test rewrites

**`eslint.config.mjs`**: New scoped rule block targeting `**/*.test.ts`, `**/*.test.tsx`, `**/*.spec.ts`, `test/**/*.ts` with `no-restricted-syntax` error for `fs.readFileSync` calls. Error message directs to spy-based behavioral tests.

**`src/main/services/annex-server.ts`**: Expose `wsAuthTypes`, `wsPeerFingerprints`, and `wss` getter through `_testing` to allow tests to simulate authenticated WS connections without a real TLS handshake.

**`src/main/services/annex-server.test.ts`**: Rewrite the two `mTLS lock state broadcast ordering` tests:
- *LOCK broadcast ordering*: stalls `buildSnapshot` via deferred `projectStore.list`, emits `connection` on `_testing.wss` with a mock WS pre-marked as `mtls`, asserts `mockBroadcastToAllWindows` fires synchronously (before `mockWs.send` is ever called)
- *close handler ordering*: same deferred approach, asserts `registeredEvents` contains `close` before buildSnapshot I/O completes

12 remaining structural `readFileSync` tests in annex-server.test.ts suppressed with per-line `eslint-disable-next-line` + `TODO(TC-CRIT-03)` — these are lower-priority source-archaeology tests for future conversion. 20 other test files with pre-existing structural `readFileSync` tests suppressed with file-level `eslint-disable` + `TODO(TC-CRIT-03)`.

### LB-CB-2026-05-02 — Popout mutation race fix

**`src/renderer/features/popout/PopoutCanvasView.tsx`**:
- Add `const initializedRef = useRef(false)` near component state declarations
- Set `initializedRef.current = true` immediately after `getCanvasState` resolves and state is applied
- Gate `sendMutation` with `if (!canvasId || !initializedRef.current) return;`

**`src/renderer/features/popout/PopoutCanvasView.test.tsx`**: New regression test `suppresses sendCanvasMutation until the initial IPC snapshot resolves` — renders with delayed `getCanvasState` mock, fires `onMoveView` during loading phase, asserts `sendCanvasMutation` NOT called, resolves the snapshot, asserts mutation IS forwarded after initialization.

## Test Plan
- [x] `npm run test:unit` — 176 files, 5360 tests pass, 4 skipped (pre-existing)
- [x] `npm run lint` — 0 errors, 2340 warnings (all pre-existing)
- [x] `npm run typecheck` — pre-existing mermaid error only (on main before this PR)
- [x] New behavioral test: LOCK_STATE_CHANGED fires before buildSnapshot resolves
- [x] New behavioral test: ws.on(close) registered before buildSnapshot resolves
- [x] Regression test: PopoutCanvasView suppresses mutations during loading phase
- [x] All 10 existing PopoutCanvasView tests still pass

## Manual Validation
The `no-restricted-syntax` rule is active — any new `fs.readFileSync` call added to a test file will produce an ESLint error. The existing structural tests are suppressed with `TODO(TC-CRIT-03)` markers for future conversion tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)