### PR TITLE
fix(settings): open right-clicked project settings + persist last-viewed section

### DIFF
--- a/docs/telemetry-design/01-overview.md
+++ b/docs/telemetry-design/01-overview.md
@@ -1,0 +1,57 @@
+# Telemetry Plugin — Overview & Backend
+
+## Problem
+
+Clubhouse currently has zero telemetry. All logs are local-only with an explicit "never transmitted" message in the UI. This makes it impossible to understand error rates, feature adoption, or debug issues across deployments.
+
+## Goal
+
+An **opt-in, privacy-first** telemetry plugin that gives operators clear control over what's sent, while providing actionable error and usage data.
+
+**Want:** errors, feature usage, session health
+**Don't want:** chat content, mission text, file paths, agent names, PII
+
+---
+
+## Backend Recommendation: Azure Application Insights
+
+### Why App Insights
+
+| Option | Verdict | Reasoning |
+|--------|---------|-----------|
+| **App Insights** | Recommended | Built-in dashboards, alerting, anomaly detection. Lightweight Node.js SDK (~200KB). Can export to ADX later via continuous export. |
+| **ADX (Kusto)** | Deferred | More powerful querying, but requires managing clusters and building ingestion pipelines. Use as a downstream sink from App Insights when needed. |
+| **Event Hubs** | Overkill | Designed for millions of events/sec. Requires a separate consumer and storage layer. App Insights uses Event Hubs internally anyway. |
+
+### SDK
+
+The `applicationinsights` Node.js SDK v3 provides `TelemetryClient` for custom events. It runs in the Electron main process — no browser dependencies.
+
+### Connection String
+
+- **Default:** Baked into the app binary (ingestion-only key). This is standard practice — VS Code does the same with `vscode-extension-telemetry`. The key cannot read data back.
+- **Override:** Advanced users can point at their own App Insights instance via a settings field.
+- **Rate limiting:** Configured on the Azure side to prevent abuse of the ingestion endpoint.
+
+---
+
+## Plugin Architecture: Built-in Plugin
+
+### Why Built-in (not Community)
+
+1. **Log stream access** — needs main-process hook into `appLog()`. Community plugins can only write logs, not read/intercept them.
+2. **App-level consent** — consent UX belongs at the app level, not scoped to a project.
+3. **Trust** — users need to know this ships from Clubhouse. A community plugin that "phones home" raises suspicion.
+4. **Still cleanly disableable** — same toggle mechanism as `canvas`, `review`, `sessions`.
+
+### Plugin Properties
+
+```
+id:              'telemetry'
+scope:           'app'
+permissions:     ['storage', 'events', 'logging']  (all safe-tier)
+settingsPanel:   'custom'
+gated by:        experimentalFlags.telemetry
+```
+
+No elevated or dangerous permissions required. This matters for user trust.

--- a/docs/telemetry-design/02-data-pipeline.md
+++ b/docs/telemetry-design/02-data-pipeline.md
@@ -1,0 +1,84 @@
+# Telemetry Plugin — Data Pipeline
+
+## Architecture
+
+```
+appLog(ns, level, msg, {meta})
+    |
+    v
+log-service.ts  ──>  JSONL on disk (unchanged)
+    |
+    +── [NEW] subscriber callback
+            |
+            v
+    TelemetryCollector
+        1. classify(entry.ns)  ──>  ALLOW or DROP
+        2. redact(entry)       ──>  strip sensitive meta, sanitize msg
+        3. ring buffer         ──>  in-memory, max 500 events
+            |
+            v
+    BatchSender (flush every 30s OR 100 events, whichever first)
+            |
+            v
+    App Insights trackEvent()
+```
+
+## Hook Point: Log Subscriber Pattern
+
+The only change to existing code: add `subscribe(fn)` / `unsubscribe(fn)` to `log-service.ts`.
+
+**Location:** `src/main/services/log-service.ts`, after the buffer push on line ~132.
+
+```typescript
+// New exports
+const subscribers: Array<(entry: LogEntry) => void> = [];
+
+export function subscribe(fn: (entry: LogEntry) => void): void {
+  subscribers.push(fn);
+}
+
+export function unsubscribe(fn: (entry: LogEntry) => void): void {
+  const idx = subscribers.indexOf(fn);
+  if (idx >= 0) subscribers.splice(idx, 1);
+}
+
+// In the log() function, after buffer.push(line):
+for (const sub of subscribers) sub(entry);
+```
+
+**Cost when disabled:** Zero. Empty array iteration is free. The subscriber only exists when the telemetry plugin is activated.
+
+## Batching Strategy
+
+| Trigger | Value | Reasoning |
+|---------|-------|-----------|
+| Time-based | 30 seconds | Keeps data fresh without excessive network calls |
+| Count-based | 100 events | Prevents large batches sitting in memory |
+| App quit | Synchronous flush | Register on `app.on('before-quit')`, same pattern as log-service |
+
+## Offline / Failure Handling
+
+- **In-memory ring buffer only.** Max 500 events. Oldest events evicted when full.
+- **No disk queue.** Telemetry is ephemeral and aggregate. Missing batches during offline periods is acceptable. Disk queuing adds complexity and creates a second copy of telemetry data on the local machine.
+- **Retry:** 3 attempts per batch with exponential backoff (1s → 4s → 16s). After 3 failures, drop the batch and log a local warning.
+
+## Transmission Payload
+
+Each event sent to App Insights:
+
+```typescript
+interface TelemetryEvent {
+  name: string;              // e.g., "error/uncaught", "usage/agent-spawned"
+  properties: {
+    sessionId: string;       // random UUID, generated at app start, not persisted
+    appVersion: string;
+    platform: string;        // darwin | win32 | linux
+    arch: string;            // x64 | arm64
+    schemaVersion: number;   // starts at 1, bumped on breaking changes
+    level: string;           // debug | info | warn | error | fatal
+    category: string;        // 'error' | 'usage' | 'health'
+    ns: string;              // original namespace
+    // ... allowlisted meta fields (varies by namespace)
+  };
+}
+```

