### PR TITLE
fix(a11y): migrate 22 files to canonical focus-ring* utilities (VQ-FI-01)

### DIFF
--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -99,7 +99,7 @@ function McpConfigRow({
                 value={configs[arg.name] || ''}
                 onChange={(e) => onConfigChange(arg.name, e.target.value)}
                 placeholder={arg.description || ''}
-                className="flex-1 text-xs bg-surface-0 border border-surface-2 rounded px-2 py-1 text-ctp-text placeholder:text-ctp-subtext0/40 placeholder:italic focus:outline-none focus:border-ctp-blue/50 transition-colors"
+                className="flex-1 text-xs bg-surface-0 border border-surface-2 rounded px-2 py-1 text-ctp-text placeholder:text-ctp-subtext0/40 placeholder:italic focus-ring-dim transition-colors"
               />
             </div>
           ))}
@@ -1160,7 +1160,7 @@ export function AgentSettingsView({ agent }: Props) {
                   onChange={(e) => { setInstructions(e.target.value); setInstructionsDirty(true); }}
                   disabled={isRunning}
                   placeholder={`Agent instructions written to ${instructionsFileLabel}...`}
-                  className={`w-full h-40 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  className={`w-full h-40 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                   spellCheck={false}
                 />
               </section>
@@ -1251,7 +1251,7 @@ export function AgentSettingsView({ agent }: Props) {
                       onChange={(e) => { setPermAllow(e.target.value); setPermDirty(true); }}
                       disabled={isRunning}
                       placeholder={"Bash(git checkout:*)\nBash(git pull:*)\nBash(npm run:*)"}
-                      className={`w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      className={`w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                       spellCheck={false}
                     />
                   </div>
@@ -1262,7 +1262,7 @@ export function AgentSettingsView({ agent }: Props) {
                       onChange={(e) => { setPermDeny(e.target.value); setPermDirty(true); }}
                       disabled={isRunning}
                       placeholder={"WebFetch\nBash(curl *)\nRead(./.env)"}
-                      className={`w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      className={`w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                       spellCheck={false}
                     />
                   </div>
@@ -1299,7 +1299,7 @@ export function AgentSettingsView({ agent }: Props) {
                     onChange={(e) => { setQadSystemPrompt(e.target.value); setQadDirty(true); }}
                     disabled={isRunning}
                     placeholder="System prompt appended to quick agents spawned by this agent..."
-                    className={`w-full h-28 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    className={`w-full h-28 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                     spellCheck={false}
                   />
                 </div>
@@ -1310,7 +1310,7 @@ export function AgentSettingsView({ agent }: Props) {
                     onChange={(e) => { setQadAllowedTools(e.target.value); setQadDirty(true); }}
                     disabled={isRunning}
                     placeholder={"Bash(npm test:*)\nEdit\nWrite"}
-                    className={`w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    className={`w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                     spellCheck={false}
                   />
                 </div>
@@ -1320,7 +1320,7 @@ export function AgentSettingsView({ agent }: Props) {
                     value={qadDefaultModel}
                     onChange={(e) => { setQadDefaultModel(e.target.value); setQadDirty(true); }}
                     disabled={isRunning}
-                    className={`w-full bg-surface-0 text-ctp-text text-sm rounded-lg px-3 py-2 border border-surface-1 focus:border-ctp-accent focus:outline-none ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    className={`w-full bg-surface-0 text-ctp-text text-sm rounded-lg px-3 py-2 border border-surface-1 focus-ring ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                   >
                     {MODEL_OPTIONS.map((opt) => (
                       <option key={opt.id} value={opt.id}>{opt.label}</option>
@@ -1334,7 +1334,7 @@ export function AgentSettingsView({ agent }: Props) {
                       onChange={(e) => { setQadCustomModel(e.target.value); setQadDirty(true); }}
                       placeholder="e.g. claude-opus-4-6"
                       disabled={isRunning}
-                      className={`mt-1.5 w-full bg-surface-0 text-ctp-text text-sm rounded-lg px-3 py-2 border border-surface-1 focus:border-ctp-accent focus:outline-none placeholder:text-ctp-overlay0 ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      className={`mt-1.5 w-full bg-surface-0 text-ctp-text text-sm rounded-lg px-3 py-2 border border-surface-1 focus-ring placeholder:text-ctp-overlay0 ${isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
                     />
                   )}
                 </div>

--- a/src/renderer/features/agents/structured/ActionBar.tsx
+++ b/src/renderer/features/agents/structured/ActionBar.tsx
@@ -44,7 +44,7 @@ export function ActionBar({ agentId: _agentId, elapsed, usage, isComplete, onSto
         <div className="flex-1 flex items-center gap-2">
           <input
             type="text"
-            className="flex-1 bg-ctp-base border border-surface-0 rounded px-2 py-1 text-xs text-ctp-text placeholder:text-ctp-subtext0 outline-none focus:border-ctp-accent/50 transition-colors"
+            className="flex-1 bg-ctp-base border border-surface-0 rounded px-2 py-1 text-xs text-ctp-text placeholder:text-ctp-subtext0 focus-ring-dim transition-colors"
             placeholder="Send a message..."
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/src/renderer/features/assistant/AssistantInput.tsx
+++ b/src/renderer/features/assistant/AssistantInput.tsx
@@ -66,7 +66,7 @@ export function AssistantInput({ onSend, disabled = false, status }: Props) {
       <div className="max-w-[600px] mx-auto flex items-end gap-2">
         <textarea
           ref={textareaRef}
-          className="flex-1 bg-ctp-base border border-surface-0 rounded-lg px-3 py-2 text-sm text-ctp-text placeholder:text-ctp-subtext0 outline-none focus:border-ctp-accent/50 transition-colors resize-none overflow-hidden"
+          className="flex-1 bg-ctp-base border border-surface-0 rounded-lg px-3 py-2 text-sm text-ctp-text placeholder:text-ctp-subtext0 focus-ring-dim transition-colors resize-none overflow-hidden"
           placeholder={placeholder}
           value={message}
           onChange={(e) => setMessage(e.target.value)}

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -238,7 +238,7 @@ export function BlueprintGallery() {
             <select
               value={sortMode}
               onChange={(e) => setSortMode(e.target.value as SortMode)}
-              className="text-[10px] bg-ctp-mantle border border-surface-0 rounded px-1.5 py-0.5 text-ctp-subtext1 outline-none"
+              className="text-[10px] bg-ctp-mantle border border-surface-0 rounded px-1.5 py-0.5 text-ctp-subtext1 focus-ring"
               data-testid="blueprint-gallery-sort"
             >
               <option value="name">Sort: Name</option>
@@ -262,7 +262,7 @@ export function BlueprintGallery() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search by name, description, or agent name..."
-            className="w-full px-3 py-1.5 text-xs bg-ctp-mantle border border-surface-0 rounded-md text-ctp-text placeholder:text-ctp-overlay0 outline-none focus:border-ctp-accent"
+            className="w-full px-3 py-1.5 text-xs bg-ctp-mantle border border-surface-0 rounded-md text-ctp-text placeholder:text-ctp-overlay0 focus-ring"
             autoFocus
             data-testid="blueprint-gallery-search"
           />

--- a/src/renderer/features/blueprints/ExportBlueprintDialog.tsx
+++ b/src/renderer/features/blueprints/ExportBlueprintDialog.tsx
@@ -129,7 +129,7 @@ export function ExportBlueprintDialog({
               value={name}
               onChange={(e) => setName(e.target.value)}
               onKeyDown={handleKeyDown}
-              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text outline-none focus:border-ctp-accent"
+              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text focus-ring"
               placeholder={canvas.name}
               data-testid="export-blueprint-name"
             />
@@ -142,7 +142,7 @@ export function ExportBlueprintDialog({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               onKeyDown={handleKeyDown}
-              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text outline-none focus:border-ctp-accent"
+              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text focus-ring"
               placeholder="Brief description of this blueprint"
               data-testid="export-blueprint-description"
             />

--- a/src/renderer/features/blueprints/ExportBundleDialog.tsx
+++ b/src/renderer/features/blueprints/ExportBundleDialog.tsx
@@ -111,7 +111,7 @@ export function ExportBundleDialog({
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text outline-none focus:border-ctp-accent"
+              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text focus-ring"
               placeholder={projectName}
               data-testid="export-bundle-name"
             />
@@ -122,7 +122,7 @@ export function ExportBundleDialog({
             <input
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text outline-none focus:border-ctp-accent"
+              className="w-full px-2 py-1.5 text-[12px] bg-surface-0 border border-surface-1 rounded text-ctp-text focus-ring"
               placeholder="Brief description of this bundle"
             />
           </div>

--- a/src/renderer/features/command-palette/CommandPaletteInput.tsx
+++ b/src/renderer/features/command-palette/CommandPaletteInput.tsx
@@ -42,7 +42,7 @@ export function CommandPaletteInput() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Type to search..."
-          className="flex-1 bg-transparent text-ctp-text text-sm outline-none placeholder:text-ctp-subtext0"
+          className="flex-1 bg-transparent text-ctp-text text-sm focus-ring placeholder:text-ctp-subtext0"
           spellCheck={false}
           autoComplete="off"
         />

--- a/src/renderer/features/focus-ring.test.tsx
+++ b/src/renderer/features/focus-ring.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for VQ-FI-01: Focus Ring Migration
+ *
+ * Each test renders a migrated interactive element and asserts that it carries
+ * the canonical focus-ring* utility class instead of the ad-hoc patterns
+ * (focus:outline-none, outline-none focus:border-ctp-accent, etc.).
+ *
+ * We check class presence because JSDOM does not compute CSS — asserting the
+ * class is present is equivalent to asserting that the canonical focus style
+ * will be applied at runtime.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HelpSearchInput } from './help/HelpSearchInput';
+import { AssistantInput } from './assistant/AssistantInput';
+import { ActionBar } from './agents/structured/ActionBar';
+import { CommandPaletteInput } from './command-palette/CommandPaletteInput';
+
+// ── CommandPaletteStore mock ───────────────────────────────────────────────
+vi.mock('../stores/commandPaletteStore', () => {
+  const hook: any = (selector: (s: any) => any) => selector({
+    query: '',
+    mode: 'all',
+    setQuery: vi.fn(),
+  });
+  hook.getState = () => ({ query: '', mode: 'all', setQuery: vi.fn() });
+  hook.subscribe = () => () => {};
+  return { useCommandPaletteStore: hook };
+});
+
+// ── CostTracker mock (child of ActionBar) ─────────────────────────────────
+vi.mock('./agents/structured/CostTracker', () => ({
+  CostTracker: () => null,
+}));
+
+// ── Helper: check no old ad-hoc patterns remain on element ────────────────
+function assertNoAdHocFocusPattern(el: HTMLElement): void {
+  const cls = el.className;
+  expect(cls, 'should not contain focus:outline-none').not.toContain('focus:outline-none');
+  expect(cls, 'should not contain focus:border-ctp-accent').not.toContain('focus:border-ctp-accent');
+  expect(cls, 'should not contain "outline-none focus:border"').not.toMatch(/outline-none.*focus:border/);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// HelpSearchInput
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('HelpSearchInput — focus ring (VQ-FI-01)', () => {
+  it('search input carries focus-ring class (was: bare outline-none)', () => {
+    render(<HelpSearchInput query="" onQueryChange={vi.fn()} />);
+    const input = screen.getByPlaceholderText('Search help...');
+    expect(input.className).toContain('focus-ring');
+    assertNoAdHocFocusPattern(input);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// CommandPaletteInput  (WCAG zero-indicator fix)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('CommandPaletteInput — focus ring (VQ-FI-01)', () => {
+  it('command palette input carries focus-ring class (was: bare outline-none, WCAG failure)', () => {
+    render(<CommandPaletteInput />);
+    const input = screen.getByPlaceholderText('Type to search...');
+    expect(input.className).toContain('focus-ring');
+    assertNoAdHocFocusPattern(input);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// AssistantInput
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('AssistantInput — focus ring (VQ-FI-01)', () => {
+  it('textarea carries focus-ring-dim class (was: outline-none focus:border-ctp-accent/50)', () => {
+    render(<AssistantInput onSend={vi.fn()} status="idle" />);
+    const ta = screen.getByPlaceholderText('Ask anything…') as HTMLTextAreaElement;
+    expect(ta.className).toContain('focus-ring-dim');
+    assertNoAdHocFocusPattern(ta);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// ActionBar
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('ActionBar — focus ring (VQ-FI-01)', () => {
+  it('message input carries focus-ring-dim class (was: outline-none focus:border-ctp-accent/50)', () => {
+    render(
+      <ActionBar
+        agentId="test-agent"
+        elapsed={0}
+        usage={null}
+        isComplete={false}
+        onStop={vi.fn()}
+        onSendMessage={vi.fn()}
+      />
+    );
+    const input = screen.getByPlaceholderText('Send a message...');
+    expect(input.className).toContain('focus-ring-dim');
+    assertNoAdHocFocusPattern(input);
+  });
+});

--- a/src/renderer/features/help/HelpSearchInput.tsx
+++ b/src/renderer/features/help/HelpSearchInput.tsx
@@ -33,7 +33,7 @@ export function HelpSearchInput({ query, onQueryChange }: HelpSearchInputProps) 
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         placeholder="Search help..."
-        className="flex-1 bg-transparent text-ctp-text text-sm outline-none placeholder:text-ctp-subtext0 min-w-0"
+        className="flex-1 bg-transparent text-ctp-text text-sm focus-ring placeholder:text-ctp-subtext0 min-w-0"
         spellCheck={false}
         autoComplete="off"
       />

--- a/src/renderer/features/settings/PairingWizard.tsx
+++ b/src/renderer/features/settings/PairingWizard.tsx
@@ -130,7 +130,7 @@ export function PairingWizard({ onClose }: PairingWizardProps) {
               onKeyDown={handlePinKeyDown}
               placeholder="000000"
               className="flex-1 px-3 py-2 text-sm rounded bg-surface-1 border border-surface-2
-                text-ctp-text placeholder:text-ctp-overlay0 outline-none focus:border-ctp-accent
+                text-ctp-text placeholder:text-ctp-overlay0 focus-ring
                 tracking-widest text-center font-mono"
             />
             <button

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -705,7 +705,7 @@ function CustomMarketplaceManager() {
                 value={addName}
                 onChange={(e) => setAddName(e.target.value)}
                 placeholder="Store name"
-                className="flex-1 px-2 py-1.5 rounded bg-ctp-base border border-surface-1 text-xs text-ctp-text placeholder:text-ctp-subtext0 outline-none focus:border-ctp-accent"
+                className="flex-1 px-2 py-1.5 rounded bg-ctp-base border border-surface-1 text-xs text-ctp-text placeholder:text-ctp-subtext0 focus-ring"
                 data-testid="custom-marketplace-name"
               />
               <input
@@ -713,7 +713,7 @@ function CustomMarketplaceManager() {
                 value={addUrl}
                 onChange={(e) => setAddUrl(e.target.value)}
                 placeholder="Registry URL (e.g. https://...registry.json)"
-                className="flex-[2] px-2 py-1.5 rounded bg-ctp-base border border-surface-1 text-xs text-ctp-text placeholder:text-ctp-subtext0 outline-none focus:border-ctp-accent"
+                className="flex-[2] px-2 py-1.5 rounded bg-ctp-base border border-surface-1 text-xs text-ctp-text placeholder:text-ctp-subtext0 focus-ring"
                 data-testid="custom-marketplace-url"
                 onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
               />

--- a/src/renderer/features/settings/PluginMarketplaceDialog.tsx
+++ b/src/renderer/features/settings/PluginMarketplaceDialog.tsx
@@ -500,7 +500,7 @@ export function PluginMarketplaceDialog({ onClose }: { onClose: () => void }) {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search plugins..."
-            className="w-full px-3 py-2 rounded-lg bg-surface-0 border border-surface-1 text-sm text-ctp-text placeholder:text-ctp-subtext0 outline-none focus:border-ctp-accent"
+            className="w-full px-3 py-2 rounded-lg bg-surface-0 border border-surface-1 text-sm text-ctp-text placeholder:text-ctp-subtext0 focus-ring"
             data-testid="marketplace-search"
           />
 

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -658,7 +658,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
               setDirty(true);
             }}
             placeholder="Default CLAUDE.md content for new agents..."
-            className="w-full h-28 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none"
+            className="w-full h-28 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring"
             spellCheck={false}
           />
         </div>
@@ -708,7 +708,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
               value={userAllowRules}
               onChange={(e) => { setPermAllow(e.target.value); setDirty(true); }}
               placeholder={"Bash(git checkout:*)\nBash(git pull:*)\nBash(npm run:*)"}
-              className="w-full h-16 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none"
+              className="w-full h-16 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring"
               spellCheck={false}
             />
           </div>
@@ -718,7 +718,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
               value={userDenyRules}
               onChange={(e) => { setPermDeny(e.target.value); setDirty(true); }}
               placeholder={"WebFetch\nBash(curl *)"}
-              className="w-full h-16 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none"
+              className="w-full h-16 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring"
               spellCheck={false}
             />
           </div>
@@ -760,7 +760,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             value={userMcpJson}
             onChange={(e) => { setMcpJson(e.target.value); setDirty(true); }}
             placeholder='{\n  "mcpServers": {}\n}'
-            className="w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus:border-ctp-accent focus:outline-none"
+            className="w-full h-20 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-3 resize-y border border-surface-1 focus-ring"
             spellCheck={false}
           />
         </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -125,6 +125,12 @@
     border-color: rgb(var(--ctp-error) / 0.5);
     box-shadow: 0 0 0 1px rgb(var(--ctp-error) / 0.3);
   }
+  .focus-ring-inset:focus,
+  .focus-ring-inset:focus-visible {
+    outline: none;
+    border-color: rgb(var(--ctp-accent));
+    box-shadow: inset 0 0 0 1px rgb(var(--ctp-accent) / 0.3);
+  }
 
   body {
     background-color: rgb(var(--ctp-base));

--- a/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
@@ -232,7 +232,7 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
           value={addressBar}
           onChange={(e) => setAddressBar(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="flex-1 min-w-0 px-2 py-0.5 rounded bg-surface-0 text-[11px] text-ctp-text border border-surface-1 outline-none focus:border-ctp-accent"
+          className="flex-1 min-w-0 px-2 py-0.5 rounded bg-surface-0 text-[11px] text-ctp-text border border-surface-1 focus-ring"
           placeholder="Enter URL..."
           data-testid="canvas-browser-address"
         />

--- a/src/renderer/plugins/builtin/browser/main.ts
+++ b/src/renderer/plugins/builtin/browser/main.ts
@@ -303,7 +303,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
         value: addressBar,
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => setAddressBar(e.target.value),
         onKeyDown: handleKeyDown,
-        className: 'flex-1 min-w-0 px-2 py-0.5 rounded bg-surface-0 text-xs text-ctp-text border border-surface-1 outline-none focus:border-ctp-accent',
+        className: 'flex-1 min-w-0 px-2 py-0.5 rounded bg-surface-0 text-xs text-ctp-text border border-surface-1 focus-ring',
         placeholder: 'Enter URL (https://example.com, localhost:3000, file:///path)...',
         'data-testid': 'browser-address-bar',
       }),

--- a/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
@@ -181,7 +181,7 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Search cards…"
-            className="w-48 h-6 pl-6 pr-2 text-xs bg-surface-0 border border-surface-1 rounded text-ctp-text placeholder:text-ctp-overlay0 outline-none focus:border-ctp-accent/50"
+            className="w-48 h-6 pl-6 pr-2 text-xs bg-surface-0 border border-surface-1 rounded text-ctp-text placeholder:text-ctp-overlay0 focus-ring-dim"
             data-testid="canvas-search-input"
           />
           <svg

--- a/src/renderer/plugins/builtin/files/FileTree.test.tsx
+++ b/src/renderer/plugins/builtin/files/FileTree.test.tsx
@@ -1182,8 +1182,8 @@ describe('FileTree — accessibility', () => {
     await screen.findByText('src');
 
     const treeContainer = container.querySelector('[role="tree"]');
-    expect(treeContainer?.className).toContain('focus:ring-1');
-    expect(treeContainer?.className).toContain('focus:ring-ctp-accent/50');
+    // Migrated to canonical focus-ring-inset utility (VQ-FI-01)
+    expect(treeContainer?.className).toContain('focus-ring-inset');
   });
 
   it('tree items have role="treeitem" and aria attributes', async () => {

--- a/src/renderer/plugins/builtin/files/FileTree.ts
+++ b/src/renderer/plugins/builtin/files/FileTree.ts
@@ -1269,7 +1269,7 @@ export function FileTree({ api }: { api: PluginAPI }) {
 
   return React.createElement('div', {
     ref: containerRef,
-    className: 'flex flex-col h-full bg-ctp-mantle text-ctp-text select-none focus:outline-none focus:ring-1 focus:ring-inset focus:ring-ctp-accent/50',
+    className: 'flex flex-col h-full bg-ctp-mantle text-ctp-text select-none focus-ring-inset',
     tabIndex: 0,
     role: 'tree',
     onKeyDown: handleKeyDown,
@@ -1381,7 +1381,7 @@ export function FileTree({ api }: { api: PluginAPI }) {
             value: filterText,
             onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFilterText(e.target.value),
             onKeyDown: (e: React.KeyboardEvent) => e.stopPropagation(), // prevent tree keyboard nav while typing
-            className: 'w-full bg-surface-0 text-ctp-text placeholder:text-ctp-subtext0 text-xs rounded px-2 py-0.5 outline-none focus:ring-1 focus:ring-ctp-accent/50 pr-5',
+            className: 'w-full bg-surface-0 text-ctp-text placeholder:text-ctp-subtext0 text-xs rounded px-2 py-0.5 focus-ring-dim pr-5',
             'aria-label': 'Filter files',
           }),
           filterText

--- a/src/renderer/plugins/builtin/files/SearchPanel.ts
+++ b/src/renderer/plugins/builtin/files/SearchPanel.ts
@@ -332,14 +332,14 @@ export function SearchPanel({ api }: { api: PluginAPI }) {
       },
         React.createElement('input', {
           type: 'text',
-          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-text outline-none placeholder:text-ctp-subtext0 focus:border-ctp-accent transition-colors',
+          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-text focus-ring placeholder:text-ctp-subtext0 transition-colors',
           placeholder: 'Include (e.g. src/**/*.ts)',
           value: includePattern,
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => setIncludePattern(e.target.value),
         }),
         React.createElement('input', {
           type: 'text',
-          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-text outline-none placeholder:text-ctp-subtext0 focus:border-ctp-accent transition-colors',
+          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-text focus-ring placeholder:text-ctp-subtext0 transition-colors',
           placeholder: 'Exclude (e.g. dist,*.min.js)',
           value: excludePattern,
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => setExcludePattern(e.target.value),

--- a/src/renderer/plugins/builtin/hub/AgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/AgentPicker.tsx
@@ -112,7 +112,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
                 <select
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
-                  className="flex-1 px-2 py-1.5 bg-surface-0 border border-surface-2 rounded text-xs text-ctp-text focus:outline-none"
+                  className="flex-1 px-2 py-1.5 bg-surface-0 border border-surface-2 rounded text-xs text-ctp-text focus-ring"
                 >
                   {modelOptions.map((m) => (
                     <option key={m.id} value={m.id}>{m.label}</option>

--- a/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
@@ -189,7 +189,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
                 <select
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
-                  className="flex-1 px-2 py-1.5 bg-surface-0 border border-surface-2 rounded text-xs text-ctp-text focus:outline-none"
+                  className="flex-1 px-2 py-1.5 bg-surface-0 border border-surface-2 rounded text-xs text-ctp-text focus-ring"
                 >
                   {modelOptions.map((m) => (
                     <option key={m.id} value={m.id}>{m.label}</option>

--- a/src/renderer/plugins/plugin-settings-renderer.tsx
+++ b/src/renderer/plugins/plugin-settings-renderer.tsx
@@ -70,7 +70,7 @@ export function PluginSettingsRenderer({ pluginId, settings, scope }: Props) {
               <select
                 value={String(value ?? '')}
                 onChange={(e) => handleChange(setting.key, e.target.value)}
-                className="w-full bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 outline-none focus:border-ctp-accent"
+                className="w-full bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 focus-ring"
               >
                 {setting.options.map((opt) => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -91,7 +91,7 @@ export function PluginSettingsRenderer({ pluginId, settings, scope }: Props) {
                 type="number"
                 value={String(value ?? '')}
                 onChange={(e) => handleChange(setting.key, Number(e.target.value))}
-                className="w-full bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 outline-none focus:border-ctp-accent"
+                className="w-full bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 focus-ring"
               />
             </div>
           );
@@ -110,7 +110,7 @@ export function PluginSettingsRenderer({ pluginId, settings, scope }: Props) {
                   value={String(value ?? '')}
                   onChange={(e) => handleChange(setting.key, e.target.value)}
                   placeholder="/path/to/directory"
-                  className="flex-1 bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 outline-none focus:border-ctp-accent"
+                  className="flex-1 bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 focus-ring"
                 />
                 <button
                   type="button"
@@ -140,7 +140,7 @@ export function PluginSettingsRenderer({ pluginId, settings, scope }: Props) {
               type="text"
               value={String(value ?? '')}
               onChange={(e) => handleChange(setting.key, e.target.value)}
-              className="w-full bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 outline-none focus:border-ctp-accent"
+              className="w-full bg-surface-0 text-ctp-text text-sm px-2 py-1.5 rounded border border-surface-2 focus-ring"
             />
           </div>
         );


### PR DESCRIPTION
## Summary
- Migrates 20 source files from ad-hoc focus ring CSS (raw `outline-none`, `focus:border-ctp-accent`, `focus:ring-1`) to the canonical `.focus-ring` / `.focus-ring-dim` / `.focus-ring-inset` utilities from Track E
- Fixes 4 WCAG 2.1 Level AA zero-indicator failures (AgentPicker, CrossProjectAgentPicker, CommandPaletteInput, HelpSearchInput had `focus:outline-none` with no replacement)
- Adds `.focus-ring-inset` CSS utility to `index.css` (inset box-shadow variant used by FileTree)

## Changes
**`src/renderer/index.css`**
- Added `.focus-ring-inset` utility: `box-shadow: inset 0 0 0 1px rgb(var(--ctp-accent) / 0.3)`

**WCAG zero-indicator fixes (had `focus:outline-none` with NO ring):**
- `AgentPicker.tsx` → `focus-ring`
- `CrossProjectAgentPicker.tsx` → `focus-ring`
- `CommandPaletteInput.tsx` → `focus-ring`
- `HelpSearchInput.tsx` → `focus-ring`

**Pattern migrations (`outline-none focus:border-ctp-accent` → `focus-ring`):**
- `AgentSettingsView.tsx` (8 textareas/inputs/selects)
- `ProjectAgentDefaultsSection.tsx` (4 textareas)
- `plugin-settings-renderer.tsx` (4 inputs)
- `ExportBlueprintDialog.tsx`, `ExportBundleDialog.tsx` (2 each)
- `BlueprintGallery.tsx`, `PluginListSettings.tsx`, `PluginMarketplaceDialog.tsx`, `PairingWizard.tsx`
- `BrowserCanvasWidget.tsx`, `browser/main.ts`, `SearchPanel.ts` (2), `CanvasSearch.tsx`

**Dim-variant migrations (`outline-none focus:border-ctp-accent/50` → `focus-ring-dim`):**
- `AgentSettingsView.tsx:102` (blue/50 border)
- `AssistantInput.tsx`, `ActionBar.tsx`, `CanvasSearch.tsx`
- `FileTree.ts:1384`

**Inset-variant migration:**
- `FileTree.ts:1272` — `focus:ring-1 focus:ring-inset focus:ring-ctp-accent/50` → `focus-ring-inset`

**Tests:**
- `focus-ring.test.tsx` — new regression tests for HelpSearchInput, CommandPaletteInput, AssistantInput, ActionBar
- `FileTree.test.tsx` — updated existing focus-ring class assertion to `focus-ring-inset`

## Test Plan
- [x] `focus-ring.test.tsx` — 4 tests assert canonical class presence + absence of old ad-hoc patterns
- [x] `FileTree.test.tsx` — updated accessibility test passes with `focus-ring-inset`
- [x] `npm test` — all non-pre-existing failures pass (pre-existing `mermaid` import failures unrelated to this PR)
- [x] `npm run lint` — 0 errors

## Manual Validation
- Focus any migrated input/textarea via keyboard (Tab key) — accent-colored border + shadow should appear
- Previously-broken elements (AgentPicker search, CrossProjectAgentPicker search, command palette, help search) now show visible keyboard focus ring
- FileTree panel: Tab to focus container — inset ring appears within bounds