### PR TITLE
feat(clubhouse-mode): @@Persona wildcard + revert @@mission from default template

### DIFF
--- a/src/main/services/agent-config.test.ts
+++ b/src/main/services/agent-config.test.ts
@@ -1259,6 +1259,58 @@ describe('updateDurableConfig', () => {
     expect(result).not.toBeNull();
     expect(result!.mission).toBeUndefined();
   });
+
+  it('persists persona field and round-trips', async () => {
+    const agents = [
+      { id: 'durable_persona', name: 'pers', color: 'indigo', createdAt: '2024-01-01' },
+    ];
+    const writtenData: Record<string, string> = {};
+    const agentsJsonPath = path.join(PROJECT_PATH, '.clubhouse', 'agents.json');
+    writtenData[agentsJsonPath] = JSON.stringify(agents);
+
+    vi.mocked(pathExists).mockImplementation(async (p: any) => String(p).endsWith('agents.json'));
+    vi.mocked(fsp.readFile).mockImplementation(async (p: any) => writtenData[String(p)] || '[]');
+    vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => {
+      writtenData[String(p)] = String(data);
+    });
+    vi.mocked(fsp.rename).mockImplementation(async (src: any, dest: any) => {
+      writtenData[String(dest)] = writtenData[String(src)] || '';
+      delete writtenData[String(src)];
+    });
+    vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
+
+    await updateDurableConfig(PROJECT_PATH, 'durable_persona', { persona: 'qa' });
+
+    const result = await getDurableConfig(PROJECT_PATH, 'durable_persona');
+    expect(result).not.toBeNull();
+    expect(result!.persona).toBe('qa');
+  });
+
+  it('removes persona field when set to empty string', async () => {
+    const agents = [
+      { id: 'durable_clearpersona', name: 'clearper', color: 'indigo', persona: 'qa', createdAt: '2024-01-01' },
+    ];
+    const writtenData: Record<string, string> = {};
+    const agentsJsonPath = path.join(PROJECT_PATH, '.clubhouse', 'agents.json');
+    writtenData[agentsJsonPath] = JSON.stringify(agents);
+
+    vi.mocked(pathExists).mockImplementation(async (p: any) => String(p).endsWith('agents.json'));
+    vi.mocked(fsp.readFile).mockImplementation(async (p: any) => writtenData[String(p)] || '[]');
+    vi.mocked(fsp.writeFile).mockImplementation(async (p: any, data: any) => {
+      writtenData[String(p)] = String(data);
+    });
+    vi.mocked(fsp.rename).mockImplementation(async (src: any, dest: any) => {
+      writtenData[String(dest)] = writtenData[String(src)] || '';
+      delete writtenData[String(src)];
+    });
+    vi.mocked(fsp.mkdir).mockResolvedValue(undefined);
+
+    await updateDurableConfig(PROJECT_PATH, 'durable_clearpersona', { persona: '' });
+
+    const result = await getDurableConfig(PROJECT_PATH, 'durable_clearpersona');
+    expect(result).not.toBeNull();
+    expect(result!.persona).toBeUndefined();
+  });
 });
 
 describe('updateSessionId', () => {

--- a/src/main/services/agent-config.ts
+++ b/src/main/services/agent-config.ts
@@ -544,6 +544,13 @@ export async function updateDurableConfig(
       delete agent.mission;
     }
   }
+  if (updates.persona !== undefined) {
+    if (updates.persona) {
+      agent.persona = updates.persona;
+    } else {
+      delete agent.persona;
+    }
+  }
   await writeAgents(projectPath, agents);
 }
 

--- a/src/main/services/materialization-service.test.ts
+++ b/src/main/services/materialization-service.test.ts
@@ -69,6 +69,7 @@ import {
   resetDefaultSkills,
   resetProjectAgentDefaults,
   resolveMissionId,
+  resolvePersonaId,
   getDefaultAgentTemplates,
   resolveSourceControlProvider,
   enableExclusions,
@@ -234,6 +235,21 @@ describe('materialization-service', () => {
       // (?? only falls through on null/undefined)
       const agent = { ...testAgent, mission: '' };
       expect(resolveMissionId(agent, { mission: 'project-default' })).toBe('');
+    });
+  });
+
+  describe('resolvePersonaId', () => {
+    it('returns per-agent persona when set', () => {
+      const agent = { ...testAgent, persona: 'qa' };
+      expect(resolvePersonaId(agent, { persona: 'project-manager' })).toBe('qa');
+    });
+
+    it('falls back to project default when agent persona unset', () => {
+      expect(resolvePersonaId(testAgent, { persona: 'project-manager' })).toBe('project-manager');
+    });
+
+    it('returns undefined when neither is set', () => {
+      expect(resolvePersonaId(testAgent, {})).toBeUndefined();
     });
   });
 