--- a/docs/telemetry-design/03-data-classification.md
+++ b/docs/telemetry-design/03-data-classification.md
@@ -1,0 +1,146 @@
+# Telemetry Plugin — Data Classification & Privacy
+
+## Namespace Tiers
+
+Every log namespace is classified into one of three tiers. Unknown/new namespaces default to **DROP**.
+
+### Tier 1 — Safe to Send (errors + health signals)
+
+These namespaces contain no user-specific data in their messages or meta:
+
+- `core:process` — uncaught exceptions, unhandled rejections
+- `core:startup` — app version, platform, startup timing
+- `core:shutdown` — clean vs dirty shutdown
+- `core:safe-mode` — crash loop detection, safe mode activation
+- `update:check` — update availability checks
+- `update:download` — update download lifecycle
+- `update:apply` — update application
+- `update:apply-on-quit` — silent update on quit
+- `update:session-resume` — session restore success/failure
+- `marketplace` — plugin install/uninstall events (not names/URLs)
+
+### Tier 2 — Safe with Field Stripping
+
+These namespaces are useful for feature adoption metrics but their meta contains sensitive fields:
+
+- `core:agent` — agent spawn/kill events (strip: agentId, model, projectPath, binary, args)
+- `core:mcp` — MCP bridge lifecycle (strip: tool names, binding details)
+- `core:structured` — structured mode lifecycle (strip: session details)
+- `core:headless` — headless agent lifecycle (strip: mission, PID)
+- `core:hook-server` — hook server health
+- `core:annex` — annex server start/stop (strip: peer fingerprints, IPs)
+
+### Tier 3 — Never Send
+
+These namespaces inherently contain project/user data:
+
+`core:file`, `core:security`, `core:materialization`, `core:agent-config`, `core:config-pipeline`, `core:project`, `core:ipc`, `core:git`, `core:companion`, `core:annex-client`, `core:annex-server`, `core:agent-queue`, `core:group-project`, `core:plugin-storage`, `core:config-diff`, `core:agent-settings`, `core:orchestrator`, `core:project-store`, `core:window`, all `plugin:*`, `marketplace:custom`, `marketplace:updates`
+
+---
+
+## Meta Field Allowlist
+
+The `meta` field is `Record<string, unknown>` — a completely open bag and the primary privacy risk.
+
+**Strategy:** Static map of `namespace -> allowed meta keys`. Everything else stripped.
+
+```
+Namespace           Allowed Keys                    Stripped Keys (examples)
+─────────────────   ─────────────────────────────   ──────────────────────────────
+core:process        [nodeVersion]                   stack, message (may contain paths)
+core:startup        [version, platform, arch]       everything else
+core:shutdown       []                              everything
+core:safe-mode      [attempt]                       lastEnabledPlugins
+core:agent          [kind]                          agentId, model, projectPath, binary, args, cwd
+core:mcp            []                              all meta
+core:structured     []                              all meta
+core:headless       []                              all meta
+update:check        [currentVersion, latestVersion] sourceUrl, downloadPath
+update:download     []                              everything
+update:apply        [platform]                      version, path
+```
+
+---
+
+## Message Sanitization
+
+| Tier | Strategy |
+|------|----------|
+| Tier 1 | Send msg truncated to 200 chars |
+| Tier 2 | Replace msg with canonical event ID (e.g., `agent:spawn`, `mcp:bridge-start`) |
+
+### Path Detection Safety Net
+
+A regex runs on ALL string values (msg + meta) regardless of allowlist:
+
+```
+/(?:\/[\w.-]+){2,}|[A-Z]:\\[\w.-\\]+/g  -->  <path>
+```
+
+This catches cases where an "allowed" meta key accidentally contains a filesystem path.
+
+### Error Type Extraction
+
+For `core:process` errors (uncaught exceptions), only the error class name is kept:
+- `TypeError: Cannot read properties of undefined` → `TypeError`
+- `Error: ENOENT: no such file or directory, open '/Users/...'` → `Error`
+
+The message and stack trace are always stripped.
+
+---
+
+## Session Anonymization
+
+- **Session ID:** Random UUID v4, generated at app start, not persisted across sessions
+- **No machine ID.** No user ID. Events cannot be correlated across sessions.
+- **Included:** appVersion, platform (darwin/win32/linux), arch (x64/arm64)
+- **Future option:** If cross-session correlation is needed later, store a random install ID in plugin storage with a UI button to regenerate it at any time
+
+---
+
+## What Gets Collected
+
+### Errors
+
+| Event | Source Namespace | Fields | Purpose |
+|-------|-----------------|--------|---------|
+| `error/uncaught` | `core:process` | errorType, level | Crash-causing error types |
+| `error/unhandled-rejection` | `core:process` | errorType, level | Async error types |
+| `error/update-failed` | `update:*` | phase, platform | Update failure tracking |
+| `error/safe-mode-triggered` | `core:safe-mode` | attempt | Crash loop frequency |
+| `error/mcp-bridge-failed` | `core:mcp` | (none) | MCP reliability |
+
+### Feature Usage
+
+| Event | Source | Fields | Purpose |
+|-------|--------|--------|---------|
+| `usage/agent-spawned` | `core:agent` | kind, isStructured | Agent type adoption |
+| `usage/agent-killed` | `core:agent` | (none) | Session length proxy |
+| `usage/structured-session` | `core:structured` | (none) | Structured mode adoption |
+| `usage/mcp-binding-created` | `core:mcp` | (none) | MCP adoption |
+| `usage/plugin-installed` | `marketplace` | (none) | Marketplace engagement |
+| `usage/headless-spawned` | `core:headless` | (none) | Headless mode adoption |
+
+### Session Health
+
+| Event | Source | Fields | Purpose |
+|-------|--------|--------|---------|
+| `health/session-start` | `core:startup` | appVersion, platform, arch | Version distribution |
+| `health/session-end` | `core:shutdown` | uptimeSeconds | Session duration |
+| `health/update-check` | `update:check` | currentVersion, latestVersion | Update staleness |
+| `health/resume-success` | `update:session-resume` | (none) | Resume reliability |
+| `health/resume-failed` | `update:session-resume` | (none) | Resume failure rate |
+
+---
+
+## What is NEVER Collected (explicit exclusions)
+
+- Chat content, messages, mission text, prompts
+- File paths, file names, file contents
+- Agent names, project names, project paths
+- Git data (branches, commits, diffs)
+- MCP tool names, tool arguments, tool results
+- Plugin IDs, plugin names, custom marketplace URLs
+- Error stack traces, error messages (only error type names)
+- IP addresses, peer fingerprints, Annex identity data
+- Model names, orchestrator-specific configuration

