### PR TITLE
fix: 5 UI regressions — z-index utilities, orchestrator dropdown, drag reorder

### DIFF
--- a/src/renderer/components/Modal.test.tsx
+++ b/src/renderer/components/Modal.test.tsx
@@ -66,4 +66,21 @@ describe('Modal', () => {
     fireEvent.click(screen.getByTestId('inner'));
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it('portals the backdrop directly under document.body with the z-modal class (regression: settings rows above modal)', () => {
+    render(
+      <Modal open={true} onClose={vi.fn()}>
+        <span>content</span>
+      </Modal>
+    );
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement;
+    expect(backdrop).not.toBeNull();
+    // Must portal to body so it escapes ancestor stacking contexts in
+    // settings/explorer panels.
+    expect(backdrop.parentElement).toBe(document.body);
+    // Must carry the named z-index utility — if this class disappears (or
+    // its Tailwind utility stops compiling) the modal falls back to
+    // z-index: auto and settings content renders above it.
+    expect(backdrop.classList.contains('z-modal')).toBe(true);
+  });
 });

--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -718,3 +718,37 @@ describe('P-C-3: AgentList polling-tick re-render optimization', () => {
     expect(isThinkingCaptures).toHaveLength(1);
   });
 });
+
+describe('AgentList drag-reorder re-render', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    isThinkingCaptures.length = 0;
+    Object.keys(activityTimestamps).forEach((k) => delete activityTimestamps[k]);
+    window.clubhouse.pty.onData = vi.fn().mockReturnValue(() => {});
+  });
+
+  it('re-renders the list in the new order after agents are reordered (regression: useShallow swallowed key-order changes)', () => {
+    const a: Agent = { id: 'a', projectId: 'proj-1', name: 'alpha', kind: 'durable', status: 'sleeping', color: 'indigo' };
+    const b: Agent = { id: 'b', projectId: 'proj-1', name: 'bravo', kind: 'durable', status: 'sleeping', color: 'indigo' };
+    const c: Agent = { id: 'c', projectId: 'proj-1', name: 'charlie', kind: 'durable', status: 'sleeping', color: 'indigo' };
+
+    useAgentStore.setState({ agents: { a, b, c } });
+
+    render(<AgentList />);
+
+    // Initial visible order: alpha, bravo, charlie
+    const initialNames = screen.getAllByTestId(/^agent-item-/).map((el) => el.textContent);
+    expect(initialNames).toEqual(['alpha', 'bravo', 'charlie']);
+
+    // Reorder via the same shape reorderAgents produces — keys reshuffled,
+    // value references identical to the previous render. Pre-fix this slipped
+    // past zustand's shallow equality and the list stayed in the old order.
+    act(() => {
+      useAgentStore.setState({ agents: { c, a, b } });
+    });
+
+    const reorderedNames = screen.getAllByTestId(/^agent-item-/).map((el) => el.textContent);
+    expect(reorderedNames).toEqual(['charlie', 'alpha', 'bravo']);
+  });
+});

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo, memo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
+import { useOrderedShallow } from '../../hooks/useOrderedShallow';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useQuickAgentStore } from '../../stores/quickAgentStore';
@@ -64,7 +64,7 @@ export function useProjectAgentBuckets(
 }
 
 function AgentListInner() {
-  const localAgents = useAgentStore(useShallow((s) => s.agents));
+  const localAgents = useAgentStore(useOrderedShallow((s) => s.agents));
   const remoteAgents = useRemoteProjectStore((s) => s.remoteAgents);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const setActiveAgent = useAgentStore((s) => s.setActiveAgent);

--- a/src/renderer/features/agents/AgentSettingsView.test.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.test.tsx
@@ -312,6 +312,75 @@ describe('AgentSettingsView', () => {
     });
   });
 
