### PR TITLE
fix(agents): enable drag-to-reorder in the durable agent list

### DIFF
--- a/src/renderer/features/agents/AgentAvatar.test.tsx
+++ b/src/renderer/features/agents/AgentAvatar.test.tsx
@@ -55,6 +55,20 @@ describe('AgentAvatar', () => {
     expect(img).toHaveAttribute('src', 'data:image/png;base64,abc');
   });
 
+  it('icon image is not natively draggable (regression: img hijacked agent-list drag-to-reorder)', () => {
+    // Native <img> elements are draggable by default in Chromium. When an
+    // agent row shows an image avatar, grabbing the row starts a native image
+    // drag and the row's HTML5 drag-to-reorder never fires. draggable={false}
+    // on the avatar image lets the row drag win.
+    useAgentStore.setState({
+      agentIcons: { 'agent-1': 'data:image/png;base64,abc' },
+    });
+
+    render(<AgentAvatar agent={makeAgent({ icon: 'custom.png' })} />);
+    const img = screen.getByAltText('bold-falcon');
+    expect(img).toHaveAttribute('draggable', 'false');
+  });
+
   it('falls back to initials when icon name set but data missing', () => {
     render(<AgentAvatar agent={makeAgent({ icon: 'custom.png' })} />);
     expect(screen.getByText('BF')).toBeInTheDocument();

--- a/src/renderer/features/agents/AgentAvatar.tsx
+++ b/src/renderer/features/agents/AgentAvatar.tsx
@@ -123,7 +123,7 @@ export function AgentAvatar({ agent, size = 'md', showRing = false, ringColor, i
     if (agent.icon && iconDataUrl) {
       return (
         <div className={`${innerSize} rounded-full overflow-hidden flex-shrink-0`}>
-          <img src={iconDataUrl} alt={agent.name} className="w-full h-full object-cover" />
+          <img src={iconDataUrl} alt={agent.name} draggable={false} className="w-full h-full object-cover" />
         </div>
       );
     }

--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -751,4 +751,32 @@ describe('AgentList drag-reorder re-render', () => {
     const reorderedNames = screen.getAllByTestId(/^agent-item-/).map((el) => el.textContent);
     expect(reorderedNames).toEqual(['charlie', 'alpha', 'bravo']);
   });
+
+  it('fires reorderAgents with the new order when a durable row is dragged onto another', () => {
+    const a: Agent = { id: 'a', projectId: 'proj-1', name: 'alpha', kind: 'durable', status: 'sleeping', color: 'indigo' };
+    const b: Agent = { id: 'b', projectId: 'proj-1', name: 'bravo', kind: 'durable', status: 'sleeping', color: 'indigo' };
+    const c: Agent = { id: 'c', projectId: 'proj-1', name: 'charlie', kind: 'durable', status: 'sleeping', color: 'indigo' };
+    const reorderAgents = vi.fn();
+    useAgentStore.setState({ agents: { a, b, c }, reorderAgents });
+
+    render(<AgentList />);
+
+    // Minimal DataTransfer stub — jsdom does not provide one.
+    const store: Record<string, string> = {};
+    const dataTransfer = {
+      effectAllowed: '',
+      dropEffect: '',
+      setData: (k: string, v: string) => { store[k] = v; },
+      getData: (k: string) => store[k] ?? '',
+    } as unknown as DataTransfer;
+
+    const src = screen.getByTestId('durable-drag-0');
+    const tgt = screen.getByTestId('durable-drag-2');
+    fireEvent.dragStart(src, { dataTransfer });
+    fireEvent.dragOver(tgt, { dataTransfer });
+    fireEvent.drop(tgt, { dataTransfer });
+
+    // alpha (idx 0) moved to idx 2 → bravo, charlie, alpha
+    expect(reorderAgents).toHaveBeenCalledWith('/project', ['b', 'c', 'a']);
+  });
 });

--- a/src/renderer/panels/ProjectRail.tsx
+++ b/src/renderer/panels/ProjectRail.tsx
@@ -148,6 +148,7 @@ const ProjectIcon = React.memo(function ProjectIcon({ project, isActive, onClick
             <img
               src={iconDataUrl}
               alt={label}
+              draggable={false}
               className={`w-full h-full object-cover ${isActive ? 'ring-2 ring-white/30 rounded-lg' : ''}`}
             />
           ) : (


### PR DESCRIPTION
## Summary
- Drag-to-reorder in the **main durable agent list** (inside a project — not the canvas) never actually worked, even after the re-render fix in #1480.
- Root cause: agent rows render an image avatar (`<img>`) when the agent has an icon. `<img>` elements are **draggable by default in Chromium**, so grabbing the row started a native *image* drag and the row's HTML5 reorder drag (`onDragStart`/`onDrop`) never fired.
- The project rail and file-tab lists use byte-for-byte identical reorder handler code but render letters/SVGs (not `<img>`), which is exactly why **only the agent list** was affected — confirmed with the reporter.

## Changes
- `src/renderer/features/agents/AgentAvatar.tsx` — set `draggable={false}` on the avatar `<img>` so the row's drag-to-reorder wins instead of a native image drag.
- `src/renderer/panels/ProjectRail.tsx` — applied the same `draggable={false}` guard to the project icon `<img>`, which carries the identical latent bug for image-based project icons (one-line, risk-free hardening).
- `src/renderer/features/agents/AgentAvatar.test.tsx` — regression test asserting the icon `<img>` renders with `draggable=false`.
- `src/renderer/features/agents/AgentList.test.tsx` — new test that fires real `dragStart`/`dragOver`/`drop` events on durable rows and asserts `reorderAgents` is called with the new order. The handler path was previously only covered indirectly via a store-mutation re-render test.

## Why #1480 wasn't enough
#1480 correctly fixed a real bug — `useShallow` swallowed key-order changes so the list wouldn't re-render after a reorder — but its "manually drag an agent up/down" verification box was never checked. The drag itself never started because the avatar image hijacked it, so the re-render fix alone couldn't surface a reorder.

## Test Plan
- [x] `npm run lint` — 0 errors (warnings unchanged from main)
- [x] `npm run typecheck` — only the pre-existing `mermaid` missing-module error; no errors in touched files
- [x] `npm test` — touched suites pass (AgentAvatar, AgentList, ProjectRail = 107 tests). The 9 failing files are the pre-existing `mermaid`/plugin-dependency suites, none of which are touched here.
- [ ] Manual: open a project with durable agents that have image icons → drag a row up/down → order changes and persists across reload.
- [ ] Manual: confirm row click-to-select and the per-row action buttons still work (drag does not interfere with normal clicks).

## Manual Validation
1. Open a project that has ≥2 durable agents, at least one with an image avatar.
2. Click and drag an agent row onto another position → the list reorders, the order persists after restarting/reloading.
3. Verify clicking a row still selects it and the action buttons (wake/stop/settings/…) still respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)