--- a/docs/telemetry-design/04-settings-and-ux.md
+++ b/docs/telemetry-design/04-settings-and-ux.md
@@ -1,0 +1,140 @@
+# Telemetry Plugin — Settings & Consent UX
+
+## Managed Settings
+
+Follows the existing `createManagedSettings()` + `createSettingsStore()` pattern. Adding a new settings definition requires changes to exactly 3 files (definition, main registration, renderer store).
+
+```typescript
+interface TelemetrySettings {
+  enabled: boolean;                    // master toggle, default: false
+  categories: {
+    errors: boolean;                   // default: true (when enabled)
+    usage: boolean;                    // default: true
+    health: boolean;                   // default: true
+  };
+  customConnectionString: string;      // default: '' (uses built-in)
+  consentShown: boolean;               // tracks if consent banner was displayed
+}
+```
+
+**Storage:** `~/.clubhouse/telemetry-settings.json`
+
+---
+
+## Consent Flow
+
+### First-Time Experience
+
+When the telemetry experimental flag is enabled and `consentShown` is false:
+
+1. A **non-blocking banner** appears in the settings view (not a modal that blocks the app)
+2. Banner text: *"Help improve Clubhouse by sharing anonymous usage data. No chat content, file paths, or personal information is ever sent."*
+3. Two buttons: **"Enable Telemetry"** / **"No Thanks"**
+4. Choice is persisted (`consentShown: true`), banner never shown again
+5. User can always change their mind later via the settings toggle
+
+This follows the existing experimental features disclaimer pattern in `ExperimentalSettingsView.tsx`.
+
+### No Defaults-On
+
+Telemetry is **off by default**. The user must explicitly opt in. This is non-negotiable for trust.
+
+---
+
+## Settings UI Layout
+
+### Telemetry Settings Panel
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Telemetry                                          │
+│                                                     │
+│  [Toggle] Enable Telemetry                          │
+│  Anonymous usage data only. No chat content,        │
+│  file paths, or personal information.               │
+│                                                     │
+│  ── Categories ──────────────────────────────────    │
+│  [Toggle] Error Reports                             │
+│           Uncaught exceptions, update failures      │
+│                                                     │
+│  [Toggle] Feature Usage                             │
+│           Which features are used, agent counts     │
+│                                                     │
+│  [Toggle] Session Health                            │
+│           Startup timing, shutdown, crash recovery   │
+│                                                     │
+│  ── Advanced ────────────────────────────────────    │
+│  Connection String  [________________________]      │
+│  Override to send to your own App Insights instance  │
+│                                                     │
+│  [Preview Data]                                     │
+│  See the last 10 events that would be sent          │
+└─────────────────────────────────────────────────────┘
+```
+
+- Category toggles only visible when master toggle is on
+- Advanced section collapsed by default
+- "Preview Data" opens a dialog (see below)
+
+### Data Preview Dialog
+
+A modal dialog showing the ring buffer contents:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Telemetry Data Preview                     [Close] │
+│                                                     │
+│  These are the most recent events that would be     │
+│  sent when telemetry is enabled.                    │
+│                                                     │
+│  ┌─ Event 1 ─────────────────────────────────────┐  │
+│  │ name: "health/session-start"                  │  │
+│  │ properties:                                   │  │
+│  │   sessionId: "a1b2c3d4-..."                   │  │
+│  │   appVersion: "0.39.0"                        │  │
+│  │   platform: "darwin"                          │  │
+│  │   arch: "arm64"                               │  │
+│  │   schemaVersion: 1                            │  │
+│  │   category: "health"                          │  │
+│  └───────────────────────────────────────────────┘  │
+│  ┌─ Event 2 ─────────────────────────────────────┐  │
+│  │ name: "usage/agent-spawned"                   │  │
+│  │ properties:                                   │  │
+│  │   kind: "durable"                             │  │
+│  │   isStructured: false                         │  │
+│  │   ...                                         │  │
+│  └───────────────────────────────────────────────┘  │
+│                                                     │
+│  Showing 10 of 47 buffered events                   │
+└─────────────────────────────────────────────────────┘
+```
+
+Exposed via IPC channel `telemetry:preview` that returns sanitized ring buffer contents.
+
+---
+
+## Logging Settings Privacy Banner Update
+
+Current text in `LoggingSettingsView.tsx` (line 36):
+> "Logs are stored on your local disk only and are never transmitted."
+
+Updated text:
+> "Logs are stored on your local disk only. If the optional telemetry plugin is enabled, anonymized usage data may be sent separately."
+
+This maintains trust by being transparent about the telemetry option's existence while making it clear logs themselves are never sent.
+
+---
+
+## Experimental Flag
+
+Add `telemetry` to the experimental settings array in `ExperimentalSettingsView.tsx`:
+
+```typescript
+{
+  id: 'telemetry',
+  label: 'Telemetry',
+  description: 'Opt-in anonymous usage data and error reporting to help improve Clubhouse.'
+}
+```
+
+The plugin only loads when this flag is `true`, following the same pattern as `sessions` and `review`.

