### PR TITLE
Fix large plaintext paste from TextEdit

### DIFF
--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -1,4 +1,4 @@
-import { _electron as electron } from '@playwright/test';
+import { _electron as electron, type Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -72,18 +72,20 @@ export async function launchApp(opts: LaunchOptions = {}) {
 async function findRendererWindow(
   electronApp: Awaited<ReturnType<typeof electron.launch>>,
 ) {
-  // Fast path: pick the first non-devtools window already open.
-  // DevTools may briefly have a non-devtools:// URL on startup, so after
-  // the URL check we verify the page has our renderer's <div id="root">.
+  // Fast path: pick the first renderer window already open.
+  // Avoid evaluating inside candidate pages here: a not-yet-ready renderer can
+  // hang evaluation while DevTools is open. The app renderer has a stable file
+  // URL under the webpack renderer bundle; DevTools never does.
   // If verification fails, we wait for the next window.
   const seen = new Set<Awaited<ReturnType<typeof electronApp.firstWindow>>>();
 
   for (const page of electronApp.windows()) {
     if (page.url().startsWith('devtools://')) { seen.add(page); continue; }
-    // Validate: wait for load so evaluate() has a JS context, then check #root.
     try {
       await page.waitForLoadState('load');
-      if (await page.evaluate(() => !!document.getElementById('root'))) return page;
+      await page.waitForTimeout(250);
+      if (page.url().startsWith('devtools://')) { seen.add(page); continue; }
+      if (isClubhouseRenderer(page)) return page;
     } catch { /* not ready */ }
     seen.add(page);
   }
@@ -100,9 +102,16 @@ async function findRendererWindow(
     if (page.url().startsWith('devtools://')) continue;
     try {
       await page.waitForLoadState('load');
-      if (await page.evaluate(() => !!document.getElementById('root'))) return page;
+      await page.waitForTimeout(250);
+      if (page.url().startsWith('devtools://')) continue;
+      if (isClubhouseRenderer(page)) return page;
     } catch { /* not ready */ }
   }
 
   throw new Error('Timed out waiting for renderer window (30 s)');
+}
+
+function isClubhouseRenderer(page: Page): boolean {
+  const url = page.url();
+  return url.startsWith('file://') && url.includes('/renderer/main_window/');
 }

--- a/src/main/ipc/app-handlers.test.ts
+++ b/src/main/ipc/app-handlers.test.ts
@@ -14,6 +14,7 @@ vi.mock('electron', () => ({
     getAllWindows: vi.fn(() => []),
   },
   ipcMain: { handle: vi.fn(), on: vi.fn() },
+  clipboard: { readText: vi.fn(() => 'native clipboard text') },
   shell: { openExternal: vi.fn(async () => {}) },
 }));
 
@@ -148,7 +149,7 @@ vi.mock('./mcp-binding-handlers', () => ({
   onMcpSettingsChanged: vi.fn(),
 }));
 
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import { registerAppHandlers } from './app-handlers';
 import * as notificationService from '../services/notification-service';
@@ -193,6 +194,7 @@ describe('app-handlers', () => {
       IPC.APP.GET_HEADLESS_SETTINGS, IPC.APP.SAVE_HEADLESS_SETTINGS,
       IPC.APP.GET_BADGE_SETTINGS, IPC.APP.SAVE_BADGE_SETTINGS,
       IPC.APP.GET_CLIPBOARD_SETTINGS, IPC.APP.SAVE_CLIPBOARD_SETTINGS,
+      IPC.APP.READ_CLIPBOARD_TEXT, IPC.APP.READ_CLIPBOARD_IMAGE,
       IPC.APP.SET_DOCK_BADGE,
       IPC.APP.GET_UPDATE_SETTINGS, IPC.APP.SAVE_UPDATE_SETTINGS,
       IPC.APP.CHECK_FOR_UPDATES, IPC.APP.GET_UPDATE_STATUS, IPC.APP.APPLY_UPDATE,
@@ -421,6 +423,13 @@ describe('app-handlers', () => {
     const handler = handleHandlers.get(IPC.APP.SAVE_CLIPBOARD_SETTINGS)!;
     await handler({}, { clipboardCompat: true });
     expect(clipboardSettings.saveSettings).toHaveBeenCalledWith({ clipboardCompat: true });
+  });
+
+  it('READ_CLIPBOARD_TEXT reads text through Electron native clipboard', async () => {
+    const handler = handleHandlers.get(IPC.APP.READ_CLIPBOARD_TEXT)!;
+    const result = await handler({});
+    expect(clipboard.readText).toHaveBeenCalled();
+    expect(result).toBe('native clipboard text');
   });
 
   // --- Dock Badge ---

--- a/src/main/ipc/app-handlers.ts
+++ b/src/main/ipc/app-handlers.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import { ArchInfo, BadgeSettings, LogEntry, LoggingSettings, NotificationSettings, ThemeId } from '../../shared/types';
 import * as notificationService from '../services/notification-service';
@@ -202,6 +202,12 @@ export function registerAppHandlers(): void {
       await clipboardSettings.saveSettings(settings);
     },
   ));
+
+  // Read text from the system clipboard using Electron's native API.
+  // Browser clipboard reads can return empty for some macOS pasteboard
+  // producers (for example large plain-text copies from TextEdit), so expose
+  // Electron's native text reader as a fallback for terminal paste.
+  ipcMain.handle(IPC.APP.READ_CLIPBOARD_TEXT, () => clipboard.readText());
 
   // Read image from the system clipboard using Electron's native API.
   // navigator.clipboard.read() is unreliable for images in Electron,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -814,6 +814,8 @@ const api = {
       ipcRenderer.invoke(IPC.APP.GET_CLIPBOARD_SETTINGS),
     saveClipboardSettings: (settings: { clipboardCompat: boolean }) =>
       ipcRenderer.invoke(IPC.APP.SAVE_CLIPBOARD_SETTINGS, settings),
+    readClipboardText: (): Promise<string> =>
+      ipcRenderer.invoke(IPC.APP.READ_CLIPBOARD_TEXT),
     readClipboardImage: (): Promise<{ base64: string; mimeType: string } | null> =>
       ipcRenderer.invoke(IPC.APP.READ_CLIPBOARD_IMAGE),
     getSessionSettings: () =>

--- a/src/renderer/features/terminal/clipboard.test.ts
+++ b/src/renderer/features/terminal/clipboard.test.ts
@@ -4,6 +4,7 @@ import { attachClipboardHandlers, readClipboard, readClipboardImage, writeClipbo
 // --- Mocks ---
 
 let mockPlatform = 'win32' as string;
+const mockReadClipboardText = vi.fn<() => Promise<string>>(async () => '');
 const mockReadClipboardImage = vi.fn<() => Promise<{ base64: string; mimeType: string } | null>>(async () => null);
 
 // Override the default setup-renderer stub with a getter so tests can swap platform
@@ -12,7 +13,7 @@ Object.defineProperty(window, 'clubhouse', {
   get: () => ({
     platform: mockPlatform,
     pty: { write: vi.fn(), resize: vi.fn(), getBuffer: vi.fn(async () => ''), onData: () => vi.fn(), onExit: () => vi.fn() },
-    app: { readClipboardImage: mockReadClipboardImage },
+    app: { readClipboardText: mockReadClipboardText, readClipboardImage: mockReadClipboardImage },
   }),
 });
 
@@ -61,6 +62,7 @@ describe('clipboard — keyboard shortcuts', () => {
     mockPlatform = 'win32';
     writeToPty = vi.fn();
     clipboardReadText.mockReset().mockResolvedValue('pasted text');
+    mockReadClipboardText.mockReset().mockResolvedValue('');
     clipboardWriteText.mockReset().mockResolvedValue(undefined);
   });
 
@@ -300,6 +302,7 @@ describe('clipboard — right-click context menu', () => {
     mockPlatform = 'win32';
     writeToPty = vi.fn();
     clipboardReadText.mockReset().mockResolvedValue('right-click paste');
+    mockReadClipboardText.mockReset().mockResolvedValue('');
     clipboardWriteText.mockReset().mockResolvedValue(undefined);
   });
 
@@ -372,6 +375,7 @@ describe('clipboard — native paste event suppression', () => {
     mockPlatform = 'win32';
     writeToPty = vi.fn();
     clipboardReadText.mockReset().mockResolvedValue('pasted text');
+    mockReadClipboardText.mockReset().mockResolvedValue('');
     clipboardWriteText.mockReset().mockResolvedValue(undefined);
   });
 
@@ -518,15 +522,34 @@ describe('readClipboardImage', () => {
 describe('readClipboard', () => {
   beforeEach(() => {
     clipboardReadText.mockReset();
+    mockReadClipboardText.mockReset().mockResolvedValue('');
   });
 
   it('returns clipboard text on success', async () => {
     clipboardReadText.mockResolvedValue('hello');
     expect(await readClipboard()).toBe('hello');
+    expect(mockReadClipboardText).not.toHaveBeenCalled();
   });
 
-  it('returns empty string on failure', async () => {
+  it('falls back to Electron native text when browser clipboard is empty', async () => {
+    const largeTextEditPlaintext = 'TextEdit plaintext block\n'.repeat(10_000);
+    clipboardReadText.mockResolvedValue('');
+    mockReadClipboardText.mockResolvedValue(largeTextEditPlaintext);
+
+    expect(await readClipboard()).toBe(largeTextEditPlaintext);
+    expect(mockReadClipboardText).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to Electron native text when browser clipboard read fails', async () => {
     clipboardReadText.mockRejectedValue(new Error('denied'));
+    mockReadClipboardText.mockResolvedValue('native text');
+
+    expect(await readClipboard()).toBe('native text');
+  });
+
+  it('returns empty string when both browser and native reads fail', async () => {
+    clipboardReadText.mockRejectedValue(new Error('denied'));
+    mockReadClipboardText.mockRejectedValue(new Error('pasteboard unavailable'));
     expect(await readClipboard()).toBe('');
   });
 });
@@ -550,6 +573,7 @@ describe('writeClipboard', () => {
 describe('pasteIntoTerminal', () => {
   beforeEach(() => {
     clipboardReadText.mockReset().mockResolvedValue('paste me');
+    mockReadClipboardText.mockReset().mockResolvedValue('');
   });
 
   it('reads clipboard and calls writeToPty', async () => {
@@ -570,6 +594,7 @@ describe('pasteIntoTerminal', () => {
 
   it('does not call writeToPty when clipboard is empty', async () => {
     clipboardReadText.mockResolvedValue('');
+    mockReadClipboardText.mockResolvedValue('');
     const term = createMockTerminal();
     const writeToPty = vi.fn();
     pasteIntoTerminal(term as any, writeToPty);
@@ -579,6 +604,7 @@ describe('pasteIntoTerminal', () => {
 
   it('calls onImagePaste when clipboard has image but no text', async () => {
     clipboardReadText.mockResolvedValue('');
+    mockReadClipboardText.mockResolvedValue('');
     // Mock the native Electron clipboard to return an image
     mockReadClipboardImage.mockResolvedValue({ base64: 'abc123', mimeType: 'image/png' });
 

--- a/src/renderer/features/terminal/clipboard.ts
+++ b/src/renderer/features/terminal/clipboard.ts
@@ -6,11 +6,20 @@ function platformIsMac(): boolean {
 
 /**
  * Read text from the system clipboard.
- * Falls back to empty string on failure (e.g. permission denied).
+ * Falls back to Electron's native clipboard when the browser Clipboard API
+ * returns empty or fails; some macOS pasteboard producers expose large
+ * plaintext more reliably through the native API.
  */
 export async function readClipboard(): Promise<string> {
   try {
-    return await navigator.clipboard.readText();
+    const text = await navigator.clipboard.readText();
+    if (text) return text;
+  } catch {
+    // Try the native Electron clipboard fallback below.
+  }
+
+  try {
+    return await window.clubhouse.app.readClipboardText();
   } catch {
     return '';
   }

--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -31,7 +31,7 @@ const mockApp = {
 
 vi.stubGlobal('window', {
   ...globalThis.window,
-  clubhouse: { annexClient: mockAnnexClient, app: mockApp },
+  clubhouse: { ...globalThis.window.clubhouse, annexClient: mockAnnexClient, app: { ...globalThis.window.clubhouse.app, ...mockApp } },
 });
 
 function makeProject(overrides: Partial<Project> = {}): Project {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -208,6 +208,7 @@ export const IPC = {
     GET_VERSION_HISTORY: 'app:get-version-history',
     GET_CLIPBOARD_SETTINGS: 'app:get-clipboard-settings',
     SAVE_CLIPBOARD_SETTINGS: 'app:save-clipboard-settings',
+    READ_CLIPBOARD_TEXT: 'app:read-clipboard-text',
     READ_CLIPBOARD_IMAGE: 'app:read-clipboard-image',
     GET_CLUBHOUSE_MODE_SETTINGS: 'app:get-clubhouse-mode-settings',
     SAVE_CLUBHOUSE_MODE_SETTINGS: 'app:save-clubhouse-mode-settings',

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -313,6 +313,7 @@ vi.stubGlobal('clubhouse', {
     getVersionHistory: async () => [],
     getClipboardSettings: async () => ({ clipboardCompat: false }),
     saveClipboardSettings: asyncNoop,
+    readClipboardText: async () => '',
     readClipboardImage: async () => null,
     getSessionSettings: async () => ({ promptForName: false, projectOverrides: {} }),
     saveSessionSettings: asyncNoop,


### PR DESCRIPTION
## Summary
- Add a native Electron clipboard text fallback for terminal paste when `navigator.clipboard.readText()` returns empty or fails.
- Cover large macOS TextEdit-style plaintext paste with renderer regression tests.
- Harden e2e `launchApp()` window selection so Playwright does not target DevTools.

## Changes
- Added `IPC.APP.READ_CLIPBOARD_TEXT`, a main-process `clipboard.readText()` handler, and preload bridge method.
- Updated terminal paste logic to prefer browser clipboard text but fall back to native Electron text before trying image paste.
- Added tests for browser success, empty-browser/native-text fallback, browser-throw/native-text fallback, and all-text-empty image fallback behavior.
- Kept renderer preload test mocks in sync and preserved the shared preload mock in ProjectRail tests.
- Updated e2e launch window selection to choose the packaged app renderer URL instead of DevTools.

## Test Plan
- [x] `npm test -- --run src/renderer/features/terminal/clipboard.test.ts src/main/ipc/app-handlers.test.ts`
- [x] `npm test -- --run test/preload-bridge-sync.test.ts src/renderer/features/terminal/clipboard.test.ts src/main/ipc/app-handlers.test.ts`
- [x] `npm test -- --run src/renderer/panels/ProjectRail.test.tsx test/preload-bridge-sync.test.ts`
- [x] `npm run typecheck`
- [x] `npm test -- --project main`
- [x] `npm test -- --project renderer`
- [x] `npm test -- --project shared`
- [x] `npm test -- --project integration`
- [x] `npm run make`
- [x] `npm run lint`
- [x] `npx playwright test e2e/agent-list-ui.spec.ts --reporter=line`

## Manual Validation
- Full `npm run validate && npm run lint` could not complete as a single command: this repo has no `build` script required by the skill, `vitest run` hung once when run as all projects together, and the full Playwright suite later blocked in unrelated Annex e2e specs (`annex-v2/full-demo` / `annex-v2/lifecycle`) after the app-window selection issue was fixed. The individual Vitest projects, package build, lint, and focused e2e launch regression all passed.