### PR TITLE
fix(terminal): declare 'projects' permission for canvas widget

### DIFF
--- a/src/renderer/plugins/builtin/terminal/manifest.test.ts
+++ b/src/renderer/plugins/builtin/terminal/manifest.test.ts
@@ -23,9 +23,15 @@ describe('terminal plugin manifest', () => {
 
   it('declares required permissions including canvas', () => {
     expect(manifest.permissions).toEqual(
-      expect.arrayContaining(['terminal', 'commands', 'agents', 'canvas', 'annex']),
+      expect.arrayContaining(['terminal', 'commands', 'agents', 'canvas', 'annex', 'projects']),
     );
-    expect(manifest.permissions).toHaveLength(5);
+    expect(manifest.permissions).toHaveLength(6);
+  });
+
+  it('declares the projects permission required by its canvas widget', () => {
+    // TerminalCanvasWidget calls api.projects.list() to populate the project
+    // picker; without this permission the canvas widget is disabled at runtime.
+    expect(manifest.permissions).toContain('projects');
   });
 
   it('contributes tab.title', () => {

--- a/src/renderer/plugins/builtin/terminal/manifest.ts
+++ b/src/renderer/plugins/builtin/terminal/manifest.ts
@@ -10,7 +10,7 @@ export const manifest: PluginManifest = {
   author: 'Clubhouse',
   engine: { api: 0.8 },
   scope: 'project',
-  permissions: ['terminal', 'commands', 'agents', 'canvas', 'annex'],
+  permissions: ['terminal', 'commands', 'agents', 'canvas', 'annex', 'projects'],
   contributes: {
     tab: { label: 'Terminal', title: 'Terminal', icon: TERMINAL_ICON, layout: 'sidebar-content' },
     commands: [{ id: 'restart', title: 'Restart Terminal', defaultBinding: 'Meta+Shift+T' }],


### PR DESCRIPTION
## Summary
- Launching the **Terminal** plugin in canvas failed with: *"Plugin Terminal was disabled: it tried to use `api.projects` without the required `projects` permission."*
- Root cause: `TerminalCanvasWidget` calls `api.projects.list()` to populate its project picker, but the plugin manifest never declared the `projects` permission, so the permission gate disabled the plugin at runtime.

## Changes
- `src/renderer/plugins/builtin/terminal/manifest.ts` — add `'projects'` to the manifest `permissions` array (now `['terminal', 'commands', 'agents', 'canvas', 'annex', 'projects']`).
- `src/renderer/plugins/builtin/terminal/manifest.test.ts` — update the permission-count assertion to `6` and add an explicit test that `'projects'` is granted, with a comment explaining why the canvas widget requires it (regression guard).

## Root Cause Detail
`api.projects` is gated by the `'projects'` permission in `plugin-api-factory.ts`. Since the Terminal plugin is project-scoped at API v0.8, the scope check passed but the permission check failed — `gated()` returned a `permissionDeniedProxy`, which fired `handlePermissionViolation()` on the call to `api.projects.list()` (`TerminalCanvasWidget.tsx:68`), disabling the plugin and surfacing the banner in `PermissionViolationBanner.tsx`. The widget's only other gated API, `api.annex`, was already declared; `api.context` is ungated.

## Test Plan
- [x] `manifest.test.ts` passes (13 tests), including the new `projects` permission assertions
- [x] `npm run typecheck` passes
- [x] `npm test` — 12116 passed, 4 skipped, 0 failures
- [x] `npm run lint` — 0 errors

## Manual Validation
1. Open a project, add a **Terminal** widget to the canvas.
2. Confirm the widget renders with its project picker and no permission-violation banner appears.
3. Confirm the project list is populated (local + remote projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)