--- a/docs/telemetry-design/05-current-log-fitness.md
+++ b/docs/telemetry-design/05-current-log-fitness.md
@@ -1,0 +1,89 @@
+# Telemetry Plugin — Current Log Fitness Assessment
+
+## What Works Well
+
+### Structured Format
+- JSONL with consistent `{ts, ns, level, msg, meta}` schema
+- Machine-parseable, easy to classify and filter
+- One entry per line, no multiline parsing needed
+
+### Namespace Granularity
+- 47+ distinct namespaces (e.g., `core:agent`, `core:mcp`, `update:check`)
+- Allows precise allowlisting at the namespace level
+- Namespace filtering already exists in the logging settings UI
+
+### Settings Infrastructure
+- Master enable/disable toggle already exists
+- Namespace-level filtering already exists
+- Retention tiers already implemented (3 days → unlimited)
+- Min log level filtering already exists
+
+### Separation of Concerns
+- Logs only flow through `appLog()` → `log()` in `log-service.ts`
+- Single chokepoint for adding a subscriber/observer
+- No other logging paths to worry about
+
+---
+
+## What Needs Improvement
+
+### Open Meta Bag
+
+The `meta` field is typed as `Record<string, unknown>` — there's no schema enforcement on what goes in. This means:
+
+- **Any caller can put anything in meta** — file paths, agent names, mission text, model names
+- **No way to statically know** what a given namespace's meta contains without reading every call site
+- **New appLog calls can introduce new sensitive data** without any review gate
+
+**Mitigation for telemetry:** The allowlist approach (namespace → allowed keys) handles this at the telemetry layer. But longer-term, consider adding typed meta interfaces per namespace.
+
+### Interpolated Messages
+
+The `msg` field often contains interpolated runtime values:
+
+```typescript
+// Examples from the codebase:
+appLog('core:agent', 'info', `Spawning ${params.kind} agent`, { meta: { agentId, model, cwd } });
+appLog('core:mcp', 'info', `Binding created for ${agentId}`, { meta: { port } });
+appLog('update:check', 'info', `Update available: ${manifest.version}`, { meta: { ... } });
+```
+
+Some of these are safe (kind names, version numbers), but others could contain paths or IDs if the interpolation pattern changes.
+
+**Mitigation for telemetry:** For Tier 2 namespaces, replace the msg with a canonical event ID rather than sending the freeform string. For Tier 1, truncate to 200 chars and run path detection regex.
+
+### No Call-Site Sensitivity Annotation
+
+There's no convention for marking which meta keys are safe vs sensitive at the appLog call site. This makes it hard to audit.
+
+**Suggested convention (for future):**
+```typescript
+// TELEMETRY: safe=[kind]; sensitive=[agentId, model, cwd, binary, args]
+appLog('core:agent', 'info', `Spawning ${params.kind} agent`, {
+  meta: { kind, agentId, model, cwd, binary, args },
+});
+```
+
+This doesn't change runtime behavior but provides a review checkpoint for PRs.
+
+---
+
+## No Structural Changes Needed
+
+The telemetry plugin does not require changes to the log format, the appLog API, or the existing logging settings. The subscriber pattern in `log-service.ts` is the only integration point. All classification and redaction happens in the new telemetry module.
+
+---
+
+## Namespace Inventory (for reference)
+
+| Category | Namespaces | Count |
+|----------|-----------|-------|
+| Core system | `core:agent`, `core:mcp`, `core:structured`, `core:headless`, `core:pty`, `core:process`, `core:startup`, `core:shutdown`, `core:safe-mode`, `core:hook-server`, `core:ipc`, `core:security`, `core:window`, `core:plugins`, `core:plugin-storage` | 15 |
+| Agent/config | `core:agent-config`, `core:agent-settings`, `core:agent-queue`, `core:materialization`, `core:config-pipeline`, `core:config-diff`, `core:orchestrator`, `core:companion` | 8 |
+| Files/project | `core:file`, `core:git`, `core:project`, `core:project-store`, `core:group-project` | 5 |
+| Networking | `core:annex`, `core:annex-client`, `core:annex-server` | 3 |
+| Updates | `update:check`, `update:download`, `update:apply`, `update:apply-on-quit`, `update:apply-detect`, `update:fetch`, `update:history`, `update:retry`, `update:session-resume` | 9 |
+| Marketplace | `marketplace`, `marketplace:custom`, `marketplace:updates` | 3 |
+| App | `app:ipc`, `app:test` | 2 |
+| Structured mode | `core:structured:acp`, `core:structured:codex` | 2 |
+| **Total** | | **47** |

