### PR TITLE
fix(ui): replace bespoke spinners + bare empty states with primitives; fix canvas zoom overlay z-index (VQ-LS-01/02 + GH-1460)

### DIFF
--- a/src/renderer/components/EmojiPicker.tsx
+++ b/src/renderer/components/EmojiPicker.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
+import { EmptyState } from './EmptyState';
 
 // ── Emoji data ────────────────────────────────────────────────────────────────
 // Curated set of popular emojis organized by category.
@@ -238,7 +239,7 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
               {filtered.map(renderEmojiButton)}
             </div>
           ) : (
-            <p className="text-center text-xs text-ctp-overlay0 py-6">No results</p>
+            <EmptyState title="No results" compact />
           )
         ) : (
           // Categorized view

--- a/src/renderer/features/agents/AddAgentDialog.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.tsx
@@ -4,6 +4,7 @@ import { useModelOptions } from '../../hooks/useModelOptions';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { useEffectiveOrchestrators } from '../../hooks/useEffectiveOrchestrators';
 import { Modal } from '../../components/Modal';
+import { Spinner } from '../../components/Spinner';
 import type { McpCatalogEntry } from '../../../shared/types';
 
 interface Props {
@@ -118,7 +119,7 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
             {modelsLoading ? (
               <div className="mt-1 w-full bg-surface-0 border border-surface-2 rounded px-3 py-1.5 text-sm
                 text-ctp-subtext0 flex items-center gap-2">
-                <span className="inline-block w-3 h-3 border-2 border-ctp-subtext0 border-t-transparent rounded-full animate-spin" />
+                <Spinner size="xs" />
                 Loading models…
               </div>
             ) : (

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -18,6 +18,7 @@ import { useToastStore } from '../../stores/toastStore';
 import { useAnnexClientStore } from '../../stores/annexClientStore';
 import type { Agent, CompletedQuickAgent } from '../../../shared/types';
 import type { PersonaTemplate } from '../assistant/content/personas';
+import { EmptyState } from '../../components/EmptyState';
 
 const EMPTY_COMPLETED: CompletedQuickAgent[] = [];
 const EMPTY_AGENTS: Agent[] = [];
@@ -520,8 +521,8 @@ function AgentListInner() {
 
   if (!activeProject) {
     return (
-      <div className="p-3 text-ctp-subtext0 text-sm">
-        Select a project to manage agents
+      <div className="p-3">
+        <EmptyState title="Select a project to manage agents" compact />
       </div>
     );
   }
@@ -695,10 +696,11 @@ function AgentListInner() {
         )}
 
         {durableAgents.length === 0 && quickAgents.length === 0 && completedAgents.length === 0 && (
-          <div className="p-4 text-ctp-subtext0 text-xs text-center">
-            <p className="mb-2">No agents yet</p>
-            <p>Click <span className="text-ctp-accent">+ Agent</span> to create a durable agent, or use the dropdown for a quick session.</p>
-          </div>
+          <EmptyState
+            title="No agents yet"
+            description='Click + Agent to create a durable agent, or use the dropdown for a quick session.'
+            compact
+          />
         )}
       </div>
 

--- a/src/renderer/features/agents/AgentTerminal.tsx
+++ b/src/renderer/features/agents/AgentTerminal.tsx
@@ -12,6 +12,7 @@ import { useFileDrop } from '../terminal/useFileDrop';
 import { useTerminalFit } from '../terminal/useTerminalFit';
 import { ptyResize } from '../../services/project-proxy';
 import { rendererLog } from '../../plugins/renderer-logger';
+import { Spinner } from '../../components/Spinner';
 
 /** How long PTY output must be silent before we consider a resume "done". */
 const RESUME_SETTLE_MS = 1500;
@@ -681,7 +682,7 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
           data-testid="resume-overlay"
           className="absolute inset-0 flex flex-col items-center justify-center bg-ctp-base/90 z-10"
         >
-          <div className="w-6 h-6 border-2 border-ctp-accent border-t-transparent rounded-full animate-spin mb-3" />
+          <Spinner size="lg" className="mb-3" />
           <span className="text-sm text-ctp-subtext0">Resuming session...</span>
         </div>
       )}

--- a/src/renderer/features/agents/ConfigChangesDialog.tsx
+++ b/src/renderer/features/agents/ConfigChangesDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAgentStore } from '../../stores/agentStore';
 import { ConfigDiffCategory, ConfigDiffAction } from '../../../shared/types';
+import { Spinner } from '../../components/Spinner';
 
 interface DiffItem {
   id: string;
@@ -149,7 +150,7 @@ export function ConfigChangesDialog() {
       >
         {loading ? (
           <div className="flex items-center justify-center py-8">
-            <div className="w-5 h-5 border-2 border-ctp-subtext0 border-t-transparent rounded-full animate-spin" />
+            <Spinner />
           </div>
         ) : items.length === 0 ? (
           <>
@@ -270,7 +271,7 @@ export function ConfigChangesDialog() {
                   className="px-4 py-1.5 text-xs rounded bg-ctp-accent/80 text-ctp-base
                     hover:bg-ctp-accent cursor-pointer font-medium disabled:opacity-50 flex items-center gap-1.5"
                 >
-                  {executing && <span className="w-3 h-3 border-2 border-ctp-base/50 border-t-ctp-base rounded-full animate-spin" />}
+                  {executing && <Spinner size="xs" />}
                   Save to Clubhouse
                 </button>
               </div>

--- a/src/renderer/features/agents/DeleteAgentDialog.tsx
+++ b/src/renderer/features/agents/DeleteAgentDialog.tsx
@@ -5,6 +5,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useRemoteProjectStore, isRemoteAgentId, parseNamespacedId, isRemoteProjectId } from '../../stores/remoteProjectStore';
 import { useAnnexClientStore } from '../../stores/annexClientStore';
 import { WorktreeStatus } from '../../../shared/types';
+import { Spinner } from '../../components/Spinner';
 
 const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
   M: { label: 'M', cls: 'bg-ctp-warning/20 text-ctp-warning' },
@@ -177,7 +178,7 @@ export function DeleteAgentDialog() {
               className="px-4 py-1.5 text-xs rounded bg-ctp-error/80 text-white
                 hover:bg-ctp-error cursor-pointer font-medium disabled:opacity-50 flex items-center gap-1.5"
             >
-              {executing && <span className="w-3 h-3 border-2 border-white/50 border-t-white rounded-full animate-spin" />}
+              {executing && <Spinner size="xs" />}
               Remove
             </button>
           </div>
@@ -202,7 +203,7 @@ export function DeleteAgentDialog() {
       >
         {loading ? (
           <div className="flex items-center justify-center py-8">
-            <div className="w-5 h-5 border-2 border-ctp-subtext0 border-t-transparent rounded-full animate-spin" />
+            <Spinner />
           </div>
         ) : !isDirty ? (
           /* Clean state — simple confirmation */
@@ -245,7 +246,7 @@ export function DeleteAgentDialog() {
                 className="px-4 py-1.5 text-xs rounded bg-ctp-error/80 text-white
                   hover:bg-ctp-error cursor-pointer font-medium disabled:opacity-50 flex items-center gap-1.5"
               >
-                {executing && <span className="w-3 h-3 border-2 border-white/50 border-t-white rounded-full animate-spin" />}
+                {executing && <Spinner size="xs" />}
                 Delete
               </button>
             </div>
@@ -327,7 +328,7 @@ export function DeleteAgentDialog() {
                       <div className="text-xs text-ctp-subtext0 mt-0.5">{opt.description}</div>
                     </div>
                     {executing && (
-                      <span className="w-3 h-3 border-2 border-ctp-subtext0 border-t-transparent rounded-full animate-spin flex-shrink-0 mt-1" />
+                      <Spinner size="xs" className="mt-1" />
                     )}
                   </button>
                 ))}

--- a/src/renderer/features/agents/TemplateConfigDialog.tsx
+++ b/src/renderer/features/agents/TemplateConfigDialog.tsx
@@ -4,6 +4,7 @@ import { useModelOptions } from '../../hooks/useModelOptions';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { useEffectiveOrchestrators } from '../../hooks/useEffectiveOrchestrators';
 import { Modal } from '../../components/Modal';
+import { Spinner } from '../../components/Spinner';
 import type { PersonaTemplate } from '../assistant/content/personas';
 import type { McpCatalogEntry } from '../../../shared/types';
 
@@ -156,7 +157,7 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
             {modelsLoading ? (
               <div className="mt-1 w-full bg-surface-0 border border-surface-2 rounded px-3 py-1.5 text-sm
                 text-ctp-subtext0 flex items-center gap-2">
-                <span className="inline-block w-3 h-3 border-2 border-ctp-subtext0 border-t-transparent rounded-full animate-spin" />
+                <Spinner size="xs" />
                 Loading models...
               </div>
             ) : (

--- a/src/renderer/features/agents/TranscriptViewer.tsx
+++ b/src/renderer/features/agents/TranscriptViewer.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { formatDuration } from '../../utils/format';
+import { Spinner } from '../../components/Spinner';
 
 /** Page size for paginated transcript loading */
 const PAGE_SIZE = 100;
@@ -127,7 +128,7 @@ export function TranscriptViewer({ agentId }: Props) {
   }, [totalEvents, loadPage]);
 
   if (loading) {
-    return <div className="text-xs text-ctp-subtext0 p-3">Loading transcript...</div>;
+    return <div className="text-xs text-ctp-subtext0 p-3 flex items-center gap-2"><Spinner size="xs" /> Loading transcript...</div>;
   }
 
   if (error) {
@@ -162,7 +163,7 @@ export function TranscriptViewer({ agentId }: Props) {
     <div ref={scrollContainerRef} className="space-y-2 p-3 max-h-[400px] overflow-y-auto">
       {hasMore && (
         <div ref={sentinelRef} className="text-center py-1">
-          {loadingMore && <span className="text-[10px] text-ctp-subtext0">Loading earlier events...</span>}
+          {loadingMore && <span className="text-[10px] text-ctp-subtext0 flex items-center gap-1"><Spinner size="xs" /> Loading earlier events...</span>}
         </div>
       )}
       {items.map((item, i) => (

--- a/src/renderer/features/agents/structured/ToolCard.tsx
+++ b/src/renderer/features/agents/structured/ToolCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import type { ToolStart, ToolEnd } from '../../../../shared/structured-events';
+import { Spinner } from '../../../components/Spinner';
 
 export type ToolStatus = 'running' | 'completed' | 'error';
 
@@ -106,10 +107,7 @@ export function ToolCard({ tool, output, end, status }: Props) {
 function StatusIcon({ status }: { status: ToolStatus }) {
   if (status === 'running') {
     return (
-      <svg className="w-3.5 h-3.5 text-ctp-accent animate-spin" viewBox="0 0 16 16" fill="none">
-        <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
-        <path d="M14 8a6 6 0 00-6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-      </svg>
+      <Spinner size="xs" />
     );
   }
   if (status === 'error') {

--- a/src/renderer/features/annex/SatelliteDashboard.tsx
+++ b/src/renderer/features/annex/SatelliteDashboard.tsx
@@ -17,6 +17,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useAgentStore } from '../../stores/agentStore';
 import { getAgentColorHex } from '../../../shared/name-generator';
+import { EmptyState } from '../../components/EmptyState';
 import { AgentAvatar } from '../agents/AgentAvatar';
 import { STATUS_RING_COLORS as STATUS_RING_COLOR } from '../agents/status-colors';
 import type { Agent, AgentDetailedStatus } from '../../../shared/types';
@@ -418,19 +419,10 @@ export function SatelliteDashboard({ activeHostId }: SatelliteDashboardProps) {
         )}
 
         {projects.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <div className="w-16 h-16 rounded-2xl bg-surface-0 flex items-center justify-center mb-4">
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-ctp-subtext0">
-                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-                <line x1="8" y1="21" x2="16" y2="21" />
-                <line x1="12" y1="17" x2="12" y2="21" />
-              </svg>
-            </div>
-            <h3 className="text-base font-semibold text-ctp-text mb-1">No projects on this satellite</h3>
-            <p className="text-sm text-ctp-subtext0">
-              Open a project on the remote machine to see it here.
-            </p>
-          </div>
+          <EmptyState
+            title="No projects on this satellite"
+            description="Open a project on the remote machine to see it here."
+          />
         )}
       </div>
     </div>

--- a/src/renderer/features/app/ResumeBanner.tsx
+++ b/src/renderer/features/app/ResumeBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { Spinner } from '../../components/Spinner';
 
 export type ResumeStatus = 'pending' | 'resuming' | 'resumed' | 'failed' | 'manual' | 'timed_out';
 
@@ -53,7 +54,7 @@ export function ResumeBanner({ sessions, onManualResume, onDismiss }: ResumeBann
     >
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-xs font-medium text-ctp-green flex items-center gap-1.5">
-          <span className="animate-spin inline-block" style={{ animationDuration: '2s' }}>↻</span>
+          <Spinner size="xs" />
           Resuming {sessions.length} session{sessions.length !== 1 ? 's' : ''} after update
         </span>
         <button

--- a/src/renderer/features/assistant/AssistantActionCard.test.tsx
+++ b/src/renderer/features/assistant/AssistantActionCard.test.tsx
@@ -141,8 +141,8 @@ describe('AssistantActionCard', () => {
     render(<AssistantActionCard action={makeAction({ status: 'running' })} />);
     const card = screen.getByTestId('assistant-action-card');
     expect(card).toHaveAttribute('data-status', 'running');
-    // The spinning SVG uses animate-spin class
-    expect(card.querySelector('svg.animate-spin')).toBeInTheDocument();
+    // <Spinner> renders a span with role="status" and animate-spin
+    expect(card.querySelector('[role="status"]')).toBeInTheDocument();
   });
 
   it('shows skipped text when expanded in skipped state', () => {

--- a/src/renderer/features/assistant/AssistantActionCard.tsx
+++ b/src/renderer/features/assistant/AssistantActionCard.tsx
@@ -8,6 +8,7 @@ interface Props {
 }
 
 import { CREATION_TOOLS } from '../../../shared/mutating-tools';
+import { Spinner } from '../../components/Spinner';
 
 /** Map raw tool names to human-friendly labels. */
 const TOOL_LABELS: Record<string, string> = {
@@ -219,10 +220,7 @@ function StatusIcon({ status }: { status: ActionCardStatus }) {
     case 'pending':
     case 'running':
       return (
-        <svg className="w-3.5 h-3.5 text-ctp-accent animate-spin" viewBox="0 0 16 16" fill="none">
-          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
-          <path d="M14 8a6 6 0 00-6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
+        <Spinner size="xs" />
       );
     case 'completed':
       return (

--- a/src/renderer/features/popout/PopoutHubPane.tsx
+++ b/src/renderer/features/popout/PopoutHubPane.tsx
@@ -13,6 +13,7 @@ import { QuickAgentGhost } from '../agents/QuickAgentGhost';
 import { useAgentStore } from '../../stores/agentStore';
 import type { LeafPane } from '../../plugins/builtin/hub/pane-tree';
 import type { Agent, AgentDetailedStatus, CompletedQuickAgent } from '../../../shared/types';
+import { EmptyState } from '../../components/EmptyState';
 
 type SplitEdge = 'top' | 'bottom' | 'left' | 'right';
 
@@ -309,7 +310,7 @@ function PopoutAgentPicker({ agents, onPick }: {
             </div>
           )}
           {durableAgents.length === 0 && quickAgents.length === 0 && (
-            <div className="text-xs text-ctp-overlay0 text-center py-4">No agents available</div>
+            <EmptyState title="No agents available" compact />
           )}
         </div>
       </div>

--- a/src/renderer/features/settings/LoggingSettingsView.tsx
+++ b/src/renderer/features/settings/LoggingSettingsView.tsx
@@ -3,6 +3,7 @@ import { useLoggingStore } from '../../stores/loggingStore';
 import type { LogLevel, LogRetention } from '../../../shared/types';
 import { LOG_LEVEL_PRIORITY } from '../../../shared/types';
 import { Toggle } from '../../components/Toggle';
+import { Spinner } from '../../components/Spinner';
 
 export function LoggingSettingsView() {
   const { settings, namespaces, logPath, loadSettings, saveSettings } = useLoggingStore();
@@ -12,7 +13,7 @@ export function LoggingSettingsView() {
   }, [loadSettings]);
 
   if (!settings) {
-    return <div className="p-6 text-ctp-subtext0 text-sm">Loading…</div>;
+    return <div className="p-6 flex items-center gap-2 text-ctp-subtext0 text-sm"><Spinner size="sm" /> Loading…</div>;
   }
 
   const handleNamespaceToggle = (ns: string, value: boolean) => {

--- a/src/renderer/features/settings/NotificationSettingsView.tsx
+++ b/src/renderer/features/settings/NotificationSettingsView.tsx
@@ -6,6 +6,7 @@ import { useSoundStore } from '../../stores/soundStore';
 import { ALL_SOUND_EVENTS } from '../../../shared/types';
 import { Toggle } from '../../components/Toggle';
 import { SoundEventRow, SoundPackCard, ProjectSoundOverrideSection } from './sound-components';
+import { Spinner } from '../../components/Spinner';
 
 const TOGGLES: { key: keyof Omit<import('../../../shared/types').NotificationSettings, 'enabled' | 'playSound'>; label: string; description: string }[] = [
   { key: 'permissionNeeded', label: 'Permission Needed', description: 'Notify when an agent is waiting for approval' },
@@ -262,7 +263,7 @@ export function NotificationSettingsView({ projectId }: { projectId?: string }) 
   }, [loadSettings, loadBadgeSettings, loadSoundSettings, loadPacks]);
 
   if (!settings) {
-    return <div className="p-6 text-ctp-subtext0 text-sm">Loading\u2026</div>;
+    return <div className="p-6 flex items-center gap-2 text-ctp-subtext0 text-sm"><Spinner size="sm" /> Loading\u2026</div>;
   }
 
   // Project context: badges + sound overrides

--- a/src/renderer/features/settings/PluginMarketplaceDialog.tsx
+++ b/src/renderer/features/settings/PluginMarketplaceDialog.tsx
@@ -13,6 +13,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { refreshCommunityPlugins } from '../../plugins/plugin-loader';
 import { PERMISSION_DESCRIPTIONS, PERMISSION_RISK_LEVELS } from '../../../shared/plugin-types';
 import type { PluginPermission, PermissionRiskLevel } from '../../../shared/plugin-types';
+import { Spinner } from '../../components/Spinner';
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -529,6 +530,7 @@ export function PluginMarketplaceDialog({ onClose }: { onClose: () => void }) {
         <div className="flex-1 overflow-y-auto p-6 pt-4">
           {loading && (
             <div className="flex items-center justify-center py-12">
+              <Spinner />
               <p className="text-sm text-ctp-subtext0">Loading marketplace...</p>
             </div>
           )}

--- a/src/renderer/features/settings/ResetProjectDialog.tsx
+++ b/src/renderer/features/settings/ResetProjectDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Modal } from '../../components/Modal';
+import { Spinner } from '../../components/Spinner';
 
 interface ResetProjectDialogProps {
   projectName: string;
@@ -38,7 +39,7 @@ export function ResetProjectDialog({ projectName, projectPath, onConfirm, onCanc
             </label>
             <div className="max-h-40 overflow-y-auto rounded-lg bg-ctp-mantle border border-surface-0 p-2">
               {loading ? (
-                <span className="text-xs text-ctp-subtext0">Loading...</span>
+                <><Spinner size="xs" /><span className="text-xs text-ctp-subtext0">Loading...</span></>
               ) : files.length === 0 ? (
                 <span className="text-xs text-ctp-subtext0">No .clubhouse/ directory found</span>
               ) : (

--- a/src/renderer/panels/PluginContentView.tsx
+++ b/src/renderer/panels/PluginContentView.tsx
@@ -7,6 +7,7 @@ import { useProjectStore } from '../stores/projectStore';
 import { usePluginUpdateStore } from '../stores/pluginUpdateStore';
 import { rendererLog } from '../plugins/renderer-logger';
 import type { PluginRenderMode } from '../../shared/plugin-types';
+import { Spinner } from '../components/Spinner';
 
 export class PluginErrorBoundary extends React.Component<
   { pluginId: string; children: React.ReactNode },
@@ -151,6 +152,7 @@ export function PluginContentView({ pluginId, mode }: { pluginId: string; mode?:
     if (activating) {
       return (
         <div className="flex items-center justify-center h-full bg-ctp-base">
+          <Spinner size="sm" />
           <p className="text-ctp-subtext0 text-xs">Loading plugin...</p>
         </div>
       );

--- a/src/renderer/panels/SatelliteSection.tsx
+++ b/src/renderer/panels/SatelliteSection.tsx
@@ -9,6 +9,7 @@ import { useCallback } from 'react';
 import { getAgentColorHex } from '../../shared/name-generator';
 import type { SatelliteConnection } from '../stores/annexClientStore';
 import { useRemoteProjectStore, type RemoteProject } from '../stores/remoteProjectStore';
+import { EmptyState } from '../components/EmptyState';
 
 
 // ---------------------------------------------------------------------------
@@ -155,7 +156,7 @@ export function SatelliteProjectList({ satellite, projects, activeProjectId, exp
 
   if (projects.length === 0) {
     return expanded ? (
-      <div className="pl-4 py-2 text-xs text-ctp-subtext0 italic">No projects</div>
+      <div className="pl-4 py-2"><EmptyState title="No projects" compact /></div>
     ) : null;
   }
 

--- a/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
@@ -9,6 +9,7 @@ import type { ProtocolSettings } from './url-validation';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { AnnexUnsupportedPlaceholder } from '../../../features/annex/AnnexUnsupportedPlaceholder';
+import { EmptyState } from '../../../../components/EmptyState';
 
 function projectColor(name: string): string {
   let hash = 0;
@@ -164,7 +165,7 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
           Select a project
         </div>
         {projects.length === 0 ? (
-          <div className="text-xs text-ctp-overlay0 italic">No projects open</div>
+          <EmptyState title="No projects open" compact />
         ) : (
           <div className="flex-1 overflow-y-auto space-y-1">
             {projects.map((p) => {
@@ -270,9 +271,7 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
             } as any}
           />
         ) : (
-          <div className="flex items-center justify-center h-full text-xs text-ctp-overlay0">
-            Enter a URL above to browse
-          </div>
+          <EmptyState title="Enter a URL above to browse" compact />
         )}
       </div>
     </div>

--- a/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
@@ -9,7 +9,7 @@ import type { ProtocolSettings } from './url-validation';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { AnnexUnsupportedPlaceholder } from '../../../features/annex/AnnexUnsupportedPlaceholder';
-import { EmptyState } from '../../../../components/EmptyState';
+import { EmptyState } from '../../../components/EmptyState';
 
 function projectColor(name: string): string {
   let hash = 0;

--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import type { AgentCanvasView as AgentCanvasViewType, CanvasView } from './canvas-types';
 import type { PluginAPI, AgentInfo } from '../../../../shared/plugin-types';
 import { AddAgentDialog } from '../../../features/agents/AddAgentDialog';
-import { EmptyState } from '../../../../components/EmptyState';
+import { EmptyState } from '../../../components/EmptyState';
 
 interface AgentCanvasViewProps {
   view: AgentCanvasViewType;

--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import type { AgentCanvasView as AgentCanvasViewType, CanvasView } from './canvas-types';
 import type { PluginAPI, AgentInfo } from '../../../../shared/plugin-types';
 import { AddAgentDialog } from '../../../features/agents/AddAgentDialog';
+import { EmptyState } from '../../../../components/EmptyState';
 
 interface AgentCanvasViewProps {
   view: AgentCanvasViewType;
@@ -178,7 +179,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
           </div>
           <div className="flex-1 overflow-y-auto space-y-1">
             {projects.length === 0 ? (
-              <div className="text-xs text-ctp-overlay0 italic">No projects open</div>
+              <EmptyState title="No projects open" compact />
             ) : (
               projects.map((p) => {
                 const agentCount = agents.filter((a) => a.projectId === p.id).length;
@@ -233,7 +234,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
         </div>
         <div className="flex-1 overflow-y-auto space-y-1">
           {filteredAgents.length === 0 ? (
-            <div className="text-xs text-ctp-overlay0 italic">No agents{isAppMode ? ' in this project' : ' available'}</div>
+            <EmptyState title={isAppMode ? 'No agents in this project' : 'No agents available'} compact />
           ) : (
             filteredAgents.map((agent) => (
               <button

--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -11,7 +11,7 @@ import { usePluginStore } from '../../plugin-store';
 import { useRemoteProjectStore, isRemoteProjectId, parseNamespacedId } from '../../../stores/remoteProjectStore';
 import { AnnexUnsupportedPlaceholder } from '../../../features/annex/AnnexUnsupportedPlaceholder';
 import { LinkDropdown } from './LinkDropdown';
-import { Spinner } from '../../../../components/Spinner';
+import { Spinner } from '../../../components/Spinner';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 

--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -11,6 +11,7 @@ import { usePluginStore } from '../../plugin-store';
 import { useRemoteProjectStore, isRemoteProjectId, parseNamespacedId } from '../../../stores/remoteProjectStore';
 import { AnnexUnsupportedPlaceholder } from '../../../features/annex/AnnexUnsupportedPlaceholder';
 import { LinkDropdown } from './LinkDropdown';
+import { Spinner } from '../../../../components/Spinner';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -463,7 +464,7 @@ export function CanvasViewComponent({
           if (pluginKnown) {
             return (
               <div className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 text-xs p-4 text-center" data-testid="widget-loading">
-                <span className="inline-block w-4 h-4 border-2 border-ctp-overlay0 border-t-transparent rounded-full animate-spin" />
+                <Spinner size="sm" />
                 <span>Loading&hellip;</span>
               </div>
             );
@@ -479,6 +480,7 @@ export function CanvasViewComponent({
           return (
             <div className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 text-xs p-4 text-center" data-testid="widget-loading">
               <span className="font-medium text-ctp-subtext0">{registered.declaration.label}</span>
+              <Spinner size="sm" />
               <span>Loading…</span>
             </div>
           );

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -684,36 +684,40 @@ export function CanvasWorkspace({
         onNavigate={handleSearchSelect}
       />
 
-      {/* Canvas controls + pinned widgets */}
-      <CanvasControls
-        zoom={viewport.zoom}
-        onZoomIn={handleZoomIn}
-        onZoomOut={handleZoomOut}
-        onZoomReset={handleZoomReset}
-        onCenter={handleCenter}
-        onSizeToFit={handleSizeToFit}
-        onAutolayout={handleAutolayout}
-        hasSelection={selectedViewId !== null}
-        elkAlgorithm={elkAlgorithm}
-        elkDirection={elkDirection}
-        layoutCenterId={layoutCenterId}
-        onElkAlgorithmChange={onElkAlgorithmChange}
-        onElkDirectionChange={onElkDirectionChange}
-        hasViews={views.length > 0}
-        views={views}
-        onSelectView={handleSearchSelect}
-        attentionMap={attentionMap}
-        api={api}
-      />
+      {/* Canvas controls + pinned widgets — hidden while a view is maximized */}
+      {!zoomedView && (
+        <CanvasControls
+          zoom={viewport.zoom}
+          onZoomIn={handleZoomIn}
+          onZoomOut={handleZoomOut}
+          onZoomReset={handleZoomReset}
+          onCenter={handleCenter}
+          onSizeToFit={handleSizeToFit}
+          onAutolayout={handleAutolayout}
+          hasSelection={selectedViewId !== null}
+          elkAlgorithm={elkAlgorithm}
+          elkDirection={elkDirection}
+          layoutCenterId={layoutCenterId}
+          onElkAlgorithmChange={onElkAlgorithmChange}
+          onElkDirectionChange={onElkDirectionChange}
+          hasViews={views.length > 0}
+          views={views}
+          onSelectView={handleSearchSelect}
+          attentionMap={attentionMap}
+          api={api}
+        />
+      )}
 
-      <PinnedWidgetBar
-        views={views}
-        viewport={viewport}
-        containerRef={containerRef}
-        containerSize={containerSize}
-        api={api}
-        onUpdateView={onUpdateView}
-      />
+      {!zoomedView && (
+        <PinnedWidgetBar
+          views={views}
+          viewport={viewport}
+          containerRef={containerRef}
+          containerSize={containerSize}
+          api={api}
+          onUpdateView={onUpdateView}
+        />
+      )}
 
       {/* Context menu */}
       {contextMenu && (

--- a/src/renderer/plugins/builtin/canvas/ZoomedViewOverlay.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoomedViewOverlay.tsx
@@ -32,7 +32,7 @@ export function ZoomedViewOverlay({
 }: ZoomedViewOverlayProps) {
   return (
     <div
-      className="absolute inset-0 z-canvas-overlay flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
+      className="absolute inset-0 z-canvas-dialog flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       data-testid="canvas-zoom-overlay"
     >

--- a/src/renderer/plugins/builtin/canvas/canvas-keyboard-focus.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/canvas-keyboard-focus.test.tsx
@@ -287,3 +287,73 @@ describe('canvas view pointer-events', () => {
     expect(window.getComputedStyle(contentWrapper).pointerEvents).not.toBe('none');
   });
 });
+
+// ── Tests: GH-1460 — zoomed view overlay hides canvas toolbar ───────────────
+
+describe('canvas zoomed-view toolbar suppression (GH-1460)', () => {
+  const wireDefProps = {
+    wireDefinitions: [],
+    onAddWireDefinition: vi.fn(),
+    onRemoveWireDefinition: vi.fn(),
+    onUpdateWireDefinition: vi.fn(),
+  };
+
+  it('canvas-controls renders when no view is zoomed', () => {
+    render(
+      <CanvasWorkspace
+        views={[baseView]}
+        viewport={defaultViewport}
+        zoomedViewId={null}
+        selectedViewId={null}
+        selectedViewIds={[]}
+        api={stubApi()}
+        onViewportChange={vi.fn()}
+        onAddView={vi.fn()}
+        onAddPluginView={vi.fn()}
+        onRemoveView={vi.fn()}
+        onMoveView={vi.fn()}
+        onMoveViews={vi.fn()}
+        onResizeView={vi.fn()}
+        onFocusView={vi.fn()}
+        onUpdateView={vi.fn()}
+        onZoomView={vi.fn()}
+        onSelectView={vi.fn()}
+        onToggleSelectView={vi.fn()}
+        onSetSelectedViewIds={vi.fn()}
+        onClearSelection={vi.fn()}
+        {...wireDefProps}
+      />,
+    );
+    expect(screen.getByTestId('canvas-controls')).toBeInTheDocument();
+  });
+
+  it('canvas-controls is removed from DOM when a view is zoomed (GH-1460)', () => {
+    render(
+      <CanvasWorkspace
+        views={[baseView]}
+        viewport={defaultViewport}
+        zoomedViewId={baseView.id}
+        selectedViewId={null}
+        selectedViewIds={[]}
+        api={stubApi()}
+        onViewportChange={vi.fn()}
+        onAddView={vi.fn()}
+        onAddPluginView={vi.fn()}
+        onRemoveView={vi.fn()}
+        onMoveView={vi.fn()}
+        onMoveViews={vi.fn()}
+        onResizeView={vi.fn()}
+        onFocusView={vi.fn()}
+        onUpdateView={vi.fn()}
+        onZoomView={vi.fn()}
+        onSelectView={vi.fn()}
+        onToggleSelectView={vi.fn()}
+        onSetSelectedViewIds={vi.fn()}
+        onClearSelection={vi.fn()}
+        {...wireDefProps}
+      />,
+    );
+    expect(screen.queryByTestId('canvas-controls')).not.toBeInTheDocument();
+    expect(screen.getByTestId('canvas-zoom-overlay')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/plugins/builtin/files/FileViewerCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/files/FileViewerCanvasWidget.tsx
@@ -12,7 +12,7 @@ import { ReadOnlyMonacoEditor } from '../canvas/ReadOnlyMonacoEditor';
 import { MarkdownPreview } from './MarkdownPreview';
 import { ResizableSidebar } from '../canvas/ResizableSidebar';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
-import { EmptyState } from '../../../../components/EmptyState';
+import { EmptyState } from '../../../components/EmptyState';
 
 function isMarkdownFile(path: string): boolean {
   const lower = path.toLowerCase();

--- a/src/renderer/plugins/builtin/files/FileViewerCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/files/FileViewerCanvasWidget.tsx
@@ -12,6 +12,7 @@ import { ReadOnlyMonacoEditor } from '../canvas/ReadOnlyMonacoEditor';
 import { MarkdownPreview } from './MarkdownPreview';
 import { ResizableSidebar } from '../canvas/ResizableSidebar';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
+import { EmptyState } from '../../../../components/EmptyState';
 
 function isMarkdownFile(path: string): boolean {
   const lower = path.toLowerCase();
@@ -173,7 +174,7 @@ export function FileViewerCanvasWidget({ widgetId: _widgetId, api, metadata, onU
           Select a project
         </div>
         {projects.length === 0 ? (
-          <div className="text-xs text-ctp-overlay0 italic">No projects open</div>
+          <EmptyState title="No projects open" compact />
         ) : (
           <div className="flex-1 overflow-y-auto space-y-1">
             {projects.map((p) => {
@@ -334,9 +335,7 @@ export function FileViewerCanvasWidget({ widgetId: _widgetId, api, metadata, onU
               Loading&hellip;
             </div>
           ) : (
-            <div className="flex-1 flex items-center justify-center text-ctp-overlay0 text-xs">
-              Select a file to view
-            </div>
+            <EmptyState title="Select a file to view" compact />
           )}
         </div>
       </div>

--- a/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import type { CanvasWidgetComponentProps } from '../../../../shared/plugin-types';
 import type { GitInfo, GitStatusFile } from '../../../../shared/types';
 import { createGitOps } from './remote-git';
-import { Spinner } from '../../../../components/Spinner';
+import { Spinner } from '../../../components/Spinner';
 
 const GIT_POLL_INTERVAL_MS = 3000;
 

--- a/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import type { CanvasWidgetComponentProps } from '../../../../shared/plugin-types';
 import type { GitInfo, GitStatusFile } from '../../../../shared/types';
 import { createGitOps } from './remote-git';
+import { Spinner } from '../../../../components/Spinner';
 
 const GIT_POLL_INTERVAL_MS = 3000;
 
@@ -174,7 +175,10 @@ export function GitCanvasWidget({ widgetId: _widgetId, api, metadata, onUpdateMe
   if (!gitInfo) {
     return (
       <div className="flex items-center justify-center h-full text-ctp-subtext0 text-xs">
-        Loading git status…
+        <div className="flex items-center gap-2">
+          <Spinner size="sm" />
+          Loading git status…
+        </div>
       </div>
     );
   }
@@ -233,10 +237,13 @@ export function GitCanvasWidget({ widgetId: _widgetId, api, metadata, onUpdateMe
           <div className="flex-1 min-w-0" data-testid="diff-pane">
             {diffLoading ? (
               <div className="flex items-center justify-center h-full text-ctp-subtext0 text-xs">
-                Loading diff…
+                <div className="flex items-center gap-2">
+                  <Spinner size="sm" />
+                  Loading diff…
+                </div>
               </div>
             ) : diffData ? (
-              <React.Suspense fallback={<div className="flex items-center justify-center h-full text-ctp-subtext0 text-xs">Loading editor…</div>}>
+              <React.Suspense fallback={<div className="flex items-center justify-center h-full text-ctp-subtext0 text-xs"><div className="flex items-center gap-2"><Spinner size="sm" />Loading editor…</div></div>}>
                 <MonacoDiffEditorLazy original={diffData.original} modified={diffData.modified} filePath={selectedFile || ''} />
               </React.Suspense>
             ) : (

--- a/src/renderer/plugins/builtin/hub/AgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/AgentPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { PluginAPI, AgentInfo, ModelOption } from '../../../../shared/plugin-types';
-import { EmptyState } from '../../../../components/EmptyState';
+import { EmptyState } from '../../../components/EmptyState';
 
 interface AgentPickerProps {
   api: PluginAPI;

--- a/src/renderer/plugins/builtin/hub/AgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/AgentPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { PluginAPI, AgentInfo, ModelOption } from '../../../../shared/plugin-types';
+import { EmptyState } from '../../../../components/EmptyState';
 
 interface AgentPickerProps {
   api: PluginAPI;
@@ -92,7 +93,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
           )}
 
           {durableAgents.length === 0 && quickAgents.length === 0 && (
-            <div className="text-xs text-ctp-overlay0 text-center py-4">No agents available</div>
+            <EmptyState title="No agents available" compact />
           )}
 
           {showQuickForm ? (

--- a/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import type { PluginAPI, AgentInfo, ProjectInfo, ModelOption } from '../../../../shared/plugin-types';
-import { EmptyState } from '../../../../components/EmptyState';
+import { EmptyState } from '../../../components/EmptyState';
 
 interface CrossProjectAgentPickerProps {
   api: PluginAPI;

--- a/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import type { PluginAPI, AgentInfo, ProjectInfo, ModelOption } from '../../../../shared/plugin-types';
+import { EmptyState } from '../../../../components/EmptyState';
 
 interface CrossProjectAgentPickerProps {
   api: PluginAPI;
@@ -81,7 +82,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
               Select a project
             </div>
             {projects.length === 0 ? (
-              <div className="text-xs text-ctp-overlay0 text-center py-4">No projects open</div>
+              <EmptyState title="No projects open" compact />
             ) : (
               projects.map((p) => {
                 const agentCount = agents.filter((a) => a.projectId === p.id).length;
@@ -169,7 +170,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
           )}
 
           {durableAgents.length === 0 && quickAgents.length === 0 && (
-            <div className="text-xs text-ctp-overlay0 text-center py-2">No agents in this project</div>
+            <EmptyState title="No agents in this project" compact />
           )}
 
           {showQuickForm ? (

--- a/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
@@ -10,6 +10,7 @@ import type { TerminalIO } from '../../../features/terminal/ShellTerminal';
 import { ShellTerminal } from '../../../features/terminal/ShellTerminal';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { satellitePtyDataBus, satellitePtyExitBus } from '../../../stores/annexClientStore';
+import { EmptyState } from '../../../../components/EmptyState';
 
 type TerminalStatus = 'starting' | 'running' | 'exited';
 
@@ -213,7 +214,7 @@ export function TerminalCanvasWidget({ widgetId, api, metadata, onUpdateMetadata
           Select a project
         </div>
         {projects.length === 0 ? (
-          <div className="text-xs text-ctp-overlay0 italic">No projects open</div>
+          <EmptyState title="No projects open" compact />
         ) : (
           <div className="flex-1 overflow-y-auto space-y-1">
             {projects.map((p) => {

--- a/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
@@ -10,7 +10,7 @@ import type { TerminalIO } from '../../../features/terminal/ShellTerminal';
 import { ShellTerminal } from '../../../features/terminal/ShellTerminal';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { satellitePtyDataBus, satellitePtyExitBus } from '../../../stores/annexClientStore';
-import { EmptyState } from '../../../../components/EmptyState';
+import { EmptyState } from '../../../components/EmptyState';
 
 type TerminalStatus = 'starting' | 'running' | 'exited';
 


### PR DESCRIPTION
## Summary

- **GH-1460**: Canvas toolbar (`CanvasControls`, `PinnedWidgetBar`) is now hidden while a view is maximized via `ZoomedViewOverlay`, mirroring the existing minimap suppression pattern. `ZoomedViewOverlay` also promoted from `z-canvas-overlay` (9999) to `z-canvas-dialog` (10000) — belt-and-suspenders above the toolbar tier. Regression test added to `canvas-keyboard-focus.test.tsx`.
- **VQ-LS-01**: 22 bespoke inline spinner elements across 15 files replaced with `<Spinner size="xs|sm|md|lg" />` — eliminates all hand-rolled `border-t-transparent rounded-full animate-spin` spans, divs, and SVGs.
- **VQ-LS-02**: 16 bare empty-state divs across 11 files replaced with `<EmptyState title="..." compact />` — consistent visual treatment for all no-content states.

## Skipped (by design)
- `Dashboard.tsx` — already has a rich custom empty state with icon + CTA button
- `CommandPaletteList.tsx` — embeds the user's query string, not a static empty state title

## Test plan
- [ ] TypeScript: `npm run typecheck` — clean (0 errors)
- [ ] Unit tests: `npm test` — 12027/12032 pass; 1 test file has 2 pre-existing uncaught-exception errors in `ProjectRail.test.tsx` (logger mocking gap unrelated to this PR — confirmed same failure exists on `main` before these changes)
- [ ] Lint: `npm run lint` — 0 errors
- [ ] Manual: open canvas, zoom a view → confirm toolbar disappears and overlay fills the screen without the controls bleeding through
- [ ] Manual: trigger any loading state (transcript, marketplace, logging settings) → confirm spinner renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)