@@ -584,6 +600,42 @@ describe('materialization-service', () => {
       const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
       expect(written.startsWith('Agent bold-falcon at .clubhouse/agents/bold-falcon/')).toBe(true);
       expect(written).toContain('Quality Assurance'); // appended at the end
+    });
+
+    it('applies project-default persona when the agent has none of its own', async () => {
+      // Agent with NO persona; project default sets qa.
+      mockSettingsFile(JSON.stringify({
+        defaults: {},
+        quickOverrides: {},
+        agentDefaults: {
+          instructions: 'Agent @@AgentName',
+          persona: 'qa',
+        },
+      }));
+
+      await materializeAgent({ projectPath: '/project', agent: testAgent, provider: mockProvider });
+
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      expect(written).toContain('Agent bold-falcon');
+      expect(written).toContain('Quality Assurance');
+    });
+
+    it('per-agent persona overrides project-default persona', async () => {
+      const agentWithPersona = { ...testAgent, persona: 'project-manager' };
+      mockSettingsFile(JSON.stringify({
+        defaults: {},
+        quickOverrides: {},
+        agentDefaults: {
+          instructions: 'Agent @@AgentName',
+          persona: 'qa', // project default — should be overridden
+        },
+      }));
+
+      await materializeAgent({ projectPath: '/project', agent: agentWithPersona, provider: mockProvider });
+
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      expect(written).toContain('Project Manager');
+      expect(written).not.toContain('Quality Assurance');
     });
 
     it('substitutes @@Mission with project default mission file content', async () => {

--- a/src/main/services/materialization-service.test.ts
+++ b/src/main/services/materialization-service.test.ts
@@ -541,7 +541,52 @@ describe('materialization-service', () => {
       expect(mockProvider.writeInstructions).not.toHaveBeenCalled();
     });
 
-    it('substitutes @@mission with project default mission file content', async () => {
+    it('substitutes @@Persona inline and skips the auto-append (no double-injection)', async () => {
+      const agentWithPersona = { ...testAgent, persona: 'qa' };
+      mockSettingsFile(JSON.stringify({
+        defaults: {},
+        quickOverrides: {},
+        agentDefaults: {
+          instructions: 'Agent @@AgentName\n\n## Role\n@@Persona\n\n## Done',
+        },
+      }));
+
+      await materializeAgent({ projectPath: '/project', agent: agentWithPersona, provider: mockProvider });
+
+      expect(mockProvider.writeInstructions).toHaveBeenCalledTimes(1);
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      // Persona content appears after the ## Role section header (inline substitution)...
+      const personaMarker = written.indexOf('Quality Assurance');
+      const roleMarker = written.indexOf('## Role');
+      const doneMarker = written.lastIndexOf('## Done');
+      expect(personaMarker).toBeGreaterThan(roleMarker);
+      // ...and before the ## Done section, proving no auto-append happens after it.
+      expect(personaMarker).toBeLessThan(doneMarker);
+      // The trailing ## Done section is preserved at the end.
+      expect(written.endsWith('## Done')).toBe(true);
+      // Persona body should appear exactly once — no double injection.
+      expect(written.match(/Quality Assurance/g)?.length).toBe(1);
+    });
+
+    it('still auto-appends persona when @@Persona is NOT in the template (backwards compat)', async () => {
+      const agentWithPersona = { ...testAgent, persona: 'qa' };
+      mockSettingsFile(JSON.stringify({
+        defaults: {},
+        quickOverrides: {},
+        agentDefaults: {
+          // No @@Persona token — preserve the pre-feature behavior.
+          instructions: 'Agent @@AgentName at @@Path',
+        },
+      }));
+
+      await materializeAgent({ projectPath: '/project', agent: agentWithPersona, provider: mockProvider });
+
+      const written = vi.mocked(mockProvider.writeInstructions).mock.calls[0][1] as string;
+      expect(written.startsWith('Agent bold-falcon at .clubhouse/agents/bold-falcon/')).toBe(true);
+      expect(written).toContain('Quality Assurance'); // appended at the end
+    });
+
+    it('substitutes @@Mission with project default mission file content', async () => {
       vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
         const fp = String(p).replace(/\\/g, '/');
         if (fp.includes('settings.json')) {
@@ -549,7 +594,7 @@ describe('materialization-service', () => {
             defaults: {},
             quickOverrides: {},
             agentDefaults: {
-              instructions: 'Agent @@AgentName\n\n@@mission',
+              instructions: 'Agent @@AgentName\n\n@@Mission',
               mission: 'do-the-thing',
             },
           });
@@ -574,7 +619,7 @@ describe('materialization-service', () => {
             defaults: {},
             quickOverrides: {},
             agentDefaults: {
-              instructions: '@@mission',
+              instructions: '@@Mission',
               mission: 'project-default',
             },
           });
@@ -590,7 +635,7 @@ describe('materialization-service', () => {
       expect(written).toBe('AGENT BODY');
     });
 
-    it('resolves @@mission to empty when mission file is missing', async () => {
+    it('resolves @@Mission to empty when mission file is missing', async () => {
       vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
         const fp = String(p).replace(/\\/g, '/');
         if (fp.includes('settings.json')) {
@@ -598,7 +643,7 @@ describe('materialization-service', () => {
             defaults: {},
             quickOverrides: {},
             agentDefaults: {
-              instructions: 'Mission:\n@@mission\nEnd.',
+              instructions: 'Mission:\n@@Mission\nEnd.',
               mission: 'missing-file',
             },
           });
@@ -843,7 +888,7 @@ describe('materialization-service', () => {
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('clubhouse-mode-settings.json');
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('.clubhouse/skills/');
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('.clubhouse/missions/');
-      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('@@mission');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('@@Mission');
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('clubhouseModeOverride');
     });
   });
@@ -854,6 +899,12 @@ describe('materialization-service', () => {
       expect(templates.instructions).toContain('@@AgentName');
       expect(templates.instructions).toContain('@@StandbyBranch');
       expect(templates.instructions).toContain('@@Path');
+    });
+
+    it('does NOT include @@Mission or @@Persona in the default body (opt-in tokens)', () => {
+      const templates = getDefaultAgentTemplates();
+      expect(templates.instructions).not.toContain('@@Mission');
+      expect(templates.instructions).not.toContain('@@Persona');
     });
 
     it('returns permissions with allow and deny lists', () => {

--- a/src/main/services/materialization-service.ts
+++ b/src/main/services/materialization-service.ts
@@ -243,6 +243,18 @@ export function resolveMissionId(
   return agent.mission ?? defaults.mission;
 }
 
+/**
+ * Resolve the effective persona ID for an agent.
+ * Per-agent override (`agent.persona`) wins; otherwise falls back to project default
+ * (`defaults.persona`). Returns undefined when neither is set.
+ */
+export function resolvePersonaId(
+  agent: DurableAgentConfig,
+  defaults: ProjectAgentDefaults,
+): string | undefined {
+  return agent.persona ?? defaults.persona;
+}
+
 // ── Source control provider resolution ───────────────────────────────────
 
 /**
@@ -279,7 +291,8 @@ export async function materializeAgent(params: {
 
   const defaults = await readProjectAgentDefaults(projectPath);
   const missionId = resolveMissionId(agent, defaults);
-  if (!defaults.instructions && !defaults.permissions && !defaults.mcpJson && !agent.persona && !missionId) {
+  const personaId = resolvePersonaId(agent, defaults);
+  if (!defaults.instructions && !defaults.permissions && !defaults.mcpJson && !personaId && !missionId) {
     // Also check source skills/templates
     const sourceSkills = await listSourceSkills(projectPath);
     const sourceTemplates = await listSourceAgentTemplates(projectPath);
@@ -293,7 +306,7 @@ export async function materializeAgent(params: {
     lintCommand: defaults.lintCommand,
   };
   const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
-  const personaContent = agent.persona ? getPersonaTemplate(agent.persona)?.content : undefined;
+  const personaContent = personaId ? getPersonaTemplate(personaId)?.content : undefined;
   const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent, personaContent);
   const conv = provider.conventions;
 
@@ -437,8 +450,9 @@ export async function previewMaterialization(params: {
     lintCommand: defaults.lintCommand,
   };
   const missionId = resolveMissionId(agent, defaults);
+  const personaId = resolvePersonaId(agent, defaults);
   const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
-  const personaContent = agent.persona ? getPersonaTemplate(agent.persona)?.content : undefined;
+  const personaContent = personaId ? getPersonaTemplate(personaId)?.content : undefined;
   const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent, personaContent);
   const _conv = provider.conventions;
 

--- a/src/main/services/materialization-service.ts
+++ b/src/main/services/materialization-service.ts
@@ -213,6 +213,7 @@ export function buildWildcardContext(
   sourceControlProvider?: SourceControlProvider,
   commands?: { buildCommand?: string; testCommand?: string; lintCommand?: string },
   mission?: string,
+  persona?: string,
 ): WildcardContext {
   const agentPath = agent.worktreePath
     ? path.relative(projectPath, agent.worktreePath).replace(/\\/g, '/') + '/'
@@ -226,6 +227,7 @@ export function buildWildcardContext(
     testCommand: commands?.testCommand,
     lintCommand: commands?.lintCommand,
     mission,
+    persona,
   };
 }
 
@@ -291,7 +293,8 @@ export async function materializeAgent(params: {
     lintCommand: defaults.lintCommand,
   };
   const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
-  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent);
+  const personaContent = agent.persona ? getPersonaTemplate(agent.persona)?.content : undefined;
+  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent, personaContent);
   const conv = provider.conventions;
 
   // 0. Clean up stale JSON content in TOML config files (legacy migration)
@@ -302,23 +305,17 @@ export async function materializeAgent(params: {
   // 1. Instructions (project defaults + persona layer)
   if (defaults.instructions) {
     const resolved = replaceWildcards(defaults.instructions, ctx);
-    // If agent has a persona, append persona instructions after project defaults
-    if (agent.persona) {
-      const persona = getPersonaTemplate(agent.persona);
-      if (persona) {
-        await provider.writeInstructions(worktreePath, `${resolved}\n\n${persona.content}`);
-      } else {
-        await provider.writeInstructions(worktreePath, resolved);
-      }
+    // Auto-append persona only when the template doesn't already use @@Persona,
+    // so users who opt into the wildcard don't get the persona injected twice.
+    const templateUsesPersonaToken = defaults.instructions.includes('@@Persona');
+    if (personaContent && !templateUsesPersonaToken) {
+      await provider.writeInstructions(worktreePath, `${resolved}\n\n${personaContent}`);
     } else {
       await provider.writeInstructions(worktreePath, resolved);
     }
-  } else if (agent.persona) {
+  } else if (personaContent) {
     // No project defaults but agent has a persona — write persona instructions alone
-    const persona = getPersonaTemplate(agent.persona);
-    if (persona) {
-      await provider.writeInstructions(worktreePath, persona.content);
-    }
+    await provider.writeInstructions(worktreePath, personaContent);
   }
 
   // 2. Permissions
@@ -441,21 +438,20 @@ export async function previewMaterialization(params: {
   };
   const missionId = resolveMissionId(agent, defaults);
   const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
-  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent);
+  const personaContent = agent.persona ? getPersonaTemplate(agent.persona)?.content : undefined;
+  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent, personaContent);
   const _conv = provider.conventions;
 
   let instructions = defaults.instructions
     ? replaceWildcards(defaults.instructions, ctx)
     : '';
 
-  // Append persona instructions to preview if agent has a persona
-  if (agent.persona) {
-    const persona = getPersonaTemplate(agent.persona);
-    if (persona) {
-      instructions = instructions
-        ? `${instructions}\n\n${persona.content}`
-        : persona.content;
-    }
+  // Auto-append persona only when the template doesn't already use @@Persona.
+  const templateUsesPersonaToken = defaults.instructions?.includes('@@Persona') ?? false;
+  if (personaContent && !templateUsesPersonaToken) {
+    instructions = instructions
+      ? `${instructions}\n\n${personaContent}`
+      : personaContent;
   }
 
   const permissions = defaults.permissions
@@ -601,9 +597,7 @@ When given a mission:
 3. Implement the work, committing frequently with descriptive messages
 4. Validate changes using \`/validate-changes\` (build, test, lint)
 5. Push changes and open a PR to main with descriptive details
-6. Return to your standby branch and pull latest from main
-
-@@mission`;
+6. Return to your standby branch and pull latest from main`;
 
   const defaultPermissions = {
     allow: [
@@ -872,7 +866,7 @@ flat markdown files under \`.clubhouse/missions/\`; the filename (minus
 \`\`\`
 
 At materialization, the content of the active mission file is substituted
-for the \`@@mission\` wildcard everywhere it appears (default CLAUDE.md
+for the \`@@Mission\` wildcard everywhere it appears (default CLAUDE.md
 template, skills, permissions, etc.).
 
 **Selecting a mission**:
@@ -881,7 +875,7 @@ template, skills, permissions, etc.).
 - Set \`mission\` on an agent in \`.clubhouse/agents.json\` to override per-agent.
 - Per-agent wins. Either value is the mission ID (filename without \`.md\`).
 
-If the mission file does not exist, \`@@mission\` resolves to an empty string —
+If the mission file does not exist, \`@@Mission\` resolves to an empty string —
 the rest of materialization still succeeds.
 
 ---
@@ -897,8 +891,11 @@ the rest of materialization still succeeds.
 | \`@@BuildCommand\`            | from project defaults                                |
 | \`@@TestCommand\`             | from project defaults                                |
 | \`@@LintCommand\`             | from project defaults                                |
-| \`@@mission\`                 | full markdown content of the active mission file     |
+| \`@@Mission\`                 | full markdown content of the active mission file     |
+| \`@@Persona\`                 | full markdown content of the active persona template |
 | \`@@If(github)…@@EndIf\`      | conditional block, kept only when provider matches   |
+
+Neither \`@@Mission\` nor \`@@Persona\` appear in the built-in default template — add them to your customized \`agentDefaults.instructions\` if you want the content inlined at a specific position. \`@@Persona\` also acts as an "opt out" of the default auto-append behavior: when your template contains the token, the persona content is substituted in place and not appended again at the bottom.
 
 ---
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -421,6 +421,7 @@ const api = {
       testCommand?: string;
       lintCommand?: string;
       mission?: string;
+      persona?: string;
       profileId?: string;
       commandPrefix?: string;
     }> =>
@@ -435,6 +436,7 @@ const api = {
       testCommand?: string;
       lintCommand?: string;
       mission?: string;
+      persona?: string;
       profileId?: string;
       commandPrefix?: string;
     }) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -420,6 +420,7 @@ const api = {
       buildCommand?: string;
       testCommand?: string;
       lintCommand?: string;
+      mission?: string;
       profileId?: string;
       commandPrefix?: string;
     }> =>
@@ -433,6 +434,7 @@ const api = {
       buildCommand?: string;
       testCommand?: string;
       lintCommand?: string;
+      mission?: string;
       profileId?: string;
       commandPrefix?: string;
     }) =>

--- a/src/renderer/features/agents/AgentSettingsView.test.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.test.tsx
@@ -381,6 +381,51 @@ describe('AgentSettingsView', () => {
     });
   });
 
+  describe('persona dropdown', () => {
+    it('renders with "Project default" selected when agent has no persona', async () => {
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({});
+      renderSettings();
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Project default')).toBeInTheDocument();
+      });
+    });
+
+    it('loads the agent\'s current persona', async () => {
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({ persona: 'qa' });
+      renderSettings();
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Quality Assurance')).toBeInTheDocument();
+      });
+    });
+
+    it('persists the new persona via updateDurableConfig (independent of override)', async () => {
+      // No clubhouseModeOverride manipulation — persona should be settable regardless.
+      const updateMock = vi.fn().mockResolvedValue(undefined);
+      (window.clubhouse.agent as any).updateDurableConfig = updateMock;
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({});
+      renderSettings();
+      const select = await screen.findByDisplayValue('Project default') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: 'qa' } });
+
+      await waitFor(() => {
+        expect(updateMock).toHaveBeenCalledWith('/project', 'agent-1', { persona: 'qa' });
+      });
+    });
+
+    it('clears the persona when set back to "Project default"', async () => {
+      const updateMock = vi.fn().mockResolvedValue(undefined);
+      (window.clubhouse.agent as any).updateDurableConfig = updateMock;
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({ persona: 'qa' });
+      renderSettings();
+      const select = await screen.findByDisplayValue('Quality Assurance') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: '' } });
+
+      await waitFor(() => {
+        expect(updateMock).toHaveBeenCalledWith('/project', 'agent-1', { persona: '' });
+      });
+    });
+  });
+
   describe('clubhouse mode', () => {
     beforeEach(() => {
       useClubhouseModeStore.setState({

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -17,6 +17,7 @@ import { TemplateConfigDialog, type TemplateConfig } from './TemplateConfigDialo
 import type { RegisteredPluginAgentTemplate } from '../../plugins/plugin-agent-template-registry';
 import { exportAgentAsTemplate } from '../blueprints/agent-template-export';
 import { serializeManifest } from '../blueprints/blueprint-export';
+import { PERSONA_TEMPLATES } from '../assistant/content/personas';
 
 type SettingsTab = 'main' | 'quick';
 
@@ -380,22 +381,32 @@ export function AgentSettingsView({ agent }: Props) {
   const clubhouseActive = projectPath ? isClubhouseModeEnabled(projectPath) : false;
   const isManagedByClubhouse = clubhouseActive && !clubhouseModeOverride;
 
+  // Persona state (per-agent override of project default)
+  const [agentPersona, setAgentPersona] = useState('');
+
   useEffect(() => {
     loadClubhouseSettings();
   }, [loadClubhouseSettings]);
 
-  // Load clubhouse mode override state from durable config
+  // Load clubhouse mode override + persona from durable config
   useEffect(() => {
     if (!projectPath) return;
     (async () => {
       try {
         const config = await window.clubhouse.agent.getDurableConfig(projectPath, agent.id);
         setClubhouseModeOverride(config?.clubhouseModeOverride ?? false);
+        setAgentPersona(config?.persona ?? '');
       } catch {
         // ignore
       }
     })();
   }, [projectPath, agent.id]);
+
+  const handlePersonaChange = async (value: string) => {
+    if (!projectPath) return;
+    setAgentPersona(value);
+    await window.clubhouse.agent.updateDurableConfig(projectPath, agent.id, { persona: value });
+  };
 
   // Load materialization preview when managed
   useEffect(() => {
@@ -943,6 +954,24 @@ export function AgentSettingsView({ agent }: Props) {
                     className="mt-1.5 w-full bg-surface-0 border border-surface-2 rounded px-2 py-1 text-sm text-ctp-text placeholder:text-ctp-overlay0 focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                 )}
+              </div>
+
+              {/* Persona */}
+              <div>
+                <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Persona</span>
+                <select
+                  value={agentPersona}
+                  onChange={(e) => handlePersonaChange(e.target.value)}
+                  className="mt-1 w-full bg-surface-0 border border-surface-2 rounded px-2 py-1 text-sm text-ctp-text focus-ring"
+                >
+                  <option value="">Project default</option>
+                  {PERSONA_TEMPLATES.map((p) => (
+                    <option key={p.id} value={p.id}>{p.name}</option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-ctp-subtext0/60">
+                  Overrides the project default persona. Applied on the next agent wake. Effective only when Clubhouse Mode is on for this project — see <code className="bg-surface-0 px-0.5 rounded">.clubhouse/clubhouse-mode.md</code>.
+                </p>
               </div>
 
               {/* Structured Mode (experimental — hidden unless opted in) */}

--- a/src/renderer/features/settings/OrchestratorSettingsView.test.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.test.tsx
@@ -179,6 +179,20 @@ describe('OrchestratorSettingsView', () => {
         expect(screen.getByText('@@AgentName')).toBeInTheDocument();
         expect(screen.getByText('@@StandbyBranch')).toBeInTheDocument();
         expect(screen.getByText('@@Path')).toBeInTheDocument();
+        // Newly surfaced wildcards
+        expect(screen.getByText('@@SourceControlProvider')).toBeInTheDocument();
+        expect(screen.getByText('@@BuildCommand')).toBeInTheDocument();
+        expect(screen.getByText('@@TestCommand')).toBeInTheDocument();
+        expect(screen.getByText('@@LintCommand')).toBeInTheDocument();
+        expect(screen.getByText('@@Mission')).toBeInTheDocument();
+        expect(screen.getByText('@@Persona')).toBeInTheDocument();
+      });
+
+      it('references the self-edit guide path when enabled', () => {
+        useClubhouseModeStore.setState({ enabled: true });
+        render(<OrchestratorSettingsView />);
+
+        expect(screen.getByText('.clubhouse/clubhouse-mode.md')).toBeInTheDocument();
       });
 
       it('hides wildcard banner when disabled', () => {

--- a/src/renderer/features/settings/OrchestratorSettingsView.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.tsx
@@ -123,8 +123,22 @@ function AppAgentSettings() {
           </button>
         </div>
         {clubhouseEnabled && (
-          <div className="px-3 py-2 rounded-lg bg-ctp-warning/10 border border-ctp-warning/20 text-xs text-ctp-warning">
-            Wildcards <code className="bg-ctp-warning/10 px-1 rounded">@@AgentName</code>, <code className="bg-ctp-warning/10 px-1 rounded">@@StandbyBranch</code>, and <code className="bg-ctp-warning/10 px-1 rounded">@@Path</code> in project defaults are resolved per-agent on each wake.
+          <div className="px-3 py-2 rounded-lg bg-ctp-warning/10 border border-ctp-warning/20 text-xs text-ctp-warning space-y-1">
+            <div>
+              Wildcards in project defaults are resolved per-agent on each wake:{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@AgentName</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@StandbyBranch</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@Path</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@SourceControlProvider</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@BuildCommand</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@TestCommand</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@LintCommand</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@Mission</code>,{' '}
+              <code className="bg-ctp-warning/10 px-1 rounded">@@Persona</code>.
+            </div>
+            <div>
+              Each Clubhouse-enabled project gets a generated self-edit guide at <code className="bg-ctp-warning/10 px-1 rounded">.clubhouse/clubhouse-mode.md</code> covering every setting on disk.
+            </div>
           </div>
         )}
         {clubhouseEnabled && (

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.test.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.test.tsx
@@ -152,16 +152,17 @@ describe('ProjectAgentDefaultsSection', () => {
     it('lists @@Mission and @@Persona in the active banner', async () => {
       renderSection({ clubhouseMode: true });
       await screen.findByText(/Clubhouse Mode active/);
-      // @@Mission appears in both the banner and the Default Mission helper text;
-      // @@Persona only in the banner. Either way both must be on the page.
+      // Both tokens are mentioned in the banner *and* in helper text under
+      // their respective inputs — just assert presence.
       expect(screen.getAllByText('@@Mission').length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText('@@Persona')).toBeInTheDocument();
+      expect(screen.getAllByText('@@Persona').length).toBeGreaterThanOrEqual(1);
     });
 
     it('references the self-edit guide path when clubhouse mode is on', async () => {
       renderSection({ clubhouseMode: true });
       await screen.findByText(/Clubhouse Mode active/);
-      expect(screen.getByText('.clubhouse/clubhouse-mode.md')).toBeInTheDocument();
+      // Referenced in the banner and again in the persona helper text.
+      expect(screen.getAllByText('.clubhouse/clubhouse-mode.md').length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -215,6 +216,61 @@ describe('ProjectAgentDefaultsSection', () => {
       await waitFor(() => {
         const call = vi.mocked(window.clubhouse.agentSettings.writeProjectAgentDefaults).mock.calls[0];
         expect(call[1].mission).toBeUndefined();
+      });
+    });
+  });
+
+  describe('default persona', () => {
+    it('renders the Default Persona dropdown', async () => {
+      renderSection();
+      expect(await screen.findByText('Default Persona')).toBeInTheDocument();
+    });
+
+    it('loads a saved persona value', async () => {
+      window.clubhouse.agentSettings.readProjectAgentDefaults = vi.fn().mockResolvedValue({
+        instructions: 'test',
+        persona: 'qa',
+      });
+      window.clubhouse.agentSettings.getProjectConfigBreakdown = vi.fn().mockResolvedValue({
+        userInstructions: 'test',
+        pluginInstructionBlocks: [],
+        allowRules: [],
+        denyRules: [],
+        skills: [],
+        agentTemplates: [],
+        mcpServers: [],
+        orphanedPluginIds: [],
+      });
+      renderSection();
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Quality Assurance')).toBeInTheDocument();
+      });
+    });
+
+    it('saves persona when set', async () => {
+      renderSection();
+      await screen.findByText('Default Persona');
+      const select = screen.getByDisplayValue('None') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: 'qa' } });
+      fireEvent.click(screen.getByText('Save Defaults'));
+
+      await waitFor(() => {
+        const call = vi.mocked(window.clubhouse.agentSettings.writeProjectAgentDefaults).mock.calls[0];
+        expect(call[1].persona).toBe('qa');
+      });
+    });
+
+    it('omits persona when left as None', async () => {
+      renderSection();
+      await screen.findByText('Default Persona');
+      // Trigger dirty without changing persona
+      const textarea = screen.getByDisplayValue('Default instructions');
+      fireEvent.change(textarea, { target: { value: 'Updated' } });
+      fireEvent.click(screen.getByText('Save Defaults'));
+
+      await waitFor(() => {
+        const call = vi.mocked(window.clubhouse.agentSettings.writeProjectAgentDefaults).mock.calls[0];
+        expect(call[1].persona).toBeUndefined();
       });
     });
   });

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.test.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.test.tsx
@@ -148,6 +148,75 @@ describe('ProjectAgentDefaultsSection', () => {
       expect(screen.getByText('@@StandbyBranch')).toBeInTheDocument();
       expect(screen.getByText('@@Path')).toBeInTheDocument();
     });
+
+    it('lists @@Mission and @@Persona in the active banner', async () => {
+      renderSection({ clubhouseMode: true });
+      await screen.findByText(/Clubhouse Mode active/);
+      // @@Mission appears in both the banner and the Default Mission helper text;
+      // @@Persona only in the banner. Either way both must be on the page.
+      expect(screen.getAllByText('@@Mission').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('@@Persona')).toBeInTheDocument();
+    });
+
+    it('references the self-edit guide path when clubhouse mode is on', async () => {
+      renderSection({ clubhouseMode: true });
+      await screen.findByText(/Clubhouse Mode active/);
+      expect(screen.getByText('.clubhouse/clubhouse-mode.md')).toBeInTheDocument();
+    });
+  });
+
+  describe('default mission', () => {
+    it('renders the Default Mission input', async () => {
+      renderSection();
+      expect(await screen.findByText('Default Mission')).toBeInTheDocument();
+    });
+
+    it('loads a saved mission value', async () => {
+      window.clubhouse.agentSettings.readProjectAgentDefaults = vi.fn().mockResolvedValue({
+        instructions: 'test',
+        mission: 'implement-and-ship',
+      });
+      window.clubhouse.agentSettings.getProjectConfigBreakdown = vi.fn().mockResolvedValue({
+        userInstructions: 'test',
+        pluginInstructionBlocks: [],
+        allowRules: [],
+        denyRules: [],
+        skills: [],
+        agentTemplates: [],
+        mcpServers: [],
+        orphanedPluginIds: [],
+      });
+      renderSection();
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('implement-and-ship')).toBeInTheDocument();
+      });
+    });
+
+    it('saves mission when set', async () => {
+      renderSection();
+      const input = await screen.findByPlaceholderText('implement-and-ship');
+      fireEvent.change(input, { target: { value: 'my-mission' } });
+      fireEvent.click(screen.getByText('Save Defaults'));
+
+      await waitFor(() => {
+        const call = vi.mocked(window.clubhouse.agentSettings.writeProjectAgentDefaults).mock.calls[0];
+        expect(call[1].mission).toBe('my-mission');
+      });
+    });
+
+    it('omits mission when left blank', async () => {
+      renderSection();
+      await screen.findByText('Default Mission');
+      // Trigger dirty without setting mission
+      const textarea = screen.getByDisplayValue('Default instructions');
+      fireEvent.change(textarea, { target: { value: 'Updated' } });
+      fireEvent.click(screen.getByText('Save Defaults'));
+
+      await waitFor(() => {
+        const call = vi.mocked(window.clubhouse.agentSettings.writeProjectAgentDefaults).mock.calls[0];
+        expect(call[1].mission).toBeUndefined();
+      });
+    });
   });
 
   describe('source control provider', () => {

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -16,6 +16,7 @@ interface ProjectAgentDefaults {
   buildCommand?: string;
   testCommand?: string;
   lintCommand?: string;
+  mission?: string;
   profileId?: string;
   commandPrefix?: string;
 }
@@ -249,6 +250,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
   const [buildCommand, setBuildCommand] = useState('');
   const [testCommand, setTestCommand] = useState('');
   const [lintCommand, setLintCommand] = useState('');
+  const [mission, setMission] = useState('');
   const [profileId, setProfileId] = useState<string | undefined>(undefined);
   const [commandPrefix, setCommandPrefix] = useState('');
   const [dirty, setDirty] = useState(false);
@@ -285,6 +287,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
       setBuildCommand(d.buildCommand || '');
       setTestCommand(d.testCommand || '');
       setLintCommand(d.lintCommand || '');
+      setMission(d.mission || '');
       setProfileId(d.profileId);
       setCommandPrefix(d.commandPrefix || '');
       setLoaded(true);
@@ -360,6 +363,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
     if (buildCommand.trim()) newDefaults.buildCommand = buildCommand.trim();
     if (testCommand.trim()) newDefaults.testCommand = testCommand.trim();
     if (lintCommand.trim()) newDefaults.lintCommand = lintCommand.trim();
+    if (mission.trim()) newDefaults.mission = mission.trim();
     if (profileId) newDefaults.profileId = profileId;
     if (commandPrefix.trim()) newDefaults.commandPrefix = commandPrefix.trim();
 
@@ -507,7 +511,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
           <span>
             {clubhouseMode
               ? <>
-                  <strong>Clubhouse Mode active.</strong> These settings are live-managed and pushed to agent worktrees on each wake. Use wildcards: <code className="bg-ctp-success/10 px-0.5 rounded">@@AgentName</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@StandbyBranch</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@Path</code>.
+                  <strong>Clubhouse Mode active.</strong> These settings are live-managed and pushed to agent worktrees on each wake. Wildcards: <code className="bg-ctp-success/10 px-0.5 rounded">@@AgentName</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@StandbyBranch</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@Path</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@BuildCommand</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@TestCommand</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@LintCommand</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@SourceControlProvider</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@Mission</code>, <code className="bg-ctp-success/10 px-0.5 rounded">@@Persona</code>. Full reference: <code className="bg-ctp-success/10 px-0.5 rounded">.clubhouse/clubhouse-mode.md</code> in this project.
                 </>
               : 'These settings are applied as snapshots when new durable agents are created. Changes here do not affect existing agents.'
             }
@@ -628,6 +632,21 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
               />
             </div>
           </div>
+        </div>
+
+        {/* Default Mission */}
+        <div>
+          <label className="block text-xs text-ctp-subtext0 mb-1">Default Mission</label>
+          <p className="text-xs text-ctp-subtext0/60 mb-2">
+            ID of a markdown file under <code className="bg-surface-0 px-0.5 rounded">.clubhouse/missions/</code> (e.g. <code className="bg-surface-0 px-0.5 rounded">implement-and-ship</code>). Its content replaces <code className="bg-surface-0 px-0.5 rounded">@@Mission</code> wherever it appears in instructions, skills, or permissions. Per-agent <code className="bg-surface-0 px-0.5 rounded">mission</code> in <code className="bg-surface-0 px-0.5 rounded">.clubhouse/agents.json</code> overrides this. Leave blank for no mission.
+          </p>
+          <input
+            value={mission}
+            onChange={(e) => { setMission(e.target.value); setDirty(true); }}
+            placeholder="implement-and-ship"
+            className="w-full bg-surface-0 border border-surface-1 rounded px-2 py-1.5 text-sm font-mono text-ctp-text focus-ring"
+            spellCheck={false}
+          />
         </div>
 
         {/* Default Free Agent Mode */}

--- a/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
+++ b/src/renderer/features/settings/ProjectAgentDefaultsSection.tsx
@@ -6,6 +6,7 @@ import { SourceAgentTemplatesSection } from './SourceAgentTemplatesSection';
 import { useProfileStore } from '../../stores/profileStore';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
 import { usePluginStore } from '../../plugins/plugin-store';
+import { PERSONA_TEMPLATES } from '../assistant/content/personas';
 
 interface ProjectAgentDefaults {
   instructions?: string;
@@ -17,6 +18,7 @@ interface ProjectAgentDefaults {
   testCommand?: string;
   lintCommand?: string;
   mission?: string;
+  persona?: string;
   profileId?: string;
   commandPrefix?: string;
 }
@@ -251,6 +253,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
   const [testCommand, setTestCommand] = useState('');
   const [lintCommand, setLintCommand] = useState('');
   const [mission, setMission] = useState('');
+  const [persona, setPersona] = useState('');
   const [profileId, setProfileId] = useState<string | undefined>(undefined);
   const [commandPrefix, setCommandPrefix] = useState('');
   const [dirty, setDirty] = useState(false);
@@ -288,6 +291,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
       setTestCommand(d.testCommand || '');
       setLintCommand(d.lintCommand || '');
       setMission(d.mission || '');
+      setPersona(d.persona || '');
       setProfileId(d.profileId);
       setCommandPrefix(d.commandPrefix || '');
       setLoaded(true);
@@ -364,6 +368,7 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
     if (testCommand.trim()) newDefaults.testCommand = testCommand.trim();
     if (lintCommand.trim()) newDefaults.lintCommand = lintCommand.trim();
     if (mission.trim()) newDefaults.mission = mission.trim();
+    if (persona) newDefaults.persona = persona;
     if (profileId) newDefaults.profileId = profileId;
     if (commandPrefix.trim()) newDefaults.commandPrefix = commandPrefix.trim();
 
@@ -647,6 +652,24 @@ export function ProjectAgentDefaultsSection({ projectPath, clubhouseMode }: Prop
             className="w-full bg-surface-0 border border-surface-1 rounded px-2 py-1.5 text-sm font-mono text-ctp-text focus-ring"
             spellCheck={false}
           />
+        </div>
+
+        {/* Default Persona */}
+        <div>
+          <label className="block text-xs text-ctp-subtext0 mb-1">Default Persona</label>
+          <select
+            value={persona}
+            onChange={(e) => { setPersona(e.target.value); setDirty(true); }}
+            className="w-64 px-3 py-1.5 text-sm rounded-lg bg-ctp-mantle border border-surface-2 text-ctp-text focus-ring-dim"
+          >
+            <option value="">None</option>
+            {PERSONA_TEMPLATES.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+          <p className="text-xs text-ctp-subtext0/60 mt-1">
+            Applied to every agent in this project unless an agent has its own persona set. Override per-agent in agent settings, or by editing <code className="bg-surface-0 px-0.5 rounded">.clubhouse/agents.json</code> — see <code className="bg-surface-0 px-0.5 rounded">.clubhouse/clubhouse-mode.md</code>. Resolves to <code className="bg-surface-0 px-0.5 rounded">@@Persona</code> and (when the template lacks that token) is auto-appended to CLAUDE.md.
+          </p>
         </div>
 
         {/* Default Free Agent Mode */}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -173,6 +173,8 @@ export interface ProjectAgentDefaults {
   commandPrefix?: string;
   /** Default mission ID. Resolved at materialization to .clubhouse/missions/<id>.md content; substituted for @@mission. */
   mission?: string;
+  /** Default persona template ID. Applied to every agent in the project unless the agent has its own `persona` set. */
+  persona?: string;
 }
 
 /** A recorded CLI session for a durable agent */

--- a/src/shared/wildcard-replacer.test.ts
+++ b/src/shared/wildcard-replacer.test.ts
@@ -233,39 +233,75 @@ describe('@@BuildCommand / @@TestCommand / @@LintCommand replacement', () => {
   });
 });
 
-describe('@@mission replacement', () => {
+describe('@@Mission replacement', () => {
   it('substitutes mission content body', () => {
     const ctxWithMission = { ...ctx, mission: '# Steps\n1. Investigate\n2. Report' };
-    expect(replaceWildcards('Mission:\n@@mission', ctxWithMission)).toBe(
+    expect(replaceWildcards('Mission:\n@@Mission', ctxWithMission)).toBe(
       'Mission:\n# Steps\n1. Investigate\n2. Report',
     );
   });
 
   it('resolves to empty string when mission is unset', () => {
-    expect(replaceWildcards('Mission:\n@@mission', ctx)).toBe('Mission:\n');
+    expect(replaceWildcards('Mission:\n@@Mission', ctx)).toBe('Mission:\n');
   });
 
   it('resolves to empty string when mission is empty string', () => {
-    expect(replaceWildcards('@@mission', { ...ctx, mission: '' })).toBe('');
+    expect(replaceWildcards('@@Mission', { ...ctx, mission: '' })).toBe('');
   });
 
   it('substitutes multiple occurrences', () => {
     const ctxWithMission = { ...ctx, mission: 'do the thing' };
-    expect(replaceWildcards('@@mission and @@mission', ctxWithMission)).toBe(
+    expect(replaceWildcards('@@Mission and @@Mission', ctxWithMission)).toBe(
       'do the thing and do the thing',
     );
   });
 
-  it('does not consume the @@ prefix of other tokens', () => {
-    // @@mission must not match @@missionFoo or similar — guard against future tokens
+  it('does not substitute lowercase @@mission (case-sensitive token)', () => {
     const ctxWithMission = { ...ctx, mission: 'X' };
-    expect(replaceWildcards('@@mission and @@AgentName', ctxWithMission)).toBe('X and bold-falcon');
+    expect(replaceWildcards('@@mission and @@Mission', ctxWithMission)).toBe('@@mission and X');
   });
 
-  it('unreplaceWildcards reverses mission content back to @@mission', () => {
+  it('does not consume the @@ prefix of other tokens', () => {
+    const ctxWithMission = { ...ctx, mission: 'X' };
+    expect(replaceWildcards('@@Mission and @@AgentName', ctxWithMission)).toBe('X and bold-falcon');
+  });
+
+  it('unreplaceWildcards reverses mission content back to @@Mission', () => {
     const ctxWithMission = { ...ctx, mission: 'unique-mission-marker-12345' };
     expect(unreplaceWildcards('Here: unique-mission-marker-12345', ctxWithMission)).toBe(
-      'Here: @@mission',
+      'Here: @@Mission',
+    );
+  });
+});
+
+describe('@@Persona replacement', () => {
+  it('substitutes persona content body', () => {
+    const ctxWithPersona = { ...ctx, persona: '## Quality Assurance\nReview the diff.' };
+    expect(replaceWildcards('Persona:\n@@Persona', ctxWithPersona)).toBe(
+      'Persona:\n## Quality Assurance\nReview the diff.',
+    );
+  });
+
+  it('resolves to empty string when persona is unset', () => {
+    expect(replaceWildcards('@@Persona', ctx)).toBe('');
+  });
+
+  it('substitutes multiple occurrences', () => {
+    const ctxWithPersona = { ...ctx, persona: 'P' };
+    expect(replaceWildcards('@@Persona and @@Persona', ctxWithPersona)).toBe('P and P');
+  });
+
+  it('mission and persona can coexist in the same template', () => {
+    const ctxBoth = { ...ctx, mission: 'M body', persona: 'P body' };
+    expect(replaceWildcards('# Header\n@@Mission\n---\n@@Persona', ctxBoth)).toBe(
+      '# Header\nM body\n---\nP body',
+    );
+  });
+
+  it('unreplaceWildcards reverses persona content back to @@Persona', () => {
+    const ctxWithPersona = { ...ctx, persona: 'unique-persona-marker-zzzzz' };
+    expect(unreplaceWildcards('X: unique-persona-marker-zzzzz', ctxWithPersona)).toBe(
+      'X: @@Persona',
     );
   });
 });

--- a/src/shared/wildcard-replacer.ts
+++ b/src/shared/wildcard-replacer.ts
@@ -7,6 +7,7 @@ export interface WildcardContext {
   testCommand?: string;    // e.g. "npm test"
   lintCommand?: string;    // e.g. "npm run lint"
   mission?: string;        // resolved mission content (full markdown body)
+  persona?: string;        // resolved persona content (full markdown body)
 }
 
 /**
@@ -23,7 +24,8 @@ export function replaceWildcards(text: string, ctx: WildcardContext): string {
     .replace(/@@BuildCommand/g, ctx.buildCommand || 'npm run build')
     .replace(/@@TestCommand/g, ctx.testCommand || 'npm test')
     .replace(/@@LintCommand/g, ctx.lintCommand || 'npm run lint')
-    .replace(/@@mission/g, ctx.mission || '');
+    .replace(/@@Mission/g, ctx.mission || '')
+    .replace(/@@Persona/g, ctx.persona || '');
 
   // Process @@If(value)...@@EndIf conditional blocks
   result = processConditionalBlocks(result, ctx);
@@ -59,7 +61,10 @@ export function unreplaceWildcards(text: string, ctx: WildcardContext): string {
     pairs.push({ value: ctx.lintCommand, token: '@@LintCommand' });
   }
   if (ctx.mission) {
-    pairs.push({ value: ctx.mission, token: '@@mission' });
+    pairs.push({ value: ctx.mission, token: '@@Mission' });
+  }
+  if (ctx.persona) {
+    pairs.push({ value: ctx.persona, token: '@@Persona' });
   }
 
   // Sort longest-value-first to avoid partial matches


### PR DESCRIPTION
## Summary

- The base CLAUDE.md template reverts to the pre-#1481 body — no opinionated mission slot baked in. Existing customizations and resets behave like before.
- \`@@mission\` is renamed to \`@@Mission\` for case-consistency with other PascalCase wildcards.
- New \`@@Persona\` wildcard resolves to the active persona template body (mirroring \`@@Mission\` semantics).
- Persona auto-append is preserved for backwards compatibility but skipped when the template uses \`@@Persona\` — so opt-in users don't get the persona injected twice.

## Motivation

Per a follow-up conversation: the default base template should be identical to what shipped pre-#1481 so existing CH-mode customizations and "Reset project agent defaults" don't pick up an injected mission slot. Mission and persona content stay available as opt-in tokens for templates that want to position them explicitly.

A redesign making \`@@Mission\` resolve to a skill name (rather than the full body) is acknowledged as cleaner; that is intentionally deferred to a separate PR. This change keeps the body-substitution semantics and only fixes the casing + adds the persona counterpart.

## What changes

| Surface | Before | After |
|---|---|---|
| Default \`agentDefaults.instructions\` | Ends with \`\\n\\n@@mission\` | Reverts to pre-#1481 body |
| Wildcard token | \`@@mission\` (lowercase) | \`@@Mission\` (PascalCase) |
| Persona wildcard | (none) | \`@@Persona\` resolves to persona body |
| Persona auto-append | Always when \`agent.persona\` set | Skipped when template contains \`@@Persona\` |
| Existing users | n/a | No behavior change (the default template + auto-append match prior behavior bit-for-bit) |

## Behaviour matrix for persona

| Template uses \`@@Persona\` | \`agent.persona\` set | Result |
|---|---|---|
| no | no | unchanged — no persona content |
| no | yes | unchanged — persona auto-appended at end (legacy behaviour) |
| yes | no | \`@@Persona\` resolves to empty; no auto-append |
| yes | yes | persona substituted inline at the token; auto-append skipped |

## Test plan

- [x] \`@@Mission\` substitutes mission body, dedupes, doesn't match \`@@mission\` (case-sensitive).
- [x] \`@@Persona\` substitutes persona body, dedupes, coexists with \`@@Mission\` in the same template.
- [x] \`unreplaceWildcards\` reverses both new tokens.
- [x] Default \`getDefaultAgentTemplates()\` body contains neither \`@@Mission\` nor \`@@Persona\` (revert assertion).
- [x] \`materializeAgent\` substitutes \`@@Persona\` inline AND skips auto-append (no double injection — body appears exactly once, trailing template content preserved).
- [x] \`materializeAgent\` still auto-appends persona when template lacks \`@@Persona\` (backwards-compat).
- [x] All existing mission tests pass under the new \`@@Mission\` token.
- [x] \`npm run typecheck\` clean.
- [x] \`npm test\` — 12124 pass / 0 fail (4 pre-existing skips, 2 pre-existing unhandled rejections in \`ProjectRail.test.tsx\` unrelated).
- [x] \`npm run lint\` — 0 errors.

## Manual validation

- [ ] Enable CH mode on a fresh project → confirm the default \`agentDefaults.instructions\` does NOT contain \`@@Mission\`.
- [ ] Set a persona on an agent without customizing the template → persona still auto-appends on the next agent wake.
- [ ] Customize \`agentDefaults.instructions\` to include \`@@Persona\` somewhere mid-body, set a persona on an agent → persona body appears at that location, NOT at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)