### PR TITLE
fix(e2e): wait for workspace topmost before right-click — TC-FLAKE-01

### DIFF
--- a/e2e/canvas-golden-path.spec.ts
+++ b/e2e/canvas-golden-path.spec.ts
@@ -243,12 +243,29 @@ test.describe('Canvas golden path', () => {
     const workspace = window.locator('[data-testid="canvas-workspace"]');
     await expect(workspace).toBeVisible({ timeout: 5_000 });
 
+    // Wait for the workspace background to be the topmost element at the target
+    // click position before right-clicking. The canvas context-menu handler guards
+    // e.target === e.currentTarget — any transient child element (canvas-tab
+    // transition overlay, initializing component) at (120,120) silently suppresses
+    // the menu. This was the root cause of the TC-FLAKE-01 intermittent failure
+    // that appeared on retry1 across two separate CI runs (#1464, #1466).
+    await window.waitForFunction(
+      () => {
+        const ws = document.querySelector('[data-testid="canvas-workspace"]') as HTMLElement | null;
+        if (!ws) return false;
+        const { left, top } = ws.getBoundingClientRect();
+        const el = document.elementFromPoint(left + 120, top + 120);
+        return el === ws;
+      },
+      { timeout: 5_000 },
+    ).catch(() => {});
+
     // Create zone at a known position — use x:120,y:120 to stay clear of the rail
     // which can overlap the workspace at small x offsets on Windows CI (causing the
     // rail's Review button to intercept the synthetic click at that viewport coordinate).
     // force:true bypasses the macOS CI stability check (element visible but not yet "stable").
     await workspace.click({ button: 'right', position: { x: 120, y: 120 }, force: true });
-    await expect(window.locator('[data-testid="canvas-context-menu"]')).toBeVisible({ timeout: 8_000 });
+    await expect(window.locator('[data-testid="canvas-context-menu"]')).toBeVisible({ timeout: 10_000 });
     await window.locator('[data-testid="canvas-context-menu-zone"]').click();
 
     const zoneCard = workspace.locator('[data-testid^="zone-card-"]').first();


### PR DESCRIPTION
## Summary

- **TC-FLAKE-01**: `canvas-golden-path.spec.ts:242` — `create zone and agent view, then delete empty zone` — intermittent context-menu failure on CI retry1 (appeared on #1464 and #1466)

## Root cause

The canvas context-menu handler (`useCanvasContextMenu.ts:62`) guards:
```ts
if (e.target !== e.currentTarget) return;
```
Any transient child element at the right-click position silently suppresses the menu with no error output. After earlier `beforeEach` cycles create and destroy canvas tabs, a brief transition state can leave a child overlay at position `(120, 120)` within the workspace. When the right-click fires during this window, `e.target !== e.currentTarget` and the menu never appears — causing `expect(canvas-context-menu).toBeVisible()` to time out.

## Fix

Added a `waitForFunction` guard before the right-click that uses `document.elementFromPoint` to confirm the workspace element is topmost at the target coordinate. Raises the context-menu visibility timeout 8s → 10s for additional margin. The guard uses `.catch(() => {})` so the test still fails with a useful message from the `expect` if something unexpectedly persistent blocks the workspace.

```ts
await window.waitForFunction(
  () => {
    const ws = document.querySelector('[data-testid="canvas-workspace"]') as HTMLElement | null;
    if (!ws) return false;
    const { left, top } = ws.getBoundingClientRect();
    const el = document.elementFromPoint(left + 120, top + 120);
    return el === ws;
  },
  { timeout: 5_000 },
).catch(() => {});
```

## Test plan

- [ ] `canvas-golden-path.spec.ts:242` passes on all three platforms (macOS, Ubuntu, Windows)
- [ ] No regressions in other canvas golden-path tests
- [ ] Pre-existing 474/474 unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)