### PR TITLE
feat(clubhouse-mode): @@mission wildcard + self-edit guide on disk

### DIFF
--- a/src/main/services/agent-config.test.ts
+++ b/src/main/services/agent-config.test.ts
@@ -1207,6 +1207,58 @@ describe('updateDurableConfig', () => {
     expect(result).not.toBeNull();
     expect(result!.lastSessionId).toBeUndefined();
   });
+
+  it('persists mission field and round-trips', async () => {
+    const agents = [
+      { id: 'durable_mission', name: 'msn', color: 'indigo', createdAt: '2024-01-01' },
+    ];
+    const writtenData: Record<string, string> = {};
+    const agentsJsonPath = path.join(PROJECT_PATH, '.clubhouse', 'agents.json');
+    writtenData[agentsJsonPath] = JSON.stringify(agents);
+
+    vi.mocked(pathExists).mockImplementation(async (p: any) => String(p).endsWith('agents.json'));
+    vi.mocked(fsp.readFile).mockImplementation(async (p: any) => writtenData[String(p)] || '[]');
+    vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => {
+      writtenData[String(p)] = String(data);
+    });
+    vi.mocked(fsp.rename).mockImplementation(async (src: any, dest: any) => {
+      writtenData[String(dest)] = writtenData[String(src)] || '';
+      delete writtenData[String(src)];
+    });
+    vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
+
+    await updateDurableConfig(PROJECT_PATH, 'durable_mission', { mission: 'investigate-and-report' });
+
+    const result = await getDurableConfig(PROJECT_PATH, 'durable_mission');
+    expect(result).not.toBeNull();
+    expect(result!.mission).toBe('investigate-and-report');
+  });
+
+  it('removes mission field when set to empty string', async () => {
+    const agents = [
+      { id: 'durable_clearmsn', name: 'clearmsn', color: 'indigo', mission: 'old-mission', createdAt: '2024-01-01' },
+    ];
+    const writtenData: Record<string, string> = {};
+    const agentsJsonPath = path.join(PROJECT_PATH, '.clubhouse', 'agents.json');
+    writtenData[agentsJsonPath] = JSON.stringify(agents);
+
+    vi.mocked(pathExists).mockImplementation(async (p: any) => String(p).endsWith('agents.json'));
+    vi.mocked(fsp.readFile).mockImplementation(async (p: any) => writtenData[String(p)] || '[]');
+    vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => {
+      writtenData[String(p)] = String(data);
+    });
+    vi.mocked(fsp.rename).mockImplementation(async (src: any, dest: any) => {
+      writtenData[String(dest)] = writtenData[String(src)] || '';
+      delete writtenData[String(src)];
+    });
+    vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
+
+    await updateDurableConfig(PROJECT_PATH, 'durable_clearmsn', { mission: '' });
+
+    const result = await getDurableConfig(PROJECT_PATH, 'durable_clearmsn');
+    expect(result).not.toBeNull();
+    expect(result!.mission).toBeUndefined();
+  });
 });
 
 describe('updateSessionId', () => {

--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -537,6 +537,13 @@ export async function updateDurableConfig(
       delete agent.mcpConfigs;
     }
   }
+  if (updates.mission !== undefined) {
+    if (updates.mission) {
+      agent.mission = updates.mission;
+    } else {
+      delete agent.mission;
+    }
+  }
   await writeAgents(projectPath, agents);
 }
 

--- a/src/main/services/agent-settings-service.test.ts
+++ b/src/main/services/agent-settings-service.test.ts
@@ -30,6 +30,7 @@ import {
   readProjectAgentDefaults, writeProjectAgentDefaults, applyAgentDefaults,
   readWrapperCatalogSnapshot, writeWrapperCatalogSnapshot,
   readMcpConfigs, writeMcpConfigs,
+  listSourceMissions, readSourceMissionContent,
   SettingsConventions,
 } from './agent-settings-service';
 import type { WrapperCatalogSnapshot } from '../../shared/types';
@@ -224,6 +225,50 @@ describe('writePermissions', () => {
 });
 
 // --- Skill content CRUD ---