--- a/docs/telemetry-design/06-implementation-map.md
+++ b/docs/telemetry-design/06-implementation-map.md
@@ -1,0 +1,85 @@
+# Telemetry Plugin — Implementation Map
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/main/services/log-service.ts` | Add `subscribe(fn)` / `unsubscribe(fn)` observer pattern (~10 lines) |
+| `src/shared/settings-definitions.ts` | Add `TELEMETRY_SETTINGS` definition |
+| `src/shared/types.ts` | Add `TelemetrySettings` interface |
+| `src/main/ipc/settings-handlers.ts` | Register managed settings (1 line) |
+| `src/renderer/plugins/builtin/index.ts` | Register telemetry plugin, gated by experimental flag |
+| `src/renderer/features/settings/ExperimentalSettingsView.tsx` | Add `telemetry` to feature array |
+| `src/renderer/features/settings/LoggingSettingsView.tsx` | Update privacy banner text |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `src/main/services/telemetry-collector.ts` | Classifier, redactor, ring buffer, batch sender |
+| `src/main/services/telemetry-settings.ts` | `createManagedSettings(TELEMETRY_SETTINGS)` |
+| `src/renderer/plugins/builtin/telemetry/manifest.ts` | Plugin manifest (app-scoped, custom settings) |
+| `src/renderer/plugins/builtin/telemetry/main.ts` | activate/deactivate lifecycle hooks |
+| `src/renderer/features/settings/TelemetrySettingsView.tsx` | Settings panel with consent, toggles, preview |
+| `src/renderer/stores/telemetryStore.ts` | `createSettingsStore(TELEMETRY_SETTINGS)` |
+
+## New Test Files
+
+| File | Coverage |
+|------|----------|
+| `src/main/services/telemetry-collector.test.ts` | Classifier, redactor, ring buffer, batch sender |
+| `src/renderer/features/settings/TelemetrySettingsView.test.tsx` | Settings UI, consent flow, preview dialog |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Infrastructure (main process)
+
+1. Add subscriber pattern to `log-service.ts`
+2. Define `TelemetrySettings` type and managed settings definition
+3. Create `telemetry-settings.ts` and register in `settings-handlers.ts`
+4. Create `telemetry-collector.ts` — classifier, redactor, ring buffer, batch sender
+5. Integrate App Insights SDK (`applicationinsights` npm package)
+
+### Phase 2: Plugin Shell (renderer)
+
+6. Create manifest and main.ts in `builtin/telemetry/`
+7. Register in `builtin/index.ts`, gated by experimental flag
+8. Add `telemetry` to `ExperimentalSettingsView.tsx`
+
+### Phase 3: Settings UI
+
+9. Create `TelemetrySettingsView.tsx` — master toggle, category toggles, consent banner
+10. Create Zustand store via `createSettingsStore()`
+11. Add IPC channel for data preview (`telemetry:preview`)
+12. Build data preview dialog
+
+### Phase 4: Privacy Review & Testing
+
+13. Write classifier unit tests — every namespace mapped, unknown namespaces dropped
+14. Write redactor unit tests — sensitive meta stripped, paths detected, allowlist enforced
+15. Write fuzz test — random meta objects, verify no paths/PII leak through
+16. Write integration test — appLog with sensitive meta → sanitized output in ring buffer
+17. Update logging settings privacy banner
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Accidental PII leak through new appLog calls | Medium | High | Path regex on all strings, meta allowlist, schema tests |
+| Performance impact from subscriber | Low | Medium | Short-circuit when no subscribers; classifier is O(1) hashmap lookup |
+| App Insights SDK size bloat | Medium | Low | Lightweight Node SDK (~200KB), not the full web SDK |
+| Users alarmed by "telemetry" | Medium | Medium | Clear settings UI, data preview, prominent "off by default" |
+| Connection string in binary | Low | Low | Ingestion-only key, rate limiting on Azure side |
+
+---
+
+## Open Questions
+
+1. **Install ID for cross-session correlation?** Currently no way to track unique installs. Is this needed for v1, or can it wait?
+2. **Custom dimensions in App Insights?** Should we define custom dimensions for the KQL queries, or keep everything in the flat properties bag?
+3. **Alert rules?** Should we pre-configure Azure Monitor alert rules (e.g., error rate spike) as part of the backend setup?
+4. **Marketplace telemetry?** Should we track which plugins are installed (by category/count, not by name) or leave marketplace out entirely?

--- a/src/renderer/panels/ProjectRail.test.tsx
+++ b/src/renderer/panels/ProjectRail.test.tsx
@@ -231,6 +231,26 @@ describe('ProjectRail context menu', () => {
     render(<ProjectRail />);
     expect(screen.queryByTestId('project-context-menu')).not.toBeInTheDocument();
   });
+
+  it('opens that project\'s settings when Settings is clicked (GH context-menu fix)', () => {
+    useProjectStore.setState({
+      projects: [makeProject({ id: 'p1', name: 'Alpha' }), makeProject({ id: 'p2', name: 'Beta' })],
+      activeProjectId: 'p2',
+    });
+
+    render(<ProjectRail />);
+    const projectButton = screen.getByTestId('project-p1');
+    fireEvent.contextMenu(projectButton.parentElement!);
+    fireEvent.click(screen.getByTestId('ctx-project-settings'));
+
+    const ui = useUIStore.getState();
+    expect(ui.explorerTab).toBe('settings');
+    // Must scope to the right-clicked project, not the literal string 'project'.
+    expect(ui.settingsContext).toBe('p1');
+    expect(ui.settingsSubPage).toBe('project');
+    // Also makes it the active project.
+    expect(useProjectStore.getState().activeProjectId).toBe('p1');
+  });
 });
 
 describe('ProjectRail pin button', () => {

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -255,8 +255,7 @@ function AnnexGatedPluginRailButton({ entry, pluginMatches, isActive, onClick, e
 export function ProjectRail() {
   const { projects, activeProjectId, setActiveProject, pickAndAddProject, reorderProjects, removeProject } =
     useProjectStore();
-  const setSettingsContext = useUIStore((s) => s.setSettingsContext);
-  const setSettingsSubPage = useUIStore((s) => s.setSettingsSubPage);
+  const openProjectSettings = useUIStore((s) => s.openProjectSettings);
   const toggleSettings = useUIStore((s) => s.toggleSettings);
   const toggleAssistant = useUIStore((s) => s.toggleAssistant);
   const toggleHelp = useUIStore((s) => s.toggleHelp);
@@ -843,9 +842,7 @@ export function ProjectRail() {
           onClose={() => setContextMenu(null)}
           onSettings={() => {
             setActiveProject(contextMenu.projectId);
-            toggleSettings();
-            setSettingsContext('project');
-            setSettingsSubPage('project');
+            openProjectSettings(contextMenu.projectId);
           }}
           onCloseProject={async () => {
             const { promise } = showConfirmDialog('Close this project? Project-specific settings may need to be reconfigured.');

--- a/src/renderer/stores/projectStore.test.ts
+++ b/src/renderer/stores/projectStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Project } from '../../shared/types';
 import { useBadgeStore } from './badgeStore';
 import { useBadgeSettingsStore } from './badgeSettingsStore';
+import { useUIStore } from './uiStore';
 
 // ---------- IPC mock ----------
 const mockProject = {
@@ -215,6 +216,27 @@ describe('projectStore', () => {
       await getState().removeProject('proj_2');
 
       expect(getState().activeProjectId).toBe('proj_1');
+    });
+
+    it('resets settings context to app when the removed project was the settings scope', async () => {
+      const p = makeProject();
+      useProjectStore.setState({ projects: [p], activeProjectId: 'proj_1' });
+      useUIStore.setState({ settingsContext: 'proj_1', settingsSubPage: 'project' });
+
+      await getState().removeProject('proj_1');
+
+      expect(useUIStore.getState().settingsContext).toBe('app');
+    });
+
+    it('leaves settings context untouched when a different project is removed', async () => {
+      const p1 = makeProject();
+      const p2 = makeProject({ id: 'proj_2', name: 'other', path: '/other' });
+      useProjectStore.setState({ projects: [p1, p2], activeProjectId: 'proj_1' });
+      useUIStore.setState({ settingsContext: 'proj_1', settingsSubPage: 'project' });
+
+      await getState().removeProject('proj_2');
+
+      expect(useUIStore.getState().settingsContext).toBe('proj_1');
     });
 
     it('LB-SM-002: clears badge store entries for the removed project', async () => {

--- a/src/renderer/stores/projectStore.ts
+++ b/src/renderer/stores/projectStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { Project } from '../../shared/types';
 import { useBadgeStore } from './badgeStore';
+import { useUIStore } from './uiStore';
 
 interface ProjectState {
   projects: Project[];
@@ -78,6 +79,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       return { projects, activeProjectId, gitStatus, projectIcons };
     });
     useBadgeStore.getState().clearProjectBadges(id);
+    // If settings was scoped to the removed project, fall back to app-level
+    // so re-entering settings doesn't land on an empty "Select a project" state.
+    if (useUIStore.getState().settingsContext === id) {
+      useUIStore.getState().setSettingsContext('app');
+    }
   },
 
   pickAndAddProject: async () => {

--- a/src/renderer/stores/uiStore.test.ts
+++ b/src/renderer/stores/uiStore.test.ts
@@ -30,7 +30,7 @@ describe('uiStore', () => {
     useUIStore.setState({
       explorerTab: 'agents',
       previousExplorerTab: null,
-      settingsSubPage: 'display',
+      settingsSubPage: 'orchestrators',
       settingsContext: 'app',
       showHome: true,
       projectExplorerTab: {},
@@ -40,8 +40,8 @@ describe('uiStore', () => {
   });
 
   describe('settingsSubPage default', () => {
-    it('defaults to display', () => {
-      expect(getState().settingsSubPage).toBe('display');
+    it('defaults to orchestrators', () => {
+      expect(getState().settingsSubPage).toBe('orchestrators');
     });
   });
 
@@ -51,8 +51,19 @@ describe('uiStore', () => {
       getState().toggleSettings();
       expect(getState().explorerTab).toBe('settings');
       expect(getState().previousExplorerTab).toBe('agents');
-      expect(getState().settingsSubPage).toBe('orchestrators');
-      expect(getState().settingsContext).toBe('app');
+    });
+
+    it('restores the last-viewed section and context when re-entering settings', () => {
+      // User was last on a project-scoped Notifications page, then left settings.
+      useUIStore.setState({
+        explorerTab: 'agents',
+        settingsSubPage: 'notifications',
+        settingsContext: 'proj-1',
+      });
+      getState().toggleSettings();
+      expect(getState().explorerTab).toBe('settings');
+      expect(getState().settingsSubPage).toBe('notifications');
+      expect(getState().settingsContext).toBe('proj-1');
     });
 
     it('exits settings mode and restores previous tab', () => {
@@ -208,10 +219,37 @@ describe('uiStore', () => {
       expect(getState().settingsSubPage).toBe('project');
     });
 
-    it('toggleSettings resets context to app', () => {
+    it('toggleSettings preserves context across re-entry', () => {
       useUIStore.setState({ explorerTab: 'agents', settingsContext: 'proj-1' });
       getState().toggleSettings();
-      expect(getState().settingsContext).toBe('app');
+      expect(getState().settingsContext).toBe('proj-1');
+    });
+  });
+
+  describe('openProjectSettings', () => {
+    it('enters settings scoped to the given project on the project page', () => {
+      useUIStore.setState({ explorerTab: 'agents', settingsContext: 'app', settingsSubPage: 'orchestrators' });
+      getState().openProjectSettings('proj-1');
+      expect(getState().explorerTab).toBe('settings');
+      expect(getState().settingsContext).toBe('proj-1');
+      expect(getState().settingsSubPage).toBe('project');
+      expect(getState().previousExplorerTab).toBe('agents');
+    });
+
+    it('preserves previousExplorerTab when already in settings', () => {
+      useUIStore.setState({ explorerTab: 'settings', previousExplorerTab: 'agents', settingsContext: 'app' });
+      getState().openProjectSettings('proj-2');
+      expect(getState().settingsContext).toBe('proj-2');
+      expect(getState().settingsSubPage).toBe('project');
+      // Coming from another settings page must not overwrite the saved origin tab.
+      expect(getState().previousExplorerTab).toBe('agents');
+    });
+
+    it('switches directly between two projects settings', () => {
+      getState().openProjectSettings('proj-1');
+      getState().openProjectSettings('proj-2');
+      expect(getState().settingsContext).toBe('proj-2');
+      expect(getState().settingsSubPage).toBe('project');
     });
   });
 

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -50,6 +50,7 @@ interface UIState {
   setSettingsSubPage: (page: SettingsSubPage) => void;
   setSettingsContext: (context: 'app' | string) => void;
   toggleSettings: () => void;
+  openProjectSettings: (projectId: string) => void;
   toggleHelp: () => void;
   toggleAssistant: () => void;
   setHelpSection: (id: string) => void;
@@ -80,7 +81,9 @@ function loadActiveHost(): string | null {
 export const useUIStore = create<UIState>((set, get) => ({
   explorerTab: 'agents',
   previousExplorerTab: null,
-  settingsSubPage: 'display',
+  // Initial section shown the first time settings is opened in a session.
+  // After that, toggleSettings restores whatever section/context was last viewed.
+  settingsSubPage: 'orchestrators',
   settingsContext: 'app',
   showHome: initialPrefs.showHome,
   pluginSettingsId: null,
@@ -124,10 +127,21 @@ export const useUIStore = create<UIState>((set, get) => ({
   toggleSettings: () => {
     const { explorerTab, previousExplorerTab } = get();
     if (explorerTab !== 'settings') {
-      set({ previousExplorerTab: explorerTab, explorerTab: 'settings', settingsSubPage: 'orchestrators', settingsContext: 'app' });
+      // Re-enter settings on the last-viewed section/context (kept in store for the session)
+      // rather than resetting to the root every time.
+      set({ previousExplorerTab: explorerTab, explorerTab: 'settings' });
     } else {
       set({ explorerTab: previousExplorerTab || 'agents', previousExplorerTab: null });
     }
+  },
+  openProjectSettings: (projectId) => {
+    const { explorerTab, previousExplorerTab } = get();
+    set({
+      previousExplorerTab: explorerTab !== 'settings' ? explorerTab : previousExplorerTab,
+      explorerTab: 'settings',
+      settingsContext: projectId,
+      settingsSubPage: 'project',
+    });
   },
   toggleHelp: () => {
     const { explorerTab, previousExplorerTab } = get();


### PR DESCRIPTION
## Summary
- **Bug 1:** Right-clicking a project in the rail and choosing **Settings** now opens *that* project's settings instead of the empty "Select a project" state.
- **Bug 2:** Leaving settings and returning now restores the last-viewed section and project context (for the session) instead of resetting to the root.

## Root causes
- **Bug 1** — `ProjectRail.tsx` passed the literal string `'project'` to `setSettingsContext()` instead of the project id. Since `settingsContext` holds either `'app'` or a real project id, the string matched no project and `ProjectSettings` fell back to its empty state.
- **Bug 2** — `toggleSettings()` hard-reset `settingsSubPage`/`settingsContext` to `orchestrators`/`app` on *every* entry, so the last location was always discarded.

## Changes
- `stores/uiStore.ts`
  - Added `openProjectSettings(projectId)` — atomically enters settings scoped to a project (sets `explorerTab: 'settings'`, `settingsContext: projectId`, `settingsSubPage: 'project'`), preserving `previousExplorerTab` correctly whether entering fresh or already in settings.
  - `toggleSettings()` no longer resets `settingsSubPage`/`settingsContext`; it restores whatever was last viewed. Initial `settingsSubPage` default changed to `'orchestrators'` so first-open behavior is unchanged.
- `panels/ProjectRail.tsx` — context-menu `onSettings` now calls `openProjectSettings(contextMenu.projectId)`; removed the now-unused `setSettingsContext`/`setSettingsSubPage` subscriptions.
- `stores/projectStore.ts` — `removeProject` resets `settingsContext` to `'app'` when the removed project was the active settings scope, so a deleted project can't leave settings stuck on the empty state.

## Test Plan
- [x] `uiStore.test.ts` — updated `toggleSettings` tests for the new restore-on-re-entry behavior; added `openProjectSettings` coverage (scopes to project + `project` sub-page, preserves origin tab when already in settings, switches between projects).
- [x] `projectStore.test.ts` — added guard tests (resets context to `app` when the scoped project is removed; leaves context untouched when a different project is removed).
- [x] `ProjectRail.test.tsx` — added a context-menu test asserting clicking **Settings** opens the right-clicked project's settings.
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 12207 passed / 4 skipped (478 files)

## Manual Validation
1. Right-click a project (not the active one) in the rail → **Settings** → confirm it opens that project's Project Settings, not the empty state.
2. Open Settings, navigate to a sub-page (e.g. Notifications / a project scope), leave settings, then reopen within a few seconds → confirm it returns to where you were rather than the root.
3. Scope settings to a project, then close that project → confirm settings falls back to the Clubhouse (app) scope rather than an empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)