### PR TITLE
fix(agents): move completed quick agents to Completed footer

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act, renderHook } from '@testing-library/react';
+import { render, screen, fireEvent, act, renderHook, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
@@ -257,7 +257,7 @@ describe('AgentList completed selector stability', () => {
     });
 
     render(<AgentList />);
-    // The completed footer shows count of orphan completed agents
+    // The completed footer shows the count of all completed agents for the project
     expect(screen.getByText('Completed (1)')).toBeInTheDocument();
   });
 
@@ -424,7 +424,7 @@ describe('AgentList child agent grouping', () => {
     expect(screen.getByTestId('agent-item-quick-orphan-1')).toBeInTheDocument();
   });
 
-  it('renders child completed ghosts under their parent durable', () => {
+  it('moves a completed quick child into the Completed footer instead of nesting it under its parent', () => {
     const durable: Agent = {
       ...defaultAgent,
       id: 'durable-1',
@@ -459,10 +459,54 @@ describe('AgentList child agent grouping', () => {
 
     // Parent durable should render
     expect(screen.getByTestId('agent-item-durable-1')).toBeInTheDocument();
-    // Child completed ghost should render (nested under parent)
-    expect(screen.getByTestId('quick-agent-ghost')).toBeInTheDocument();
-    // Completed footer should show 0 orphan completed (the child belongs to a parent)
-    expect(screen.getByText('Completed (0)')).toBeInTheDocument();
+    // The completed child should render exactly once — in the footer, not nested
+    expect(screen.getAllByTestId('quick-agent-ghost')).toHaveLength(1);
+    // The single ghost lives inside the Completed footer
+    const footer = screen.getByTestId('completed-footer');
+    expect(within(footer).getByTestId('quick-agent-ghost')).toBeInTheDocument();
+    // Completed count now includes the parented child
+    expect(screen.getByText('Completed (1)')).toBeInTheDocument();
+  });
+
+  it('counts both parented and orphan completed agents in the footer', () => {
+    const durable: Agent = {
+      ...defaultAgent,
+      id: 'durable-1',
+      name: 'parent-durable',
+      kind: 'durable',
+    };
+
+    useAgentStore.setState({
+      agents: { [durable.id]: durable },
+      activeAgentId: durable.id,
+      agentActivity: {},
+    });
+
+    const base = {
+      projectId: 'proj-1',
+      summary: null,
+      filesModified: [],
+      exitCode: 0,
+      completedAt: Date.now(),
+    };
+    const parentedCompleted: CompletedQuickAgent = {
+      ...base, id: 'completed-child-1', name: 'done-child', mission: 'child task', parentAgentId: 'durable-1',
+    };
+    const orphanCompleted: CompletedQuickAgent = {
+      ...base, id: 'completed-orphan-1', name: 'done-orphan', mission: 'orphan task',
+    };
+
+    useQuickAgentStore.setState({
+      completedAgents: { 'proj-1': [parentedCompleted, orphanCompleted] },
+      selectedCompletedId: null,
+    });
+
+    render(<AgentList />);
+
+    // Both completed agents live in the footer
+    const footer = screen.getByTestId('completed-footer');
+    expect(within(footer).getAllByTestId('quick-agent-ghost')).toHaveLength(2);
+    expect(screen.getByText('Completed (2)')).toBeInTheDocument();
   });
 });
 

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -221,22 +221,6 @@ function AgentListInner() {
     return map;
   }, [quickAgents]);
 
-  const childCompletedByParent = useMemo(() => {
-    const map = new Map<string, CompletedQuickAgent[]>();
-    for (const completed of completedAgents) {
-      if (completed.parentAgentId) {
-        const list = map.get(completed.parentAgentId);
-        if (list) list.push(completed);
-        else map.set(completed.parentAgentId, [completed]);
-      }
-    }
-    return map;
-  }, [completedAgents]);
-
-  const orphanCompleted = useMemo(
-    () => completedAgents.filter((r) => !r.parentAgentId),
-    [completedAgents]
-  );
 
   useEffect(() => {
     if (showMissionInput && missionInputRef.current) {
@@ -609,7 +593,6 @@ function AgentListInner() {
             </div>
             {durableAgents.map((durable, i) => {
               const childQuick = childQuickByParent.get(durable.id) ?? [];
-              const childCompleted = childCompletedByParent.get(durable.id) ?? [];
               const isMissionTarget = showMissionInput && quickTargetParentId === durable.id;
 
               return (
@@ -646,7 +629,8 @@ function AgentListInner() {
                   </div>
                   {/* Inline mission input targeting this durable */}
                   {isMissionTarget && renderMissionInput(true)}
-                  {/* Child quick agents (indented) */}
+                  {/* Child quick agents (indented). Completed children are not
+                      nested here — they move to the Completed footer below. */}
                   {childQuick.map((child) => (
                     <AgentListItem
                       key={child.id}
@@ -654,17 +638,6 @@ function AgentListInner() {
                       isActive={child.id === activeAgentId}
                       isThinking={isThinking(child.id)}
                       onSelect={() => { selectCompleted(null); setActiveAgent(child.id, activeProjectId ?? undefined); }}
-                      isNested
-                    />
-                  ))}
-                  {/* Child completed ghosts (indented) */}
-                  {childCompleted.map((completed) => (
-                    <QuickAgentGhostCompact
-                      key={completed.id}
-                      completed={completed}
-                      onDismiss={() => activeProjectId && dismissCompleted(activeProjectId, completed.id)}
-                      onDelete={() => activeProjectId && dismissCompleted(activeProjectId, completed.id)}
-                      onSelect={() => { setActiveAgent(null, activeProjectId ?? undefined); selectCompleted(completed.id); }}
                       isNested
                     />
                   ))}
@@ -719,9 +692,9 @@ function AgentListInner() {
             >
               <polyline points="9 18 15 12 9 6" />
             </svg>
-            <span>Completed ({orphanCompleted.length})</span>
+            <span>Completed ({completedAgents.length})</span>
           </button>
-          {!completedCollapsed && orphanCompleted.length > 0 && (
+          {!completedCollapsed && completedAgents.length > 0 && (
             <button
               onClick={() => activeProjectId && clearCompleted(activeProjectId)}
               data-testid="completed-clear-all"
@@ -736,11 +709,11 @@ function AgentListInner() {
           className="overflow-hidden transition-[max-height,min-height] duration-300 ease-in-out"
           style={{
             maxHeight: completedCollapsed ? 0 : '33vh',
-            minHeight: completedCollapsed ? 0 : (orphanCompleted.length > 0 ? '120px' : 0),
+            minHeight: completedCollapsed ? 0 : (completedAgents.length > 0 ? '120px' : 0),
           }}
         >
           <div className="overflow-y-auto pb-2" style={{ maxHeight: '33vh' }}>
-            {orphanCompleted.map((completed) => (
+            {completedAgents.map((completed) => (
               <QuickAgentGhostCompact
                 key={completed.id}
                 completed={completed}


### PR DESCRIPTION
## Summary
- Finished quick agents spawned under a durable agent used to linger nested beneath their parent as "done" ghosts in the agent list — the user didn't want them sticking around there.
- Now **all** completed quick agents (parented or orphan) move into the bottom **Completed** section once they finish.
- Running quick children still nest under their durable parent until they're done — no change to in-progress behavior.

## Changes
- `AgentList.tsx`:
  - Removed the `childCompletedByParent` map and the nested rendering of completed ghosts under each durable.
  - Removed the `orphanCompleted` filter; the Completed footer now renders **all** `completedAgents` for the project (count, clear-all visibility, min-height, and list all use `completedAgents`).
- `AgentList.test.tsx`:
  - Reworked the prior "renders child completed ghosts under their parent durable" test into "moves a completed quick child into the Completed footer instead of nesting it" — asserts the ghost renders exactly once, inside the `completed-footer`, and the count includes it.
  - Added a test asserting the footer counts both parented and orphan completed agents.

## Test Plan
- [x] Completed quick agent with a `parentAgentId` is **not** nested under its durable.
- [x] Completed quick agent with a `parentAgentId` appears in the Completed footer and is counted.
- [x] Orphan completed quick agents still appear in the footer (no regression).
- [x] Completed count = parented + orphan combined.
- [x] Running quick children still nest under their durable parent (existing test retained).

## Validation
- `npm run typecheck` ✓
- `npm test` ✓ (12196 passed, 0 failures; AgentList suite 30 tests pass)
- `npm run lint` ✓ (0 errors)

## Manual Validation
1. Create a durable agent, spawn a quick agent under it.
2. Let the quick agent finish.
3. Confirm it no longer shows nested under the durable and instead appears in the bottom **Completed** section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)