### PR TITLE
fix: Monaco editors render white on custom themes + Git view loses file selection

### DIFF
--- a/src/renderer/components/SettingsMonacoEditor.test.tsx
+++ b/src/renderer/components/SettingsMonacoEditor.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../themes/index', () => ({
 
 vi.mock('../plugins/builtin/files/monaco-theme', () => ({
   generateMonacoTheme: () => ({ base: 'vs-dark', inherit: true, rules: [], colors: {} }),
+  loadMonaco: () => import('monaco-editor'),
+  ensureThemes: async () => {},
+  applyMonacoTheme: () => {},
 }));
 
 vi.mock('../stores/themeStore', () => ({

--- a/src/renderer/components/SettingsMonacoEditor.tsx
+++ b/src/renderer/components/SettingsMonacoEditor.tsx
@@ -1,26 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useThemeStore } from '../stores/themeStore';
-
-// Cached module reference — populated on first dynamic import
-let monacoModule: any | null = null;
-let themesRegistered = false;
-
-async function loadMonaco() {
-  if (!monacoModule) {
-    monacoModule = await import('monaco-editor');
-  }
-  return monacoModule;
-}
-
-async function ensureThemes(m: any): Promise<void> {
-  if (themesRegistered) return;
-  const { THEMES } = await import('../themes/index');
-  const { generateMonacoTheme } = await import('../plugins/builtin/files/monaco-theme');
-  for (const [id, theme] of Object.entries(THEMES)) {
-    m.editor.defineTheme(`clubhouse-${id}`, generateMonacoTheme(theme as any) as any);
-  }
-  themesRegistered = true;
-}
+import { loadMonaco, ensureThemes, applyMonacoTheme } from '../plugins/builtin/files/monaco-theme';
 
 interface SettingsMonacoEditorProps {
   value: string;
@@ -106,7 +86,7 @@ export function SettingsMonacoEditor({
   // React to theme changes
   useEffect(() => {
     if (!editorRef.current || !monacoRef.current) return;
-    monacoRef.current.editor.setTheme(`clubhouse-${themeId}`);
+    applyMonacoTheme(monacoRef.current, themeId);
   }, [themeId]);
 
   // Sync value changes from outside

--- a/src/renderer/plugins/builtin/canvas/MonacoDiffEditor.tsx
+++ b/src/renderer/plugins/builtin/canvas/MonacoDiffEditor.tsx
@@ -1,27 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { generateMonacoTheme } from '../files/monaco-theme';
+import { loadMonaco, ensureThemes, applyMonacoTheme } from '../files/monaco-theme';
 import { useThemeStore } from '../../../stores/themeStore';
 import { languageFromPath } from './ReadOnlyMonacoEditor';
-
-// Cached module reference — populated on first dynamic import
-let monacoModule: any | null = null;
-let themesRegistered = false;
-
-async function loadMonaco() {
-  if (!monacoModule) {
-    monacoModule = await import('monaco-editor');
-  }
-  return monacoModule;
-}
-
-async function ensureThemes(m: any): Promise<void> {
-  if (themesRegistered) return;
-  const { THEMES } = await import('../../../themes/index');
-  for (const [id, theme] of Object.entries(THEMES)) {
-    m.editor.defineTheme(`clubhouse-${id}`, generateMonacoTheme(theme as any) as any);
-  }
-  themesRegistered = true;
-}
 
 interface MonacoDiffEditorProps {
   original: string;
@@ -111,7 +91,7 @@ export function MonacoDiffEditor({ original, modified, filePath }: MonacoDiffEdi
   // React to theme changes
   useEffect(() => {
     if (!monacoRef.current) return;
-    monacoRef.current.editor.setTheme(`clubhouse-${themeId}`);
+    applyMonacoTheme(monacoRef.current, themeId);
   }, [themeId]);
 
   return React.createElement('div', {

--- a/src/renderer/plugins/builtin/canvas/ReadOnlyMonacoEditor.tsx
+++ b/src/renderer/plugins/builtin/canvas/ReadOnlyMonacoEditor.tsx
@@ -1,27 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { generateMonacoTheme } from '../files/monaco-theme';
+import { loadMonaco, ensureThemes, applyMonacoTheme } from '../files/monaco-theme';
 import { EXT_TO_LANG } from '../files/file-icons';
 import { useThemeStore } from '../../../stores/themeStore';
-
-// Cached module reference — populated on first dynamic import
-let monacoModule: any | null = null;
-let themesRegistered = false;
-
-async function loadMonaco() {
-  if (!monacoModule) {
-    monacoModule = await import('monaco-editor');
-  }
-  return monacoModule;
-}
-
-async function ensureThemes(m: any): Promise<void> {
-  if (themesRegistered) return;
-  const { THEMES } = await import('../../../themes/index');
-  for (const [id, theme] of Object.entries(THEMES)) {
-    m.editor.defineTheme(`clubhouse-${id}`, generateMonacoTheme(theme as any) as any);
-  }
-  themesRegistered = true;
-}
 
 /** Detect Monaco language from a file path's extension */
 export function languageFromPath(filePath: string): string {
@@ -147,7 +127,7 @@ export function ReadOnlyMonacoEditor({ value, filePath, readOnly = true, onSave 
   // React to theme changes
   useEffect(() => {
     if (!monacoRef.current) return;
-    monacoRef.current.editor.setTheme(`clubhouse-${themeId}`);
+    applyMonacoTheme(monacoRef.current, themeId);
   }, [themeId]);
 
   return React.createElement('div', {

--- a/src/renderer/plugins/builtin/files/MonacoEditor.test.tsx
+++ b/src/renderer/plugins/builtin/files/MonacoEditor.test.tsx
@@ -10,6 +10,9 @@ vi.mock('../../../themes/index', () => ({
 
 vi.mock('./monaco-theme', () => ({
   generateMonacoTheme: () => ({ base: 'vs-dark', inherit: true, rules: [], colors: {} }),
+  loadMonaco: () => import('monaco-editor'),
+  ensureThemes: async () => {},
+  applyMonacoTheme: () => {},
 }));
 
 vi.mock('../../../stores/themeStore', () => ({

--- a/src/renderer/plugins/builtin/files/MonacoEditor.ts
+++ b/src/renderer/plugins/builtin/files/MonacoEditor.ts
@@ -1,27 +1,7 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
-import { generateMonacoTheme } from './monaco-theme';
+import { loadMonaco, ensureThemes, applyMonacoTheme } from './monaco-theme';
 import { useThemeStore } from '../../../stores/themeStore';
 import type { ScrollState } from './state';
-
-// Cached module reference — populated on first dynamic import
-let monacoModule: any | null = null;
-let themesRegistered = false;
-
-async function loadMonaco() {
-  if (!monacoModule) {
-    monacoModule = await import('monaco-editor');
-  }
-  return monacoModule;
-}
-
-async function ensureThemes(m: any): Promise<void> {
-  if (themesRegistered) return;
-  const { THEMES } = await import('../../../themes/index');
-  for (const [id, theme] of Object.entries(THEMES)) {
-    m.editor.defineTheme(`clubhouse-${id}`, generateMonacoTheme(theme as any) as any);
-  }
-  themesRegistered = true;
-}
 
 // ── Model Cache ──────────────────────────────────────────────────────
 // Maintain one ITextModel per file path for efficient tab switching.
@@ -342,7 +322,7 @@ export function MonacoEditor({
   // React to theme changes
   useEffect(() => {
     if (!editorRef.current || !monacoRef.current) return;
-    monacoRef.current.editor.setTheme(`clubhouse-${themeId}`);
+    applyMonacoTheme(monacoRef.current, themeId);
   }, [themeId]);
 
   // When value prop changes externally (e.g., file reloaded from disk), update model

--- a/src/renderer/plugins/builtin/files/monaco-theme.test.ts
+++ b/src/renderer/plugins/builtin/files/monaco-theme.test.ts
@@ -1,4 +1,6 @@
-import { generateMonacoTheme } from './monaco-theme';
+import { describe, it, expect, vi } from 'vitest';
+import { generateMonacoTheme, registerAllMonacoThemes, applyMonacoTheme } from './monaco-theme';
+import { registerTheme, unregisterTheme, BUILTIN_THEMES } from '../../../themes';
 import type { ThemeDefinition } from '../../../../shared/types';
 
 const mockTheme: ThemeDefinition = {
@@ -74,5 +76,54 @@ describe('generateMonacoTheme', () => {
     const lightTheme = { ...mockTheme, type: 'light' as const };
     const result = generateMonacoTheme(lightTheme);
     expect(result.base).toBe('vs');
+  });
+});
+
+function mockMonaco() {
+  return { editor: { defineTheme: vi.fn(), setTheme: vi.fn() } };
+}
+
+describe('registerAllMonacoThemes', () => {
+  it('defines a Monaco theme for every builtin theme', () => {
+    const m = mockMonaco();
+    registerAllMonacoThemes(m);
+    for (const id of Object.keys(BUILTIN_THEMES)) {
+      expect(m.editor.defineTheme).toHaveBeenCalledWith(`clubhouse-${id}`, expect.anything());
+    }
+  });
+
+  it('also defines plugin-contributed themes (the bug fix)', () => {
+    const pluginTheme: ThemeDefinition = { ...mockTheme, id: 'plugin-dark' as any, name: 'Plugin Dark' };
+    registerTheme(pluginTheme);
+    try {
+      const m = mockMonaco();
+      registerAllMonacoThemes(m);
+      // Without this, plugin themes were never defined in Monaco, so selecting
+      // one fell back to Monaco's default light theme (white editor).
+      expect(m.editor.defineTheme).toHaveBeenCalledWith('clubhouse-plugin-dark', expect.anything());
+    } finally {
+      unregisterTheme('plugin-dark' as any);
+    }
+  });
+});
+
+describe('applyMonacoTheme', () => {
+  it('defines the theme before applying it so plugin themes resolve', () => {
+    const pluginTheme: ThemeDefinition = { ...mockTheme, id: 'plugin-apply' as any, name: 'Plugin Apply' };
+    registerTheme(pluginTheme);
+    try {
+      const m = mockMonaco();
+      applyMonacoTheme(m, 'plugin-apply');
+      expect(m.editor.defineTheme).toHaveBeenCalledWith('clubhouse-plugin-apply', expect.anything());
+      expect(m.editor.setTheme).toHaveBeenCalledWith('clubhouse-plugin-apply');
+    } finally {
+      unregisterTheme('plugin-apply' as any);
+    }
+  });
+
+  it('still applies a theme id that is not in the registry', () => {
+    const m = mockMonaco();
+    applyMonacoTheme(m, 'catppuccin-mocha');
+    expect(m.editor.setTheme).toHaveBeenCalledWith('clubhouse-catppuccin-mocha');
   });
 });

--- a/src/renderer/plugins/builtin/files/monaco-theme.ts
+++ b/src/renderer/plugins/builtin/files/monaco-theme.ts
@@ -1,4 +1,5 @@
 import type { ThemeDefinition } from '../../../../shared/types';
+import { getAllThemes, getTheme, onRegistryChange } from '../../../themes';
 
 function stripHash(hex: string): string {
   return hex.replace(/^#/, '');
@@ -81,4 +82,65 @@ export function generateMonacoTheme(theme: ThemeDefinition): IStandaloneThemeDat
       'inputOption.hoverBackground': theme.colors.surface1,
     },
   };
+}
+
+// ── Shared Monaco runtime ────────────────────────────────────────────
+//
+// Every Monaco surface (file editor, diff viewer, read-only viewer, settings
+// editor) needs the same two things before it can render with a Clubhouse
+// theme: the Monaco module loaded, and every Clubhouse theme defined inside
+// Monaco. Centralising this here ensures all surfaces register the *full*
+// theme registry — builtins AND plugin-contributed themes.
+//
+// Previously each surface only registered the builtin themes, so selecting a
+// plugin theme left Monaco on its default light ('vs') theme, rendering the
+// editor bright white in an otherwise dark app.
+
+let monacoModule: any | null = null;
+let themesRegistered = false;
+let registryListenerAttached = false;
+
+export async function loadMonaco(): Promise<any> {
+  if (!monacoModule) {
+    monacoModule = await import('monaco-editor');
+  }
+  return monacoModule;
+}
+
+/** Define every theme in the dynamic registry (builtins + plugin-contributed) with Monaco. */
+export function registerAllMonacoThemes(m: any): void {
+  for (const [id, theme] of Object.entries(getAllThemes())) {
+    m.editor.defineTheme(`clubhouse-${id}`, generateMonacoTheme(theme as ThemeDefinition) as any);
+  }
+}
+
+/**
+ * Ensure all known themes are registered with Monaco and stay in sync with the
+ * registry. Idempotent: the heavy registration runs once, but a registry
+ * listener re-registers whenever plugin themes are added/removed/updated so a
+ * later-contributed theme is always defined before it can be selected.
+ */
+export async function ensureThemes(m: any): Promise<void> {
+  if (!registryListenerAttached) {
+    registryListenerAttached = true;
+    onRegistryChange(() => {
+      if (monacoModule) registerAllMonacoThemes(monacoModule);
+    });
+  }
+  if (themesRegistered) return;
+  registerAllMonacoThemes(m);
+  themesRegistered = true;
+}
+
+/**
+ * Apply a Clubhouse theme by id. Defines the theme just-in-time (so a plugin
+ * theme that wasn't registered at editor-creation time still resolves) and then
+ * sets it. Falls back to a plain setTheme if the id is unknown.
+ */
+export function applyMonacoTheme(m: any, themeId: string): void {
+  const theme = getTheme(themeId);
+  if (theme) {
+    m.editor.defineTheme(`clubhouse-${themeId}`, generateMonacoTheme(theme) as any);
+  }
+  m.editor.setTheme(`clubhouse-${themeId}`);
 }

--- a/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/git/GitCanvasWidget.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import type { CanvasWidgetComponentProps } from '../../../../shared/plugin-types';
 import type { GitInfo, GitStatusFile } from '../../../../shared/types';
 import { createGitOps } from './remote-git';
+import { evaluateSelectionPersistence } from './selection';
 import { Spinner } from '../../../components/Spinner';
 
 const GIT_POLL_INTERVAL_MS = 3000;
@@ -63,6 +64,9 @@ export function GitCanvasWidget({ widgetId: _widgetId, api, metadata, onUpdateMe
   // a real file switch (show "Loading diff…") from a background poll refresh
   // (silently update so the diff doesn't flash).
   const diffFetchKeyRef = useRef<string | null>(null);
+  // Consecutive polls in which the selected file was absent from a non-empty
+  // status. Used to avoid dropping the selection on a single transient read.
+  const selectionMissesRef = useRef(0);
 
   const git = useMemo(
     () => effectivePath ? createGitOps(effectivePath, projectId) : null,
@@ -83,11 +87,17 @@ export function GitCanvasWidget({ widgetId: _widgetId, api, metadata, onUpdateMe
     return () => { clearInterval(id); document.removeEventListener('visibilitychange', onVis); };
   }, [git]);
 
-  // Clear selection when file disappears from status
+  // Clear selection when the file genuinely disappears from status — but tolerate
+  // transient/empty poll results so a flaky read doesn't reset the diff view.
   useEffect(() => {
     if (!selectedFile || !gitInfo) return;
-    const exists = gitInfo.status.some((f) => f.path === selectedFile);
-    if (!exists) {
+    const { drop, misses } = evaluateSelectionPersistence(
+      gitInfo.status,
+      selectedFile,
+      selectionMissesRef.current,
+    );
+    selectionMissesRef.current = misses;
+    if (drop) {
       setSelectedFile(null);
       setDiffData(null);
     }

--- a/src/renderer/plugins/builtin/git/selection.test.ts
+++ b/src/renderer/plugins/builtin/git/selection.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateSelectionPersistence } from './selection';
+
+describe('evaluateSelectionPersistence', () => {
+  it('keeps selection when the file is present in status', () => {
+    const status = [{ path: 'a.ts' }, { path: 'b.ts' }];
+    const result = evaluateSelectionPersistence(status, 'a.ts', 0);
+    expect(result).toEqual({ drop: false, misses: 0 });
+  });
+
+  it('resets the miss counter when the file reappears', () => {
+    const status = [{ path: 'a.ts' }];
+    const result = evaluateSelectionPersistence(status, 'a.ts', 1);
+    expect(result).toEqual({ drop: false, misses: 0 });
+  });
+
+  it('never drops the selection when nothing is selected', () => {
+    const result = evaluateSelectionPersistence([], null, 0);
+    expect(result).toEqual({ drop: false, misses: 0 });
+  });
+
+  it('does not drop on a transient empty status snapshot', () => {
+    // Empty status = likely a failed/partial read. Preserve both the
+    // selection and the existing miss count.
+    const result = evaluateSelectionPersistence([], 'a.ts', 1);
+    expect(result).toEqual({ drop: false, misses: 1 });
+  });
+
+  it('does not drop on the first miss from a non-empty status', () => {
+    const status = [{ path: 'other.ts' }];
+    const result = evaluateSelectionPersistence(status, 'a.ts', 0);
+    expect(result).toEqual({ drop: false, misses: 1 });
+  });
+
+  it('drops only after two consecutive non-empty misses', () => {
+    const status = [{ path: 'other.ts' }];
+    const first = evaluateSelectionPersistence(status, 'a.ts', 0);
+    expect(first).toEqual({ drop: false, misses: 1 });
+    const second = evaluateSelectionPersistence(status, 'a.ts', first.misses);
+    expect(second).toEqual({ drop: true, misses: 2 });
+  });
+
+  it('does not let a transient empty poll between two misses cause a false drop', () => {
+    const populated = [{ path: 'other.ts' }];
+    // Miss 1 (file genuinely absent)
+    const a = evaluateSelectionPersistence(populated, 'a.ts', 0);
+    expect(a).toEqual({ drop: false, misses: 1 });
+    // Transient empty read — counter held, no drop
+    const b = evaluateSelectionPersistence([], 'a.ts', a.misses);
+    expect(b).toEqual({ drop: false, misses: 1 });
+    // File comes back — counter resets
+    const c = evaluateSelectionPersistence([{ path: 'a.ts' }], 'a.ts', b.misses);
+    expect(c).toEqual({ drop: false, misses: 0 });
+  });
+});

--- a/src/renderer/plugins/builtin/git/selection.ts
+++ b/src/renderer/plugins/builtin/git/selection.ts
@@ -1,0 +1,35 @@
+/**
+ * Selection-persistence logic for the git diff views.
+ *
+ * Both the canvas widget and the sidebar/main panel poll `git.info()` on an
+ * interval. A transient or failed read can return an empty (or briefly
+ * incomplete) status snapshot. Dropping the user's file selection on any single
+ * such poll resets the diff view to "Select a file" while they're still looking
+ * at it. This helper keeps the decision pure and well-tested.
+ */
+
+export interface SelectionPersistenceResult {
+  /** Whether the current selection should be cleared. */
+  drop: boolean;
+  /** Updated count of consecutive polls in which the file was absent. */
+  misses: number;
+}
+
+/**
+ * Decide whether a background status poll should drop the current file
+ * selection. The selection is only dropped once the file has been absent from a
+ * non-empty status across two consecutive polls; empty snapshots are treated as
+ * transient reads and never drop the selection.
+ */
+export function evaluateSelectionPersistence(
+  status: Array<{ path: string }>,
+  selectedFile: string | null,
+  consecutiveMisses: number,
+): SelectionPersistenceResult {
+  if (!selectedFile) return { drop: false, misses: 0 };
+  if (status.some((f) => f.path === selectedFile)) return { drop: false, misses: 0 };
+  // Empty snapshots are almost always transient (failed/partial read) — ignore.
+  if (status.length === 0) return { drop: false, misses: consecutiveMisses };
+  const misses = consecutiveMisses + 1;
+  return { drop: misses >= 2, misses };
+}

--- a/src/renderer/plugins/builtin/git/state.test.ts
+++ b/src/renderer/plugins/builtin/git/state.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { gitState } from './state';
+
+afterEach(() => {
+  // Restore a clean baseline without going through the public reset (which is
+  // itself under test) so one test can't leak listeners into another.
+  gitState.setSelectedFile(null);
+  gitState.setSelectedCommit(null);
+  gitState.listeners.clear();
+});
+
+describe('gitState.reset', () => {
+  it('clears data and UI selection state', () => {
+    gitState.setSelectedFile('src/a.ts');
+    gitState.setSelectedCommit('abc123');
+    gitState.setCommitMessage('wip');
+
+    gitState.reset();
+
+    expect(gitState.selectedFile).toBeNull();
+    expect(gitState.selectedCommit).toBeNull();
+    expect(gitState.commitMessage).toBe('');
+  });
+
+  it('keeps listeners subscribed so mounted panels keep updating', () => {
+    let notifications = 0;
+    gitState.subscribe(() => { notifications += 1; });
+
+    gitState.reset();
+    expect(notifications).toBeGreaterThan(0); // reset itself notifies
+
+    const afterReset = notifications;
+    gitState.setSelectedFile('src/b.ts');
+    expect(notifications).toBe(afterReset + 1); // still receiving updates
+  });
+});

--- a/src/renderer/plugins/builtin/git/state.ts
+++ b/src/renderer/plugins/builtin/git/state.ts
@@ -86,7 +86,11 @@ export const gitState = {
   },
 
   reset(): void {
+    // Reset data/UI state but keep listeners: components subscribe via
+    // useSyncExternalStore on mount and don't re-subscribe afterwards, so
+    // clearing listeners here would leave any still-mounted panel frozen
+    // (no re-render on subsequent updates).
     Object.assign(this, defaultState);
-    this.listeners.clear();
+    this.notify();
   },
 };


### PR DESCRIPTION
## Summary
- **Bug 5 — Monaco file editor is white in dark mode on custom themes.** Every Monaco surface only registered the **9 built-in** themes with Monaco, so selecting a plugin/custom theme left Monaco on its default light (`vs`) theme — rendering the editor bright white. This affected the file editor, the git diff viewer, the read-only viewer, and the settings JSON editor (they share the same code).
- **Bug 6 — Git view drops the selected file and shows "Select a file".** The Git canvas widget cleared the selection whenever a single `git.info()` poll didn't contain the file. A transient/empty read reset the diff view while the user was still looking at it.

## Changes

### Monaco theming (Bug 5)
- Centralized `loadMonaco` / `ensureThemes` into `monaco-theme.ts` and made them register the **full dynamic theme registry** (`getAllThemes()` — builtins **and** plugin-contributed themes), not just the builtins.
- `ensureThemes` now subscribes to `onRegistryChange`, re-registering Monaco themes whenever plugin themes are added/removed/updated.
- New `applyMonacoTheme(m, themeId)` defines the theme just-in-time before `setTheme`, so a freshly-selected plugin theme always resolves instead of silently falling back to white.
- Refactored all four Monaco surfaces (`MonacoEditor`, `MonacoDiffEditor`, `ReadOnlyMonacoEditor`, `SettingsMonacoEditor`) onto the shared helpers — removing 4 copies of the builtins-only registration bug.

### Git selection persistence (Bug 6)
- New pure helper `evaluateSelectionPersistence` (in `git/selection.ts`): ignores empty status snapshots (transient reads) and only drops the selection after the file is absent from a **non-empty** status across **two consecutive** polls.
- `GitCanvasWidget` uses it via a miss-count ref instead of clearing on the first miss.
- `gitState.reset()` no longer clears live listeners (it would freeze any still-mounted panel, since `useSyncExternalStore` subscribes only once on mount); it now resets state and notifies.

## Test Plan
- [x] `monaco-theme.test.ts` — `registerAllMonacoThemes` defines a theme for every builtin **and** for a plugin-contributed theme; `applyMonacoTheme` defines-before-set so plugin themes resolve, and still applies an id not in the registry.
- [x] `selection.test.ts` — keeps selection when present; ignores transient empty polls; drops only after two consecutive non-empty misses; an empty poll between misses doesn't cause a false drop.
- [x] `state.test.ts` — `reset()` clears data/selection but keeps listeners so mounted panels keep updating.
- [x] Existing `diff-flash`, `GitCanvasWidget`, and `MonacoEditor` suites still pass (mock updated for relocated `loadMonaco`/`ensureThemes`).
- [x] `tsc --noEmit` clean; `eslint .` 0 errors.

## Manual Validation
1. Switch to a plugin/custom dark theme, open a file in the Files plugin → editor renders dark (not white). Verify the git diff viewer and Settings JSON editor too.
2. Switch themes while an editor is open → editor recolors live.
3. In the Git canvas widget, select a file and watch the diff across several poll cycles (~10s) → selection and diff persist; it does not flip back to "Select a file".

## Notes
- Rebased onto latest `origin/main` (incl. #1490).
- Pre-existing, unrelated: `mermaid` was missing from this worktree's `node_modules` (declared in package.json); installed locally for a clean typecheck. A few full-suite tests (`ProjectRail`) are flaky via cross-file pollution on `main` independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)