+
+describe('listSourceMissions', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('lists .md files from .clubhouse/missions/ with id derived from filename', async () => {
+    vi.mocked(fsp.readdir).mockResolvedValue([
+      { name: 'implement.md', isFile: () => true, isDirectory: () => false } as any,
+      { name: 'investigate.md', isFile: () => true, isDirectory: () => false } as any,
+      { name: 'README', isFile: () => true, isDirectory: () => false } as any, // ignored — no .md
+      { name: 'sub', isFile: () => false, isDirectory: () => true } as any,    // ignored — directory
+    ]);
+    const missions = await listSourceMissions('/project');
+    expect(missions.map((m) => m.id).sort()).toEqual(['implement', 'investigate']);
+  });
+
+  it('returns empty array when missions dir is missing', async () => {
+    vi.mocked(fsp.readdir).mockRejectedValue(makeEnoent('/project/.clubhouse/missions'));
+    expect(await listSourceMissions('/project')).toEqual([]);
+  });
+});
+
+describe('readSourceMissionContent', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('reads the mission .md file body', async () => {
+    vi.mocked(fsp.readFile).mockResolvedValue('# Mission steps');
+    const result = await readSourceMissionContent('/project', 'implement');
+    expect(result).toBe('# Mission steps');
+    expect(fsp.readFile).toHaveBeenCalledWith(
+      path.join('/project', '.clubhouse', 'missions', 'implement.md'),
+      'utf-8',
+    );
+  });
+
+  it('returns empty string when mission file does not exist', async () => {
+    vi.mocked(fsp.readFile).mockRejectedValue(makeEnoent('/project/.clubhouse/missions/missing.md'));
+    expect(await readSourceMissionContent('/project', 'missing')).toBe('');
+  });
+
+  it('returns empty string for empty mission id without touching disk', async () => {
+    expect(await readSourceMissionContent('/project', '')).toBe('');
+    expect(fsp.readFile).not.toHaveBeenCalled();
+  });
+});
 
 describe('readSkillContent', () => {
   beforeEach(() => { vi.clearAllMocks(); });

--- a/src/main/services/agent-settings-service.ts
+++ b/src/main/services/agent-settings-service.ts
@@ -226,6 +226,42 @@ export async function deleteSourceSkill(projectPath: string, skillName: string):
 }
 
 /**
+ * List source mission files under .clubhouse/missions/.
+ * Each mission is a single .md file; the mission ID is the basename without extension.
+ */
+export async function listSourceMissions(projectPath: string): Promise<Array<{ id: string; path: string }>> {
+  const missionsDir = path.join(projectPath, '.clubhouse', 'missions');
+  try {
+    const entries = await fsp.readdir(missionsDir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && e.name.endsWith('.md'))
+      .map((e) => ({ id: e.name.replace(/\.md$/, ''), path: path.join(missionsDir, e.name) }));
+  } catch (err) {
+    if (!isEnoent(err)) {
+      appLog(LOG_NS, 'warn', `Failed to list missions from ${missionsDir}`, { meta: { error: err instanceof Error ? err.message : String(err) } });
+    }
+    return [];
+  }
+}
+
+/**
+ * Read the content of a mission file at .clubhouse/missions/<id>.md.
+ * Returns empty string when the mission file does not exist or fails to read.
+ */
+export async function readSourceMissionContent(projectPath: string, missionId: string): Promise<string> {
+  if (!missionId) return '';
+  const filePath = path.join(projectPath, '.clubhouse', 'missions', `${missionId}.md`);
+  try {
+    return await fsp.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if (!isEnoent(err)) {
+      appLog(LOG_NS, 'warn', `Failed to read mission "${missionId}" at ${filePath}`, { meta: { error: err instanceof Error ? err.message : String(err) } });
+    }
+    return '';
+  }
+}
+
+/**
  * Read the content of a source agent template's README.md file (project-level .clubhouse/agent-templates/).
  */
 export async function readSourceAgentTemplateContent(projectPath: string, agentName: string): Promise<string> {

--- a/src/main/services/materialization-service.test.ts
+++ b/src/main/services/materialization-service.test.ts
@@ -543,7 +543,7 @@ describe('materialization-service', () => {
 
     it('substitutes @@mission with project default mission file content', async () => {
       vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
-        const fp = String(p);
+        const fp = String(p).replace(/\\/g, '/');
         if (fp.includes('settings.json')) {
           return JSON.stringify({
             defaults: {},
@@ -568,7 +568,7 @@ describe('materialization-service', () => {
     it('per-agent mission overrides project default mission', async () => {
       const agentWithMission = { ...testAgent, mission: 'agent-override' };
       vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
-        const fp = String(p);
+        const fp = String(p).replace(/\\/g, '/');
         if (fp.includes('settings.json')) {
           return JSON.stringify({
             defaults: {},
@@ -592,7 +592,7 @@ describe('materialization-service', () => {
 
     it('resolves @@mission to empty when mission file is missing', async () => {
       vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
-        const fp = String(p);
+        const fp = String(p).replace(/\\/g, '/');
         if (fp.includes('settings.json')) {
           return JSON.stringify({
             defaults: {},
@@ -623,7 +623,7 @@ describe('materialization-service', () => {
 
       // No fsp.readFile calls should target .clubhouse/missions/
       const missionReads = vi.mocked(fsp.readFile).mock.calls.filter(
-        (call) => String(call[0]).includes('/missions/'),
+        (call) => String(call[0]).replace(/\\/g, '/').includes('/missions/'),
       );
       expect(missionReads).toHaveLength(0);
     });

--- a/src/main/services/materialization-service.test.ts
+++ b/src/main/services/materialization-service.test.ts
@@ -65,8 +65,10 @@ import {
   previewMaterialization,
   ensureDefaultTemplates,
   ensureDefaultSkills,
+  ensureClubhouseModeReadme,
   resetDefaultSkills,
   resetProjectAgentDefaults,
+  resolveMissionId,
   getDefaultAgentTemplates,
   resolveSourceControlProvider,
   enableExclusions,
@@ -78,6 +80,7 @@ import {
   TEST_SKILL_CONTENT,
   LINT_SKILL_CONTENT,
   VALIDATE_CHANGES_SKILL_CONTENT,
+  CLUBHOUSE_MODE_README_CONTENT,
 } from './materialization-service';
 import * as clubhouseModeSettings from './clubhouse-mode-settings';
 import * as gitExcludeManager from './git-exclude-manager';
@@ -199,6 +202,38 @@ describe('materialization-service', () => {
       expect(ctx.buildCommand).toBeUndefined();
       expect(ctx.testCommand).toBeUndefined();
       expect(ctx.lintCommand).toBeUndefined();
+    });
+
+    it('passes through mission content when provided', () => {
+      const ctx = buildWildcardContext(testAgent, '/project', undefined, undefined, '# Mission body');
+      expect(ctx.mission).toBe('# Mission body');
+    });
+
+    it('omits mission when not provided', () => {
+      const ctx = buildWildcardContext(testAgent, '/project');
+      expect(ctx.mission).toBeUndefined();
+    });
+  });
+
+  describe('resolveMissionId', () => {
+    it('returns per-agent mission when set', () => {
+      const agent = { ...testAgent, mission: 'per-agent' };
+      expect(resolveMissionId(agent, { mission: 'project-default' })).toBe('per-agent');
+    });
+
+    it('falls back to project default when agent mission unset', () => {
+      expect(resolveMissionId(testAgent, { mission: 'project-default' })).toBe('project-default');
+    });
+
+    it('returns undefined when neither is set', () => {
+      expect(resolveMissionId(testAgent, {})).toBeUndefined();
+    });
+
+    it('treats empty-string per-agent mission as a deliberate clear (not unset)', () => {
+      // agent.mission === '' is unusual but should not fall through to defaults
+      // (?? only falls through on null/undefined)
+      const agent = { ...testAgent, mission: '' };
+      expect(resolveMissionId(agent, { mission: 'project-default' })).toBe('');
     });
   });
 
@@ -505,6 +540,93 @@ describe('materialization-service', () => {
 
       expect(mockProvider.writeInstructions).not.toHaveBeenCalled();
     });
+
+    it('substitutes @@mission with project default mission file content', async () => {
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p);
+        if (fp.includes('settings.json')) {
+          return JSON.stringify({
+            defaults: {},
+            quickOverrides: {},
+            agentDefaults: {
+              instructions: 'Agent @@AgentName\n\n@@mission',
+              mission: 'do-the-thing',
+            },
+          });
+        }
+        if (fp.endsWith('missions/do-the-thing.md')) return '# Mission body content';
+        throw new Error('ENOENT');
+      });
+
+      await materializeAgent({ projectPath: '/project', agent: testAgent, provider: mockProvider });
+
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      expect(written).toContain('Agent bold-falcon');
+      expect(written).toContain('# Mission body content');
+    });
+
+    it('per-agent mission overrides project default mission', async () => {
+      const agentWithMission = { ...testAgent, mission: 'agent-override' };
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p);
+        if (fp.includes('settings.json')) {
+          return JSON.stringify({
+            defaults: {},
+            quickOverrides: {},
+            agentDefaults: {
+              instructions: '@@mission',
+              mission: 'project-default',
+            },
+          });
+        }
+        if (fp.endsWith('missions/agent-override.md')) return 'AGENT BODY';
+        if (fp.endsWith('missions/project-default.md')) return 'PROJECT BODY';
+        throw new Error('ENOENT');
+      });
+
+      await materializeAgent({ projectPath: '/project', agent: agentWithMission, provider: mockProvider });
+
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      expect(written).toBe('AGENT BODY');
+    });
+
+    it('resolves @@mission to empty when mission file is missing', async () => {
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p);
+        if (fp.includes('settings.json')) {
+          return JSON.stringify({
+            defaults: {},
+            quickOverrides: {},
+            agentDefaults: {
+              instructions: 'Mission:\n@@mission\nEnd.',
+              mission: 'missing-file',
+            },
+          });
+        }
+        throw new Error('ENOENT'); // mission file does not exist
+      });
+
+      await materializeAgent({ projectPath: '/project', agent: testAgent, provider: mockProvider });
+
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      expect(written).toBe('Mission:\n\nEnd.');
+    });
+
+    it('does not attempt to read mission file when neither agent nor defaults set mission', async () => {
+      mockSettingsFile(JSON.stringify({
+        defaults: {},
+        quickOverrides: {},
+        agentDefaults: { instructions: 'No mission here' },
+      }));
+
+      await materializeAgent({ projectPath: '/project', agent: testAgent, provider: mockProvider });
+
+      // No fsp.readFile calls should target .clubhouse/missions/
+      const missionReads = vi.mocked(fsp.readFile).mock.calls.filter(
+        (call) => String(call[0]).includes('/missions/'),
+      );
+      expect(missionReads).toHaveLength(0);
+    });
   });
 
   describe('previewMaterialization', () => {
@@ -673,6 +795,56 @@ describe('materialization-service', () => {
         (call) => (call[0] as string).includes('SKILL.md'),
       );
       expect(skillWrites).toHaveLength(0);
+    });
+
+    it('writes clubhouse-mode.md self-edit guide when missing', async () => {
+      mockSettingsFile(JSON.stringify({ defaults: {}, quickOverrides: {} }));
+
+      await ensureDefaultTemplates('/project');
+
+      const readmeWrite = vi.mocked(fsp.writeFile).mock.calls.find(
+        (call) => (call[0] as string).endsWith('clubhouse-mode.md'),
+      );
+      expect(readmeWrite).toBeDefined();
+      expect(readmeWrite![1]).toBe(CLUBHOUSE_MODE_README_CONTENT);
+    });
+  });
+
+  describe('ensureClubhouseModeReadme', () => {
+    it('writes the readme when missing', async () => {
+      vi.mocked(pathExists).mockResolvedValue(false);
+
+      await ensureClubhouseModeReadme('/project');
+
+      const readmeWrite = vi.mocked(fsp.writeFile).mock.calls.find(
+        (call) => (call[0] as string).endsWith('clubhouse-mode.md'),
+      );
+      expect(readmeWrite).toBeDefined();
+      expect((readmeWrite![0] as string).replace(/\\/g, '/')).toBe('/project/.clubhouse/clubhouse-mode.md');
+    });
+
+    it('no-ops when the readme already exists (never overwrites user edits)', async () => {
+      vi.mocked(pathExists).mockImplementation(async (p: string) =>
+        p.endsWith('clubhouse-mode.md'),
+      );
+
+      await ensureClubhouseModeReadme('/project');
+
+      const readmeWrite = vi.mocked(fsp.writeFile).mock.calls.find(
+        (call) => (call[0] as string).endsWith('clubhouse-mode.md'),
+      );
+      expect(readmeWrite).toBeUndefined();
+    });
+
+    it('readme content documents all settings layers', () => {
+      // Sanity check: the guide actually mentions the load-bearing files
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('.clubhouse/settings.json');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('.clubhouse/agents.json');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('clubhouse-mode-settings.json');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('.clubhouse/skills/');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('.clubhouse/missions/');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('@@mission');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('clubhouseModeOverride');
     });
   });
 

--- a/src/main/services/materialization-service.ts
+++ b/src/main/services/materialization-service.ts
@@ -10,6 +10,7 @@ import {
   listSourceSkills,
   listSourceAgentTemplates,
   writeProjectAgentDefaults,
+  readSourceMissionContent,
 } from './agent-settings-service';
 import { SettingsConventions } from './agent-settings-service';
 import * as clubhouseModeSettings from './clubhouse-mode-settings';
@@ -211,6 +212,7 @@ export function buildWildcardContext(
   projectPath: string,
   sourceControlProvider?: SourceControlProvider,
   commands?: { buildCommand?: string; testCommand?: string; lintCommand?: string },
+  mission?: string,
 ): WildcardContext {
   const agentPath = agent.worktreePath
     ? path.relative(projectPath, agent.worktreePath).replace(/\\/g, '/') + '/'
@@ -223,7 +225,20 @@ export function buildWildcardContext(
     buildCommand: commands?.buildCommand,
     testCommand: commands?.testCommand,
     lintCommand: commands?.lintCommand,
+    mission,
   };
+}
+
+/**
+ * Resolve the effective mission ID for an agent.
+ * Per-agent override (`agent.mission`) wins; otherwise falls back to project default
+ * (`defaults.mission`). Returns undefined when neither is set.
+ */
+export function resolveMissionId(
+  agent: DurableAgentConfig,
+  defaults: ProjectAgentDefaults,
+): string | undefined {
+  return agent.mission ?? defaults.mission;
 }
 
 // ── Source control provider resolution ───────────────────────────────────
@@ -261,7 +276,8 @@ export async function materializeAgent(params: {
   if (!worktreePath) return;
 
   const defaults = await readProjectAgentDefaults(projectPath);
-  if (!defaults.instructions && !defaults.permissions && !defaults.mcpJson && !agent.persona) {
+  const missionId = resolveMissionId(agent, defaults);
+  if (!defaults.instructions && !defaults.permissions && !defaults.mcpJson && !agent.persona && !missionId) {
     // Also check source skills/templates
     const sourceSkills = await listSourceSkills(projectPath);
     const sourceTemplates = await listSourceAgentTemplates(projectPath);
@@ -274,7 +290,8 @@ export async function materializeAgent(params: {
     testCommand: defaults.testCommand,
     lintCommand: defaults.lintCommand,
   };
-  const ctx = buildWildcardContext(agent, projectPath, scp, commands);
+  const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
+  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent);
   const conv = provider.conventions;
 
   // 0. Clean up stale JSON content in TOML config files (legacy migration)
@@ -422,7 +439,9 @@ export async function previewMaterialization(params: {
     testCommand: defaults.testCommand,
     lintCommand: defaults.lintCommand,
   };
-  const ctx = buildWildcardContext(agent, projectPath, scp, commands);
+  const missionId = resolveMissionId(agent, defaults);
+  const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
+  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent);
   const _conv = provider.conventions;
 
   let instructions = defaults.instructions
@@ -582,7 +601,9 @@ When given a mission:
 3. Implement the work, committing frequently with descriptive messages
 4. Validate changes using \`/validate-changes\` (build, test, lint)
 5. Push changes and open a PR to main with descriptive details
-6. Return to your standby branch and pull latest from main`;
+6. Return to your standby branch and pull latest from main
+
+@@mission`;
 
   const defaultPermissions = {
     allow: [
@@ -640,6 +661,9 @@ export async function ensureDefaultTemplates(projectPath: string): Promise<void>
 
   // Always ensure default skills exist (even when defaults already exist)
   await ensureDefaultSkills(projectPath);
+
+  // Always ensure the self-edit guide exists (idempotent — never overwrites edits)
+  await ensureClubhouseModeReadme(projectPath);
 }
 
 /**
@@ -704,6 +728,213 @@ async function writeDefaultSkills(projectPath: string, force: boolean): Promise<
   } catch {
     // Best effort
   }
+}
+
+/**
+ * Self-edit guide written to .clubhouse/clubhouse-mode.md on enable.
+ * Documents where every Clubhouse-mode setting lives on disk so an agent
+ * (or the user) can edit configuration without needing the UI.
+ */
+export const CLUBHOUSE_MODE_README_CONTENT = `# Clubhouse Mode — Self-Edit Guide
+
+This file is generated when Clubhouse Mode is enabled. It documents where
+settings live on disk and how to change them without using the UI.
+
+It is safe to edit. Clubhouse will never overwrite it once it exists.
+
+---
+
+## Settings layers
+
+Three layers, all editable from disk:
+
+| Layer            | File                                                  | Scope                          |
+|------------------|-------------------------------------------------------|--------------------------------|
+| App-wide         | \`<userData>/clubhouse-mode-settings.json\`             | enabled flag, project overrides|
+| Project          | \`.clubhouse/settings.json\`                            | defaults applied to all agents |
+| Per-agent        | \`.clubhouse/agents.json\`                              | overrides for a single agent   |
+
+\`<userData>\` is Electron's per-user app data dir:
+- macOS: \`~/Library/Application Support/Clubhouse/\`
+- Linux: \`~/.config/Clubhouse/\`
+- Windows: \`%APPDATA%\\Clubhouse\\\`
+
+**Precedence** (highest first): per-agent → project override → app-wide.
+
+### Toggle Clubhouse Mode for this project (override)
+
+Edit \`<userData>/clubhouse-mode-settings.json\`:
+
+\`\`\`json
+{
+  "enabled": true,
+  "projectOverrides": {
+    "/absolute/path/to/this/project": true
+  }
+}
+\`\`\`
+
+Set the override to \`false\` to disable just this project while keeping the
+app-wide setting unchanged. Delete the key to clear the override.
+
+### Toggle per-agent override
+
+Find the agent in \`.clubhouse/agents.json\` and add:
+
+\`\`\`json
+{ "clubhouseModeOverride": true }
+\`\`\`
+
+Setting it to \`false\` opts that agent out of materialization on wake.
+
+---
+
+## Project defaults (\`.clubhouse/settings.json\`)
+
+The \`agentDefaults\` object is what gets materialized into each agent worktree
+when Clubhouse Mode runs:
+
+\`\`\`json
+{
+  "agentDefaults": {
+    "instructions": "...CLAUDE.md template with @@wildcards...",
+    "permissions": { "allow": ["Read(@@Path**)"], "deny": ["Read(../**)"] },
+    "mcpJson": "{ \\"mcpServers\\": { ... } }",
+    "freeAgentMode": false,
+    "sourceControlProvider": "github",
+    "buildCommand": "npm run build",
+    "testCommand": "npm test",
+    "lintCommand": "npm run lint",
+    "mission": "implement-and-ship"
+  }
+}
+\`\`\`
+
+Any agent without an explicit override inherits these.
+
+---
+
+## Per-agent overrides (\`.clubhouse/agents.json\`)
+
+Each entry in the \`agents\` array supports per-agent overrides:
+
+\`\`\`json
+{
+  "id": "durable_...",
+  "name": "bold-falcon",
+  "branch": "bold-falcon/standby",
+  "persona": "qa",
+  "mission": "investigate-and-report",
+  "clubhouseModeOverride": true,
+  "mcpIds": ["github"],
+  "model": "claude-opus-4-7"
+}
+\`\`\`
+
+Editable fields: \`persona\`, \`mission\`, \`clubhouseModeOverride\`,
+\`freeAgentMode\`, \`model\`, \`orchestrator\`, \`structuredMode\`, \`mcpIds\`,
+\`mcpConfigs\`, \`mcpOverride\`.
+
+Edits take effect on the next agent wake (which re-materializes the worktree).
+
+---
+
+## Preserved skills (\`.clubhouse/skills/\`)
+
+Skills live in \`.clubhouse/skills/<skill-name>/SKILL.md\`. On materialization
+they are copied to each agent worktree at \`.claude/skills/<skill-name>/\`
+with \`@@\` wildcards substituted.
+
+- **Edit** an existing skill: change \`.clubhouse/skills/<name>/SKILL.md\`.
+- **Add** a new skill: create \`.clubhouse/skills/<new-name>/SKILL.md\` with a
+  YAML frontmatter \`name:\` and \`description:\`, then a markdown body.
+- **Delete**: remove the directory. On next wake, the skill is pruned from
+  every agent worktree automatically.
+
+Default skills (\`mission\`, \`test\`, \`build\`, \`lint\`, \`validate-changes\`,
+\`create-pr\`, \`go-standby\`) are written on enable but never overwritten —
+edit them freely.
+
+---
+
+## Missions (\`.clubhouse/missions/\`)
+
+A **mission** is a reusable end-to-end task flow (e.g. \`look at spec → fix →
+add tests → run until green → open PR → return to standby\`). Missions are
+flat markdown files under \`.clubhouse/missions/\`; the filename (minus
+\`.md\`) is the mission ID.
+
+\`\`\`
+.clubhouse/missions/
+  implement-and-ship.md
+  investigate-and-report.md
+  quick-bugfix.md
+\`\`\`
+
+At materialization, the content of the active mission file is substituted
+for the \`@@mission\` wildcard everywhere it appears (default CLAUDE.md
+template, skills, permissions, etc.).
+
+**Selecting a mission**:
+- Set \`agentDefaults.mission\` in \`.clubhouse/settings.json\` for the
+  project-wide default.
+- Set \`mission\` on an agent in \`.clubhouse/agents.json\` to override per-agent.
+- Per-agent wins. Either value is the mission ID (filename without \`.md\`).
+
+If the mission file does not exist, \`@@mission\` resolves to an empty string —
+the rest of materialization still succeeds.
+
+---
+
+## Wildcards available to all templates
+
+| Token                       | Resolves to                                          |
+|-----------------------------|------------------------------------------------------|
+| \`@@AgentName\`               | e.g. \`bold-falcon\`                                   |
+| \`@@StandbyBranch\`           | e.g. \`bold-falcon/standby\`                           |
+| \`@@Path\`                    | e.g. \`.clubhouse/agents/bold-falcon/\`                |
+| \`@@SourceControlProvider\`   | \`github\` or \`azure-devops\`                           |
+| \`@@BuildCommand\`            | from project defaults                                |
+| \`@@TestCommand\`             | from project defaults                                |
+| \`@@LintCommand\`             | from project defaults                                |
+| \`@@mission\`                 | full markdown content of the active mission file     |
+| \`@@If(github)…@@EndIf\`      | conditional block, kept only when provider matches   |
+
+---
+
+## Common edits
+
+| Goal                                       | Edit                                                       |
+|--------------------------------------------|------------------------------------------------------------|
+| Change project default mission             | \`agentDefaults.mission\` in \`.clubhouse/settings.json\`     |
+| Give one agent a different mission         | \`mission\` in that agent's entry in \`.clubhouse/agents.json\`|
+| Tweak a skill body                         | Edit the file under \`.clubhouse/skills/<name>/SKILL.md\`    |
+| Add a new wildcard target                  | (Code change — see \`src/shared/wildcard-replacer.ts\`)      |
+| Disable Clubhouse Mode for this project    | \`projectOverrides[<path>] = false\` in user settings        |
+| Opt one agent out of materialization       | \`clubhouseModeOverride: false\` in that agent's entry       |
+
+---
+
+## What gets pruned vs preserved
+
+On every wake, materialization:
+
+- **Overwrites** the agent's \`CLAUDE.md\`, \`.claude/settings.local.json\` permissions block, and \`.mcp.json\` from the project defaults.
+- **Copies** every \`.clubhouse/skills/*\` and \`.clubhouse/agent-templates/*\` into the worktree with wildcards resolved.
+- **Prunes** worktree skills/templates that no longer exist in source.
+- **Never touches** any other file in the worktree, including agent-local edits to skills that don't exist in source.
+`;
+
+/**
+ * Write the Clubhouse Mode self-edit guide to \`.clubhouse/clubhouse-mode.md\`.
+ * Idempotent — never overwrites an existing file so user edits survive.
+ */
+export async function ensureClubhouseModeReadme(projectPath: string): Promise<void> {
+  const clubhouseDir = path.join(projectPath, '.clubhouse');
+  const readmePath = path.join(clubhouseDir, 'clubhouse-mode.md');
+  if (await pathExists(readmePath)) return;
+  await fsp.mkdir(clubhouseDir, { recursive: true });
+  await fsp.writeFile(readmePath, CLUBHOUSE_MODE_README_CONTENT, 'utf-8');
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -171,6 +171,8 @@ export interface ProjectAgentDefaults {
   profileId?: string;
   /** Shell command prefix prepended before the CLI binary (e.g. ". ./init.ps1 &&") */
   commandPrefix?: string;
+  /** Default mission ID. Resolved at materialization to .clubhouse/missions/<id>.md content; substituted for @@mission. */
+  mission?: string;
 }
 
 /** A recorded CLI session for a durable agent */
@@ -213,6 +215,8 @@ export interface DurableAgentConfig {
   mcpOverride?: boolean;
   /** Persona template ID applied at creation. Used to re-inject instructions on materialization. */
   persona?: string;
+  /** Mission ID overriding the project default. Resolved to .clubhouse/missions/<id>.md content; substituted for @@mission. */
+  mission?: string;
   /** CLI agent name to load (e.g. "k8s-assistant" → --agent k8s-assistant) */
   agentFile?: string;
   /** Directory to search for the agent file (e.g. "~/.copilot/agents/" → --source ...) */
@@ -289,6 +293,7 @@ export interface DurableConfigUpdates {
   mcpConfigs?: Record<string, Record<string, string>> | null;
   structuredMode?: boolean;
   persona?: string;
+  mission?: string;
 }
 
 export interface ClubhouseModeSettings {

--- a/src/shared/wildcard-replacer.test.ts
+++ b/src/shared/wildcard-replacer.test.ts
@@ -232,3 +232,40 @@ describe('@@BuildCommand / @@TestCommand / @@LintCommand replacement', () => {
     expect(replaceWildcards(input, ctxWithCmds)).toBe('1. make build\n2. make test\n3. make lint');
   });
 });
+
+describe('@@mission replacement', () => {
+  it('substitutes mission content body', () => {
+    const ctxWithMission = { ...ctx, mission: '# Steps\n1. Investigate\n2. Report' };
+    expect(replaceWildcards('Mission:\n@@mission', ctxWithMission)).toBe(
+      'Mission:\n# Steps\n1. Investigate\n2. Report',
+    );
+  });
+
+  it('resolves to empty string when mission is unset', () => {
+    expect(replaceWildcards('Mission:\n@@mission', ctx)).toBe('Mission:\n');
+  });
+
+  it('resolves to empty string when mission is empty string', () => {
+    expect(replaceWildcards('@@mission', { ...ctx, mission: '' })).toBe('');
+  });
+
+  it('substitutes multiple occurrences', () => {
+    const ctxWithMission = { ...ctx, mission: 'do the thing' };
+    expect(replaceWildcards('@@mission and @@mission', ctxWithMission)).toBe(
+      'do the thing and do the thing',
+    );
+  });
+
+  it('does not consume the @@ prefix of other tokens', () => {
+    // @@mission must not match @@missionFoo or similar — guard against future tokens
+    const ctxWithMission = { ...ctx, mission: 'X' };
+    expect(replaceWildcards('@@mission and @@AgentName', ctxWithMission)).toBe('X and bold-falcon');
+  });
+
+  it('unreplaceWildcards reverses mission content back to @@mission', () => {
+    const ctxWithMission = { ...ctx, mission: 'unique-mission-marker-12345' };
+    expect(unreplaceWildcards('Here: unique-mission-marker-12345', ctxWithMission)).toBe(
+      'Here: @@mission',
+    );
+  });
+});

--- a/src/shared/wildcard-replacer.ts
+++ b/src/shared/wildcard-replacer.ts
@@ -6,6 +6,7 @@ export interface WildcardContext {
   buildCommand?: string;   // e.g. "npm run build"
   testCommand?: string;    // e.g. "npm test"
   lintCommand?: string;    // e.g. "npm run lint"
+  mission?: string;        // resolved mission content (full markdown body)
 }
 
 /**
@@ -21,7 +22,8 @@ export function replaceWildcards(text: string, ctx: WildcardContext): string {
     .replace(/@@SourceControlProvider/g, ctx.sourceControlProvider || '')
     .replace(/@@BuildCommand/g, ctx.buildCommand || 'npm run build')
     .replace(/@@TestCommand/g, ctx.testCommand || 'npm test')
-    .replace(/@@LintCommand/g, ctx.lintCommand || 'npm run lint');
+    .replace(/@@LintCommand/g, ctx.lintCommand || 'npm run lint')
+    .replace(/@@mission/g, ctx.mission || '');
 
   // Process @@If(value)...@@EndIf conditional blocks
   result = processConditionalBlocks(result, ctx);
@@ -55,6 +57,9 @@ export function unreplaceWildcards(text: string, ctx: WildcardContext): string {
   }
   if (ctx.lintCommand) {
     pairs.push({ value: ctx.lintCommand, token: '@@LintCommand' });
+  }
+  if (ctx.mission) {
+    pairs.push({ value: ctx.mission, token: '@@mission' });
   }
 
   // Sort longest-value-first to avoid partial matches


### PR DESCRIPTION
## Summary

- New \`@@mission\` wildcard: substitutes the body of a mission file (\`.clubhouse/missions/<id>.md\`) into materialized templates. Per-project default lives in \`agentDefaults.mission\`; per-agent override lives on the agent record in \`agents.json\`. Per-agent wins.
- New self-edit guide written to \`.clubhouse/clubhouse-mode.md\` on enable. Single source of truth documenting every Clubhouse-mode setting's location on disk (app / project / per-agent), override toggle paths, preserved skills, missions, and the full wildcard table. Idempotent — never overwrites once written.
- Default CLAUDE.md template now ends with \`@@mission\` so missions work out of the box; the wildcard is also usable anywhere else (skills, permissions, MCP config) via existing materialization wildcard-replacement pipeline.

## Motivation

Agents need to change Clubhouse-mode settings from disk without depending on the UI, and the team wants a reusable, file-backed library of end-to-end task flows (mission templates) that minimizes the need for per-agent overrides. This PR ships both: the docs file makes disk locations discoverable, and \`@@mission\` plus a flat \`.clubhouse/missions/\` library gives a clean place to author common flows.

## What's intentionally out of scope

- **UI**: no settings picker for mission. Set it via \`.clubhouse/settings.json\` (\`agentDefaults.mission\`) or \`.clubhouse/agents.json\` (per-agent \`mission\`). The IPC plumbing (\`updateDurableConfig\` now accepts \`mission\`) is in place for a future picker.
- **No backfill** of personas through the same self-edit path — this PR fixes only \`mission\` in \`updateDurableConfig\`; \`persona\` and \`structuredMode\` were not previously persisted via updates and that pre-existing gap is left for a separate PR.

## Files

- \`src/shared/wildcard-replacer.ts\` — \`@@mission\` token in both \`replaceWildcards\` and \`unreplaceWildcards\`.
- \`src/shared/types.ts\` — \`mission?: string\` added to \`ProjectAgentDefaults\`, \`DurableAgentConfig\`, \`DurableConfigUpdates\`.
- \`src/main/services/agent-settings-service.ts\` — \`listSourceMissions\` + \`readSourceMissionContent\`.
- \`src/main/services/materialization-service.ts\` — \`resolveMissionId\`, mission loading in \`materializeAgent\` and \`previewMaterialization\`, \`CLUBHOUSE_MODE_README_CONTENT\`, \`ensureClubhouseModeReadme\`, default CLAUDE.md template appends \`@@mission\`, wired into \`ensureDefaultTemplates\`.
- \`src/main/services/agent-config.ts\` — \`updateDurableConfig\` persists \`mission\` (empty string clears).

## Test plan

- [x] \`wildcard-replacer.test.ts\` — \`@@mission\` substitution (set / unset / empty / multi / round-trip), guards against partial matches with adjacent tokens.
- [x] \`materialization-service.test.ts\` — \`buildWildcardContext\` mission pass-through, \`resolveMissionId\` precedence, \`materializeAgent\` substitutes project-default mission, per-agent overrides project, missing mission file resolves to empty, no mission file read when neither is set, \`ensureClubhouseModeReadme\` writes when missing / no-ops when present, generated readme references all the load-bearing files.
- [x] \`agent-settings-service.test.ts\` — \`listSourceMissions\` returns IDs, ignores non-\`.md\` and dirs, handles missing dir; \`readSourceMissionContent\` reads, ENOENT → empty, empty ID → no disk touch.
- [x] \`agent-config.test.ts\` — \`updateDurableConfig\` persists mission, empty string clears.
- [x] \`npm run typecheck\` clean.
- [x] \`npm test\` — 12082/12086 pass (4 pre-existing skips, 2 pre-existing unhandled rejections in \`ProjectRail.test.tsx\` unrelated to this PR).
- [x] \`npm run lint\` — 0 errors.

## Manual validation needed before merge

- [ ] Enable Clubhouse Mode on a fresh project; confirm \`.clubhouse/clubhouse-mode.md\` is written and the content makes sense.
- [ ] Create \`.clubhouse/missions/test.md\`, set \`agentDefaults.mission = "test"\` in \`.clubhouse/settings.json\`, wake an agent, verify the mission body appears in the agent's \`CLAUDE.md\`.
- [ ] Set per-agent \`mission\` to a different ID in \`.clubhouse/agents.json\`, re-wake, verify per-agent overrides the project default.

## Notes

- The project's \`.clubhouse/\` directory is created at runtime in user projects when Clubhouse Mode is enabled; this PR does **not** add a tracked \`.clubhouse/clubhouse-mode.md\` to the repo — the file is generated by \`ensureClubhouseModeReadme\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)