+  describe('orchestrator dropdown', () => {
+    // Make sure two orchestrators are enabled so the <select> renders (the
+    // single-orchestrator path shows a static label instead).
+    function setupMultiOrch() {
+      useOrchestratorStore.setState({
+        enabled: ['claude-code', 'github-copilot'],
+        allOrchestrators: [
+          {
+            id: 'claude-code',
+            displayName: 'Claude Code',
+            shortName: 'CC',
+            capabilities: { headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true },
+            conventions: {
+              configDir: '.claude',
+              localInstructionsFile: 'CLAUDE.md',
+              legacyInstructionsFile: 'CLAUDE.md',
+              mcpConfigFile: '.mcp.json',
+              skillsDir: 'skills',
+              agentTemplatesDir: 'agents',
+              localSettingsFile: 'settings.local.json',
+            },
+          },
+          {
+            id: 'github-copilot',
+            displayName: 'GitHub Copilot',
+            shortName: 'GHCP',
+            capabilities: { headless: false, structuredOutput: false, hooks: false, sessionResume: false, permissions: false },
+            conventions: {
+              configDir: '.github',
+              localInstructionsFile: '.github/copilot-instructions.md',
+              legacyInstructionsFile: '.github/copilot-instructions.md',
+              mcpConfigFile: 'mcp.json',
+              skillsDir: 'skills',
+              agentTemplatesDir: 'agents',
+              localSettingsFile: 'settings.json',
+            },
+          },
+        ],
+      } as any);
+    }
+
+    it('patches the agent store after change so the controlled dropdown reflects the new value (regression: dropdown stuck on previous value)', async () => {
+      setupMultiOrch();
+      renderSettings({ orchestrator: 'claude-code' });
+
+      const select = screen.getByDisplayValue('Claude Code') as HTMLSelectElement;
+      expect(select.value).toBe('claude-code');
+
+      fireEvent.change(select, { target: { value: 'github-copilot' } });
+
+      // IPC persistence happens
+      await waitFor(() => {
+        expect(window.clubhouse.agent.updateDurableConfig).toHaveBeenCalledWith(
+          '/project',
+          'agent-1',
+          { orchestrator: 'github-copilot' },
+        );
+      });
+
+      // CRITICAL: the in-memory store is patched in the same handler. The
+      // parent panel re-derives the `agent` prop from this store, so without
+      // this update the dropdown shows the old orchestrator even though the
+      // next agent start uses the new one.
+      await waitFor(() => {
+        expect(useAgentStore.getState().agents['agent-1'].orchestrator).toBe('github-copilot');
+      });
+    });
+  });
+
   describe('clubhouse mode', () => {
     beforeEach(() => {
       useClubhouseModeStore.setState({

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -267,6 +267,16 @@ export function AgentSettingsView({ agent }: Props) {
   const handleOrchestratorChange = async (value: string) => {
     if (!projectPath) return;
     await window.clubhouse.agent.updateDurableConfig(projectPath, agent.id, { orchestrator: value });
+    useAgentStore.setState((s) => {
+      const existing = s.agents[agent.id];
+      if (!existing) return s;
+      return {
+        agents: {
+          ...s.agents,
+          [agent.id]: { ...existing, orchestrator: value },
+        },
+      };
+    });
   };
 
   // Agent model state

--- a/src/renderer/features/annex/SatelliteLockOverlay.test.tsx
+++ b/src/renderer/features/annex/SatelliteLockOverlay.test.tsx
@@ -97,4 +97,24 @@ describe('SatelliteLockOverlay – pause floatie positioning', () => {
 
     expect(container.innerHTML).toBe('');
   });
+
+  it('uses fixed positioning and the z-canvas-overlay class (regression: overlay rendered behind explorer/content panels)', () => {
+    const { container } = render(
+      <SatelliteLockOverlay
+        lockState={{ ...baseLockState, paused: false }}
+        onDisconnect={noop}
+        onPause={noop}
+        onDisableAndDisconnect={noop}
+      />,
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).not.toBeNull();
+    // Without z-canvas-overlay compiling to z-index: 9999, the overlay falls
+    // back to z-index: auto and is occluded by later siblings (explorer +
+    // content panels), so its buttons can't be clicked.
+    expect(root.classList.contains('fixed')).toBe(true);
+    expect(root.classList.contains('inset-0')).toBe(true);
+    expect(root.classList.contains('z-canvas-overlay')).toBe(true);
+  });
 });

--- a/src/renderer/features/blueprints/ExportBlueprintDialog.tsx
+++ b/src/renderer/features/blueprints/ExportBlueprintDialog.tsx
@@ -103,7 +103,7 @@ export function ExportBlueprintDialog({
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: "var(--z-top)" }}
+      style={{ zIndex: "var(--z-index-top)" }}
       onClick={handleBackdropClick}
       data-testid="export-blueprint-dialog"
     >

--- a/src/renderer/features/blueprints/ExportBundleDialog.tsx
+++ b/src/renderer/features/blueprints/ExportBundleDialog.tsx
@@ -95,7 +95,7 @@ export function ExportBundleDialog({
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: "var(--z-top)" }}
+      style={{ zIndex: "var(--z-index-top)" }}
       onClick={handleBackdropClick}
       data-testid="export-bundle-dialog"
     >

--- a/src/renderer/features/blueprints/ImportBundleDialog.tsx
+++ b/src/renderer/features/blueprints/ImportBundleDialog.tsx
@@ -55,7 +55,7 @@ export function ImportBundleDialog({ bundle, onImport, onClose }: ImportBundleDi
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: "var(--z-top)" }}
+      style={{ zIndex: "var(--z-index-top)" }}
       onClick={handleBackdropClick}
       data-testid="import-bundle-dialog"
     >

--- a/src/renderer/hooks/useOrderedShallow.test.ts
+++ b/src/renderer/hooks/useOrderedShallow.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useOrderedShallow } from './useOrderedShallow';
+
+describe('useOrderedShallow', () => {
+  it('returns previous reference when keys and values match in the same order', () => {
+    const { result } = renderHook(() =>
+      useOrderedShallow<{ x: Record<string, number> }, Record<string, number>>((s) => s.x),
+    );
+    const selector = result.current;
+
+    const first = { a: 1, b: 2 };
+    const r1 = selector({ x: first });
+    expect(r1).toBe(first);
+
+    const second = { a: 1, b: 2 };
+    const r2 = selector({ x: second });
+    expect(r2).toBe(first);
+  });
+
+  it('returns the new reference when key order changes (regression: drag-reorder)', () => {
+    const { result } = renderHook(() =>
+      useOrderedShallow<{ x: Record<string, number> }, Record<string, number>>((s) => s.x),
+    );
+    const selector = result.current;
+
+    const first = { a: 1, b: 2, c: 3 };
+    selector({ x: first });
+
+    const reordered = { c: 3, a: 1, b: 2 };
+    const r2 = selector({ x: reordered });
+    expect(r2).toBe(reordered);
+    expect(r2).not.toBe(first);
+  });
+
+  it('returns the new reference when a value changes (status polling with content delta)', () => {
+    const { result } = renderHook(() =>
+      useOrderedShallow<{ x: Record<string, { status: string }> }, Record<string, { status: string }>>((s) => s.x),
+    );
+    const selector = result.current;
+
+    const a = { status: 'idle' };
+    const b = { status: 'idle' };
+    const first = { a, b };
+    selector({ x: first });
+
+    const updatedA = { status: 'running' };
+    const second = { a: updatedA, b };
+    const r2 = selector({ x: second });
+    expect(r2).toBe(second);
+    expect(r2).not.toBe(first);
+  });
+
+  it('returns the new reference when a key is added or removed', () => {
+    const { result } = renderHook(() =>
+      useOrderedShallow<{ x: Record<string, number> }, Record<string, number>>((s) => s.x),
+    );
+    const selector = result.current;
+
+    const first = { a: 1, b: 2 };
+    selector({ x: first });
+
+    const added = { a: 1, b: 2, c: 3 };
+    expect(selector({ x: added })).toBe(added);
+
+    const removed = { a: 1 };
+    expect(selector({ x: removed })).toBe(removed);
+  });
+
+  it('handles primitives and null without throwing', () => {
+    const { result } = renderHook(() =>
+      useOrderedShallow<{ x: number | null }, number | null>((s) => s.x),
+    );
+    const selector = result.current;
+    expect(selector({ x: null })).toBe(null);
+    expect(selector({ x: null })).toBe(null);
+    expect(selector({ x: 5 })).toBe(5);
+    expect(selector({ x: 5 })).toBe(5);
+    expect(selector({ x: 6 })).toBe(6);
+  });
+});

--- a/src/renderer/hooks/useOrderedShallow.ts
+++ b/src/renderer/hooks/useOrderedShallow.ts
@@ -1,0 +1,45 @@
+import { useMemo, useRef } from 'react';
+
+function shallowOrderAware<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) return true;
+  if (
+    typeof a !== 'object' ||
+    typeof b !== 'object' ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  const keysA = Object.keys(a as object);
+  const keysB = Object.keys(b as object);
+  if (keysA.length !== keysB.length) return false;
+  for (let i = 0; i < keysA.length; i++) {
+    const key = keysA[i];
+    if (key !== keysB[i]) return false;
+    if (!Object.is((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) return false;
+  }
+  return true;
+}
+
+/**
+ * Like zustand's `useShallow`, but treats reordered objects as different.
+ *
+ * Use this for state where insertion order is part of the value (e.g. an
+ * agents map whose key order drives the visible list order). `useShallow`
+ * returns the previous reference when keys and values match — which means
+ * reorderings are silently dropped and the consumer never re-renders.
+ */
+export function useOrderedShallow<S, U>(selector: (state: S) => U): (state: S) => U {
+  const prev = useRef<U | undefined>(undefined);
+  return useMemo(
+    () => (state: S) => {
+      const next = selector(state);
+      if (prev.current !== undefined && shallowOrderAware(prev.current, next)) {
+        return prev.current;
+      }
+      prev.current = next;
+      return next;
+    },
+    [],
+  );
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -36,15 +36,17 @@
   --color-status-info: rgb(var(--ctp-info));
   --color-status-success: rgb(var(--ctp-success));
 
-  /* Named z-index scale — use z-modal, z-toast, etc. instead of ad-hoc z-50/z-[9999] */
-  --z-raised: 10;
-  --z-dropdown-backdrop: 40;
-  --z-dropdown: 50;
-  --z-modal: 200;
-  --z-toast: 300;
-  --z-canvas-overlay: 9999;
-  --z-canvas-dialog: 10000;
-  --z-top: 100000;
+  /* Named z-index scale — use z-modal, z-toast, etc. instead of ad-hoc z-50/z-[9999].
+     Tailwind v4 requires the --z-index-* namespace to generate z-* utilities; the prior --z-*
+     prefix produced no CSS at all, leaving modals/dropdowns/overlays at z-auto. */
+  --z-index-raised: 10;
+  --z-index-dropdown-backdrop: 40;
+  --z-index-dropdown: 50;
+  --z-index-modal: 200;
+  --z-index-toast: 300;
+  --z-index-canvas-overlay: 9999;
+  --z-index-canvas-dialog: 10000;
+  --z-index-top: 100000;
 }
 
 @import '@xterm/xterm/css/xterm.css';

--- a/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireInstructionsDialog.tsx
@@ -91,7 +91,7 @@ export function WireInstructionsDialog({ binding, onSave, onClose }: WireInstruc
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: "var(--z-top)" }}
+      style={{ zIndex: "var(--z-index-top)" }}
       onMouseDown={handleBackdropMouseDown}
       onClick={handleBackdropClick}
       data-testid="wire-instructions-dialog"

--- a/src/renderer/plugins/builtin/canvas/WireToolPermissionsDialog.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireToolPermissionsDialog.tsx
@@ -123,7 +123,7 @@ export function WireToolPermissionsDialog({ binding, onSave, onClose }: WireTool
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
-      style={{ zIndex: "var(--z-top)" }}
+      style={{ zIndex: "var(--z-index-top)" }}
       onMouseDown={handleBackdropMouseDown}
       onClick={handleBackdropClick}
       data-testid="wire-tool-permissions-dialog"

--- a/src/renderer/zIndex.ts
+++ b/src/renderer/zIndex.ts
@@ -2,7 +2,7 @@
  * Named z-index scale — use these instead of ad-hoc numeric values.
  *
  * Tailwind utilities are also available (e.g. z-modal, z-toast) via @theme in index.css.
- * Use the CSS custom property form (style={{ zIndex: 'var(--z-top)' }}) or these constants
+ * Use the CSS custom property form (style={{ zIndex: 'var(--z-index-top)' }}) or these constants
  * for inline styles where Tailwind classes aren't available.
  */
 export const Z_INDEX = {

--- a/test/tailwind-z-index-utilities.test.ts
+++ b/test/tailwind-z-index-utilities.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression: the named z-index utilities (z-modal, z-toast, z-dropdown,
+ * z-canvas-overlay, z-canvas-dialog, z-top, z-raised, z-dropdown-backdrop)
+ * must compile to real CSS rules with the expected z-index values.
+ *
+ * Tailwind v4 generates `z-*` utilities only from the `--z-index-*`
+ * namespace — not `--z-*`. A previous version of `src/renderer/index.css`
+ * declared `--z-modal: 200; --z-toast: 300; …` which set CSS custom
+ * properties on :root but produced NO Tailwind utilities. Every modal,
+ * dropdown, and overlay using these classes silently fell back to
+ * `z-index: auto`, breaking visible stacking in update-gate modals,
+ * project context menus, and the Annex SatelliteLockOverlay.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFile, writeFile, unlink } from 'fs/promises';
+import * as path from 'path';
+import postcss from 'postcss';
+import tailwindcss from '@tailwindcss/postcss';
+
+const projectRoot = path.resolve(__dirname, '..');
+const indexCssPath = path.join(projectRoot, 'src/renderer/index.css');
+
+async function compileWithProbe(probeClasses: string[]): Promise<string> {
+  const htmlPath = path.join(__dirname, '.tailwind-z-probe.html');
+  await writeFile(htmlPath, `<div class="${probeClasses.join(' ')}"></div>`);
+  try {
+    const baseCss = await readFile(indexCssPath, 'utf8');
+    // Force the probe HTML into Tailwind's content scan
+    const input = `@source "${htmlPath}";\n${baseCss}`;
+    const result = await postcss([tailwindcss()]).process(input, { from: indexCssPath });
+    return result.css;
+  } finally {
+    try { await unlink(htmlPath); } catch { /* ignore */ }
+  }
+}
+
+/** Extracts the z-index value Tailwind emitted for the given utility class. */
+function findZIndexFor(css: string, utility: string): string | undefined {
+  // Tailwind v4 emits ".z-modal { z-index: var(--z-index-modal); }" or the
+  // computed value depending on configuration. We accept either form and
+  // resolve var() references against the :root declarations.
+  const escapedUtility = utility.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const ruleRe = new RegExp(`\\.${escapedUtility}\\s*\\{[^}]*z-index\\s*:\\s*([^;}]+)`, 'i');
+  const match = css.match(ruleRe);
+  if (!match) return undefined;
+  const value = match[1].trim();
+  const varMatch = value.match(/^var\((--[a-z0-9-]+)\)$/i);
+  if (varMatch) {
+    const varName = varMatch[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const rootRe = new RegExp(`${varName}\\s*:\\s*([^;\\n]+)`);
+    const rootMatch = css.match(rootRe);
+    if (rootMatch) return rootMatch[1].trim();
+  }
+  return value;
+}
+
+describe('Tailwind named z-index utilities', () => {
+  const expected: Record<string, string> = {
+    'z-raised': '10',
+    'z-dropdown-backdrop': '40',
+    'z-dropdown': '50',
+    'z-modal': '200',
+    'z-toast': '300',
+    'z-canvas-overlay': '9999',
+    'z-canvas-dialog': '10000',
+    'z-top': '100000',
+  };
+
+  it('compiles every named z-index utility to its declared value', async () => {
+    const css = await compileWithProbe(Object.keys(expected));
+    for (const [utility, value] of Object.entries(expected)) {
+      const actual = findZIndexFor(css, utility);
+      expect(actual, `${utility} should resolve to ${value}, got ${actual ?? '(no rule emitted)'}`).toBe(value);
+    }
+  }, 30_000);
+
+  it('preserves the documented z-order: toast > modal > dropdown > raised', async () => {
+    const css = await compileWithProbe(['z-raised', 'z-dropdown', 'z-modal', 'z-toast']);
+    const z = (u: string) => parseInt(findZIndexFor(css, u) ?? 'NaN', 10);
+    expect(z('z-toast')).toBeGreaterThan(z('z-modal'));
+    expect(z('z-modal')).toBeGreaterThan(z('z-dropdown'));
+    expect(z('z-dropdown')).toBeGreaterThan(z('z-raised'));
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Fixes five UI bugs surfaced in manual testing of beta.23:

1. **Auto-resume update gate modal sat below settings rows.** Same root cause as 4 & 5: Tailwind v4 emits `z-*` utilities only from `--z-index-*`, not `--z-*`. Every named z utility (`z-modal`, `z-toast`, `z-dropdown`, `z-canvas-overlay`, `z-canvas-dialog`, `z-top`, `z-raised`, `z-dropdown-backdrop`) compiled to nothing, so the modal fell back to `z-index: auto` and lost the stacking fight to whichever sibling rendered later.
2. **Cannot drag-and-drop agents in the list to reorder.** The agent-list re-render perf fix (#1465) wrapped the `s.agents` subscription in zustand's `useShallow`. Shallow equality compares keys and values but ignores key order, so a reorder produced an object with identical refs in a new order and was treated as equal — the previous reference was returned and `AgentList` never re-rendered.
3. **Orchestrator dropdown didn't visually change when set to a non-CC orchestrator.** `handleOrchestratorChange` persisted to disk via IPC but never patched the in-memory `useAgentStore`. The parent panel re-derives its `agent` prop from the store, so the controlled `<select>` kept showing the previous value even though the next start used the new orchestrator.
4. **Right-click "close project" context menu had no background / wasn't clickable.** `ProjectContextMenu` uses `bg-ctp-mantle z-dropdown` — both correct — but `z-dropdown` didn't compile (see 1), so the menu sat at `z-index: auto` and lost to the rail's `z-30`.
5. **Annex `SatelliteLockOverlay` only appeared over the middle accessory panel.** Same cause as 1: `z-canvas-overlay` didn't compile, so the overlay's `fixed inset-0` lost to later-rendered sibling panels.

## Changes

- **`src/renderer/index.css`** — renames the `@theme` block from `--z-*` to `--z-index-*` so Tailwind actually generates the utilities. The class names in JSX (`z-modal`, `z-canvas-overlay`, …) are unchanged.
- **5 dialogs** (`Wire*Dialog`, `Export*Dialog`, `ImportBundleDialog`) — updates the inline `style={{ zIndex: 'var(--z-top)' }}` references.
- **`src/renderer/zIndex.ts`** — docstring example updated.
- **`src/renderer/hooks/useOrderedShallow.ts`** (new) — like zustand's `useShallow` but also rejects reordered objects. Drop-in replacement for the agent-list subscription that preserves polling-tick perf while fixing drag reorder.
- **`src/renderer/features/agents/AgentList.tsx`** — swap `useShallow` → `useOrderedShallow` for the `s.agents` subscription.
- **`src/renderer/features/agents/AgentSettingsView.tsx`** — `handleOrchestratorChange` now patches `useAgentStore` after the IPC call, matching the existing `handleFreeAgentModeChange` / `handleStructuredModeChange` pattern.

## Regression coverage

Six new test additions, picked to catch the exact failure mode each fix targets:

- `test/tailwind-z-index-utilities.test.ts` — compiles `src/renderer/index.css` through `@tailwindcss/postcss` and asserts every named z utility resolves to its documented integer value. Fails on the prior `--z-*` namespace because Tailwind emits no rules.
- `src/renderer/components/Modal.test.tsx` — asserts the backdrop portals to `document.body` and keeps the `z-modal` class.
- `src/renderer/features/annex/SatelliteLockOverlay.test.tsx` — asserts the overlay root carries `fixed inset-0 z-canvas-overlay`.
- `src/renderer/features/agents/AgentSettingsView.test.tsx` — `orchestrator dropdown` block: change → store patched with the new orchestrator id.
- `src/renderer/features/agents/AgentList.test.tsx` — `drag-reorder re-render` block: mutates `s.agents` into a reordered map with identical value references and asserts the rendered order changes (the exact shape the previous `useShallow` swallowed).
- `src/renderer/hooks/useOrderedShallow.test.ts` — direct tests for the comparator (reorder / add / remove / no-op / poll-tick / primitives).

## Test plan

- [x] `npm run lint` — 0 errors on touched files (warnings unchanged from main)
- [x] `npm test` — 11,870 pass; the 9 failing files are pre-existing (missing `mermaid` package) and untouched by this PR
- [ ] Manual: open the auto-resume update gate while on a settings sub-page — modal sits above all settings rows
- [ ] Manual: drag a durable agent up/down in the list — order persists and rerenders
- [ ] Manual: agent settings → switch orchestrator from Claude Code to another — dropdown shows the new value instantly
- [ ] Manual: right-click a project in the rail — context menu has solid background and items are clickable
- [ ] Manual: connect a remote controller (Annex) — lock overlay covers all three panels and its buttons respond