### PR TITLE
fix(vq-sk-01): replace text-[10px] with text-xs across 74 source files (WCAG)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,6 +91,10 @@ export default tseslint.config(
           selector: "JSXAttribute[name.name='className'][value.value=/\\bz-modal\\b/]",
           message: 'Use <Modal> from src/renderer/components/Modal.tsx instead of a bespoke fixed overlay with z-modal.',
         },
+        {
+          selector: "JSXAttribute[name.name='className'][value.value=/text-\\[10px\\]/]",
+          message: 'Use text-xs (12px) instead of text-[10px] — WCAG minimum font-size requirement.',
+        },
       ],
     },
   },

--- a/src/renderer/components/Badge.tsx
+++ b/src/renderer/components/Badge.tsx
@@ -37,7 +37,7 @@ export function Badge({ type, value, className = '', inline = false }: BadgeProp
       <span
         data-testid="badge-count"
         className={`
-          ${inline ? 'min-w-[16px] h-4 text-[9px] px-1' : 'min-w-[18px] h-[18px] text-[10px] px-1'}
+          ${inline ? 'min-w-[16px] h-4 text-[9px] px-1' : 'min-w-[18px] h-[18px] text-xs px-1'}
           rounded-full bg-ctp-error text-white font-bold
           inline-flex items-center justify-center flex-shrink-0 leading-none
           ${className}

--- a/src/renderer/components/EmojiPicker.tsx
+++ b/src/renderer/components/EmojiPicker.tsx
@@ -248,7 +248,7 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
               key={cat.id}
               ref={(el) => { categoryRefs.current[cat.id] = el; }}
             >
-              <div className="text-[10px] font-semibold text-ctp-overlay0 uppercase tracking-wider pt-2 pb-1 px-0.5 sticky top-0 bg-ctp-mantle">
+              <div className="text-xs font-semibold text-ctp-overlay0 uppercase tracking-wider pt-2 pb-1 px-0.5 sticky top-0 bg-ctp-mantle">
                 {cat.label}
               </div>
               <div className="flex flex-wrap gap-0.5">

--- a/src/renderer/features/agents/AddAgentDialog.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.tsx
@@ -167,7 +167,7 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
               className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
             />
             <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use git worktree</span>
-            <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+            <span className="text-xs text-ctp-subtext0/70 ml-1">
               (isolated branch + directory)
             </span>
           </label>
@@ -187,7 +187,7 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
                 className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
               />
               <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use Structured Mode</span>
-              <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+              <span className="text-xs text-ctp-subtext0/70 ml-1">
                 {supportsStructured ? '(rich event UI)' : '(not supported)'}
               </span>
             </label>
@@ -206,7 +206,7 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
               className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
             />
             <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Free Agent Mode</span>
-            <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+            <span className="text-xs text-ctp-subtext0/70 ml-1">
               {supportsPermissions ? '(skip all permissions)' : '(not supported)'}
             </span>
           </label>

--- a/src/renderer/features/agents/AgentAvatar.tsx
+++ b/src/renderer/features/agents/AgentAvatar.tsx
@@ -80,7 +80,7 @@ interface Props {
 const SIZE_CONFIG = {
   xs: { outer: 'w-7 h-7', inner: 'w-5 h-5', font: 'text-[8px]', icon: 20, bolt: 8 },
   sm: { outer: 'w-8 h-8', inner: 'w-6 h-6', font: 'text-[9px]', icon: 24, bolt: 10 },
-  md: { outer: 'w-9 h-9', inner: 'w-7 h-7', font: 'text-[10px]', icon: 28, bolt: 12 },
+  md: { outer: 'w-9 h-9', inner: 'w-7 h-7', font: 'text-xs', icon: 28, bolt: 12 },
   lg: { outer: 'w-14 h-14', inner: 'w-12 h-12', font: 'text-base', icon: 48, bolt: 16 },
 };
 

--- a/src/renderer/features/agents/AgentGalleryDialog.tsx
+++ b/src/renderer/features/agents/AgentGalleryDialog.tsx
@@ -127,7 +127,7 @@ export function AgentGalleryDialog({ onClose, onCreate }: Props) {
                     </div>
                     <div className="min-w-0">
                       <div className="text-xs font-semibold text-ctp-text truncate">{persona.name}</div>
-                      <div className="text-[10px] text-ctp-subtext0 mt-0.5 line-clamp-2 leading-tight">
+                      <div className="text-xs text-ctp-subtext0 mt-0.5 line-clamp-2 leading-tight">
                         {persona.description}
                       </div>
                     </div>

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -438,7 +438,7 @@ function AgentListInner() {
     return (
       <div className={`py-3 border-b border-surface-0/50 space-y-2 ${isNested ? 'pl-7 pr-3' : 'px-3'}`}>
         {targetParentAgent && (
-          <div className="text-[10px] text-ctp-overlay0">
+          <div className="text-xs text-ctp-overlay0">
             Quick agent in {targetParentAgent.name}'s worktree
           </div>
         )}
@@ -460,7 +460,7 @@ function AgentListInner() {
           <select
             value={quickModel}
             onChange={(e) => setQuickModel(e.target.value)}
-            className="flex-1 min-w-0 px-1.5 py-1 text-[10px] rounded bg-surface-0 border border-surface-2
+            className="flex-1 min-w-0 px-1.5 py-1 text-xs rounded bg-surface-0 border border-surface-2
               text-ctp-text focus-ring"
           >
             {MODEL_OPTIONS.map((opt) => (
@@ -471,7 +471,7 @@ function AgentListInner() {
             <select
               value={quickOrchestrator || enabledOrchestrators[0]?.id}
               onChange={(e) => setQuickOrchestrator(e.target.value)}
-              className="flex-1 min-w-0 px-1.5 py-1 text-[10px] rounded bg-surface-0 border border-surface-2
+              className="flex-1 min-w-0 px-1.5 py-1 text-xs rounded bg-surface-0 border border-surface-2
                 text-ctp-text focus-ring"
             >
               {enabledOrchestrators.map((o) => (
@@ -492,16 +492,16 @@ function AgentListInner() {
             disabled={!supportsPermissions}
             className="w-3 h-3 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
           />
-          <span className="text-[10px] text-ctp-subtext0">Free Agent Mode</span>
+          <span className="text-xs text-ctp-subtext0">Free Agent Mode</span>
           {quickFreeAgentMode && supportsPermissions && (
-            <span className="text-[10px] text-ctp-error">skip all permissions</span>
+            <span className="text-xs text-ctp-error">skip all permissions</span>
           )}
         </label>
         <div className="flex gap-1.5">
           <button
             onClick={handleMissionSubmit}
             disabled={!mission.trim()}
-            className="flex-1 px-2 py-1 text-[10px] rounded bg-ctp-accent/20 text-ctp-accent
+            className="flex-1 px-2 py-1 text-xs rounded bg-ctp-accent/20 text-ctp-accent
               hover:bg-ctp-accent/30 transition-colors cursor-pointer
               disabled:opacity-40 disabled:cursor-not-allowed"
           >
@@ -509,7 +509,7 @@ function AgentListInner() {
           </button>
           <button
             onClick={handleCancelMission}
-            className="px-2 py-1 text-[10px] rounded border border-surface-0
+            className="px-2 py-1 text-xs rounded border border-surface-0
               hover:bg-surface-0 transition-colors cursor-pointer text-ctp-subtext1"
           >
             Cancel
@@ -637,7 +637,7 @@ function AgentListInner() {
                     />
                     {activeProfile && durable.orchestrator && !isOrchestratorInProfile(durable.orchestrator) && (
                       <span
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-yellow-500"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-yellow-500"
                         title={`${durable.orchestrator} is not configured in the "${activeProfile.name}" profile`}
                       >
                         ⚠
@@ -725,7 +725,7 @@ function AgentListInner() {
             <button
               onClick={() => activeProjectId && clearCompleted(activeProjectId)}
               data-testid="completed-clear-all"
-              className="text-[10px] normal-case tracking-normal text-ctp-overlay0 hover:text-ctp-text cursor-pointer font-normal"
+              className="text-xs normal-case tracking-normal text-ctp-overlay0 hover:text-ctp-text cursor-pointer font-normal"
             >
               Clear all
             </button>

--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -411,7 +411,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
               const orchId = agent.orchestrator || 'claude-code';
               const c = getOrchestratorColor(orchId);
               return (
-                <span className="text-[10px] px-1.5 py-0.5 rounded truncate"
+                <span className="text-xs px-1.5 py-0.5 rounded truncate"
                   style={{ backgroundColor: c.bg, color: c.text }}>
                   {getOrchestratorLabel(orchId, allOrchestrators)}
                 </span>
@@ -423,20 +423,20 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
                 ? getModelColor(agent.model)
                 : { bg: 'rgb(var(--ctp-overlay1) / 0.15)', text: 'rgb(var(--ctp-overlay1))' };
               return (
-                <span className="text-[10px] px-1.5 py-0.5 rounded truncate font-mono"
+                <span className="text-xs px-1.5 py-0.5 rounded truncate font-mono"
                   style={{ backgroundColor: c.bg, color: c.text }}>
                   {modelLabel}
                 </span>
               );
             })()}
             {agent.freeAgentMode && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded truncate"
+              <span className="text-xs px-1.5 py-0.5 rounded truncate"
                 style={{ backgroundColor: 'rgb(var(--ctp-error) / 0.15)', color: 'rgb(var(--ctp-error))' }}>
                 Free
               </span>
             )}
             {agent.mcpIds && agent.mcpIds.length > 0 && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded truncate"
+              <span className="text-xs px-1.5 py-0.5 rounded truncate"
                 style={{ backgroundColor: 'rgb(var(--ctp-accent2) / 0.15)', color: 'rgb(var(--ctp-accent2))' }}
                 title={agent.mcpIds.join(', ')}>
                 {agent.mcpIds.length} MCP{agent.mcpIds.length !== 1 ? 's' : ''}

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -65,13 +65,13 @@ function McpConfigRow({
           <span className="text-xs text-ctp-text truncate flex items-center gap-1.5">
             {entry.name}
             {entry.state === 'new' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-green/15 text-ctp-green uppercase tracking-wider">new</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-green/15 text-ctp-green uppercase tracking-wider">new</span>
             )}
             {entry.state === 'changed' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-yellow/15 text-ctp-yellow uppercase tracking-wider">changed</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-yellow/15 text-ctp-yellow uppercase tracking-wider">changed</span>
             )}
             {entry.state === 'removed' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-red/15 text-ctp-red uppercase tracking-wider">removed</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-red/15 text-ctp-red uppercase tracking-wider">removed</span>
             )}
           </span>
         </label>
@@ -79,7 +79,7 @@ function McpConfigRow({
           <button
             type="button"
             onClick={() => setExpanded(!expanded)}
-            className="text-[10px] text-ctp-subtext0 hover:text-ctp-text transition-colors shrink-0 px-1"
+            className="text-xs text-ctp-subtext0 hover:text-ctp-text transition-colors shrink-0 px-1"
             title="Configure parameters"
           >
             {expanded ? '▴' : '▾'}
@@ -90,7 +90,7 @@ function McpConfigRow({
         <div className="mt-1.5 ml-7 mb-2 space-y-1.5">
           {textArgs.map((arg) => (
             <div key={arg.name} className="flex items-center gap-2">
-              <span className="text-[10px] text-ctp-subtext0 font-mono w-28 text-right shrink-0 flex items-center justify-end gap-1">
+              <span className="text-xs text-ctp-subtext0 font-mono w-28 text-right shrink-0 flex items-center justify-end gap-1">
                 {arg.required && <span className="w-1 h-1 rounded-full bg-ctp-yellow inline-block" title="Required" />}
                 {arg.name.replace(/^--/, '')}
               </span>
@@ -113,7 +113,7 @@ function McpConfigRow({
                     type="button"
                     onClick={() => onConfigChange(arg.name, active ? '' : 'true')}
                     title={arg.description || ''}
-                    className={`text-[10px] px-2 py-0.5 rounded-full border transition-colors ${
+                    className={`text-xs px-2 py-0.5 rounded-full border transition-colors ${
                       active
                         ? 'border-ctp-blue/50 bg-ctp-blue/15 text-ctp-blue'
                         : 'border-surface-2 text-ctp-subtext0 hover:border-ctp-subtext0'
@@ -774,7 +774,7 @@ export function AgentSettingsView({ agent }: Props) {
               disabled={isRunning}
               className="w-3 h-3 rounded border-surface-2 bg-surface-0 accent-ctp-accent"
             />
-            <span className="text-[10px] text-ctp-subtext0">Enable local overrides</span>
+            <span className="text-xs text-ctp-subtext0">Enable local overrides</span>
           </label>
         </div>
       )}
@@ -962,7 +962,7 @@ export function AgentSettingsView({ agent }: Props) {
                     <span className="text-sm text-ctp-text">Structured Mode</span>
                   </label>
                   {structuredMode && (capabilities?.structuredMode ?? false) && (
-                    <p className="mt-1 text-[10px] text-ctp-subtext0 pl-6">
+                    <p className="mt-1 text-xs text-ctp-subtext0 pl-6">
                       This agent will run with rich event streaming instead of a PTY terminal.
                     </p>
                   )}
@@ -995,12 +995,12 @@ export function AgentSettingsView({ agent }: Props) {
                   <span className="text-sm text-ctp-text">Free Agent Mode</span>
                 </label>
                 {freeAgentMode && (capabilities?.permissions ?? false) && (
-                  <p className="mt-1 text-[10px] text-ctp-error pl-6">
+                  <p className="mt-1 text-xs text-ctp-error pl-6">
                     This agent will run with full access — no tool approvals required.
                   </p>
                 )}
                 {!(capabilities?.permissions ?? false) && (
-                  <p className="mt-1 text-[10px] text-ctp-subtext0/60 pl-6">
+                  <p className="mt-1 text-xs text-ctp-subtext0/60 pl-6">
                     Not supported by {orchestratorInfo?.displayName || 'this orchestrator'}.
                   </p>
                 )}
@@ -1049,7 +1049,7 @@ export function AgentSettingsView({ agent }: Props) {
         {activeTab === 'main' && (
           <div className="space-y-6">
             {/* Shared settings note */}
-            <div className="text-[10px] text-ctp-subtext0/60 flex items-start gap-1.5 bg-ctp-mantle border border-surface-0 rounded-lg px-3 py-2">
+            <div className="text-xs text-ctp-subtext0/60 flex items-start gap-1.5 bg-ctp-mantle border border-surface-0 rounded-lg px-3 py-2">
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0 mt-0.5">
                 <circle cx="12" cy="12" r="10" />
                 <line x1="12" y1="16" x2="12" y2="12" />
@@ -1078,7 +1078,7 @@ export function AgentSettingsView({ agent }: Props) {
                     <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider mb-2">Resolved Permissions</h3>
                     {preview.permissions.allow && preview.permissions.allow.length > 0 && (
                       <div className="mb-2">
-                        <span className="text-[10px] text-ctp-subtext0/60">Allow</span>
+                        <span className="text-xs text-ctp-subtext0/60">Allow</span>
                         <pre className="bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-2 border border-surface-1 opacity-70">
                           {preview.permissions.allow.join('\n')}
                         </pre>
@@ -1086,7 +1086,7 @@ export function AgentSettingsView({ agent }: Props) {
                     )}
                     {preview.permissions.deny && preview.permissions.deny.length > 0 && (
                       <div>
-                        <span className="text-[10px] text-ctp-subtext0/60">Deny</span>
+                        <span className="text-xs text-ctp-subtext0/60">Deny</span>
                         <pre className="bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-2 border border-surface-1 opacity-70">
                           {preview.permissions.deny.join('\n')}
                         </pre>
@@ -1131,7 +1131,7 @@ export function AgentSettingsView({ agent }: Props) {
                 <div className="flex items-center justify-between mb-2">
                   <div>
                     <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Instructions</h3>
-                    <span className="text-[10px] text-ctp-subtext0/60 font-mono">{instructionsFileLabel}</span>
+                    <span className="text-xs text-ctp-subtext0/60 font-mono">{instructionsFileLabel}</span>
                   </div>
                   <div className="flex gap-2">
                     <button
@@ -1204,7 +1204,7 @@ export function AgentSettingsView({ agent }: Props) {
             {!isManagedByClubhouse && mcpLoaded && mcpCatalog.length > 0 && (
               <section>
                 <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider mb-2">Launch Wrapper MCPs</h3>
-                <p className="text-[10px] text-ctp-subtext0/60 mb-2">
+                <p className="text-xs text-ctp-subtext0/60 mb-2">
                   MCPs injected via the launch wrapper when this agent starts. Expand entries to configure parameters.
                 </p>
                 <div className="grid grid-cols-2 gap-1">
@@ -1228,7 +1228,7 @@ export function AgentSettingsView({ agent }: Props) {
                 <div className="flex items-center justify-between mb-2">
                   <div>
                     <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Permissions</h3>
-                    <span className="text-[10px] text-ctp-subtext0/60 font-mono">{permissionsPathLabel}</span>
+                    <span className="text-xs text-ctp-subtext0/60 font-mono">{permissionsPathLabel}</span>
                   </div>
                   <button
                     onClick={handleSavePermissions}
@@ -1363,7 +1363,7 @@ export function AgentSettingsView({ agent }: Props) {
                     <span className="text-xs text-ctp-subtext0">Free Agent Mode by default</span>
                   </label>
                   {!(capabilities?.permissions ?? false) && (
-                    <p className="mt-1 text-[10px] text-ctp-subtext0/60">
+                    <p className="mt-1 text-xs text-ctp-subtext0/60">
                       Not supported by {orchestratorInfo?.displayName || 'this orchestrator'}.
                     </p>
                   )}

--- a/src/renderer/features/agents/AgentTemplatesSection.tsx
+++ b/src/renderer/features/agents/AgentTemplatesSection.tsx
@@ -155,7 +155,7 @@ export function AgentTemplatesSection({ worktreePath, projectPath, disabled, ref
       <div className="flex items-center justify-between mb-2">
         <div>
           <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Agent Definitions</h3>
-          <span className="text-[10px] text-ctp-subtext0/60 font-mono">{pathLabel || '.claude/agents/'}</span>
+          <span className="text-xs text-ctp-subtext0/60 font-mono">{pathLabel || '.claude/agents/'}</span>
         </div>
         <button
           onClick={handleCreate}
@@ -172,7 +172,7 @@ export function AgentTemplatesSection({ worktreePath, projectPath, disabled, ref
 
       {/* Built-in (filesystem) templates */}
       {hasPluginTemplates && templates.length > 0 && (
-        <p className="text-[10px] text-ctp-subtext0/50 uppercase tracking-wider mb-1 mt-2">Built-in</p>
+        <p className="text-xs text-ctp-subtext0/50 uppercase tracking-wider mb-1 mt-2">Built-in</p>
       )}
       {templates.length === 0 && !hasPluginTemplates ? (
         <p className="text-xs text-ctp-subtext0/60 py-2">No agent definitions found.</p>
@@ -227,7 +227,7 @@ export function AgentTemplatesSection({ worktreePath, projectPath, disabled, ref
         const groupName = pluginTemplates[0]?.pluginName || pluginId;
         return (
           <div key={pluginId} className="mt-3" data-testid={`plugin-template-group-${pluginId}`}>
-            <p className="text-[10px] text-ctp-subtext0/50 uppercase tracking-wider mb-1">
+            <p className="text-xs text-ctp-subtext0/50 uppercase tracking-wider mb-1">
               {groupName}
             </p>
             <div className="space-y-1">
@@ -248,7 +248,7 @@ export function AgentTemplatesSection({ worktreePath, projectPath, disabled, ref
                         {entry.template.name}
                       </span>
                       {entry.template.description && (
-                        <span className="text-[10px] text-ctp-subtext0/60 truncate block">
+                        <span className="text-xs text-ctp-subtext0/60 truncate block">
                           {entry.template.description}
                         </span>
                       )}

--- a/src/renderer/features/agents/AgentTerminal.tsx
+++ b/src/renderer/features/agents/AgentTerminal.tsx
@@ -667,7 +667,7 @@ export function AgentTerminal({ agentId, focused, zoneThemeId }: Props) {
           onClick={handleScrollToBottom}
           className="absolute top-2 right-2 z-10 flex items-center gap-1 px-2 py-1 rounded-md
             bg-surface-0/90 hover:bg-ctp-surface1 text-ctp-subtext0 hover:text-ctp-text
-            text-[10px] font-medium shadow-lg backdrop-blur-sm transition-all duration-150
+            text-xs font-medium shadow-lg backdrop-blur-sm transition-all duration-150
             border border-ctp-surface1/50"
           title="Scroll to bottom"
         >

--- a/src/renderer/features/agents/ConfigChangesDialog.tsx
+++ b/src/renderer/features/agents/ConfigChangesDialog.tsx
@@ -215,7 +215,7 @@ export function ConfigChangesDialog() {
                               onChange={() => toggleItem(item.id)}
                               className="accent-ctp-accent flex-shrink-0"
                             />
-                            <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono font-bold flex-shrink-0 ${badge.cls}`}>
+                            <span className={`px-1.5 py-0.5 rounded text-xs font-mono font-bold flex-shrink-0 ${badge.cls}`}>
                               {badge.label}
                             </span>
                             <span className="text-xs text-ctp-text truncate flex-1">
@@ -224,7 +224,7 @@ export function ConfigChangesDialog() {
                             {canExpand && (
                               <button
                                 onClick={() => toggleExpand(item.id)}
-                                className="text-[10px] text-ctp-subtext0 hover:text-ctp-text cursor-pointer flex-shrink-0"
+                                className="text-xs text-ctp-subtext0 hover:text-ctp-text cursor-pointer flex-shrink-0"
                               >
                                 {isExpanded ? 'Hide diff' : 'View diff'}
                               </button>

--- a/src/renderer/features/agents/DeleteAgentDialog.tsx
+++ b/src/renderer/features/agents/DeleteAgentDialog.tsx
@@ -279,7 +279,7 @@ export function DeleteAgentDialog() {
                       const badge = STATUS_BADGE[f.status] || { label: f.status, cls: 'bg-gray-500/20 text-gray-300' };
                       return (
                         <div key={f.path} className="flex items-center gap-2 text-xs">
-                          <span className={`px-1 py-0.5 rounded text-[10px] font-mono font-bold ${badge.cls}`}>
+                          <span className={`px-1 py-0.5 rounded text-xs font-mono font-bold ${badge.cls}`}>
                             {badge.label}
                           </span>
                           <span className="text-ctp-subtext1 truncate">{f.path}</span>

--- a/src/renderer/features/agents/HeadlessAgentView.tsx
+++ b/src/renderer/features/agents/HeadlessAgentView.tsx
@@ -425,7 +425,7 @@ export function HeadlessAgentView({ agent }: Props) {
         {/* Agent info */}
         <div className="text-center">
           <div className="flex items-center justify-center gap-2 mb-1">
-            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-ctp-accent/20 text-ctp-accent">
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-ctp-accent/20 text-ctp-accent">
               Headless
             </span>
             <span className="text-xs text-ctp-subtext0 font-mono tabular-nums">
@@ -440,7 +440,7 @@ export function HeadlessAgentView({ agent }: Props) {
         {/* Live transcript feed */}
         <div className="w-full bg-ctp-mantle border border-surface-0 rounded-lg overflow-hidden">
           <div className="flex items-center justify-between px-3 py-1.5 border-b border-surface-0">
-            <span className="text-[10px] text-ctp-subtext0 uppercase tracking-wider">Live Activity</span>
+            <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Live Activity</span>
             <span className="w-1.5 h-1.5 rounded-full bg-ctp-success animate-pulse" />
           </div>
           <div

--- a/src/renderer/features/agents/McpJsonSection.tsx
+++ b/src/renderer/features/agents/McpJsonSection.tsx
@@ -66,7 +66,7 @@ export function McpJsonSection({ worktreePath, projectPath, disabled, refreshKey
       <div className="flex items-center justify-between mb-2">
         <div>
           <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">MCP Servers</h3>
-          <span className="text-[10px] text-ctp-subtext0/60 font-mono">{pathLabel || '.mcp.json'}</span>
+          <span className="text-xs text-ctp-subtext0/60 font-mono">{pathLabel || '.mcp.json'}</span>
         </div>
         <button
           onClick={handleSave}
@@ -99,7 +99,7 @@ export function McpJsonSection({ worktreePath, projectPath, disabled, refreshKey
             <line x1="12" y1="9" x2="12" y2="13" />
             <line x1="12" y1="17" x2="12.01" y2="17" />
           </svg>
-          <span className="text-[10px] text-ctp-warning">{error}</span>
+          <span className="text-xs text-ctp-warning">{error}</span>
         </div>
       )}
     </section>

--- a/src/renderer/features/agents/QuickAgentDialog.tsx
+++ b/src/renderer/features/agents/QuickAgentDialog.tsx
@@ -192,7 +192,7 @@ export function QuickAgentDialog() {
             className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
           />
           <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Free Agent Mode</span>
-          <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+          <span className="text-xs text-ctp-subtext0/70 ml-1">
             {supportsPermissions ? '(autonomous permissions)' : '(not supported)'}
           </span>
         </label>
@@ -210,7 +210,7 @@ export function QuickAgentDialog() {
               text-ctp-text placeholder:text-ctp-overlay0
               focus-ring resize-none"
           />
-          <span className="text-[10px] text-ctp-overlay0 mt-0.5 block">
+          <span className="text-xs text-ctp-overlay0 mt-0.5 block">
             {navigator.platform.includes('Mac') ? '\u2318' : 'Ctrl'}+Enter to submit
           </span>
         </label>

--- a/src/renderer/features/agents/QuickAgentGhost.tsx
+++ b/src/renderer/features/agents/QuickAgentGhost.tsx
@@ -81,7 +81,7 @@ export function QuickAgentGhost({ completed, onDismiss, onDelete }: Props) {
           <div className="flex items-center gap-2 flex-wrap">
             <ExitBadge exitCode={completed.exitCode} cancelled={completed.cancelled} />
             {completed.headless && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-ctp-accent/20 text-ctp-accent">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-ctp-accent/20 text-ctp-accent">
                 Headless
               </span>
             )}
@@ -89,7 +89,7 @@ export function QuickAgentGhost({ completed, onDismiss, onDelete }: Props) {
               const orchId = completed.orchestrator || 'claude-code';
               const c = getOrchestratorColor(orchId);
               return (
-                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px]"
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs"
                   style={{ backgroundColor: c.bg, color: c.text }}>
                   {getOrchestratorLabel(orchId, allOrchestrators)}
                 </span>
@@ -98,7 +98,7 @@ export function QuickAgentGhost({ completed, onDismiss, onDelete }: Props) {
             {completed.model && (() => {
               const c = getModelColor(completed.model);
               return (
-                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono"
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono"
                   style={{ backgroundColor: c.bg, color: c.text }}>
                   {formatModelLabel(completed.model)}
                 </span>
@@ -114,12 +114,12 @@ export function QuickAgentGhost({ completed, onDismiss, onDelete }: Props) {
           {(completed.durationMs != null || (completed.toolsUsed && completed.toolsUsed.length > 0)) && (
             <div className="flex items-center gap-2 flex-wrap">
               {completed.durationMs != null && (
-                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-surface-0 text-ctp-subtext1">
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-surface-0 text-ctp-subtext1">
                   {formatDuration(completed.durationMs)}
                 </span>
               )}
               {completed.toolsUsed && completed.toolsUsed.map((tool) => (
-                <span key={tool} className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-surface-0 text-ctp-subtext0 font-mono">
+                <span key={tool} className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-surface-0 text-ctp-subtext0 font-mono">
                   {tool}
                 </span>
               ))}
@@ -268,7 +268,7 @@ export function QuickAgentGhostCompact({ completed, onDismiss, onDelete: _onDele
               </span>
             );
           })()}
-          <span className="text-[10px] text-ctp-subtext0 truncate">
+          <span className="text-xs text-ctp-subtext0 truncate">
             {completed.summary || 'Interrupted'}
             {completed.filesModified.length > 0 && ` · ${completed.filesModified.length} file${completed.filesModified.length === 1 ? '' : 's'}`}
             {completed.durationMs != null && ` · ${formatDuration(completed.durationMs)}`}
@@ -277,7 +277,7 @@ export function QuickAgentGhostCompact({ completed, onDismiss, onDelete: _onDele
       </div>
 
       {/* Timestamp */}
-      <span className="text-[10px] text-ctp-overlay0 flex-shrink-0">{relativeTime(completed.completedAt)}</span>
+      <span className="text-xs text-ctp-overlay0 flex-shrink-0">{relativeTime(completed.completedAt)}</span>
 
       {/* Dismiss (trash icon) */}
       <button

--- a/src/renderer/features/agents/SessionPickerDialog.tsx
+++ b/src/renderer/features/agents/SessionPickerDialog.tsx
@@ -78,7 +78,7 @@ function SessionRow({
                 {session.friendlyName || `Session ${session.sessionId.slice(0, 8)}`}
               </span>
               {isLatest && (
-                <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-ctp-accent/20 text-ctp-accent shrink-0">
+                <span className="text-xs px-1.5 py-0.5 rounded-full bg-ctp-accent/20 text-ctp-accent shrink-0">
                   latest
                 </span>
               )}
@@ -225,7 +225,7 @@ export function SessionPickerDialog({ agentId, projectPath, orchestrator, onResu
           {!loading && sessions.length > 0 && (
             <>
               <div className="px-3 pt-1 pb-1">
-                <span className="text-[10px] uppercase tracking-wider text-ctp-subtext0 font-medium">Recent</span>
+                <span className="text-xs uppercase tracking-wider text-ctp-subtext0 font-medium">Recent</span>
               </div>
               {sessions.slice(0, RECENT_COUNT).map((session, idx) => (
                 <SessionRow
@@ -250,7 +250,7 @@ export function SessionPickerDialog({ agentId, projectPath, orchestrator, onResu
           {!loading && sessions.length > RECENT_COUNT && (
             <>
               <div className="px-3 pt-3 pb-1">
-                <span className="text-[10px] uppercase tracking-wider text-ctp-subtext0 font-medium">Older</span>
+                <span className="text-xs uppercase tracking-wider text-ctp-subtext0 font-medium">Older</span>
               </div>
               {sessions.slice(RECENT_COUNT).map((session, idx) => (
                 <SessionRow

--- a/src/renderer/features/agents/SkillsSection.tsx
+++ b/src/renderer/features/agents/SkillsSection.tsx
@@ -133,7 +133,7 @@ export function SkillsSection({ worktreePath, projectPath, disabled, refreshKey,
       <div className="flex items-center justify-between mb-2">
         <div>
           <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Skills</h3>
-          <span className="text-[10px] text-ctp-subtext0/60 font-mono">{pathLabel || '.claude/skills/'}</span>
+          <span className="text-xs text-ctp-subtext0/60 font-mono">{pathLabel || '.claude/skills/'}</span>
         </div>
         <button
           onClick={handleCreate}

--- a/src/renderer/features/agents/TemplateConfigDialog.tsx
+++ b/src/renderer/features/agents/TemplateConfigDialog.tsx
@@ -103,7 +103,7 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
           </div>
           <div>
             <h2 className="text-base font-semibold text-ctp-text">Configure {persona.name}</h2>
-            <p className="text-[10px] text-ctp-subtext0">{persona.description}</p>
+            <p className="text-xs text-ctp-subtext0">{persona.description}</p>
           </div>
         </div>
 
@@ -205,7 +205,7 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
               className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
             />
             <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use git worktree</span>
-            <span className="text-[10px] text-ctp-subtext0/70 ml-1">(isolated branch + directory)</span>
+            <span className="text-xs text-ctp-subtext0/70 ml-1">(isolated branch + directory)</span>
           </label>
 
           {/* Structured Mode (experimental — hidden unless opted in) */}
@@ -223,7 +223,7 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
                 className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-accent focus:ring-ctp-accent"
               />
               <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Use Structured Mode</span>
-              <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+              <span className="text-xs text-ctp-subtext0/70 ml-1">
                 {supportsStructured ? '(rich event UI)' : '(not supported)'}
               </span>
             </label>
@@ -242,7 +242,7 @@ export function TemplateConfigDialog({ persona, personaColor, projectPath, onClo
               className="w-4 h-4 rounded border-surface-2 bg-surface-0 text-ctp-error focus:ring-ctp-error accent-red-500"
             />
             <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Free Agent Mode</span>
-            <span className="text-[10px] text-ctp-subtext0/70 ml-1">
+            <span className="text-xs text-ctp-subtext0/70 ml-1">
               {supportsPermissions ? '(skip all permissions)' : '(not supported)'}
             </span>
           </label>

--- a/src/renderer/features/agents/TranscriptViewer.tsx
+++ b/src/renderer/features/agents/TranscriptViewer.tsx
@@ -163,13 +163,13 @@ export function TranscriptViewer({ agentId }: Props) {
     <div ref={scrollContainerRef} className="space-y-2 p-3 max-h-[400px] overflow-y-auto">
       {hasMore && (
         <div ref={sentinelRef} className="text-center py-1">
-          {loadingMore && <span className="text-[10px] text-ctp-subtext0 flex items-center gap-1"><Spinner size="xs" /> Loading earlier events...</span>}
+          {loadingMore && <span className="text-xs text-ctp-subtext0 flex items-center gap-1"><Spinner size="xs" /> Loading earlier events...</span>}
         </div>
       )}
       {items.map((item, i) => (
         <TranscriptItem key={i} item={item} />
       ))}
-      <div className="text-[10px] text-ctp-subtext0 text-right">
+      <div className="text-xs text-ctp-subtext0 text-right">
         {events.length} of {totalEvents} events loaded
       </div>
     </div>
@@ -290,7 +290,7 @@ function TranscriptItem({ item }: { item: DisplayItem }) {
   return (
     <div className="border-t border-surface-0 pt-2 mt-2">
       {item.text && <p className="text-xs text-ctp-text mb-1">{item.text}</p>}
-      <div className="flex gap-3 text-[10px] text-ctp-subtext0">
+      <div className="flex gap-3 text-xs text-ctp-subtext0">
         {item.costUsd != null && <span>${item.costUsd.toFixed(4)}</span>}
         {item.durationMs != null && <span>{formatDuration(item.durationMs)}</span>}
       </div>

--- a/src/renderer/features/agents/structured/ActionBar.tsx
+++ b/src/renderer/features/agents/structured/ActionBar.tsx
@@ -68,7 +68,7 @@ export function ActionBar({ agentId: _agentId, elapsed, usage, isComplete, onSto
       {usage && <CostTracker usage={usage} />}
 
       {/* Elapsed time */}
-      <span className="text-[10px] text-ctp-subtext0 tabular-nums">{formatElapsed(elapsed)}</span>
+      <span className="text-xs text-ctp-subtext0 tabular-nums">{formatElapsed(elapsed)}</span>
 
       {/* Stop button */}
       {!isComplete && (

--- a/src/renderer/features/agents/structured/CommandOutputPanel.tsx
+++ b/src/renderer/features/agents/structured/CommandOutputPanel.tsx
@@ -70,14 +70,14 @@ export function CommandOutputPanel({ command, defaultExpanded = true }: Props) {
         <span className="text-xs font-mono text-ctp-text truncate">{command.command}</span>
         <span className="ml-auto">
           {isRunning ? (
-            <span className="text-[10px] text-ctp-accent flex items-center gap-1">
+            <span className="text-xs text-ctp-accent flex items-center gap-1">
               <span className="w-1.5 h-1.5 rounded-full bg-ctp-accent animate-pulse" />
               Running
             </span>
           ) : isFailed ? (
-            <span className="text-[10px] text-ctp-red">exit {command.exitCode ?? '?'}</span>
+            <span className="text-xs text-ctp-red">exit {command.exitCode ?? '?'}</span>
           ) : (
-            <span className="text-[10px] text-ctp-green">exit 0</span>
+            <span className="text-xs text-ctp-green">exit 0</span>
           )}
         </span>
       </button>
@@ -92,7 +92,7 @@ export function CommandOutputPanel({ command, defaultExpanded = true }: Props) {
           />
           {isTruncated && (
             <button
-              className="w-full py-1 text-[10px] text-ctp-subtext0 hover:text-ctp-text border-t border-surface-0 transition-colors cursor-pointer"
+              className="w-full py-1 text-xs text-ctp-subtext0 hover:text-ctp-text border-t border-surface-0 transition-colors cursor-pointer"
               onClick={() => setShowAll(true)}
             >
               Show all ({outputLines.length} lines)

--- a/src/renderer/features/agents/structured/CostTracker.tsx
+++ b/src/renderer/features/agents/structured/CostTracker.tsx
@@ -14,7 +14,7 @@ export function CostTracker({ usage }: Props) {
 
   return (
     <div
-      className="relative inline-flex items-center gap-1.5 text-[10px] text-ctp-subtext0 tabular-nums"
+      className="relative inline-flex items-center gap-1.5 text-xs text-ctp-subtext0 tabular-nums"
       data-testid="cost-tracker"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
@@ -30,7 +30,7 @@ export function CostTracker({ usage }: Props) {
 
       {/* Tooltip breakdown */}
       {showTooltip && (
-        <div className="absolute bottom-full left-0 mb-1 bg-ctp-crust border border-surface-0 rounded px-2 py-1.5 text-[10px] text-ctp-subtext1 shadow-lg whitespace-nowrap z-10">
+        <div className="absolute bottom-full left-0 mb-1 bg-ctp-crust border border-surface-0 rounded px-2 py-1.5 text-xs text-ctp-subtext1 shadow-lg whitespace-nowrap z-10">
           <div>Input: {usage.inputTokens.toLocaleString()}</div>
           <div>Output: {usage.outputTokens.toLocaleString()}</div>
           {usage.cacheReadTokens != null && (

--- a/src/renderer/features/agents/structured/ErrorBanner.tsx
+++ b/src/renderer/features/agents/structured/ErrorBanner.tsx
@@ -28,7 +28,7 @@ export function ErrorBanner({ error }: Props) {
           <div className="flex items-center gap-2">
             <span className="text-xs font-medium text-ctp-red">{error.code}</span>
             {error.toolId && (
-              <span className="text-[10px] text-ctp-subtext0 font-mono">({error.toolId})</span>
+              <span className="text-xs text-ctp-subtext0 font-mono">({error.toolId})</span>
             )}
           </div>
           <p className="text-xs text-ctp-subtext1 mt-0.5 break-words">{error.message}</p>

--- a/src/renderer/features/agents/structured/FileDiffViewer.tsx
+++ b/src/renderer/features/agents/structured/FileDiffViewer.tsx
@@ -38,7 +38,7 @@ export function FileDiffViewer({ diff, defaultExpanded = false }: Props) {
       >
         <ChangeTypeBadge type={diff.changeType} />
         <span className="text-xs font-mono text-ctp-text truncate">{diff.path}</span>
-        <span className="ml-auto flex items-center gap-1.5 text-[10px] tabular-nums">
+        <span className="ml-auto flex items-center gap-1.5 text-xs tabular-nums">
           {stats.added > 0 && <span className="text-ctp-green">+{stats.added}</span>}
           {stats.removed > 0 && <span className="text-ctp-red">-{stats.removed}</span>}
         </span>
@@ -91,7 +91,7 @@ function ChangeTypeBadge({ type }: { type: FileDiff['changeType'] }) {
   }[type];
 
   return (
-    <span className={`text-[10px] px-1.5 py-0.5 rounded ${color}`}>{label}</span>
+    <span className={`text-xs px-1.5 py-0.5 rounded ${color}`}>{label}</span>
   );
 }
 

--- a/src/renderer/features/agents/structured/PlanProgress.tsx
+++ b/src/renderer/features/agents/structured/PlanProgress.tsx
@@ -23,7 +23,7 @@ export function PlanProgress({ plan }: Props) {
           <line x1="5" y1="10" x2="9" y2="10" />
         </svg>
         <span className="text-xs font-medium text-ctp-text">Plan</span>
-        <span className="text-[10px] text-ctp-subtext0 ml-auto tabular-nums">
+        <span className="text-xs text-ctp-subtext0 ml-auto tabular-nums">
           {completed}/{plan.steps.length} complete
         </span>
       </div>

--- a/src/renderer/features/agents/structured/ToolCard.tsx
+++ b/src/renderer/features/agents/structured/ToolCard.tsx
@@ -47,7 +47,7 @@ export function ToolCard({ tool, output, end, status }: Props) {
         )}
         <span className="ml-auto flex items-center gap-2">
           {end && (
-            <span className="text-[10px] text-ctp-subtext0 tabular-nums">
+            <span className="text-xs text-ctp-subtext0 tabular-nums">
               {formatDuration(end.durationMs)}
             </span>
           )}
@@ -60,7 +60,7 @@ export function ToolCard({ tool, output, end, status }: Props) {
         <div className="border-t border-surface-0">
           {/* Input section */}
           <button
-            className="w-full flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-ctp-subtext0 hover:bg-surface-0/30 transition-colors cursor-pointer"
+            className="w-full flex items-center gap-1.5 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-0/30 transition-colors cursor-pointer"
             onClick={() => setInputExpanded((e) => !e)}
           >
             <ChevronIcon expanded={inputExpanded} />
@@ -75,7 +75,7 @@ export function ToolCard({ tool, output, end, status }: Props) {
           {/* Output section */}
           {(output || status === 'running') && (
             <div className="border-t border-surface-0">
-              <div className="px-3 py-1.5 text-[10px] text-ctp-subtext0 flex items-center gap-1.5">
+              <div className="px-3 py-1.5 text-xs text-ctp-subtext0 flex items-center gap-1.5">
                 Output
                 {status === 'running' && (
                   <span className="text-ctp-accent animate-pulse">(streaming...)</span>

--- a/src/renderer/features/annex/AnnexUnsupportedPlaceholder.tsx
+++ b/src/renderer/features/annex/AnnexUnsupportedPlaceholder.tsx
@@ -27,7 +27,7 @@ export function AnnexUnsupportedPlaceholder({ widgetType, reason }: AnnexUnsuppo
         <div className="text-xs font-medium text-ctp-subtext1">
           {widgetType} unavailable over Annex
         </div>
-        <div className="text-[10px] text-ctp-overlay0 max-w-[200px]">
+        <div className="text-xs text-ctp-overlay0 max-w-[200px]">
           {reason || 'This widget type cannot be viewed over a remote connection.'}
         </div>
       </div>

--- a/src/renderer/features/annex/SatelliteDashboard.tsx
+++ b/src/renderer/features/annex/SatelliteDashboard.tsx
@@ -194,7 +194,7 @@ function RemoteProjectCard({ project, agents, satelliteId, agentIcons, detailedS
           {statusDots.map((d) => (
             <span
               key={d.label}
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-0 text-[10px] text-ctp-subtext1"
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-0 text-xs text-ctp-subtext1"
               title={`${d.count} ${d.label}`}
             >
               <span className={`w-1.5 h-1.5 rounded-full ${d.color} ${d.pulse ? 'animate-pulse' : ''}`} />
@@ -381,7 +381,7 @@ export function SatelliteDashboard({ activeHostId }: SatelliteDashboardProps) {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-bold text-ctp-text">{satelliteName}</h1>
-              <span className="text-[10px] font-medium text-ctp-peach bg-ctp-peach/10 px-2 py-0.5 rounded-full">
+              <span className="text-xs font-medium text-ctp-peach bg-ctp-peach/10 px-2 py-0.5 rounded-full">
                 Remote
               </span>
             </div>

--- a/src/renderer/features/assistant/AssistantActionCard.tsx
+++ b/src/renderer/features/assistant/AssistantActionCard.tsx
@@ -107,10 +107,10 @@ export function AssistantActionCard({ action, onApprove, onSkip }: Props) {
         )}
         <span className="ml-auto flex items-center gap-2 shrink-0">
           {action.status === 'completed' && summary && (
-            <span className="text-[10px] text-ctp-success truncate max-w-[140px]">{summary}</span>
+            <span className="text-xs text-ctp-success truncate max-w-[140px]">{summary}</span>
           )}
           {action.durationMs != null && action.status === 'completed' && (
-            <span className="text-[10px] text-ctp-subtext0 tabular-nums">
+            <span className="text-xs text-ctp-subtext0 tabular-nums">
               {action.durationMs < 1000 ? `${action.durationMs}ms` : `${(action.durationMs / 1000).toFixed(1)}s`}
             </span>
           )}
@@ -147,7 +147,7 @@ export function AssistantActionCard({ action, onApprove, onSkip }: Props) {
           {/* Input parameters */}
           {action.input && Object.keys(action.input).length > 0 && (
             <details className="group">
-              <summary className="px-3 py-1.5 text-[10px] text-ctp-subtext0 cursor-pointer hover:text-ctp-subtext1 select-none">
+              <summary className="px-3 py-1.5 text-xs text-ctp-subtext0 cursor-pointer hover:text-ctp-subtext1 select-none">
                 Parameters
               </summary>
               <pre className="px-3 pb-2 text-xs text-ctp-subtext1 font-mono overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words">
@@ -159,7 +159,7 @@ export function AssistantActionCard({ action, onApprove, onSkip }: Props) {
           {/* Output */}
           {action.output && action.status !== 'error' && (
             <details className="group" open={action.status === 'completed' && !!summary}>
-              <summary className="px-3 py-1.5 text-[10px] text-ctp-subtext0 cursor-pointer hover:text-ctp-subtext1 select-none">
+              <summary className="px-3 py-1.5 text-xs text-ctp-subtext0 cursor-pointer hover:text-ctp-subtext1 select-none">
                 Result
               </summary>
               <pre className="px-3 pb-2 text-xs text-ctp-subtext1 font-mono overflow-x-auto max-h-60 overflow-y-auto whitespace-pre-wrap break-words">

--- a/src/renderer/features/assistant/AssistantFeed.tsx
+++ b/src/renderer/features/assistant/AssistantFeed.tsx
@@ -275,7 +275,7 @@ const ActionGroupCard = React.memo(function ActionGroupCard({ group, actions, on
           {group.status === 'running' ? '...' : group.status === 'completed' ? '\u2713' : group.status === 'error' ? '\u2717' : '\u25CB'}
         </span>
         <span className="text-xs font-medium text-ctp-text">{group.label}</span>
-        <span className="ml-auto text-[10px] text-ctp-subtext0 tabular-nums">
+        <span className="ml-auto text-xs text-ctp-subtext0 tabular-nums">
           {completedCount}/{actions.length}
         </span>
         <svg

--- a/src/renderer/features/assistant/AssistantHeader.tsx
+++ b/src/renderer/features/assistant/AssistantHeader.tsx
@@ -76,7 +76,7 @@ export function AssistantHeader({ onReset, mode, onModeChange, orchestrator, onO
           <select
             value={orchestrator || ''}
             onChange={(e) => onOrchestratorChange(e.target.value || null)}
-            className="bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-subtext0 outline-none cursor-pointer"
+            className="bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-xs text-ctp-subtext0 outline-none cursor-pointer"
             title="Orchestrator"
             data-testid="orchestrator-select"
           >
@@ -93,7 +93,7 @@ export function AssistantHeader({ onReset, mode, onModeChange, orchestrator, onO
             <button
               key={m}
               onClick={() => onModeChange(m)}
-              className={`px-2 py-1 text-[10px] font-medium transition-colors cursor-pointer ${
+              className={`px-2 py-1 text-xs font-medium transition-colors cursor-pointer ${
                 mode === m
                   ? 'bg-ctp-accent text-white shadow-sm'
                   : 'text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-0'

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -229,7 +229,7 @@ export function BlueprintGallery() {
             <button
               onClick={handleOpenFromFile}
               disabled={importing === '__open_from_file__'}
-              className="text-[10px] px-2 py-0.5 bg-ctp-mantle border border-surface-0 rounded text-ctp-subtext1 hover:text-ctp-text hover:border-ctp-accent disabled:opacity-50"
+              className="text-xs px-2 py-0.5 bg-ctp-mantle border border-surface-0 rounded text-ctp-subtext1 hover:text-ctp-text hover:border-ctp-accent disabled:opacity-50"
               data-testid="blueprint-gallery-open-from-file"
               title="Open a blueprint .json from anywhere on disk"
             >
@@ -239,7 +239,7 @@ export function BlueprintGallery() {
             <select
               value={sortMode}
               onChange={(e) => setSortMode(e.target.value as SortMode)}
-              className="text-[10px] bg-ctp-mantle border border-surface-0 rounded px-1.5 py-0.5 text-ctp-subtext1 focus-ring"
+              className="text-xs bg-ctp-mantle border border-surface-0 rounded px-1.5 py-0.5 text-ctp-subtext1 focus-ring"
               data-testid="blueprint-gallery-sort"
             >
               <option value="name">Sort: Name</option>
@@ -405,14 +405,14 @@ function BlueprintCard({
       >
         <div className="text-xs font-medium text-ctp-text truncate w-full">{bp.name}</div>
         {bp.description && (
-          <div className="text-[10px] text-ctp-subtext0 line-clamp-2">{bp.description}</div>
+          <div className="text-xs text-ctp-subtext0 line-clamp-2">{bp.description}</div>
         )}
-        <div className="flex items-center gap-2 text-[10px] text-ctp-overlay0 mt-auto">
+        <div className="flex items-center gap-2 text-xs text-ctp-overlay0 mt-auto">
           <span>{bp.viewCount} view{bp.viewCount !== 1 ? 's' : ''}</span>
           {bp.agentCount > 0 && <span>{bp.agentCount} agent{bp.agentCount !== 1 ? 's' : ''}</span>}
           {bp.wireCount > 0 && <span>{bp.wireCount} wire{bp.wireCount !== 1 ? 's' : ''}</span>}
         </div>
-        <div className="flex items-center gap-1 text-[10px] text-ctp-overlay0 truncate w-full">
+        <div className="flex items-center gap-1 text-xs text-ctp-overlay0 truncate w-full">
           <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="flex-shrink-0">
             <path d="M2 4l6-2 6 2v8l-6 2-6-2z" />
             <path d="M8 2v12" />
@@ -504,7 +504,7 @@ function PreviewPanel({
       <div className="px-4 py-3 border-b border-surface-0">
         <div className="text-xs font-semibold text-ctp-text mb-1">{bp.name}</div>
         {bp.description && (
-          <div className="text-[10px] text-ctp-subtext0 mb-2">{bp.description}</div>
+          <div className="text-xs text-ctp-subtext0 mb-2">{bp.description}</div>
         )}
         <button
           onClick={onImport}
@@ -517,7 +517,7 @@ function PreviewPanel({
       </div>
 
       {/* Metadata */}
-      <div className="px-4 py-2 border-b border-surface-0 text-[10px] text-ctp-subtext0 space-y-1">
+      <div className="px-4 py-2 border-b border-surface-0 text-xs text-ctp-subtext0 space-y-1">
         <div className="flex justify-between"><span>Source</span><span className="text-ctp-text">{bp.source}</span></div>
         <div className="flex justify-between"><span>Version</span><span className="text-ctp-text">{bp.version}</span></div>
         {bp.createdAt && (
@@ -527,15 +527,15 @@ function PreviewPanel({
 
       {/* View breakdown */}
       <div className="px-4 py-2 border-b border-surface-0">
-        <div className="text-[10px] font-medium text-ctp-subtext1 mb-1.5">Views ({bp.viewCount})</div>
+        <div className="text-xs font-medium text-ctp-subtext1 mb-1.5">Views ({bp.viewCount})</div>
         <div className="flex flex-wrap gap-1.5">
           {Object.entries(typeBreakdown).map(([type, count]) => (
-            <span key={type} className={`text-[10px] px-1.5 py-0.5 rounded ${typeColor(type)}`}>
+            <span key={type} className={`text-xs px-1.5 py-0.5 rounded ${typeColor(type)}`}>
               {count} {type}
             </span>
           ))}
           {bp.wireCount > 0 && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-0 text-ctp-subtext0">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-surface-0 text-ctp-subtext0">
               {bp.wireCount} wire{bp.wireCount !== 1 ? 's' : ''}
             </span>
           )}
@@ -545,10 +545,10 @@ function PreviewPanel({
       {/* Agent list */}
       {bp.agentNames.length > 0 && (
         <div className="px-4 py-2 border-b border-surface-0">
-          <div className="text-[10px] font-medium text-ctp-subtext1 mb-1.5">Agents</div>
+          <div className="text-xs font-medium text-ctp-subtext1 mb-1.5">Agents</div>
           <div className="space-y-1">
             {bp.agentNames.map((name, i) => (
-              <div key={i} className="flex items-center gap-1.5 text-[10px] text-ctp-text">
+              <div key={i} className="flex items-center gap-1.5 text-xs text-ctp-text">
                 <div className="w-1.5 h-1.5 rounded-full bg-ctp-accent flex-shrink-0" />
                 {name}
               </div>
@@ -560,7 +560,7 @@ function PreviewPanel({
       {/* Mini layout preview */}
       {viewRects.length > 0 && (
         <div className="px-4 py-2">
-          <div className="text-[10px] font-medium text-ctp-subtext1 mb-1.5">Layout Preview</div>
+          <div className="text-xs font-medium text-ctp-subtext1 mb-1.5">Layout Preview</div>
           <MiniLayoutPreview views={viewRects} />
         </div>
       )}

--- a/src/renderer/features/help/HelpSectionNav.tsx
+++ b/src/renderer/features/help/HelpSectionNav.tsx
@@ -15,7 +15,7 @@ export function HelpSectionNav({ sections, pluginSections, activeSectionId, onSe
       </div>
       <nav className="flex-1 py-1 flex flex-col overflow-y-auto">
         <div className="px-3 pt-2 pb-1">
-          <span className="text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider">Features</span>
+          <span className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Features</span>
         </div>
         {sections.map((section) => (
           <button
@@ -38,7 +38,7 @@ export function HelpSectionNav({ sections, pluginSections, activeSectionId, onSe
           <>
             <div className="w-full border-t border-surface-0 my-1" />
             <div className="px-3 pt-2 pb-1">
-              <span className="text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider">Plugins</span>
+              <span className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Plugins</span>
             </div>
             {pluginSections.map((section) => (
               <button

--- a/src/renderer/features/popout/PopoutAgentView.tsx
+++ b/src/renderer/features/popout/PopoutAgentView.tsx
@@ -83,7 +83,7 @@ export function PopoutAgentView({ agentId, projectId }: PopoutAgentViewProps) {
           <div className="flex items-center gap-1 ml-1 flex-shrink-0">
             <button
               onClick={handleView}
-              className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
+              className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
               title="View in main window"
               data-testid="popout-view-button"
             >
@@ -92,7 +92,7 @@ export function PopoutAgentView({ agentId, projectId }: PopoutAgentViewProps) {
             {isRunning && (
               <button
                 onClick={handleKill}
-                className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30"
+                className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30"
                 title="Stop agent"
                 data-testid="popout-stop-button"
               >
@@ -102,7 +102,7 @@ export function PopoutAgentView({ agentId, projectId }: PopoutAgentViewProps) {
             {!isRunning && agent.kind === 'durable' && (
               <button
                 onClick={handleWake}
-                className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success hover:bg-ctp-success/30"
+                className="text-xs px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success hover:bg-ctp-success/30"
                 title="Wake agent"
                 data-testid="popout-wake-button"
               >

--- a/src/renderer/features/popout/PopoutHubPane.tsx
+++ b/src/renderer/features/popout/PopoutHubPane.tsx
@@ -204,14 +204,14 @@ export function PopoutHubPane({
                 <div className="flex items-center gap-1 ml-1 flex-shrink-0">
                   <button
                     onClick={(e) => { e.stopPropagation(); handleViewInApp(); }}
-                    className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
+                    className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
                     title="View in main window"
                   >
                     View
                   </button>
                   <button
                     onClick={(e) => { e.stopPropagation(); onZoom(pane.id); }}
-                    className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
+                    className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
                     title={isZoomed ? 'Restore pane' : 'Zoom pane'}
                     data-testid="zoom-button"
                   >
@@ -220,7 +220,7 @@ export function PopoutHubPane({
                   {agent.status === 'running' && (
                     <button
                       onClick={(e) => { e.stopPropagation(); handleKill(); }}
-                      className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30"
+                      className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30"
                       title="Stop agent"
                     >
                       Stop
@@ -228,7 +228,7 @@ export function PopoutHubPane({
                   )}
                   <button
                     onClick={(e) => { e.stopPropagation(); handleUnassign(); }}
-                    className="text-[10px] px-1 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-ctp-error/20 hover:text-ctp-error"
+                    className="text-xs px-1 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-ctp-error/20 hover:text-ctp-error"
                     title="Remove from pane"
                   >
                     &times;
@@ -277,7 +277,7 @@ function PopoutAgentPicker({ agents, onPick }: {
           </div>
           {durableAgents.length > 0 && (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wider text-ctp-overlay0 mb-1">Durable</div>
+              <div className="text-xs uppercase tracking-wider text-ctp-overlay0 mb-1">Durable</div>
               {durableAgents.map((a) => (
                 <button
                   key={a.id}
@@ -286,7 +286,7 @@ function PopoutAgentPicker({ agents, onPick }: {
                 >
                   <AgentAvatarWithRing agent={a} />
                   <span className="text-xs text-ctp-text truncate flex-1">{a.name}</span>
-                  <span className={`text-[10px] ${a.status === 'running' ? 'text-ctp-success' : a.status === 'error' ? 'text-ctp-error' : 'text-ctp-overlay0'}`}>
+                  <span className={`text-xs ${a.status === 'running' ? 'text-ctp-success' : a.status === 'error' ? 'text-ctp-error' : 'text-ctp-overlay0'}`}>
                     {a.status}
                   </span>
                 </button>
@@ -295,7 +295,7 @@ function PopoutAgentPicker({ agents, onPick }: {
           )}
           {quickAgents.length > 0 && (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wider text-ctp-overlay0 mb-1">Quick</div>
+              <div className="text-xs uppercase tracking-wider text-ctp-overlay0 mb-1">Quick</div>
               {quickAgents.map((a) => (
                 <button
                   key={a.id}
@@ -304,7 +304,7 @@ function PopoutAgentPicker({ agents, onPick }: {
                 >
                   <AgentAvatarWithRing agent={a} />
                   <span className="text-xs text-ctp-text truncate flex-1">{a.name}</span>
-                  <span className="text-[10px] text-ctp-success">running</span>
+                  <span className="text-xs text-ctp-success">running</span>
                 </button>
               ))}
             </div>
@@ -347,7 +347,7 @@ function EdgeIndicator({ edge, active, onSplit }: {
       <button
         className={`
           absolute ${positionClass} z-20 flex items-center justify-center w-5 h-5 rounded-full
-          text-[10px] font-bold transition-all duration-100 cursor-pointer
+          text-xs font-bold transition-all duration-100 cursor-pointer
           ${active
             ? 'bg-ctp-accent text-white shadow-md scale-110'
             : 'bg-surface-1/60 text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-subtext0'

--- a/src/renderer/features/projects/Dashboard.tsx
+++ b/src/renderer/features/projects/Dashboard.tsx
@@ -337,7 +337,7 @@ function ProjectCard({ project }: { project: Project }) {
           {statusDots.map((d) => (
             <span
               key={d.label}
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-0 text-[10px] text-ctp-subtext1"
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-0 text-xs text-ctp-subtext1"
               title={`${d.count} ${d.label}`}
             >
               <span className={`w-1.5 h-1.5 rounded-full ${d.color} ${d.pulse ? 'animate-pulse' : ''}`} />

--- a/src/renderer/features/settings/OrchestratorSettingsView.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.tsx
@@ -139,7 +139,7 @@ function AppAgentSettings() {
               <option value="github">GitHub (gh CLI)</option>
               <option value="azure-devops">Azure DevOps (az CLI)</option>
             </select>
-            <p className="text-[10px] text-ctp-subtext0/60">
+            <p className="text-xs text-ctp-subtext0/60">
               App-wide default. Projects can override in their own settings.
             </p>
           </div>
@@ -214,7 +214,7 @@ function AppAgentSettings() {
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-ctp-text">{o.displayName}</span>
                     {o.badge && (
-                      <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded-full bg-ctp-accent/20 text-ctp-accent border border-ctp-accent/30 shadow-[0_0_6px_rgba(var(--ctp-accent),0.3)]">
+                      <span className="px-1.5 py-0.5 text-xs font-semibold uppercase tracking-wider rounded-full bg-ctp-accent/20 text-ctp-accent border border-ctp-accent/30 shadow-[0_0_6px_rgba(var(--ctp-accent),0.3)]">
                         {o.badge}
                       </span>
                     )}

--- a/src/renderer/features/settings/PluginListSettings.tsx
+++ b/src/renderer/features/settings/PluginListSettings.tsx
@@ -81,7 +81,7 @@ function PermissionInfoPopup({ entry }: { entry: PluginRegistryEntry }) {
       <button
         ref={btnRef}
         onClick={handleToggle}
-        className="flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-semibold text-ctp-subtext0 hover:text-ctp-text bg-surface-1 hover:bg-surface-2 cursor-pointer"
+        className="flex items-center justify-center w-4 h-4 rounded-full text-xs font-semibold text-ctp-subtext0 hover:text-ctp-text bg-surface-1 hover:bg-surface-2 cursor-pointer"
         title="View permissions"
       >
         i
@@ -94,7 +94,7 @@ function PermissionInfoPopup({ entry }: { entry: PluginRegistryEntry }) {
         >
           <p className="text-xs font-semibold text-ctp-subtext1 mb-2">Permissions</p>
           {isAppScoped && hasCrossProjectPerm && (
-            <p className="text-[10px] text-ctp-peach mb-2" data-testid="app-scope-cross-project-note">
+            <p className="text-xs text-ctp-peach mb-2" data-testid="app-scope-cross-project-note">
               This is an app-scoped plugin — cross-project access is implicit and does not require per-project enablement.
             </p>
           )}
@@ -112,7 +112,7 @@ function PermissionInfoPopup({ entry }: { entry: PluginRegistryEntry }) {
                       </span>
                     )}
                   </div>
-                  <p className="text-[10px] text-ctp-subtext0">
+                  <p className="text-xs text-ctp-subtext0">
                     {isAppScoped && isCrossProject
                       ? PERMISSION_DESCRIPTIONS[perm].replace(
                           /where the plugin is (?:also )?enabled/,
@@ -133,17 +133,17 @@ function PermissionInfoPopup({ entry }: { entry: PluginRegistryEntry }) {
 function SourceBadge({ entry }: { entry: PluginRegistryEntry }) {
   if (entry.source === 'builtin') {
     return (
-      <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent">Built-in</span>
+      <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent">Built-in</span>
     );
   }
   if (entry.source === 'marketplace') {
     return (
-      <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success">Official</span>
+      <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success">Official</span>
     );
   }
   if (entry.source === 'community') {
     return (
-      <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0">Community</span>
+      <span className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0">Community</span>
     );
   }
   return null;
@@ -246,11 +246,11 @@ function OrphanInjectionsBanner({
           <div className="flex flex-wrap gap-2">
             {orphans.map((id) => (
               <div key={id} className="flex items-center gap-1">
-                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach">{id}</span>
+                <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach">{id}</span>
                 <button
                   onClick={() => handleClean(id)}
                   disabled={cleaning !== null}
-                  className="text-[10px] px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
+                  className="text-xs px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
                   data-testid={`clean-orphan-btn-${id}`}
                 >
                   {cleaning === id ? 'Cleaning…' : 'Clean up'}
@@ -326,14 +326,14 @@ function PluginInjectionsPanel({
         <button
           onClick={handleClean}
           disabled={cleaning}
-          className="text-[10px] px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
+          className="text-xs px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50"
           data-testid={`clean-injections-btn-${pluginId}`}
         >
           {cleaning ? 'Cleaning...' : 'Remove all'}
         </button>
       </div>
       {cleanError && (
-        <p className="text-[10px] text-ctp-error mb-1">{cleanError}</p>
+        <p className="text-xs text-ctp-error mb-1">{cleanError}</p>
       )}
       <ul className="space-y-0.5 list-disc list-inside">
         {injections.skills.map((s) => (
@@ -396,29 +396,29 @@ function PluginRow({
             <span className="text-sm font-medium text-ctp-text">{entry.manifest.name}</span>
             <span className="text-xs text-ctp-subtext0">v{entry.manifest.version}</span>
             <SourceBadge entry={entry} />
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-overlay1">API {entry.manifest.engine.api}</span>
+            <span className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-overlay1">API {entry.manifest.engine.api}</span>
             <PermissionInfoPopup entry={entry} />
             {isIncompatible && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Incompatible</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Incompatible</span>
             )}
             {!isIncompatible && DEPRECATED_PLUGIN_API_VERSIONS[entry.manifest.engine.api] && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400" title={`API ${entry.manifest.engine.api} will be removed in ${DEPRECATED_PLUGIN_API_VERSIONS[entry.manifest.engine.api]}`}>Deprecated API</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400" title={`API ${entry.manifest.engine.api} will be removed in ${DEPRECATED_PLUGIN_API_VERSIONS[entry.manifest.engine.api]}`}>Deprecated API</span>
             )}
             {isErrored && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Error</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Error</span>
             )}
             {isPendingApproval && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach" data-testid={`pending-badge-${entry.manifest.id}`}>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach" data-testid={`pending-badge-${entry.manifest.id}`}>
                 New permissions
               </span>
             )}
             {updateVersion && !isUpdating && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success" data-testid={`update-badge-${entry.manifest.id}`}>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success" data-testid={`update-badge-${entry.manifest.id}`}>
                 v{updateVersion} available
               </span>
             )}
             {isUpdating && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent animate-pulse" data-testid={`update-phase-${entry.manifest.id}`}>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent animate-pulse" data-testid={`update-phase-${entry.manifest.id}`}>
                 {UPDATE_PHASE_LABELS[updatePhase] || 'Updating...'}
               </span>
             )}
@@ -438,8 +438,8 @@ function PluginRow({
                 <p className="text-xs text-ctp-error">{message}</p>
                 {stack && (
                   <details className="mt-1">
-                    <summary className="text-[10px] text-ctp-error/70 cursor-pointer">View details</summary>
-                    <pre className="text-[10px] text-ctp-error/70 bg-surface-0 p-2 rounded mt-1 overflow-auto max-h-32 whitespace-pre-wrap">{stack}</pre>
+                    <summary className="text-xs text-ctp-error/70 cursor-pointer">View details</summary>
+                    <pre className="text-xs text-ctp-error/70 bg-surface-0 p-2 rounded mt-1 overflow-auto max-h-32 whitespace-pre-wrap">{stack}</pre>
                   </details>
                 )}
               </div>
@@ -456,7 +456,7 @@ function PluginRow({
                   return (
                     <span
                       key={perm}
-                      className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${
+                      className={`text-xs px-1.5 py-0.5 rounded font-mono ${
                         risk === 'dangerous'
                           ? 'bg-ctp-error/20 text-ctp-error'
                           : 'bg-yellow-500/20 text-yellow-400'
@@ -660,10 +660,10 @@ function CustomMarketplaceManager() {
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium text-ctp-text">{m.name}</span>
                       {!m.enabled && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0">Disabled</span>
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0">Disabled</span>
                       )}
                     </div>
-                    <p className="text-[10px] text-ctp-subtext0 truncate mt-0.5" title={m.url}>{m.url}</p>
+                    <p className="text-xs text-ctp-subtext0 truncate mt-0.5" title={m.url}>{m.url}</p>
                   </div>
                   <div className="flex items-center gap-2 ml-3">
                     <button
@@ -1224,7 +1224,7 @@ export function PluginListSettings() {
                 )}
               </div>
               {lastCheck && (
-                <p className="text-[10px] text-ctp-subtext0/70 mb-2" data-testid="last-check-time">
+                <p className="text-xs text-ctp-subtext0/70 mb-2" data-testid="last-check-time">
                   Last checked: {new Date(lastCheck).toLocaleString()}
                 </p>
               )}

--- a/src/renderer/features/settings/PluginMarketplaceDialog.tsx
+++ b/src/renderer/features/settings/PluginMarketplaceDialog.tsx
@@ -76,35 +76,35 @@ function PluginCard({ plugin, featured, installed, installing, onInstall, betaPl
             <span className="text-sm font-medium text-ctp-text">{plugin.name}</span>
             <span className="text-xs text-ctp-subtext0">v{plugin.latest}</span>
             {plugin.official && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success">Official</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-success/20 text-ctp-success">Official</span>
             )}
             {plugin.marketplaceName && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+              <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
                 {plugin.marketplaceName}
               </span>
             )}
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-overlay1">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-overlay1">
               API {release.api}
             </span>
             {!compatible && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Incompatible</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Incompatible</span>
             )}
             {compatible && deprecatedRemoval && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-warning/20 text-status-warning" title={`API ${release.api} will be removed in ${deprecatedRemoval}`}>Deprecated</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-status-warning/20 text-status-warning" title={`API ${release.api} will be removed in ${deprecatedRemoval}`}>Deprecated</span>
             )}
             {installed && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent">Installed</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-accent/20 text-ctp-accent">Installed</span>
             )}
           </div>
           <p className="text-xs text-ctp-subtext0 mt-1">{plugin.description}</p>
-          <div className="flex items-center gap-3 mt-2 text-[10px] text-ctp-subtext0">
+          <div className="flex items-center gap-3 mt-2 text-xs text-ctp-subtext0">
             <span>by {plugin.author}</span>
             <span>{formatBytes(release.size)}</span>
           </div>
           {plugin.tags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
               {plugin.tags.map((tag) => (
-                <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-surface-0 text-ctp-subtext0">
+                <span key={tag} className="text-xs px-1.5 py-0.5 rounded bg-surface-0 text-ctp-subtext0">
                   {tag}
                 </span>
               ))}
@@ -145,7 +145,7 @@ function PluginCard({ plugin, featured, installed, installing, onInstall, betaPl
                 )}
                 <button
                   onClick={() => setShowPerms(!showPerms)}
-                  className="text-[10px] text-ctp-subtext0 hover:text-ctp-text cursor-pointer"
+                  className="text-xs text-ctp-subtext0 hover:text-ctp-text cursor-pointer"
                 >
                   {showPerms ? 'Hide' : 'View'} permissions ({release.permissions.length})
                 </button>
@@ -162,7 +162,7 @@ function PluginCard({ plugin, featured, installed, installing, onInstall, betaPl
                 <span className="text-xs font-mono text-ctp-accent">{perm}</span>
                 <RiskBadge permission={perm} />
               </div>
-              <p className="text-[10px] text-ctp-subtext0">
+              <p className="text-xs text-ctp-subtext0">
                 {PERMISSION_DESCRIPTIONS[perm as PluginPermission] || 'Unknown permission'}
               </p>
             </div>
@@ -175,19 +175,19 @@ function PluginCard({ plugin, featured, installed, installing, onInstall, betaPl
         return (
           <div className="mt-3 pt-3 border-t border-surface-0 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-mauve/20 text-ctp-mauve font-medium">
+              <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-mauve/20 text-ctp-mauve font-medium">
                 Beta available: v{betaPlugin.latest}
               </span>
               {betaPlugin.marketplaceName && (
-                <span className="text-[10px] text-ctp-subtext0">from {betaPlugin.marketplaceName}</span>
+                <span className="text-xs text-ctp-subtext0">from {betaPlugin.marketplaceName}</span>
               )}
               {betaRelease && (
-                <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-overlay1">
+                <span className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-overlay1">
                   API {betaRelease.api}
                 </span>
               )}
               {!betaCompatible && (
-                <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Incompatible</span>
+                <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error">Incompatible</span>
               )}
             </div>
             <button
@@ -583,7 +583,7 @@ export function PluginMarketplaceDialog({ onClose }: { onClose: () => void }) {
 
         {/* Footer */}
         <div className="px-6 py-4 border-t border-surface-1 flex items-center justify-between">
-          <p className="text-[10px] text-ctp-subtext0">
+          <p className="text-xs text-ctp-subtext0">
             {data ? `${allPlugins.length} plugin(s) available` : ''}
             {customPlugins.length > 0 ? ` (${customPlugins.length} from custom registries)` : ''}
           </p>

--- a/src/renderer/features/settings/ProfilesSettingsView.tsx
+++ b/src/renderer/features/settings/ProfilesSettingsView.tsx
@@ -38,7 +38,7 @@ function EnvVarEditor({ entries, suggestedKeys, onChange }: EnvEditorProps) {
   return (
     <div className="space-y-2">
       {suggestedKeys.length > 0 && (
-        <p className="text-[10px] text-ctp-subtext0/60">
+        <p className="text-xs text-ctp-subtext0/60">
           Suggested keys: {suggestedKeys.map((k) => (
             <code key={k} className="bg-surface-0/30 px-1 rounded mx-0.5">{k}</code>
           ))}
@@ -115,7 +115,7 @@ function OrchestratorSection({ orchestratorName, entry, suggestedKeys, onUpdate,
         <span className="text-xs font-medium text-ctp-text">{orchestratorName}</span>
         <button
           onClick={onRemove}
-          className="text-[10px] text-ctp-red hover:underline cursor-pointer"
+          className="text-xs text-ctp-red hover:underline cursor-pointer"
         >
           Remove
         </button>
@@ -336,7 +336,7 @@ export function ProfilesSettingsView() {
                   <div>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-ctp-text font-medium">{p.name}</span>
-                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-surface-1 text-ctp-subtext0">
+                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-surface-1 text-ctp-subtext0">
                         {getOrchestratorNames(p)}
                       </span>
                     </div>

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -154,17 +154,17 @@ function OrphanBanner({
           <p className="text-xs font-medium text-ctp-peach mb-1">
             Orphaned plugin injections detected
           </p>
-          <p className="text-[10px] text-ctp-subtext0 mb-2">
+          <p className="text-xs text-ctp-subtext0 mb-2">
             These uninstalled plugins left configs in your project defaults:
           </p>
           <div className="flex flex-wrap gap-2">
             {orphanedPluginIds.map((id) => (
               <div key={id} className="flex items-center gap-1">
-                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach">{id}</span>
+                <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-ctp-peach/20 text-ctp-peach">{id}</span>
                 <button
                   onClick={() => handleClean(id)}
                   disabled={cleaning !== null}
-                  className="text-[10px] px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
+                  className="text-xs px-1.5 py-0.5 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
                 >
                   {cleaning === id ? 'Cleaning...' : 'Clean up'}
                 </button>
@@ -176,7 +176,7 @@ function OrphanBanner({
           <button
             onClick={handleCleanAll}
             disabled={cleaning !== null}
-            className="shrink-0 text-[10px] px-2 py-1 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
+            className="shrink-0 text-xs px-2 py-1 rounded border border-ctp-error/30 text-ctp-error hover:bg-ctp-error/10 cursor-pointer disabled:opacity-50 transition-colors"
           >
             {cleaning ? 'Cleaning...' : 'Clean all'}
           </button>
@@ -494,7 +494,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
 
       <div className="space-y-4">
         {/* Mode note */}
-        <div className={`text-[10px] flex items-start gap-1.5 rounded-lg px-3 py-2 ${
+        <div className={`text-xs flex items-start gap-1.5 rounded-lg px-3 py-2 ${
           clubhouseMode
             ? 'text-ctp-success bg-ctp-success/10 border border-ctp-success/20'
             : 'text-ctp-subtext0/60 bg-ctp-mantle border border-surface-0'
@@ -535,7 +535,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             <option value="github">GitHub (gh CLI)</option>
             <option value="azure-devops">Azure DevOps (az CLI)</option>
           </select>
-          <p className="text-[10px] text-ctp-subtext0/60 mt-1">
+          <p className="text-xs text-ctp-subtext0/60 mt-1">
             Replaces <code className="bg-surface-0 px-0.5 rounded">@@SourceControlProvider</code> in skill templates and controls conditional blocks.
           </p>
         </div>
@@ -562,12 +562,12 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
                   <option key={p.id} value={p.id}>{p.name}</option>
                 ))}
               </select>
-              <p className="text-[10px] text-ctp-subtext0/60 mt-1">
+              <p className="text-xs text-ctp-subtext0/60 mt-1">
                 Profile env vars are injected when agents in this project spawn.
                 {activeProfile && ' Only orchestrators configured in the profile appear in agent creation.'}
               </p>
               {coveredNames.length > 0 && (
-                <p className="text-[10px] text-ctp-accent/80 mt-1">
+                <p className="text-xs text-ctp-accent/80 mt-1">
                   Covers: {coveredNames.join(', ')}
                 </p>
               )}
@@ -585,7 +585,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             className="w-full bg-surface-0 border border-surface-1 rounded px-2 py-1.5 text-sm font-mono text-ctp-text focus-ring"
             spellCheck={false}
           />
-          <p className="text-[10px] text-ctp-subtext0/60 mt-1">
+          <p className="text-xs text-ctp-subtext0/60 mt-1">
             Shell command prepended before the agent CLI binary. Use this to source environment setup scripts (e.g. <code className="bg-surface-0 px-0.5 rounded">. ./init.ps1</code>). Runs in the same shell so exported variables and PATH changes are inherited by the agent.
           </p>
         </div>
@@ -593,12 +593,12 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
         {/* Build / Test / Lint Commands */}
         <div>
           <label className="block text-xs text-ctp-subtext0 mb-1">Project Commands</label>
-          <p className="text-[10px] text-ctp-subtext0/60 mb-2">
+          <p className="text-xs text-ctp-subtext0/60 mb-2">
             Configure the commands agents use to build, test, and lint your project. These replace <code className="bg-surface-0 px-0.5 rounded">@@BuildCommand</code>, <code className="bg-surface-0 px-0.5 rounded">@@TestCommand</code>, and <code className="bg-surface-0 px-0.5 rounded">@@LintCommand</code> in skills.
           </p>
           <div className="grid grid-cols-3 gap-2">
             <div>
-              <label className="block text-[10px] text-ctp-subtext0/60 mb-0.5">Build</label>
+              <label className="block text-xs text-ctp-subtext0/60 mb-0.5">Build</label>
               <input
                 value={buildCommand}
                 onChange={(e) => { setBuildCommand(e.target.value); setDirty(true); }}
@@ -608,7 +608,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
               />
             </div>
             <div>
-              <label className="block text-[10px] text-ctp-subtext0/60 mb-0.5">Test</label>
+              <label className="block text-xs text-ctp-subtext0/60 mb-0.5">Test</label>
               <input
                 value={testCommand}
                 onChange={(e) => { setTestCommand(e.target.value); setDirty(true); }}
@@ -618,7 +618,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
               />
             </div>
             <div>
-              <label className="block text-[10px] text-ctp-subtext0/60 mb-0.5">Lint</label>
+              <label className="block text-xs text-ctp-subtext0/60 mb-0.5">Lint</label>
               <input
                 value={lintCommand}
                 onChange={(e) => { setLintCommand(e.target.value); setDirty(true); }}
@@ -641,7 +641,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
           <span className="text-xs text-ctp-subtext0">Free Agent Mode by default</span>
         </label>
         {freeAgentMode && (
-          <p className="text-[10px] text-ctp-error pl-6">
+          <p className="text-xs text-ctp-error pl-6">
             New agents will skip all permission prompts by default.
           </p>
         )}
@@ -704,7 +704,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
         <div className="space-y-2">
           <label className="block text-xs text-ctp-subtext0">Default Permissions</label>
           <div>
-            <label className="block text-[10px] text-ctp-subtext0/60 mb-0.5">Allowed tools (one per line)</label>
+            <label className="block text-xs text-ctp-subtext0/60 mb-0.5">Allowed tools (one per line)</label>
             <textarea
               value={userAllowRules}
               onChange={(e) => { setPermAllow(e.target.value); setDirty(true); }}
@@ -714,7 +714,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             />
           </div>
           <div>
-            <label className="block text-[10px] text-ctp-subtext0/60 mb-0.5">Auto-deny tools (one per line)</label>
+            <label className="block text-xs text-ctp-subtext0/60 mb-0.5">Auto-deny tools (one per line)</label>
             <textarea
               value={userDenyRules}
               onChange={(e) => { setPermDeny(e.target.value); setDirty(true); }}
@@ -731,7 +731,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             <label className="block text-xs text-ctp-subtext0 mb-1">Plugin Permissions</label>
             {pluginAllowRules.length > 0 && (
               <div className="mb-2">
-                <span className="text-[10px] text-ctp-subtext0/60">Allow rules:</span>
+                <span className="text-xs text-ctp-subtext0/60">Allow rules:</span>
                 <ConfigItemList
                   items={pluginAllowRules}
                   orphanedPluginIds={orphanedPluginIds}
@@ -742,7 +742,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             )}
             {pluginDenyRules.length > 0 && (
               <div>
-                <span className="text-[10px] text-ctp-subtext0/60">Deny rules:</span>
+                <span className="text-xs text-ctp-subtext0/60">Deny rules:</span>
                 <ConfigItemList
                   items={pluginDenyRules}
                   orphanedPluginIds={orphanedPluginIds}

--- a/src/renderer/features/settings/ProjectSettings.tsx
+++ b/src/renderer/features/settings/ProjectSettings.tsx
@@ -422,20 +422,20 @@ function LaunchWrapperSection({ projectId, projectPath }: { projectId: string; p
                     <span className="text-xs text-ctp-text truncate flex items-center gap-1.5">
                       {entry.name}
                       {entry.state === 'new' && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-green/15 text-ctp-green uppercase tracking-wider">new</span>
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-green/15 text-ctp-green uppercase tracking-wider">new</span>
                       )}
                       {entry.state === 'changed' && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-yellow/15 text-ctp-yellow uppercase tracking-wider">changed</span>
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-yellow/15 text-ctp-yellow uppercase tracking-wider">changed</span>
                       )}
                       {entry.state === 'removed' && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-red/15 text-ctp-red uppercase tracking-wider">removed</span>
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-red/15 text-ctp-red uppercase tracking-wider">removed</span>
                       )}
                     </span>
                   </label>
                 );
               })}
             </div>
-            <p className="text-[10px] text-ctp-subtext0/50 mt-1.5 italic">
+            <p className="text-xs text-ctp-subtext0/50 mt-1.5 italic">
               Configure per-MCP parameters in each agent&apos;s settings.
             </p>
           </div>

--- a/src/renderer/features/settings/SourceAgentTemplatesSection.tsx
+++ b/src/renderer/features/settings/SourceAgentTemplatesSection.tsx
@@ -129,7 +129,7 @@ export function SourceAgentTemplatesSection({ projectPath }: Props) {
       <div className="flex items-center justify-between mb-2">
         <div>
           <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Agent Definitions</h3>
-          <span className="text-[10px] text-ctp-subtext0/60 font-mono">.clubhouse/agent-templates/</span>
+          <span className="text-xs text-ctp-subtext0/60 font-mono">.clubhouse/agent-templates/</span>
         </div>
         <button
           onClick={handleCreate}

--- a/src/renderer/features/settings/SourceSkillsSection.tsx
+++ b/src/renderer/features/settings/SourceSkillsSection.tsx
@@ -129,7 +129,7 @@ export function SourceSkillsSection({ projectPath }: Props) {
       <div className="flex items-center justify-between mb-2">
         <div>
           <h3 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider">Skills</h3>
-          <span className="text-[10px] text-ctp-subtext0/60 font-mono">.clubhouse/skills/</span>
+          <span className="text-xs text-ctp-subtext0/60 font-mono">.clubhouse/skills/</span>
         </div>
         <button
           onClick={handleCreate}

--- a/src/renderer/features/settings/sound-components.tsx
+++ b/src/renderer/features/settings/sound-components.tsx
@@ -169,7 +169,7 @@ export function SoundPackCard({
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-ctp-text">{pack.name}</span>
           {pack.source === 'plugin' && (
-            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-surface-2 text-ctp-subtext0 rounded">Plugin</span>
+            <span className="px-1.5 py-0.5 text-xs font-medium bg-surface-2 text-ctp-subtext0 rounded">Plugin</span>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -199,7 +199,7 @@ export function SoundPackCard({
       )}
       <div className="flex gap-1.5 flex-wrap">
         {events.map((event) => (
-          <span key={event} className="px-1.5 py-0.5 text-[10px] bg-surface-1 text-ctp-subtext0 rounded">
+          <span key={event} className="px-1.5 py-0.5 text-xs bg-surface-1 text-ctp-subtext0 rounded">
             {SOUND_EVENT_LABELS[event]}
           </span>
         ))}

--- a/src/renderer/panels/ExplorerRail.tsx
+++ b/src/renderer/panels/ExplorerRail.tsx
@@ -98,7 +98,7 @@ function SettingsContextPicker() {
             `}
           >
             <span
-              className="w-[18px] h-[18px] rounded flex items-center justify-center text-[10px] font-bold flex-shrink-0 overflow-hidden"
+              className="w-[18px] h-[18px] rounded flex items-center justify-center text-xs font-bold flex-shrink-0 overflow-hidden"
               style={p.icon && projectIcons[p.id] ? undefined : { backgroundColor: `${getAgentColorHex(p.color)}20`, color: getAgentColorHex(p.color) }}
             >
               {p.icon && projectIcons[p.id] ? (

--- a/src/renderer/panels/SatelliteSection.tsx
+++ b/src/renderer/panels/SatelliteSection.tsx
@@ -128,7 +128,7 @@ export function SatelliteHostRow({ satellite, expanded, isActive, onClick }: {
             <span
               role="button"
               onClick={handleRetry}
-              className="text-[10px] text-ctp-subtext0 hover:text-ctp-text opacity-0 group-hover:opacity-100 transition-opacity pr-2 cursor-pointer"
+              className="text-xs text-ctp-subtext0 hover:text-ctp-text opacity-0 group-hover:opacity-100 transition-opacity pr-2 cursor-pointer"
               title="Retry connection"
             >
               retry

--- a/src/renderer/plugins/builtin/agent-queue/AgentQueueCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/agent-queue/AgentQueueCanvasWidget.tsx
@@ -29,7 +29,7 @@ export function AgentQueueCanvasWidget({
         </div>
         <div className="space-y-1">
           <div className="text-xs font-medium text-ctp-subtext1">MCP Required</div>
-          <div className="text-[10px] text-ctp-overlay0 max-w-[200px]">
+          <div className="text-xs text-ctp-overlay0 max-w-[200px]">
             Agent Queue requires MCP to be enabled. Enable it in Settings &gt; MCP.
           </div>
         </div>
@@ -210,7 +210,7 @@ function QueueView({
       <div className="flex items-center justify-between px-3 py-2 border-b border-surface-2 shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           <span className="font-medium text-ctp-text truncate">{queue.name}</span>
-          <span className="text-[10px] text-ctp-overlay0">
+          <span className="text-xs text-ctp-overlay0">
             {runningCount > 0 && <span className="text-ctp-green mr-1">{runningCount} running</span>}
             {pendingCount > 0 && <span className="text-ctp-yellow mr-1">{pendingCount} pending</span>}
           </span>
@@ -235,7 +235,7 @@ function QueueView({
           {tasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 p-4">
               <div className="text-sm">No tasks yet</div>
-              <div className="text-[10px] text-center max-w-[200px]">
+              <div className="text-xs text-center max-w-[200px]">
                 Wire an agent to this queue. The agent can then invoke tasks using MCP tools.
               </div>
             </div>
@@ -250,7 +250,7 @@ function QueueView({
       )}
 
       {/* Footer status bar */}
-      <div className="flex items-center gap-3 px-3 py-1.5 border-t border-surface-2 text-[10px] text-ctp-overlay0 shrink-0">
+      <div className="flex items-center gap-3 px-3 py-1.5 border-t border-surface-2 text-xs text-ctp-overlay0 shrink-0">
         <span>{tasks.length} total</span>
         {completedCount > 0 && <span className="text-ctp-green">{completedCount} done</span>}
         {failedCount > 0 && <span className="text-ctp-red">{failedCount} failed</span>}
@@ -278,10 +278,10 @@ function TaskRow({ task }: { task: AgentQueueTaskSummary }) {
         <span className="text-ctp-text truncate flex-1" title={task.mission}>
           {task.mission.length > 80 ? task.mission.slice(0, 80) + '...' : task.mission}
         </span>
-        <span className="text-[10px] text-ctp-overlay0 shrink-0">{task.status}</span>
+        <span className="text-xs text-ctp-overlay0 shrink-0">{task.status}</span>
       </div>
       {task.agentName && (
-        <div className="text-[10px] text-ctp-overlay0 ml-3.5 mt-0.5">
+        <div className="text-xs text-ctp-overlay0 ml-3.5 mt-0.5">
           {task.agentName}
           {task.completedAt && ` \u00b7 ${formatDuration(task.createdAt, task.completedAt)}`}
         </div>
@@ -328,7 +328,7 @@ function QueueSettings({
   return (
     <div className="flex-1 overflow-y-auto p-3 space-y-3">
       <div>
-        <label className="block text-[10px] text-ctp-overlay0 mb-1">Concurrency</label>
+        <label className="block text-xs text-ctp-overlay0 mb-1">Concurrency</label>
         <input
           type="number"
           min="1"
@@ -341,7 +341,7 @@ function QueueSettings({
       </div>
       {enabledOrchestrators.length > 0 && (
         <div>
-          <label className="block text-[10px] text-ctp-overlay0 mb-1">Orchestrator</label>
+          <label className="block text-xs text-ctp-overlay0 mb-1">Orchestrator</label>
           <select
             value={orchestrator || enabledOrchestrators[0]?.id || ''}
             onChange={(e) => {
@@ -358,7 +358,7 @@ function QueueSettings({
         </div>
       )}
       <div>
-        <label className="block text-[10px] text-ctp-overlay0 mb-1">Model (optional)</label>
+        <label className="block text-xs text-ctp-overlay0 mb-1">Model (optional)</label>
         <input
           type="text"
           value={model}
@@ -369,7 +369,7 @@ function QueueSettings({
         />
       </div>
       <div className="flex items-center justify-between">
-        <label className="text-[10px] text-ctp-overlay0">Free Agent Mode</label>
+        <label className="text-xs text-ctp-overlay0">Free Agent Mode</label>
         <input
           type="checkbox"
           checked={freeAgent}
@@ -381,7 +381,7 @@ function QueueSettings({
         />
       </div>
       <div className="flex items-center justify-between">
-        <label className="text-[10px] text-ctp-overlay0">Auto Worktree</label>
+        <label className="text-xs text-ctp-overlay0">Auto Worktree</label>
         <input
           type="checkbox"
           checked={autoWorktree}

--- a/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/browser/BrowserCanvasWidget.tsx
@@ -197,7 +197,7 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
   return (
     <div className="flex flex-col h-full">
       {/* Header bar */}
-      <div className="flex items-center gap-1 px-1.5 py-1 bg-surface-0/50 border-b border-surface-0 text-[10px] text-ctp-subtext0 flex-shrink-0">
+      <div className="flex items-center gap-1 px-1.5 py-1 bg-surface-0/50 border-b border-surface-0 text-xs text-ctp-subtext0 flex-shrink-0">
         {isAppMode && (
           <button
             className="hover:text-ctp-text transition-colors mr-1"
@@ -208,21 +208,21 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
           </button>
         )}
         <button
-          className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
+          className="w-5 h-5 flex items-center justify-center rounded text-xs text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
           onClick={handleBack}
           title="Back"
         >
           &larr;
         </button>
         <button
-          className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
+          className="w-5 h-5 flex items-center justify-center rounded text-xs text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
           onClick={handleForward}
           title="Forward"
         >
           &rarr;
         </button>
         <button
-          className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
+          className="w-5 h-5 flex items-center justify-center rounded text-xs text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
           onClick={handleReload}
           title="Reload"
         >
@@ -238,7 +238,7 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
           data-testid="canvas-browser-address"
         />
         <button
-          className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
+          className="w-5 h-5 flex items-center justify-center rounded text-xs text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text"
           onClick={handleDevTools}
           title="Toggle DevTools"
         >
@@ -251,7 +251,7 @@ export function BrowserCanvasWidget({ widgetId, api, metadata, onUpdateMetadata,
 
       {/* Error banner */}
       {error && (
-        <div className="px-2 py-1.5 bg-ctp-red/10 border-b border-ctp-red/20 text-[10px] text-ctp-red flex-shrink-0">
+        <div className="px-2 py-1.5 bg-ctp-red/10 border-b border-ctp-red/20 text-xs text-ctp-red flex-shrink-0">
           {error}
         </div>
       )}

--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -163,7 +163,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
       <div className="flex flex-col items-center justify-center h-full gap-2 p-4">
         <div className="w-8 h-8 rounded-full bg-surface-1 animate-pulse" />
         <span className="text-xs text-ctp-subtext0 truncate max-w-full">{name}</span>
-        <span className="text-[10px] text-ctp-overlay0">Connecting...</span>
+        <span className="text-xs text-ctp-overlay0">Connecting...</span>
       </div>
     );
   }
@@ -199,7 +199,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
                     </div>
                     <span className="text-[11px] text-ctp-text truncate flex-1">{p.name}</span>
                     {agentCount > 0 && (
-                      <span className="text-[10px] text-ctp-overlay0">{agentCount}</span>
+                      <span className="text-xs text-ctp-overlay0">{agentCount}</span>
                     )}
                   </button>
                 );
@@ -224,7 +224,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
         {isAppMode && selectedProjectId && (
           <button
             onClick={handleBackToProjects}
-            className="text-[10px] text-ctp-overlay0 hover:text-ctp-text flex items-center gap-1 mb-2"
+            className="text-xs text-ctp-overlay0 hover:text-ctp-text flex items-center gap-1 mb-2"
           >
             &larr; Back
           </button>
@@ -247,7 +247,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
                 <span className="text-xs text-ctp-text truncate flex-1">
                   {agent.name || agent.id}
                 </span>
-                <span className={`text-[10px] ${
+                <span className={`text-xs ${
                   agent.status === 'running' ? 'text-ctp-success' :
                   agent.status === 'error' ? 'text-ctp-error' :
                   'text-ctp-overlay0'

--- a/src/renderer/plugins/builtin/canvas/CanvasControls.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasControls.tsx
@@ -166,7 +166,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
                 <line x1="12" y1="10" x2="12" y2="14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                 <circle cx="12" cy="17.5" r="1" fill="currentColor" />
               </svg>
-              <span className="text-[10px] font-mono text-ctp-warning min-w-[2ch] text-center">
+              <span className="text-xs font-mono text-ctp-warning min-w-[2ch] text-center">
                 {count}
               </span>
             </div>
@@ -209,7 +209,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
                 <line x1="12" y1="8" x2="12" y2="22" />
                 <path d="M5 12H2a10 10 0 0 0 20 0h-3" />
               </svg>
-              <span className="text-[10px] font-mono text-ctp-accent min-w-[2ch] text-center">
+              <span className="text-xs font-mono text-ctp-accent min-w-[2ch] text-center">
                 {anchorCount}
               </span>
             </div>
@@ -297,7 +297,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
               className="absolute top-full right-0 mt-1 w-56 bg-ctp-mantle border border-surface-0 rounded-lg shadow-lg p-2 z-dropdown"
               data-testid="canvas-auto-layout-menu"
             >
-              <div className="text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider mb-1.5 px-1">Auto Layout</div>
+              <div className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider mb-1.5 px-1">Auto Layout</div>
               {ALGORITHMS.map((alg) => (
                 <button
                   key={alg}
@@ -325,7 +325,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
               {(algorithm === 'layered' || algorithm === 'mrtree') && (
                 <>
                   <div className="w-full h-px bg-surface-0 my-1.5" />
-                  <div className="text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider mb-1 px-1">Direction</div>
+                  <div className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider mb-1 px-1">Direction</div>
                   <div className="flex gap-1 px-1" data-testid="layout-direction-picker">
                     {DIRECTIONS.map((dir) => (
                       <button
@@ -353,7 +353,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
               {algorithm === 'radial' && (
                 <>
                   <div className="w-full h-px bg-surface-0 my-1.5" />
-                  <div className="text-[10px] text-ctp-subtext0 px-1">
+                  <div className="text-xs text-ctp-subtext0 px-1">
                     {hasSelection
                       ? 'Radiates from selected card'
                       : layoutCenterId
@@ -383,7 +383,7 @@ export function CanvasControls({ zoom, hasViews, views, onZoomIn, onZoomOut, onZ
       </button>
       <button
         onClick={onZoomReset}
-        className="min-w-[3rem] h-6 flex items-center justify-center rounded text-[10px] text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors font-mono"
+        className="min-w-[3rem] h-6 flex items-center justify-center rounded text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors font-mono"
         title="Reset zoom"
         data-testid="canvas-zoom-reset"
       >

--- a/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasSearch.tsx
@@ -194,7 +194,7 @@ export function CanvasSearch({ views, onSelectView }: CanvasSearchProps) {
         </div>
         {/* Match counter — shown when cycling through multiple results */}
         {cycling && query.trim() && filteredViews.length > 1 && (
-          <span className="text-[10px] text-ctp-overlay0 tabular-nums whitespace-nowrap" data-testid="canvas-search-match-count">
+          <span className="text-xs text-ctp-overlay0 tabular-nums whitespace-nowrap" data-testid="canvas-search-match-count">
             {((selectedIndex - 1 + filteredViews.length) % filteredViews.length) + 1} / {filteredViews.length}
           </span>
         )}

--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -583,7 +583,7 @@ export function CanvasViewComponent({
         {/* Expanded content — hidden when collapsed */}
         {!isCollapsedVisually && (
           <>
-            <span className="text-[10px] text-ctp-overlay1 bg-surface-0 rounded px-1.5 py-0.5 font-medium leading-none flex-shrink-0">
+            <span className="text-xs text-ctp-overlay1 bg-surface-0 rounded px-1.5 py-0.5 font-medium leading-none flex-shrink-0">
               Anchor
             </span>
 
@@ -713,7 +713,7 @@ export function CanvasViewComponent({
         {/* Agent identity chip */}
         {agentInfo && <AgentAvatar agentId={agentInfo.id} size="sm" showStatusRing />}
 
-        <span className="text-[10px] text-ctp-overlay1 bg-surface-0 rounded px-1.5 py-0.5 font-medium leading-none">
+        <span className="text-xs text-ctp-overlay1 bg-surface-0 rounded px-1.5 py-0.5 font-medium leading-none">
           {formatViewType(view.type === 'plugin' ? (view as PluginCanvasViewType).pluginWidgetType.split(':').pop() || '' : view.type)}
         </span>
         <InlineRename
@@ -723,7 +723,7 @@ export function CanvasViewComponent({
           }}
         />
         {projectContext && (
-          <span className="text-[10px] text-ctp-overlay0 truncate flex-shrink-0">({projectContext})</span>
+          <span className="text-xs text-ctp-overlay0 truncate flex-shrink-0">({projectContext})</span>
         )}
 
         {/* Quick action buttons */}

--- a/src/renderer/plugins/builtin/canvas/LinkDropdown.tsx
+++ b/src/renderer/plugins/builtin/canvas/LinkDropdown.tsx
@@ -93,7 +93,7 @@ export function LinkDropdown({ agentView, views, onClose }: LinkDropdownProps) {
       onMouseDown={(e) => e.stopPropagation()}
       data-testid="link-dropdown"
     >
-      <div className="px-3 py-2 text-[10px] text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0">
+      <div className="px-3 py-2 text-xs text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0">
         Link to Widget
       </div>
       {targets.length === 0 ? (
@@ -119,7 +119,7 @@ export function LinkDropdown({ agentView, views, onClose }: LinkDropdownProps) {
                   bound ? 'bg-ctp-accent' : 'bg-ctp-overlay0'
                 }`} />
                 <span className="truncate">{targetLabel(target)}</span>
-                <span className="text-[10px] text-ctp-overlay0 flex-shrink-0 ml-auto">
+                <span className="text-xs text-ctp-overlay0 flex-shrink-0 ml-auto">
                   {targetKind(target)}
                 </span>
               </button>

--- a/src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireConfigPopover.tsx
@@ -129,7 +129,7 @@ export function WireConfigPopover({ binding, x, y, onClose, onAddWireDefinition,
         {/* Header */}
         <div className="px-3 py-2 bg-ctp-base border-b border-surface-0">
           <div className="text-xs text-ctp-text font-medium">Wire Connection</div>
-          <div className="text-[10px] text-ctp-subtext0 mt-0.5">
+          <div className="text-xs text-ctp-subtext0 mt-0.5">
             {binding.label} ({binding.targetKind})
           </div>
         </div>
@@ -150,7 +150,7 @@ export function WireConfigPopover({ binding, x, y, onClose, onAddWireDefinition,
               <span className="flex-1 text-xs text-ctp-subtext0">
                 Bidirectional
                 {forceBidirectional && !bidirectional && (
-                  <span className="ml-1 text-[10px] text-ctp-subtext1">(project setting)</span>
+                  <span className="ml-1 text-xs text-ctp-subtext1">(project setting)</span>
                 )}
               </span>
               <Toggle
@@ -175,7 +175,7 @@ export function WireConfigPopover({ binding, x, y, onClose, onAddWireDefinition,
               Tool Permissions
             </span>
             {hasDisabledTools && (
-              <span className="text-[10px] text-ctp-overlay0 flex-shrink-0">
+              <span className="text-xs text-ctp-overlay0 flex-shrink-0">
                 {liveBinding.disabledTools!.length} off
               </span>
             )}

--- a/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
@@ -100,14 +100,14 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
         {/* Header */}
         <div className="px-4 py-3 bg-ctp-base border-b border-surface-0">
           <div className="text-sm text-ctp-text font-medium">Wire Instructions</div>
-          <div className="text-[10px] text-ctp-subtext0 mt-0.5">
+          <div className="text-xs text-ctp-subtext0 mt-0.5">
             {binding.label} ({binding.targetKind})
           </div>
         </div>
 
         {/* Tool selector */}
         <div className="px-4 pt-3">
-          <label className="text-[10px] text-ctp-subtext1 uppercase tracking-wider font-medium">
+          <label className="text-xs text-ctp-subtext1 uppercase tracking-wider font-medium">
             Apply to
           </label>
           <select
@@ -135,7 +135,7 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
             className="w-full h-32 bg-ctp-base border border-surface-2 rounded px-2.5 py-2 text-xs text-ctp-text placeholder:text-ctp-overlay0 resize-none focus-ring"
             data-testid="wire-instructions-textarea"
           />
-          <div className="text-[10px] text-ctp-overlay0 mt-1">
+          <div className="text-xs text-ctp-overlay0 mt-1">
             {selectedTool === '*'
               ? 'Applied to all tools on this wire unless overridden per-tool.'
               : `Applied only to the ${toolLabel(selectedTool)} tool.`}
@@ -144,7 +144,7 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
 
         {/* Footer */}
         <div className="px-4 py-3 border-t border-surface-0 flex items-center justify-between">
-          <span className="text-[10px] text-ctp-overlay0">
+          <span className="text-xs text-ctp-overlay0">
             {instructionCount > 0 ? `${instructionCount} instruction${instructionCount > 1 ? 's' : ''} set` : 'No instructions set'}
           </span>
           <div className="flex gap-2">

--- a/src/renderer/plugins/builtin/canvas/WireToolPermissionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireToolPermissionsDialog.tsx
@@ -132,7 +132,7 @@ export function WireToolPermissionsDialog({ binding, onSave, onClose }: WireTool
         {/* Header */}
         <div className="px-4 py-3 bg-ctp-base border-b border-surface-0">
           <div className="text-sm text-ctp-text font-medium">Tool Permissions</div>
-          <div className="text-[10px] text-ctp-subtext0 mt-0.5">
+          <div className="text-xs text-ctp-subtext0 mt-0.5">
             {binding.label} ({binding.targetKind})
           </div>
         </div>
@@ -141,15 +141,15 @@ export function WireToolPermissionsDialog({ binding, onSave, onClose }: WireTool
         <div className="px-4 pt-2 flex gap-2">
           <button
             onClick={handleEnableAll}
-            className="text-[10px] text-ctp-accent hover:underline"
+            className="text-xs text-ctp-accent hover:underline"
             data-testid="wire-permissions-enable-all"
           >
             Enable All
           </button>
-          <span className="text-[10px] text-ctp-overlay0">|</span>
+          <span className="text-xs text-ctp-overlay0">|</span>
           <button
             onClick={handleDisableAll}
-            className="text-[10px] text-ctp-red hover:underline"
+            className="text-xs text-ctp-red hover:underline"
             data-testid="wire-permissions-disable-all"
           >
             Disable All
@@ -171,7 +171,7 @@ export function WireToolPermissionsDialog({ binding, onSave, onClose }: WireTool
                     {toolLabel(suffix)}
                   </div>
                   {TOOL_HINTS[suffix] && (
-                    <div className="text-[10px] text-ctp-overlay0 truncate">
+                    <div className="text-xs text-ctp-overlay0 truncate">
                       {TOOL_HINTS[suffix]}
                     </div>
                   )}
@@ -184,7 +184,7 @@ export function WireToolPermissionsDialog({ binding, onSave, onClose }: WireTool
 
         {/* Footer */}
         <div className="px-4 py-3 border-t border-surface-0 flex items-center justify-between">
-          <span className="text-[10px] text-ctp-overlay0">
+          <span className="text-xs text-ctp-overlay0">
             {enabledCount}/{suffixes.length} enabled
           </span>
           <div className="flex gap-2">

--- a/src/renderer/plugins/builtin/canvas/ZoneCard.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoneCard.tsx
@@ -182,7 +182,7 @@ const ZoneThemePicker = React.forwardRef<HTMLDivElement, ZoneThemePickerProps>(
                   <div className="w-3 h-3 rounded-full" style={{ backgroundColor: theme.colors.text }} />
                   <div className="w-3 h-3 rounded-full" style={{ backgroundColor: theme.colors.accent }} />
                 </div>
-                <span className="text-[10px] font-medium text-left truncate w-full" style={{ color: theme.colors.text }}>
+                <span className="text-xs font-medium text-left truncate w-full" style={{ color: theme.colors.text }}>
                   {theme.name}
                 </span>
               </button>

--- a/src/renderer/plugins/builtin/canvas/ZoomedViewOverlay.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoomedViewOverlay.tsx
@@ -42,16 +42,16 @@ export function ZoomedViewOverlay({
       >
         {/* Title bar */}
         <div className="flex items-center gap-1.5 px-3 py-2 bg-ctp-mantle border-b border-surface-0 flex-shrink-0">
-          <span className="text-[10px] text-ctp-overlay1 bg-surface-0 rounded px-1.5 py-0.5 font-medium leading-none">
+          <span className="text-xs text-ctp-overlay1 bg-surface-0 rounded px-1.5 py-0.5 font-medium leading-none">
             {formatViewType(view.type)}
           </span>
           <span className="text-xs text-ctp-subtext0 truncate flex-1">{view.title}</span>
           {(() => {
             const ctx = buildProjectContext(view, api.projects.list());
-            return ctx ? <span className="text-[10px] text-ctp-overlay0 truncate flex-shrink-0">({ctx})</span> : null;
+            return ctx ? <span className="text-xs text-ctp-overlay0 truncate flex-shrink-0">({ctx})</span> : null;
           })()}
           <button
-            className="text-[10px] px-2 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text transition-colors"
+            className="text-xs px-2 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text transition-colors"
             onClick={onClose}
             data-testid="canvas-zoom-restore"
           >

--- a/src/renderer/plugins/builtin/files/FileTree.ts
+++ b/src/renderer/plugins/builtin/files/FileTree.ts
@@ -101,7 +101,7 @@ function GitBadge({ status }: { status: string }) {
   }
 
   return React.createElement('span', {
-    className: `text-[10px] font-bold ${color} ml-auto flex-shrink-0 pl-1`,
+    className: `text-xs font-bold ${color} ml-auto flex-shrink-0 pl-1`,
   }, letter);
 }
 
@@ -1287,7 +1287,7 @@ export function FileTree({ api }: { api: PluginAPI }) {
         // Branch indicator — show worktree branch or "No Worktree" for agent dirs without one
         (currentBranch || rootPath !== '.')
           ? React.createElement('div', {
-              className: 'flex items-center gap-1 text-[10px] text-ctp-subtext0 flex-shrink-0',
+              className: 'flex items-center gap-1 text-xs text-ctp-subtext0 flex-shrink-0',
               title: currentBranch ? `Branch: ${currentBranch}` : 'No worktree',
             },
               GitBranchIcon,
@@ -1299,7 +1299,7 @@ export function FileTree({ api }: { api: PluginAPI }) {
         // Worktree selector
         worktrees.length > 0
           ? React.createElement('select', {
-              className: 'flex-1 min-w-0 text-[10px] bg-surface-0 text-ctp-text border-none rounded px-1 py-0.5 cursor-pointer truncate outline-none',
+              className: 'flex-1 min-w-0 text-xs bg-surface-0 text-ctp-text border-none rounded px-1 py-0.5 cursor-pointer truncate outline-none',
               value: rootPath,
               onChange: (e: React.ChangeEvent<HTMLSelectElement>) => handleRootChange(e.target.value),
               title: 'Switch worktree root',
@@ -1322,7 +1322,7 @@ export function FileTree({ api }: { api: PluginAPI }) {
         // Selection count badge
         selectionCount > 1
           ? React.createElement('span', {
-              className: 'text-[10px] text-ctp-accent font-medium mr-auto pl-1',
+              className: 'text-xs text-ctp-accent font-medium mr-auto pl-1',
               title: `${selectionCount} items selected`,
             }, `${selectionCount} selected`)
           : null,

--- a/src/renderer/plugins/builtin/files/FileViewer.ts
+++ b/src/renderer/plugins/builtin/files/FileViewer.ts
@@ -123,7 +123,7 @@ interface EditorStatusBarProps {
 
 function EditorStatusBar({ line, column, language }: EditorStatusBarProps) {
   return React.createElement('div', {
-    className: 'flex items-center justify-between px-3 py-0.5 border-t border-surface-0 bg-ctp-mantle flex-shrink-0 text-[10px] text-ctp-subtext0 select-none',
+    className: 'flex items-center justify-between px-3 py-0.5 border-t border-surface-0 bg-ctp-mantle flex-shrink-0 text-xs text-ctp-subtext0 select-none',
   },
     React.createElement('span', null, `Ln ${line}, Col ${column}`),
     React.createElement('div', { className: 'flex items-center gap-3' },
@@ -455,7 +455,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
           React.createElement('polyline', { points: '14 2 14 8 20 8' }),
         ),
         React.createElement('p', { className: 'text-xs' }, 'Select a file to view'),
-        React.createElement('p', { className: 'text-[10px] mt-1 opacity-60' }, 'Click a file in the sidebar'),
+        React.createElement('p', { className: 'text-xs mt-1 opacity-60' }, 'Click a file in the sidebar'),
       ),
     );
   }
@@ -489,14 +489,14 @@ export function FileViewer({ api }: { api: PluginAPI }) {
         : null,
       lang !== 'plaintext'
         ? React.createElement('span', {
-            className: 'text-[10px] px-1.5 py-0.5 rounded bg-surface-0 text-ctp-subtext0 flex-shrink-0',
+            className: 'text-xs px-1.5 py-0.5 rounded bg-surface-0 text-ctp-subtext0 flex-shrink-0',
           }, lang)
         : null,
     ),
     React.createElement('div', { className: 'flex items-center gap-2 flex-shrink-0' },
       // Preview/Source toggle for markdown and SVG
       (loadedFile.fileType === 'markdown' || loadedFile.fileType === 'svg')
-        ? React.createElement('div', { className: 'flex items-center bg-surface-0 rounded text-[10px]' },
+        ? React.createElement('div', { className: 'flex items-center bg-surface-0 rounded text-xs' },
             React.createElement('button', {
               className: `px-2 py-0.5 rounded ${previewMode === 'preview' ? 'bg-surface-1 text-ctp-text' : 'text-ctp-subtext0'}`,
               onClick: () => setPreviewMode('preview'),
@@ -508,7 +508,7 @@ export function FileViewer({ api }: { api: PluginAPI }) {
           )
         : null,
       React.createElement('span', {
-        className: 'text-[10px] text-ctp-subtext0 truncate max-w-[200px]',
+        className: 'text-xs text-ctp-subtext0 truncate max-w-[200px]',
         title: activeTab.filePath,
       }, activeTab.filePath),
       React.createElement(OpenInFinderButton, { api, relativePath: activeTab.filePath }),

--- a/src/renderer/plugins/builtin/files/FileViewerCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/files/FileViewerCanvasWidget.tsx
@@ -206,7 +206,7 @@ export function FileViewerCanvasWidget({ widgetId: _widgetId, api, metadata, onU
   return (
     <div className="flex flex-col h-full">
       {/* Header bar */}
-      <div className="flex items-center gap-1 px-2 py-1 bg-surface-0/50 border-b border-surface-0 text-[10px] text-ctp-subtext0 flex-shrink-0">
+      <div className="flex items-center gap-1 px-2 py-1 bg-surface-0/50 border-b border-surface-0 text-xs text-ctp-subtext0 flex-shrink-0">
         {isAppMode && (
           <button
             className="hover:text-ctp-text transition-colors mr-1"
@@ -228,7 +228,7 @@ export function FileViewerCanvasWidget({ widgetId: _widgetId, api, metadata, onU
           <>
             <span className="text-ctp-overlay0 mx-0.5">/</span>
             <select
-              className="text-[10px] bg-surface-0 text-ctp-subtext1 border-none rounded px-1 py-0.5 cursor-pointer truncate outline-none max-w-[120px]"
+              className="text-xs bg-surface-0 text-ctp-subtext1 border-none rounded px-1 py-0.5 cursor-pointer truncate outline-none max-w-[120px]"
               value={rootPath}
               onChange={(e) => handleSelectWorktree(e.target.value)}
               title="Switch worktree root"
@@ -274,7 +274,7 @@ export function FileViewerCanvasWidget({ widgetId: _widgetId, api, metadata, onU
           </>
         )}
         {filePath && isMarkdownFile(filePath) && fileContent !== null && (
-          <div className="flex items-center bg-surface-0 rounded text-[10px] ml-2">
+          <div className="flex items-center bg-surface-0 rounded text-xs ml-2">
             <button
               className={`px-2 py-0.5 rounded cursor-pointer ${previewMode === 'preview' ? 'bg-surface-1 text-ctp-text' : 'text-ctp-subtext0'}`}
               onClick={() => setPreviewMode('preview')}

--- a/src/renderer/plugins/builtin/files/SearchPanel.ts
+++ b/src/renderer/plugins/builtin/files/SearchPanel.ts
@@ -58,7 +58,7 @@ function ToggleButton({ label, active, onClick, title }: {
   title: string;
 }) {
   return React.createElement('button', {
-    className: `px-1 py-0 text-[10px] font-mono rounded border transition-colors ${
+    className: `px-1 py-0 text-xs font-mono rounded border transition-colors ${
       active
         ? 'bg-surface-1 border-ctp-accent text-ctp-accent'
         : 'bg-transparent border-surface-0 text-ctp-subtext0 hover:text-ctp-text hover:border-surface-1'
@@ -114,7 +114,7 @@ function FileResultGroup({ result, onMatchClick }: {
         title: result.filePath,
       }, result.filePath),
       React.createElement('span', {
-        className: 'text-[10px] text-ctp-subtext0 flex-shrink-0 ml-1',
+        className: 'text-xs text-ctp-subtext0 flex-shrink-0 ml-1',
       }, String(result.matches.length)),
     ),
 
@@ -127,10 +127,10 @@ function FileResultGroup({ result, onMatchClick }: {
           onClick: () => onMatchClick(result.filePath, match.line),
         },
           React.createElement('span', {
-            className: 'text-ctp-subtext0 flex-shrink-0 w-8 text-right font-mono text-[10px]',
+            className: 'text-ctp-subtext0 flex-shrink-0 w-8 text-right font-mono text-xs',
           }, String(match.line)),
           React.createElement('span', {
-            className: 'truncate font-mono text-[10px] leading-4',
+            className: 'truncate font-mono text-xs leading-4',
           },
             React.createElement(HighlightedLine, {
               lineContent: match.lineContent,
@@ -142,7 +142,7 @@ function FileResultGroup({ result, onMatchClick }: {
       ),
       result.matches.length > 100
         ? React.createElement('div', {
-            className: 'px-2 py-0.5 text-[10px] text-ctp-subtext0 italic',
+            className: 'px-2 py-0.5 text-xs text-ctp-subtext0 italic',
           }, `... and ${result.matches.length - 100} more matches`)
         : null,
     ),
@@ -316,7 +316,7 @@ export function SearchPanel({ api }: { api: PluginAPI }) {
         }),
         React.createElement('div', { className: 'flex-1' }),
         React.createElement('button', {
-          className: `text-[10px] px-1 rounded transition-colors ${
+          className: `text-xs px-1 rounded transition-colors ${
             showFilters
               ? 'text-ctp-accent'
               : 'text-ctp-subtext0 hover:text-ctp-text'
@@ -332,14 +332,14 @@ export function SearchPanel({ api }: { api: PluginAPI }) {
       },
         React.createElement('input', {
           type: 'text',
-          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-text focus-ring placeholder:text-ctp-subtext0 transition-colors',
+          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-xs text-ctp-text focus-ring placeholder:text-ctp-subtext0 transition-colors',
           placeholder: 'Include (e.g. src/**/*.ts)',
           value: includePattern,
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => setIncludePattern(e.target.value),
         }),
         React.createElement('input', {
           type: 'text',
-          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-[10px] text-ctp-text focus-ring placeholder:text-ctp-subtext0 transition-colors',
+          className: 'w-full bg-ctp-base border border-surface-0 rounded px-1.5 py-0.5 text-xs text-ctp-text focus-ring placeholder:text-ctp-subtext0 transition-colors',
           placeholder: 'Exclude (e.g. dist,*.min.js)',
           value: excludePattern,
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => setExcludePattern(e.target.value),
@@ -349,7 +349,7 @@ export function SearchPanel({ api }: { api: PluginAPI }) {
 
     // Status line
     (results || searching) && React.createElement('div', {
-      className: 'flex items-center gap-1 px-2 py-0.5 text-[10px] text-ctp-subtext0 border-b border-surface-0 flex-shrink-0',
+      className: 'flex items-center gap-1 px-2 py-0.5 text-xs text-ctp-subtext0 border-b border-surface-0 flex-shrink-0',
     },
       searching
         ? React.createElement(React.Fragment, null, SpinnerIcon, ' Searching...')

--- a/src/renderer/plugins/builtin/files/TabBar.ts
+++ b/src/renderer/plugins/builtin/files/TabBar.ts
@@ -221,7 +221,7 @@ function TabItem({
       // Show close button on hover, dirty dot otherwise
       (hovered || isActive)
         ? React.createElement('button', {
-            className: `w-4 h-4 flex items-center justify-center rounded text-[10px]
+            className: `w-4 h-4 flex items-center justify-center rounded text-xs
               ${tab.isDirty
                 ? 'text-ctp-warning hover:bg-surface-1'
                 : 'text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-text'

--- a/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
@@ -277,7 +277,7 @@ function FileSection({ title, sectionKey, files, collapsed, selectedFile, onSele
   return (
     <>
       <button
-        className="w-full flex items-center gap-1 px-3 py-1.5 text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0 hover:bg-surface-0"
+        className="w-full flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0 hover:bg-surface-0"
         onClick={() => onToggle(sectionKey)}
         data-testid={`section-${sectionKey}`}
       >

--- a/src/renderer/plugins/builtin/git/main.ts
+++ b/src/renderer/plugins/builtin/git/main.ts
@@ -206,8 +206,8 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
       gitInfo.ahead > 0 && h('span', { className: 'text-[9px] text-ctp-green' }, `↑${gitInfo.ahead}`),
       gitInfo.behind > 0 && h('span', { className: 'text-[9px] text-ctp-red' }, `↓${gitInfo.behind}`),
       h('span', { className: 'flex-1' }),
-      h('button', { className: 'text-[10px] text-ctp-subtext0 hover:text-ctp-text px-1', onClick: handlePull, title: 'Pull' }, '↓'),
-      h('button', { className: 'text-[10px] text-ctp-subtext0 hover:text-ctp-text px-1', onClick: handlePush, title: 'Push' }, '↑'),
+      h('button', { className: 'text-xs text-ctp-subtext0 hover:text-ctp-text px-1', onClick: handlePull, title: 'Pull' }, '↓'),
+      h('button', { className: 'text-xs text-ctp-subtext0 hover:text-ctp-text px-1', onClick: handlePush, title: 'Push' }, '↑'),
     ),
     // Staged
     renderFileSection('Staged', 'staged', staged, expandedSections, handleSelectFile, handleUnstage, null),
@@ -218,11 +218,11 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
     // Stage all / Unstage all buttons
     (staged.length > 0 || unstaged.length > 0 || untracked.length > 0) && h('div', { className: 'px-3 py-1 flex gap-1 border-b border-surface-0' },
       (unstaged.length > 0 || untracked.length > 0) && h('button', {
-        className: 'text-[10px] px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
+        className: 'text-xs px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
         onClick: handleStageAll,
       }, 'Stage All'),
       staged.length > 0 && h('button', {
-        className: 'text-[10px] px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
+        className: 'text-xs px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
         onClick: handleUnstageAll,
       }, 'Unstage All'),
     ),
@@ -261,11 +261,11 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
     gitInfo.stashCount > 0 && renderCollapseSection(`Stash (${gitInfo.stashCount})`, 'stash', expandedSections, () =>
       h('div', { className: 'px-3 py-1 flex gap-1' },
         h('button', {
-          className: 'text-[10px] px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
+          className: 'text-xs px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
           onClick: handleStash,
         }, 'Stash'),
         h('button', {
-          className: 'text-[10px] px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
+          className: 'text-xs px-2 py-0.5 rounded bg-surface-0 text-ctp-subtext0 hover:text-ctp-text transition-colors',
           onClick: handleStashPop,
         }, 'Pop'),
       ),
@@ -458,7 +458,7 @@ function renderFileSection(
   const expanded = expandedSections[sectionKey] !== false;
   return h(React.Fragment, null,
     h('button', {
-      className: 'w-full flex items-center gap-1 px-3 py-1.5 text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0 hover:bg-surface-0',
+      className: 'w-full flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0 hover:bg-surface-0',
       onClick: () => gitState.toggleSection(sectionKey),
     },
       h('span', { className: `transition-transform ${expanded ? 'rotate-90' : ''}` }, '▸'),
@@ -506,7 +506,7 @@ function renderCollapseSection(
   const expanded = expandedSections[sectionKey] !== false;
   return h(React.Fragment, null,
     h('button', {
-      className: 'w-full flex items-center gap-1 px-3 py-1.5 text-[10px] font-semibold text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0 hover:bg-surface-0',
+      className: 'w-full flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider border-b border-surface-0 hover:bg-surface-0',
       onClick: () => gitState.toggleSection(sectionKey),
     },
       h('span', { className: `transition-transform ${expanded ? 'rotate-90' : ''}` }, '▸'),

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -59,7 +59,7 @@ export function GroupProjectCanvasWidget({
         </div>
         <div className="space-y-1">
           <div className="text-xs font-medium text-ctp-subtext1">MCP Required</div>
-          <div className="text-[10px] text-ctp-overlay0 max-w-[200px]">
+          <div className="text-xs text-ctp-overlay0 max-w-[200px]">
             Group Project requires MCP to be enabled. Enable it in Settings &gt; MCP.
           </div>
         </div>
@@ -299,12 +299,12 @@ function ProjectCard({
           title={pollingEnabled ? 'Polling active — click to stop' : 'Enable agent polling'}
         >
           <PollingIcon size={12} active={pollingEnabled} />
-          <span className="text-[10px] font-medium">{pollingEnabled ? 'Poll: On' : 'Poll: Off'}</span>
+          <span className="text-xs font-medium">{pollingEnabled ? 'Poll: On' : 'Poll: Off'}</span>
         </button>
       </div>
 
       {/* Activity summary */}
-      <div className="flex items-center gap-3 text-[10px] text-ctp-subtext0">
+      <div className="flex items-center gap-3 text-xs text-ctp-subtext0">
         <span>{topics.length} topic{topics.length !== 1 ? 's' : ''}</span>
         <span>{totalMessages} msg{totalMessages !== 1 ? 's' : ''}{totalNew > 0 && <span className="text-ctp-green ml-0.5">+{totalNew} new</span>}</span>
       </div>
@@ -322,7 +322,7 @@ function ProjectCard({
           {members.map((m) => (
             <span
               key={m.agentId}
-              className="px-2 py-0.5 text-[10px] bg-surface-0 text-ctp-subtext1 rounded-full"
+              className="px-2 py-0.5 text-xs bg-surface-0 text-ctp-subtext1 rounded-full"
             >
               {m.agentName || m.agentId}
             </span>
@@ -610,7 +610,7 @@ function ExpandedProjectView({
       {/* Inline Description & Instructions Editor */}
       <div className="flex gap-3 px-3 py-2 border-t border-surface-1 bg-ctp-mantle/50">
         <div className="flex-1 min-w-0">
-          <label className="block text-[10px] font-semibold uppercase tracking-wider text-ctp-subtext0 mb-1">Description</label>
+          <label className="block text-xs font-semibold uppercase tracking-wider text-ctp-subtext0 mb-1">Description</label>
           <textarea
             value={editDesc}
             onChange={(e) => setEditDesc(e.target.value)}
@@ -620,7 +620,7 @@ function ExpandedProjectView({
           />
         </div>
         <div className="flex-1 min-w-0">
-          <label className="block text-[10px] font-semibold uppercase tracking-wider text-ctp-subtext0 mb-1">Instructions</label>
+          <label className="block text-xs font-semibold uppercase tracking-wider text-ctp-subtext0 mb-1">Instructions</label>
           <textarea
             value={editInstr}
             onChange={(e) => setEditInstr(e.target.value)}
@@ -631,8 +631,8 @@ function ExpandedProjectView({
         </div>
         <div className="flex flex-col justify-between flex-shrink-0 gap-1.5 w-44">
           <div>
-            <div className="text-[10px] font-semibold uppercase tracking-wider text-ctp-subtext0 mb-0.5">Default permissions</div>
-            <div className="text-[10px] text-ctp-subtext0 leading-snug">
+            <div className="text-xs font-semibold uppercase tracking-wider text-ctp-subtext0 mb-0.5">Default permissions</div>
+            <div className="text-xs text-ctp-subtext0 leading-snug">
               {GROUP_PROJECT_CORE_TOOL_SUFFIXES.length} message tools on.
               {' '}
               {enabledPrivilegedDefaults === 0
@@ -641,7 +641,7 @@ function ExpandedProjectView({
             </div>
             <button
               onClick={() => setShowDefaultPermissionsDialog(true)}
-              className="mt-1 px-2 py-1 text-[10px] font-medium rounded bg-surface-0 text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors"
+              className="mt-1 px-2 py-1 text-xs font-medium rounded bg-surface-0 text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors"
               data-testid="group-project-default-permissions-button"
             >
               Set defaults
@@ -664,14 +664,14 @@ function ExpandedProjectView({
               >
                 {saving ? 'Saving...' : 'Save'}
               </button>
-              <span className="text-[10px] text-ctp-overlay0 whitespace-nowrap" title={`${disabledDefaultCount} tools disabled by default`}>
+              <span className="text-xs text-ctp-overlay0 whitespace-nowrap" title={`${disabledDefaultCount} tools disabled by default`}>
                 {disabledDefaultCount} off
               </span>
             </div>
             {confirmClearAll ? (
               <button
                 onClick={handleClearAll}
-                className="w-full px-2 py-1.5 text-[10px] font-medium bg-ctp-red text-white rounded hover:opacity-90 transition-opacity"
+                className="w-full px-2 py-1.5 text-xs font-medium bg-ctp-red text-white rounded hover:opacity-90 transition-opacity"
                 data-testid="group-project-confirm-clear-all"
               >
                 Confirm Clear
@@ -679,7 +679,7 @@ function ExpandedProjectView({
             ) : (
               <button
                 onClick={() => setConfirmClearAll(true)}
-                className="w-full px-2 py-1.5 text-[10px] font-medium text-ctp-red bg-ctp-red/10 rounded hover:bg-ctp-red/20 transition-colors"
+                className="w-full px-2 py-1.5 text-xs font-medium text-ctp-red bg-ctp-red/10 rounded hover:bg-ctp-red/20 transition-colors"
                 title="Clear all messages (keeps description, instructions, and wires)"
                 data-testid="group-project-clear-all"
               >
@@ -699,7 +699,7 @@ function ExpandedProjectView({
           onResize={resizeTopics}
           onToggleCollapse={toggleTopicsCollapse}
         >
-          <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider bg-ctp-accent/10 text-ctp-accent sticky top-0 z-10">
+          <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider bg-ctp-accent/10 text-ctp-accent sticky top-0 z-10">
             Topics
           </div>
           {/* All virtual topic */}
@@ -712,7 +712,7 @@ function ExpandedProjectView({
             }`}
           >
             <div className="font-medium">All</div>
-            <div className="text-[10px] text-ctp-overlay0 mt-0.5">
+            <div className="text-xs text-ctp-overlay0 mt-0.5">
               {topics.reduce((sum, t) => sum + t.messageCount, 0)} msgs
             </div>
           </button>
@@ -733,7 +733,7 @@ function ExpandedProjectView({
                   {t.isProtected && <ShieldIcon size={10} />}
                   {t.topic}
                 </div>
-                <div className="text-[10px] text-ctp-overlay0 mt-0.5">
+                <div className="text-xs text-ctp-overlay0 mt-0.5">
                   {t.messageCount} msg{t.messageCount !== 1 ? 's' : ''}
                   {t.newMessageCount > 0 && (
                     <span className="ml-1 text-ctp-green">+{t.newMessageCount}</span>
@@ -797,10 +797,10 @@ function ExpandedProjectView({
                   className="w-full text-left px-3 py-2"
                 >
                   <div className="flex items-center gap-1.5 text-xs">
-                    <span className="bg-ctp-accent/15 text-ctp-accent rounded px-1 py-0.5 text-[10px] font-medium truncate max-w-[80px]">
+                    <span className="bg-ctp-accent/15 text-ctp-accent rounded px-1 py-0.5 text-xs font-medium truncate max-w-[80px]">
                       {senderShort(m.sender)}
                     </span>
-                    <span className="ml-auto text-[10px] text-ctp-overlay0 flex-shrink-0">
+                    <span className="ml-auto text-xs text-ctp-overlay0 flex-shrink-0">
                       {formatTime(m.timestamp)}
                     </span>
                   </div>
@@ -826,7 +826,7 @@ function ExpandedProjectView({
           {selectedMessage ? (
             <div className="text-xs space-y-2">
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="bg-ctp-accent/15 text-ctp-accent rounded px-1.5 py-0.5 text-[10px] font-medium">
+                <span className="bg-ctp-accent/15 text-ctp-accent rounded px-1.5 py-0.5 text-xs font-medium">
                   {selectedMessage.sender}
                 </span>
                 <span className="text-ctp-overlay0">
@@ -859,7 +859,7 @@ function ExpandedProjectView({
       {/* Action Bar (agent count only) */}
       <div className="flex items-center gap-2 px-3 py-1.5 border-t border-surface-1 bg-ctp-mantle">
         <RobotIcon size={12} />
-        <span className="text-[10px] text-ctp-subtext0">
+        <span className="text-xs text-ctp-subtext0">
           {members.length} agent{members.length !== 1 ? 's' : ''} connected
         </span>
       </div>
@@ -984,7 +984,7 @@ function ExpandedHeader({
         title={pollingEnabled ? 'Polling active — click to stop' : 'Enable agent polling'}
       >
         <PollingIcon size={12} active={pollingEnabled} />
-        <span className="text-[10px] font-medium">{pollingEnabled ? 'Poll: On' : 'Poll: Off'}</span>
+        <span className="text-xs font-medium">{pollingEnabled ? 'Poll: On' : 'Poll: Off'}</span>
       </button>
     </div>
   );
@@ -1160,7 +1160,7 @@ function RetentionSettings({ groupProjectId }: { groupProjectId: string }) {
 
   return (
     <div className="flex items-center gap-3 px-3 py-2 border-t border-surface-1 bg-ctp-mantle/30">
-      <span className="text-[10px] font-semibold uppercase tracking-wider text-ctp-subtext0">Retention</span>
+      <span className="text-xs font-semibold uppercase tracking-wider text-ctp-subtext0">Retention</span>
       <label className="flex items-center gap-1.5 text-xs text-ctp-subtext1">
         Per topic:
         <input
@@ -1182,7 +1182,7 @@ function RetentionSettings({ groupProjectId }: { groupProjectId: string }) {
         />
       </label>
       {trimEstimate != null && trimEstimate > 0 && (
-        <span className="text-[10px] text-ctp-red font-medium">
+        <span className="text-xs text-ctp-red font-medium">
           {trimEstimate} msg{trimEstimate !== 1 ? 's' : ''} will be removed
         </span>
       )}
@@ -1190,7 +1190,7 @@ function RetentionSettings({ groupProjectId }: { groupProjectId: string }) {
         <button
           onClick={handleSave}
           disabled={saving}
-          className="px-2 py-0.5 text-[10px] font-medium bg-ctp-red text-white rounded hover:opacity-90 disabled:opacity-40 transition-opacity"
+          className="px-2 py-0.5 text-xs font-medium bg-ctp-red text-white rounded hover:opacity-90 disabled:opacity-40 transition-opacity"
         >
           {saving ? 'Trimming...' : 'Confirm Trim'}
         </button>
@@ -1198,7 +1198,7 @@ function RetentionSettings({ groupProjectId }: { groupProjectId: string }) {
         <button
           onClick={handleSave}
           disabled={saving}
-          className="px-2 py-0.5 text-[10px] font-medium bg-ctp-accent text-white rounded hover:opacity-90 disabled:opacity-40 transition-opacity"
+          className="px-2 py-0.5 text-xs font-medium bg-ctp-accent text-white rounded hover:opacity-90 disabled:opacity-40 transition-opacity"
         >
           {saving ? 'Saving...' : 'Save'}
         </button>

--- a/src/renderer/plugins/builtin/hub/AgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/AgentPicker.tsx
@@ -56,7 +56,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
 
           {durableAgents.length > 0 && (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wider text-ctp-overlay0 mb-1">Durable</div>
+              <div className="text-xs uppercase tracking-wider text-ctp-overlay0 mb-1">Durable</div>
               {durableAgents.map((a) => (
                 <button
                   key={a.id}
@@ -67,7 +67,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
                   <span className="text-xs text-ctp-text truncate flex-1">
                     {a.name}
                   </span>
-                  <span className={`text-[10px] ${a.status === 'running' ? 'text-ctp-success' : a.status === 'error' ? 'text-ctp-error' : 'text-ctp-overlay0'}`}>
+                  <span className={`text-xs ${a.status === 'running' ? 'text-ctp-success' : a.status === 'error' ? 'text-ctp-error' : 'text-ctp-overlay0'}`}>
                     {a.status}
                   </span>
                 </button>
@@ -77,7 +77,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
 
           {quickAgents.length > 0 && (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wider text-ctp-overlay0 mb-1">Quick</div>
+              <div className="text-xs uppercase tracking-wider text-ctp-overlay0 mb-1">Quick</div>
               {quickAgents.map((a) => (
                 <button
                   key={a.id}
@@ -86,7 +86,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
                 >
                   <AgentAvatar agentId={a.id} size="sm" showStatusRing />
                   <span className="text-xs text-ctp-text truncate flex-1">{a.name}</span>
-                  <span className="text-[10px] text-ctp-success">running</span>
+                  <span className="text-xs text-ctp-success">running</span>
                 </button>
               ))}
             </div>
@@ -129,7 +129,7 @@ export function AgentPicker({ api, agents, onPick }: AgentPickerProps) {
               </div>
               <button
                 onClick={() => setShowQuickForm(false)}
-                className="text-[10px] text-ctp-overlay0 hover:text-ctp-text"
+                className="text-xs text-ctp-overlay0 hover:text-ctp-text"
               >
                 Cancel
               </button>

--- a/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
+++ b/src/renderer/plugins/builtin/hub/CrossProjectAgentPicker.tsx
@@ -95,7 +95,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
                     className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg bg-surface-0 hover:bg-surface-1 text-left transition-colors"
                   >
                     <div
-                      className="w-7 h-7 rounded-md flex items-center justify-center text-[10px] font-bold text-white flex-shrink-0"
+                      className="w-7 h-7 rounded-md flex items-center justify-center text-xs font-bold text-white flex-shrink-0"
                       style={{ backgroundColor: color }}
                     >
                       {initials}
@@ -104,7 +104,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
                       <div className="text-xs text-ctp-text truncate">{p.name}</div>
                     </div>
                     {agentCount > 0 && (
-                      <span className="text-[10px] text-ctp-overlay0">{agentCount}</span>
+                      <span className="text-xs text-ctp-overlay0">{agentCount}</span>
                     )}
                   </button>
                 );
@@ -123,7 +123,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
         <div className="w-full max-w-xs space-y-3">
           <button
             onClick={handleBack}
-            className="text-[10px] text-ctp-overlay0 hover:text-ctp-text flex items-center gap-1 mb-1"
+            className="text-xs text-ctp-overlay0 hover:text-ctp-text flex items-center gap-1 mb-1"
           >
             &larr; Back
           </button>
@@ -133,7 +133,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
 
           {durableAgents.length > 0 && (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wider text-ctp-overlay0 mb-1">Durable</div>
+              <div className="text-xs uppercase tracking-wider text-ctp-overlay0 mb-1">Durable</div>
               {durableAgents.map((a) => (
                 <button
                   key={a.id}
@@ -144,7 +144,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
                   <span className="text-xs text-ctp-text truncate flex-1">
                     {a.name}
                   </span>
-                  <span className={`text-[10px] ${a.status === 'running' ? 'text-ctp-success' : a.status === 'error' ? 'text-ctp-error' : 'text-ctp-overlay0'}`}>
+                  <span className={`text-xs ${a.status === 'running' ? 'text-ctp-success' : a.status === 'error' ? 'text-ctp-error' : 'text-ctp-overlay0'}`}>
                     {a.status}
                   </span>
                 </button>
@@ -154,7 +154,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
 
           {quickAgents.length > 0 && (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wider text-ctp-overlay0 mb-1">Quick</div>
+              <div className="text-xs uppercase tracking-wider text-ctp-overlay0 mb-1">Quick</div>
               {quickAgents.map((a) => (
                 <button
                   key={a.id}
@@ -163,7 +163,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
                 >
                   <AgentAvatar agentId={a.id} size="sm" showStatusRing />
                   <span className="text-xs text-ctp-text truncate flex-1">{a.name}</span>
-                  <span className="text-[10px] text-ctp-success">running</span>
+                  <span className="text-xs text-ctp-success">running</span>
                 </button>
               ))}
             </div>
@@ -206,7 +206,7 @@ export function CrossProjectAgentPicker({ api, agents, onPick }: CrossProjectAge
               </div>
               <button
                 onClick={() => setShowQuickForm(false)}
-                className="text-[10px] text-ctp-overlay0 hover:text-ctp-text"
+                className="text-xs text-ctp-overlay0 hover:text-ctp-text"
               >
                 Cancel
               </button>

--- a/src/renderer/plugins/builtin/hub/HubPane.tsx
+++ b/src/renderer/plugins/builtin/hub/HubPane.tsx
@@ -243,7 +243,7 @@ export function HubPane({
                 <div className="flex items-center gap-1 ml-1 flex-shrink-0">
                   <button
                     onClick={(e) => { e.stopPropagation(); handleViewInAgents(); }}
-                    className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
+                    className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
                     title="View in Agents"
                   >
                     View
@@ -251,7 +251,7 @@ export function HubPane({
                   {onZoom && (
                     <button
                       onClick={(e) => { e.stopPropagation(); onZoom(pane.id); }}
-                      className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
+                      className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
                       title={isZoomed ? 'Restore pane' : 'Zoom pane'}
                       data-testid="zoom-button"
                     >
@@ -260,7 +260,7 @@ export function HubPane({
                   )}
                   <button
                     onClick={(e) => { e.stopPropagation(); handlePopOut(); }}
-                    className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
+                    className="text-xs px-1.5 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text"
                     title="Pop out in new window"
                     data-testid="popout-button"
                   >
@@ -269,7 +269,7 @@ export function HubPane({
                   {agent.status === 'running' && (
                     <button
                       onClick={(e) => { e.stopPropagation(); handleKill(); }}
-                      className="text-[10px] px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30"
+                      className="text-xs px-1.5 py-0.5 rounded bg-ctp-error/20 text-ctp-error hover:bg-ctp-error/30"
                       title="Stop agent"
                     >
                       Stop
@@ -277,7 +277,7 @@ export function HubPane({
                   )}
                   <button
                     onClick={(e) => { e.stopPropagation(); handleUnassign(); }}
-                    className="text-[10px] px-1 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-ctp-error/20 hover:text-ctp-error"
+                    className="text-xs px-1 py-0.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-ctp-error/20 hover:text-ctp-error"
                     title="Remove from pane"
                   >
                     &times;
@@ -334,7 +334,7 @@ function EdgeIndicator({ edge, active, onSplit }: {
       <button
         className={`
           absolute ${positionClass} z-20 flex items-center justify-center w-5 h-5 rounded-full
-          text-[10px] font-bold transition-all duration-100 cursor-pointer
+          text-xs font-bold transition-all duration-100 cursor-pointer
           ${active
             ? 'bg-ctp-accent text-white shadow-md scale-110'
             : 'bg-surface-1/60 text-ctp-overlay0 hover:bg-surface-1 hover:text-ctp-subtext0'

--- a/src/renderer/plugins/builtin/sessions/main.ts
+++ b/src/renderer/plugins/builtin/sessions/main.ts
@@ -202,7 +202,7 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
 
               // Expand indicator
               React.createElement('span', {
-                className: 'text-[10px] text-ctp-overlay0 flex-shrink-0 transition-transform',
+                className: 'text-xs text-ctp-overlay0 flex-shrink-0 transition-transform',
                 style: { transform: isExpanded ? 'rotate(90deg)' : 'none' },
               }, '\u25B8'),
             ),
@@ -235,7 +235,7 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
                       React.createElement('span', { className: 'truncate' },
                         session.friendlyName || `Session ${session.sessionId.slice(0, 8)}...`
                       ),
-                      React.createElement('span', { className: 'text-[10px] text-ctp-overlay0 flex-shrink-0' },
+                      React.createElement('span', { className: 'text-xs text-ctp-overlay0 flex-shrink-0' },
                         formatRelativeTime(session.lastActiveAt),
                       ),
                     ),
@@ -254,7 +254,7 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
           className: 'mx-3 my-2 border-t border-surface-0',
         }),
         React.createElement('div', {
-          className: 'px-3 py-1 text-[10px] text-ctp-subtext0 uppercase tracking-wider',
+          className: 'px-3 py-1 text-xs text-ctp-subtext0 uppercase tracking-wider',
         }, 'Completed'),
         completedAgents.map((completed) => React.createElement('button', {
           key: completed.id,
@@ -273,7 +273,7 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
               style: { borderColor: 'rgb(var(--ctp-overlay0))' },
             },
               React.createElement('div', {
-                className: 'w-6 h-6 rounded-full flex items-center justify-center bg-surface-2 text-ctp-subtext0 text-[10px]',
+                className: 'w-6 h-6 rounded-full flex items-center justify-center bg-surface-2 text-ctp-subtext0 text-xs',
               }, '\u26A1'),
             ),
             React.createElement('div', { className: 'flex-1 min-w-0' },
@@ -519,13 +519,13 @@ function CompletedAgentDetail({ api, agentId, agentName }: { api: PluginAPI; age
       },
         // Mission
         completed.mission && React.createElement('div', { className: 'mb-3' },
-          React.createElement('div', { className: 'text-[10px] text-ctp-overlay0 uppercase tracking-wider mb-1' }, 'Mission'),
+          React.createElement('div', { className: 'text-xs text-ctp-overlay0 uppercase tracking-wider mb-1' }, 'Mission'),
           React.createElement('div', { className: 'text-xs text-ctp-text' }, completed.mission),
         ),
 
         // Summary
         completed.summary && React.createElement('div', { className: 'mb-3' },
-          React.createElement('div', { className: 'text-[10px] text-ctp-overlay0 uppercase tracking-wider mb-1' }, 'Summary'),
+          React.createElement('div', { className: 'text-xs text-ctp-overlay0 uppercase tracking-wider mb-1' }, 'Summary'),
           React.createElement('div', { className: 'text-xs text-ctp-subtext1 line-clamp-5' }, completed.summary),
         ),
 
@@ -537,16 +537,16 @@ function CompletedAgentDetail({ api, agentId, agentName }: { api: PluginAPI; age
 
         // Completed time
         React.createElement('div', {
-          className: 'text-[10px] text-ctp-overlay0',
+          className: 'text-xs text-ctp-overlay0',
         }, `Completed ${formatRelativeTime(new Date(completed.completedAt).toISOString())}`),
 
         // File list
         completed.filesModified.length > 0 && React.createElement('div', { className: 'mt-2 pt-2 border-t border-surface-0' },
-          React.createElement('div', { className: 'text-[10px] text-ctp-overlay0 uppercase tracking-wider mb-1' }, 'Modified files'),
+          React.createElement('div', { className: 'text-xs text-ctp-overlay0 uppercase tracking-wider mb-1' }, 'Modified files'),
           React.createElement('div', { className: 'space-y-0.5' },
             completed.filesModified.map((f) => React.createElement('div', {
               key: f,
-              className: 'text-[10px] text-ctp-subtext0 truncate',
+              className: 'text-xs text-ctp-subtext0 truncate',
               title: f,
             }, f)),
           ),
@@ -582,7 +582,7 @@ function SessionSummaryCard({ summary }: { summary: SessionSummary }) {
 
     // Additional info row
     React.createElement('div', {
-      className: 'flex items-center gap-3 mt-2 pt-2 border-t border-surface-0 text-[10px] text-ctp-overlay0',
+      className: 'flex items-center gap-3 mt-2 pt-2 border-t border-surface-0 text-xs text-ctp-overlay0',
     },
       summary.model && React.createElement('span', null, `Model: ${summary.model}`),
       summary.orchestrator && React.createElement('span', null, `Provider: ${getOrchestratorLabel(summary.orchestrator)}`),
@@ -592,10 +592,10 @@ function SessionSummaryCard({ summary }: { summary: SessionSummary }) {
     // Expandable file list
     summary.filesModified.length > 0 && React.createElement('div', { className: 'mt-2' },
       React.createElement('button', {
-        className: 'text-[10px] text-ctp-info hover:underline cursor-pointer',
+        className: 'text-xs text-ctp-info hover:underline cursor-pointer',
         onClick: () => setFilesExpanded(!filesExpanded),
       }, filesExpanded ? 'Hide files' : `Show ${summary.filesModified.length} modified files`),
-      filesExpanded && React.createElement('div', { className: 'mt-1 text-[10px] text-ctp-subtext0 space-y-0.5' },
+      filesExpanded && React.createElement('div', { className: 'mt-1 text-xs text-ctp-subtext0 space-y-0.5' },
         summary.filesModified.map((f) => React.createElement('div', {
           key: f,
           className: 'truncate',
@@ -612,7 +612,7 @@ function StatBadge(label: string, value: string) {
     className: 'px-2 py-1.5 rounded bg-ctp-crust',
   },
     React.createElement('div', { className: 'text-xs font-medium text-ctp-text' }, value),
-    React.createElement('div', { className: 'text-[10px] text-ctp-overlay0' }, label),
+    React.createElement('div', { className: 'text-xs text-ctp-overlay0' }, label),
   );
 }
 
@@ -665,7 +665,7 @@ function TimelineSection({ events, playback }: {
       ([1, 3, 5] as const).map((speed) =>
         React.createElement('button', {
           key: speed,
-          className: `px-1.5 py-0.5 text-[10px] rounded cursor-pointer transition-colors ${
+          className: `px-1.5 py-0.5 text-xs rounded cursor-pointer transition-colors ${
             playback.speed === speed
               ? 'bg-ctp-accent text-ctp-base font-medium'
               : 'bg-surface-0 text-ctp-subtext0 hover:bg-surface-1'
@@ -676,7 +676,7 @@ function TimelineSection({ events, playback }: {
 
       // Time display
       React.createElement('span', {
-        className: 'ml-auto text-[10px] text-ctp-overlay0',
+        className: 'ml-auto text-xs text-ctp-overlay0',
       }, `${currentOffset} / ${totalDuration}`),
     ),
 
@@ -760,7 +760,7 @@ function EventList({ events, totalEvents, playback, onLoadMore, listRef }: {
     'data-testid': 'session-event-list',
   },
     React.createElement('div', {
-      className: 'text-[10px] text-ctp-subtext0 mb-1 uppercase tracking-wider',
+      className: 'text-xs text-ctp-subtext0 mb-1 uppercase tracking-wider',
     }, `Events (${events.length}${events.length < totalEvents ? ` of ${totalEvents}` : ''})`),
 
     events.map((event, idx) => {
@@ -788,16 +788,16 @@ function EventList({ events, totalEvents, playback, onLoadMore, listRef }: {
         onClick: () => sessionsState.setPlaybackIndex(idx),
       },
         React.createElement('div', { className: 'flex items-center gap-2' },
-          React.createElement('span', { className: 'flex-shrink-0 text-[10px]' }, icon),
+          React.createElement('span', { className: 'flex-shrink-0 text-xs' }, icon),
           React.createElement('span', {
             className: `flex-1 truncate ${isActive ? 'text-ctp-text' : 'text-ctp-subtext1'}`,
           }, label),
           React.createElement('span', {
-            className: 'flex-shrink-0 text-[10px] text-ctp-overlay0',
+            className: 'flex-shrink-0 text-xs text-ctp-overlay0',
           }, offset),
         ),
         event.filePath && React.createElement('div', {
-          className: 'ml-5 text-[10px] text-ctp-overlay0 truncate',
+          className: 'ml-5 text-xs text-ctp-overlay0 truncate',
         }, event.filePath),
       );
     }),
@@ -805,7 +805,7 @@ function EventList({ events, totalEvents, playback, onLoadMore, listRef }: {
     // Load more sentinel
     events.length < totalEvents && React.createElement('div', {
       ref: sentinelRef,
-      className: 'py-2 text-center text-[10px] text-ctp-overlay0',
+      className: 'py-2 text-center text-xs text-ctp-overlay0',
     }, 'Loading more events...'),
   );
 }

--- a/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/terminal/TerminalCanvasWidget.tsx
@@ -265,7 +265,7 @@ export function TerminalCanvasWidget({ widgetId, api, metadata, onUpdateMetadata
         <div className="flex items-center gap-1 mb-2">
           {isAppMode && (
             <button
-              className="text-[10px] text-ctp-subtext0 hover:text-ctp-text transition-colors mr-1"
+              className="text-xs text-ctp-subtext0 hover:text-ctp-text transition-colors mr-1"
               onClick={handleBackToProjects}
               title="Back to projects"
             >
@@ -288,7 +288,7 @@ export function TerminalCanvasWidget({ widgetId, api, metadata, onUpdateMetadata
                 className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg bg-surface-0 hover:bg-surface-1 text-left transition-colors"
                 onClick={() => handleSelectCwd(wt.path)}
               >
-                <div className={`w-5 h-5 rounded flex items-center justify-center text-[10px] font-mono flex-shrink-0 ${
+                <div className={`w-5 h-5 rounded flex items-center justify-center text-xs font-mono flex-shrink-0 ${
                   wt.isBare ? 'text-ctp-green bg-ctp-green/10' : 'text-ctp-mauve bg-ctp-mauve/10'
                 }`}>
                   {wt.isBare ? '*' : 'W'}
@@ -312,7 +312,7 @@ export function TerminalCanvasWidget({ widgetId, api, metadata, onUpdateMetadata
   // Step 3: Terminal view
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-1 px-2 py-1 bg-surface-0/50 border-b border-surface-0 text-[10px] text-ctp-subtext0 flex-shrink-0">
+      <div className="flex items-center gap-1 px-2 py-1 bg-surface-0/50 border-b border-surface-0 text-xs text-ctp-subtext0 flex-shrink-0">
         <button
           className="flex items-center gap-1 px-1.5 py-0.5 rounded text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-1 transition-colors"
           onClick={handleRestart}

--- a/src/renderer/plugins/builtin/terminal/main.ts
+++ b/src/renderer/plugins/builtin/terminal/main.ts
@@ -126,7 +126,7 @@ export function SidebarPanel({ api }: { api: PluginAPI }) {
           className: 'mx-3 my-2 border-t border-surface-0',
         }),
         React.createElement('div', {
-          className: 'px-3 py-1 text-[10px] text-ctp-subtext0 uppercase tracking-wider',
+          className: 'px-3 py-1 text-xs text-ctp-subtext0 uppercase tracking-wider',
         }, 'No worktree'),
         noWorktreeAgents.map((name) =>
           React.createElement('div', {


### PR DESCRIPTION
## Summary

- **VQ-SK-01**: Replaces all 74 source-file occurrences of `text-[10px]` (10px — below WCAG minimum font size) with `text-xs` (12px — canonical Tailwind class, WCAG-compliant)
- Adds ESLint `no-restricted-syntax` rule to ban `text-[10px]` in className JSX attributes, preventing regression
- Zero `text-[10px]` remaining in src/ after sweep (`rg 'text-\[10px\]' src/` → 0 results)

## Scope

75 files changed (74 source files + `eslint.config.mjs`). All changes are mechanical `text-[10px]` → `text-xs` substitutions with no logic changes.

## Validation

- Typecheck: pre-existing `mermaid` module error unrelated to this PR (present on main)
- Tests: same 9 pre-existing failures as main — zero new failures
- Lint: same 941 pre-existing errors as main — zero `text-[10px]` violations

## Test plan

- [x] `rg 'text-\[10px\]' src/` returns 0 results
- [x] ESLint rule added to `eslint.config.mjs` under `src/**/*.tsx, src/**/*.ts` block
- [x] No new typecheck/test/lint regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)