### PR TITLE
feat(personas): group-project-pm persona + user-global persona library

### DIFF
--- a/src/main/ipc/agent-settings-handlers.ts
+++ b/src/main/ipc/agent-settings-handlers.ts
@@ -317,16 +317,16 @@ export function registerAgentSettingsHandlers(): void {
   ));
 
   ipcMain.handle(IPC.AGENT.WRITE_SOURCE_PERSONA_CONTENT, withValidatedArgs(
-    [stringArg(), stringArg(), stringArg({ minLength: 0 })],
-    async (_event, projectPath, personaId, content) => {
-      await agentSettings.writeSourcePersonaContent(projectPath, personaId, content);
+    [stringArg(), stringArg(), stringArg({ minLength: 0 }), stringArg({ optional: true })],
+    async (_event, projectPath, personaId, content, scope) => {
+      await agentSettings.writeSourcePersonaContent(projectPath, personaId, content, scope === 'user' ? 'user' : 'project');
     },
   ));
 
   ipcMain.handle(IPC.AGENT.DELETE_SOURCE_PERSONA, withValidatedArgs(
-    [stringArg(), stringArg()],
-    async (_event, projectPath, personaId) => {
-      await agentSettings.deleteSourcePersona(projectPath, personaId);
+    [stringArg(), stringArg(), stringArg({ optional: true })],
+    async (_event, projectPath, personaId, scope) => {
+      await agentSettings.deleteSourcePersona(projectPath, personaId, scope === 'user' ? 'user' : 'project');
     },
   ));
 

--- a/src/main/services/agent-settings-service.test.ts
+++ b/src/main/services/agent-settings-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as path from 'path';
+import * as os from 'os';
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
@@ -341,12 +342,22 @@ describe('readSourcePersonaContent', () => {
     expect(await readSourcePersonaContent('/project', '')).toBe('');
     expect(fsp.readFile).not.toHaveBeenCalled();
   });
+
+  it('reads from the user-global library under the home dir for scope "user"', async () => {
+    vi.mocked(fsp.readFile).mockResolvedValue('# User persona');
+    const result = await readSourcePersonaContent('/project', 'qa', 'user');
+    expect(result).toBe('# User persona');
+    expect(fsp.readFile).toHaveBeenCalledWith(
+      path.join(os.homedir(), '.clubhouse', 'personas', 'qa.md'),
+      'utf-8',
+    );
+  });
 });
 
 describe('writeSourcePersonaContent', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it('creates the personas dir and writes <id>.md', async () => {
+  it('creates the project personas dir and writes <id>.md', async () => {
     await writeSourcePersonaContent('/project', 'qa', '# Persona body');
     expect(fsp.mkdir).toHaveBeenCalledWith(path.join('/project', '.clubhouse', 'personas'), { recursive: true });
     expect(fsp.writeFile).toHaveBeenCalledWith(
@@ -355,15 +366,30 @@ describe('writeSourcePersonaContent', () => {
       'utf-8',
     );
   });
+
+  it('writes to the user-global library under the home dir for scope "user"', async () => {
+    await writeSourcePersonaContent('/project', 'qa', '# User persona', 'user');
+    const userDir = path.join(os.homedir(), '.clubhouse', 'personas');
+    expect(fsp.mkdir).toHaveBeenCalledWith(userDir, { recursive: true });
+    expect(fsp.writeFile).toHaveBeenCalledWith(path.join(userDir, 'qa.md'), '# User persona', 'utf-8');
+  });
 });
 
 describe('deleteSourcePersona', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it('removes the persona file with force (no-op when missing)', async () => {
+  it('removes the project persona file with force (no-op when missing)', async () => {
     await deleteSourcePersona('/project', 'qa');
     expect(fsp.rm).toHaveBeenCalledWith(
       path.join('/project', '.clubhouse', 'personas', 'qa.md'),
+      { force: true },
+    );
+  });
+
+  it('removes the user-global persona file for scope "user"', async () => {
+    await deleteSourcePersona('/project', 'qa', 'user');
+    expect(fsp.rm).toHaveBeenCalledWith(
+      path.join(os.homedir(), '.clubhouse', 'personas', 'qa.md'),
       { force: true },
     );
   });

--- a/src/main/services/agent-settings-service.ts
+++ b/src/main/services/agent-settings-service.ts
@@ -280,12 +280,31 @@ export async function deleteSourceMission(projectPath: string, missionId: string
 }
 
 /**
- * List user-authored persona files under .clubhouse/personas/.
+ * The scope of an on-disk persona store.
+ * - 'project': <projectPath>/.clubhouse/personas/ — scoped to one project.
+ * - 'user': ~/.clubhouse/personas/ — the user's personal library, reusable across projects.
+ */
+export type PersonaScope = 'project' | 'user';
+
+/**
+ * Resolve the personas directory for a given scope. The user-global library
+ * lives under the home directory (consistent with ~/.clubhouse/group-projects,
+ * ~/.clubhouse/agent-icons); the project library lives under the project's
+ * .clubhouse directory. `projectPath` is ignored for the 'user' scope.
+ */
+export function personasDirFor(projectPath: string, scope: PersonaScope = 'project'): string {
+  return scope === 'user'
+    ? path.join(os.homedir(), '.clubhouse', 'personas')
+    : path.join(projectPath, '.clubhouse', 'personas');
+}
+
+/**
+ * List user-authored persona files for a scope (project or user-global).
  * Each persona is a single .md file; the persona ID is the basename without extension.
  * Built-in persona templates are layered on top of these by the materialization service.
  */
-export async function listSourcePersonaFiles(projectPath: string): Promise<Array<{ id: string; path: string }>> {
-  const personasDir = path.join(projectPath, '.clubhouse', 'personas');
+export async function listSourcePersonaFiles(projectPath: string, scope: PersonaScope = 'project'): Promise<Array<{ id: string; path: string }>> {
+  const personasDir = personasDirFor(projectPath, scope);
   try {
     const entries = await fsp.readdir(personasDir, { withFileTypes: true });
     return entries
@@ -300,13 +319,12 @@ export async function listSourcePersonaFiles(projectPath: string): Promise<Array
 }
 
 /**
- * Read the on-disk content of a persona file at .clubhouse/personas/<id>.md.
- * Returns empty string when the file does not exist (callers fall back to the
- * built-in persona template).
+ * Read the on-disk content of a persona file for a scope. Returns empty string
+ * when the file does not exist (callers fall back to the next layer / built-in).
  */
-export async function readSourcePersonaContent(projectPath: string, personaId: string): Promise<string> {
+export async function readSourcePersonaContent(projectPath: string, personaId: string, scope: PersonaScope = 'project'): Promise<string> {
   if (!personaId) return '';
-  const filePath = path.join(projectPath, '.clubhouse', 'personas', `${personaId}.md`);
+  const filePath = path.join(personasDirFor(projectPath, scope), `${personaId}.md`);
   try {
     return await fsp.readFile(filePath, 'utf-8');
   } catch (err) {
@@ -318,22 +336,23 @@ export async function readSourcePersonaContent(projectPath: string, personaId: s
 }
 
 /**
- * Write the content of a persona file at .clubhouse/personas/<id>.md, creating
- * the directory if needed. A disk persona overrides the built-in template of the
- * same ID at materialization.
+ * Write the content of a persona file for a scope, creating the directory if
+ * needed. A project persona overrides a user persona overrides the built-in
+ * template of the same ID at materialization.
  */
-export async function writeSourcePersonaContent(projectPath: string, personaId: string, content: string): Promise<void> {
-  const dir = path.join(projectPath, '.clubhouse', 'personas');
+export async function writeSourcePersonaContent(projectPath: string, personaId: string, content: string, scope: PersonaScope = 'project'): Promise<void> {
+  const dir = personasDirFor(projectPath, scope);
   await fsp.mkdir(dir, { recursive: true });
   await fsp.writeFile(path.join(dir, `${personaId}.md`), content, 'utf-8');
 }
 
 /**
- * Delete a persona file at .clubhouse/personas/<id>.md. No-op if missing.
- * Built-in persona templates of the same ID remain available afterward.
+ * Delete a persona file for a scope. No-op if missing. Built-in persona
+ * templates of the same ID remain available afterward, as do personas in other
+ * scopes.
  */
-export async function deleteSourcePersona(projectPath: string, personaId: string): Promise<void> {
-  const filePath = path.join(projectPath, '.clubhouse', 'personas', `${personaId}.md`);
+export async function deleteSourcePersona(projectPath: string, personaId: string, scope: PersonaScope = 'project'): Promise<void> {
+  const filePath = path.join(personasDirFor(projectPath, scope), `${personaId}.md`);
   await fsp.rm(filePath, { force: true });
 }
 

--- a/src/main/services/materialization-service.test.ts
+++ b/src/main/services/materialization-service.test.ts
@@ -329,12 +329,32 @@ describe('materialization-service', () => {
       expect(await resolvePersonaContent('/project', undefined)).toBeUndefined();
     });
 
-    it('prefers the on-disk persona file when present', async () => {
+    it('prefers the project on-disk persona file when present', async () => {
       vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
-        if (String(p).replace(/\\/g, '/').endsWith('.clubhouse/personas/qa.md')) return 'CUSTOM QA PERSONA';
+        const fp = String(p).replace(/\\/g, '/');
+        if (fp.startsWith('/project') && fp.endsWith('.clubhouse/personas/qa.md')) return 'PROJECT QA PERSONA';
         throw new Error('ENOENT');
       });
-      expect(await resolvePersonaContent('/project', 'qa')).toBe('CUSTOM QA PERSONA');
+      expect(await resolvePersonaContent('/project', 'qa')).toBe('PROJECT QA PERSONA');
+    });
+
+    it('falls back to the user-global persona when no project file exists', async () => {
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p).replace(/\\/g, '/');
+        // Project layer (under /project) misses; user-global layer (under home) hits.
+        if (!fp.startsWith('/project') && fp.endsWith('.clubhouse/personas/qa.md')) return 'USER QA PERSONA';
+        throw new Error('ENOENT');
+      });
+      expect(await resolvePersonaContent('/project', 'qa')).toBe('USER QA PERSONA');
+    });
+
+    it('project layer wins over user-global layer for the same id', async () => {
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p).replace(/\\/g, '/');
+        if (!fp.endsWith('.clubhouse/personas/qa.md')) throw new Error('ENOENT');
+        return fp.startsWith('/project') ? 'PROJECT QA PERSONA' : 'USER QA PERSONA';
+      });
+      expect(await resolvePersonaContent('/project', 'qa')).toBe('PROJECT QA PERSONA');
     });
 
     it('falls back to the built-in template when no disk file exists', async () => {
@@ -358,17 +378,26 @@ describe('materialization-service', () => {
       expect(personas.map((p) => p.id)).toContain('qa');
     });
 
-    it('lets a disk persona shadow a built-in of the same id', async () => {
+    it('tags a user-global persona and lets a project persona shadow it', async () => {
       vi.mocked(fsp.readdir).mockImplementation(async (p: unknown) => {
-        if (String(p).replace(/\\/g, '/').includes('.clubhouse/personas')) {
+        const fp = String(p).replace(/\\/g, '/');
+        if (!fp.endsWith('.clubhouse/personas')) return [] as any;
+        if (fp.startsWith('/project')) {
+          // Project layer defines only "qa" (shadows built-in + user)
           return [{ name: 'qa.md', isFile: () => true, isDirectory: () => false }] as any;
         }
-        return [] as any;
+        // User-global layer defines "qa" and a brand-new "my-reviewer"
+        return [
+          { name: 'qa.md', isFile: () => true, isDirectory: () => false },
+          { name: 'my-reviewer.md', isFile: () => true, isDirectory: () => false },
+        ] as any;
       });
       const personas = await listAvailablePersonas('/project');
       const qa = personas.filter((p) => p.id === 'qa');
       expect(qa).toHaveLength(1);
-      expect(qa[0].source).toBe('disk');
+      expect(qa[0].source).toBe('project'); // project layer wins the source tag
+      const reviewer = personas.find((p) => p.id === 'my-reviewer');
+      expect(reviewer?.source).toBe('user'); // only in user-global layer
     });
   });
 
@@ -1043,6 +1072,11 @@ describe('materialization-service', () => {
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('testCommand');
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('lintCommand');
       expect(CLUBHOUSE_MODE_README_CONTENT).toContain('sourceControlProvider');
+    });
+
+    it('documents the user-global persona library and precedence', () => {
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('~/.clubhouse/personas/');
+      expect(CLUBHOUSE_MODE_README_CONTENT).toContain('user-global → built-in');
     });
   });
 

--- a/src/main/services/materialization-service.ts
+++ b/src/main/services/materialization-service.ts
@@ -259,18 +259,20 @@ export function resolvePersonaId(
 }
 
 /**
- * Resolve the effective persona content for a persona ID.
- * Prefers a user-authored on-disk persona (.clubhouse/personas/<id>.md) and
- * falls back to the built-in persona template of the same ID. Returns undefined
- * when neither exists.
+ * Resolve the effective persona content for a persona ID, layered by scope.
+ * Precedence: project (.clubhouse/personas/<id>.md) → user
+ * (~/.clubhouse/personas/<id>.md) → built-in persona template. Returns undefined
+ * when none exists.
  */
 export async function resolvePersonaContent(
   projectPath: string,
   personaId: string | undefined,
 ): Promise<string | undefined> {
   if (!personaId) return undefined;
-  const onDisk = await readSourcePersonaContent(projectPath, personaId);
-  if (onDisk) return onDisk;
+  const project = await readSourcePersonaContent(projectPath, personaId, 'project');
+  if (project) return project;
+  const user = await readSourcePersonaContent(projectPath, personaId, 'user');
+  if (user) return user;
   return getPersonaTemplate(personaId)?.content;
 }
 
@@ -324,29 +326,35 @@ export async function resolveSourceControlProvider(
  */
 export async function listAvailablePersonas(
   projectPath: string,
-): Promise<Array<{ id: string; name: string; source: 'builtin' | 'disk' }>> {
-  const diskFiles = await listSourcePersonaFiles(projectPath);
-  const diskIds = new Set(diskFiles.map((f) => f.id));
-  const builtins = PERSONA_TEMPLATES
-    .filter((p) => !diskIds.has(p.id))
-    .map((p) => ({ id: p.id, name: p.name, source: 'builtin' as const }));
-  const disk = diskFiles.map((f) => ({
-    id: f.id,
-    name: getPersonaTemplate(f.id)?.name ?? f.id,
-    source: 'disk' as const,
-  }));
-  return [...disk, ...builtins].sort((a, b) => a.name.localeCompare(b.name));
+): Promise<Array<{ id: string; name: string; source: 'builtin' | 'user' | 'project' }>> {
+  const [projectFiles, userFiles] = await Promise.all([
+    listSourcePersonaFiles(projectPath, 'project'),
+    listSourcePersonaFiles(projectPath, 'user'),
+  ]);
+
+  // Merge layered by precedence: project > user > built-in. The effective source
+  // tag is the highest-precedence layer that defines the id.
+  const byId = new Map<string, { id: string; name: string; source: 'builtin' | 'user' | 'project' }>();
+  for (const p of PERSONA_TEMPLATES) {
+    byId.set(p.id, { id: p.id, name: p.name, source: 'builtin' });
+  }
+  for (const f of userFiles) {
+    byId.set(f.id, { id: f.id, name: getPersonaTemplate(f.id)?.name ?? f.id, source: 'user' });
+  }
+  for (const f of projectFiles) {
+    byId.set(f.id, { id: f.id, name: getPersonaTemplate(f.id)?.name ?? f.id, source: 'project' });
+  }
+  return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**
- * Read persona content for editing in the UI: the on-disk file if present,
- * otherwise the built-in template content as a starting point. Returns empty
- * string when neither exists.
+ * Read persona content for editing in the UI: the effective layered content
+ * (project → user → built-in) as a starting point. Returns empty string when
+ * none exists.
  */
 export async function readPersonaForEdit(projectPath: string, personaId: string): Promise<string> {
-  const onDisk = await readSourcePersonaContent(projectPath, personaId);
-  if (onDisk) return onDisk;
-  return getPersonaTemplate(personaId)?.content ?? '';
+  const resolved = await resolvePersonaContent(projectPath, personaId);
+  return resolved ?? '';
 }
 
 /**
@@ -1030,19 +1038,25 @@ agent. The content is substituted for the \`@@Persona\` wildcard, or appended to
 the instructions when the template doesn't reference the token.
 
 Clubhouse ships a built-in persona library. To customize, author an on-disk
-persona file — a flat markdown file under \`.clubhouse/personas/\`, where the
-filename (minus \`.md\`) is the persona ID:
+persona file — a flat markdown file where the filename (minus \`.md\`) is the
+persona ID. There are two on-disk scopes:
 
 \`\`\`
-.clubhouse/personas/
-  qa.md            # overrides the built-in "qa" persona
-  my-reviewer.md   # a brand-new persona
+.clubhouse/personas/        # project-scoped — this project only
+  qa.md                     # overrides the built-in "qa" persona here
+  my-reviewer.md            # a project-specific persona
+
+~/.clubhouse/personas/      # user-global — reusable across ALL your projects
+  my-reviewer.md            # author once, use in any project
 \`\`\`
 
-At materialization, persona content resolves **disk-first**: if
-\`.clubhouse/personas/<id>.md\` exists it wins; otherwise the built-in template
-of the same ID is used. Built-ins are never written to disk automatically — they
-remain available until you shadow one with a file of the same name.
+At materialization, persona content resolves by precedence: **project →
+user-global → built-in**. A \`.clubhouse/personas/<id>.md\` wins; otherwise a
+\`~/.clubhouse/personas/<id>.md\` is used; otherwise the built-in template of the
+same ID. Built-ins are never written to disk automatically — they remain
+available until you shadow one with a file of the same name. Put personas you
+want everywhere in \`~/.clubhouse/personas/\`; use \`.clubhouse/personas/\` to
+tweak one only for this project.
 
 **Selecting a persona** works exactly like missions:
 - Set \`agentDefaults.persona\` in \`.clubhouse/settings.json\` for the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -396,14 +396,14 @@ const api = {
       ipcRenderer.invoke(IPC.AGENT.WRITE_SOURCE_MISSION_CONTENT, projectPath, missionId, content),
     deleteSourceMission: (projectPath: string, missionId: string): Promise<void> =>
       ipcRenderer.invoke(IPC.AGENT.DELETE_SOURCE_MISSION, projectPath, missionId),
-    listSourcePersonas: (projectPath: string): Promise<Array<{ id: string; name: string; source: 'builtin' | 'disk' }>> =>
+    listSourcePersonas: (projectPath: string): Promise<Array<{ id: string; name: string; source: 'builtin' | 'user' | 'project' }>> =>
       ipcRenderer.invoke(IPC.AGENT.LIST_SOURCE_PERSONAS, projectPath),
     readSourcePersonaContent: (projectPath: string, personaId: string): Promise<string> =>
       ipcRenderer.invoke(IPC.AGENT.READ_SOURCE_PERSONA_CONTENT, projectPath, personaId),
-    writeSourcePersonaContent: (projectPath: string, personaId: string, content: string): Promise<void> =>
-      ipcRenderer.invoke(IPC.AGENT.WRITE_SOURCE_PERSONA_CONTENT, projectPath, personaId, content),
-    deleteSourcePersona: (projectPath: string, personaId: string): Promise<void> =>
-      ipcRenderer.invoke(IPC.AGENT.DELETE_SOURCE_PERSONA, projectPath, personaId),
+    writeSourcePersonaContent: (projectPath: string, personaId: string, content: string, scope?: 'project' | 'user'): Promise<void> =>
+      ipcRenderer.invoke(IPC.AGENT.WRITE_SOURCE_PERSONA_CONTENT, projectPath, personaId, content, scope),
+    deleteSourcePersona: (projectPath: string, personaId: string, scope?: 'project' | 'user'): Promise<void> =>
+      ipcRenderer.invoke(IPC.AGENT.DELETE_SOURCE_PERSONA, projectPath, personaId, scope),
     createSkill: (basePath: string, name: string, isSource: boolean, projectPath?: string) =>
       ipcRenderer.invoke(IPC.AGENT.CREATE_SKILL, basePath, name, isSource, projectPath),
     createAgentTemplate: (basePath: string, name: string, isSource: boolean, projectPath?: string) =>

--- a/src/renderer/features/agents/WildcardLibraryField.tsx
+++ b/src/renderer/features/agents/WildcardLibraryField.tsx
@@ -5,8 +5,14 @@ export interface LibraryOption {
   id: string;
   /** Display label (falls back to id). */
   label?: string;
-  /** Origin marker shown as a chip; e.g. 'builtin' | 'disk'. */
+  /** Origin marker shown as a chip; e.g. 'builtin' | 'user' | 'project'. */
   source?: string;
+}
+
+/** A writable storage scope for authored items (e.g. project vs user-global). */
+export interface ScopeOption {
+  value: string;
+  label: string;
 }
 
 interface Props {
@@ -27,12 +33,16 @@ interface Props {
   onChange: (id: string) => void;
   /** Load the editable content for an id. */
   loadContent: (id: string) => Promise<string>;
-  /** Persist content for an id (create or overwrite). */
-  saveContent: (id: string, content: string) => Promise<void>;
-  /** Delete a library item by id. */
-  deleteItem: (id: string) => Promise<void>;
+  /** Persist content for an id (create or overwrite), to the given scope when provided. */
+  saveContent: (id: string, content: string, scope?: string) => Promise<void>;
+  /** Delete a library item by id, from the given scope when provided. */
+  deleteItem: (id: string, scope?: string) => Promise<void>;
   /** Called after the library changes so the parent can refresh option lists. */
   onLibraryChanged: () => void;
+  /** When set, the editor shows a storage-scope selector (e.g. project vs user-global). */
+  scopeOptions?: ScopeOption[];
+  /** Initial/selected scope value when the editor opens (defaults to the first scope option). */
+  initialScope?: string;
 }
 
 const ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
@@ -58,6 +68,8 @@ export function WildcardLibraryField({
   saveContent,
   deleteItem,
   onLibraryChanged,
+  scopeOptions,
+  initialScope,
 }: Props) {
   const [mode, setMode] = useState<EditorMode>('closed');
   const [content, setContent] = useState('');
@@ -65,6 +77,9 @@ export function WildcardLibraryField({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [scope, setScope] = useState<string>(initialScope ?? scopeOptions?.[0]?.value ?? '');
+
+  const resetScope = () => setScope(initialScope ?? scopeOptions?.[0]?.value ?? '');
 
   // Close the editor whenever the field is disabled (e.g. agent starts running).
   useEffect(() => {
@@ -78,6 +93,7 @@ export function WildcardLibraryField({
   const openEdit = async () => {
     if (!value) return;
     setError('');
+    resetScope();
     setLoading(true);
     setMode('edit');
     setCopyId('');
@@ -92,6 +108,7 @@ export function WildcardLibraryField({
 
   const openNew = () => {
     setError('');
+    resetScope();
     setContent('');
     setCopyId('');
     setMode('new');
@@ -116,7 +133,7 @@ export function WildcardLibraryField({
     setSaving(true);
     setError('');
     try {
-      await saveContent(value, content);
+      await saveContent(value, content, scopeOptions ? scope : undefined);
       onLibraryChanged();
       setMode('closed');
     } catch (e) {
@@ -141,7 +158,7 @@ export function WildcardLibraryField({
     setSaving(true);
     setError('');
     try {
-      await saveContent(id, content);
+      await saveContent(id, content, scopeOptions ? scope : undefined);
       onLibraryChanged();
       onChange(id);
       setMode('closed');
@@ -157,7 +174,7 @@ export function WildcardLibraryField({
     setSaving(true);
     setError('');
     try {
-      await deleteItem(value);
+      await deleteItem(value, scopeOptions ? scope : undefined);
       onLibraryChanged();
       onChange('');
       setMode('closed');
@@ -184,7 +201,7 @@ export function WildcardLibraryField({
           <option value="">{inheritLabel}</option>
           {options.map((o) => (
             <option key={o.id} value={o.id}>
-              {(o.label || o.id) + (o.source === 'disk' ? ' · custom' : '')}
+              {(o.label || o.id) + (o.source && o.source !== 'builtin' ? ` · ${o.source}` : '')}
             </option>
           ))}
         </select>
@@ -239,6 +256,21 @@ export function WildcardLibraryField({
                 placeholder={`${value}-copy`}
                 className="w-full bg-surface-0 border border-surface-2 rounded px-2 py-1 text-sm text-ctp-text placeholder:text-ctp-overlay0 focus-ring"
               />
+            </div>
+          )}
+          {scopeOptions && scopeOptions.length > 0 && (
+            <div>
+              <label className="block text-xs text-ctp-subtext0 mb-1">Save scope</label>
+              <select
+                value={scope}
+                onChange={(e) => setScope(e.target.value)}
+                disabled={saving}
+                className="w-full bg-surface-0 border border-surface-2 rounded px-2 py-1 text-sm text-ctp-text focus-ring"
+              >
+                {scopeOptions.map((s) => (
+                  <option key={s.value} value={s.value}>{s.label}</option>
+                ))}
+              </select>
             </div>
           )}
           {error && <p className="text-xs text-ctp-error">{error}</p>}

--- a/src/renderer/features/agents/WildcardSettingsForm.tsx
+++ b/src/renderer/features/agents/WildcardSettingsForm.tsx
@@ -131,6 +131,16 @@ export function WildcardSettingsForm({ projectPath, agentId, disabled, refreshKe
   const missionOptions: LibraryOption[] = data.missions.map((m) => ({ id: m.id }));
   const personaOptions: LibraryOption[] = data.personas.map((p) => ({ id: p.id, label: `${p.name} (${p.id})`, source: p.source }));
 
+  // Personas can be authored project-scoped or in the user-global library
+  // (reusable across projects). Default the editor's scope to where the
+  // currently-selected persona already lives.
+  const personaScopeOptions = [
+    { value: 'project', label: 'This project (.clubhouse/personas/)' },
+    { value: 'user', label: 'All my projects (~/.clubhouse/personas/)' },
+  ];
+  const selectedPersonaSource = data.personas.find((p) => p.id === form.persona)?.source;
+  const personaInitialScope = selectedPersonaSource === 'user' ? 'user' : 'project';
+
   return (
     <div className="space-y-5">
       <div className="flex items-center justify-between">
@@ -221,16 +231,18 @@ export function WildcardSettingsForm({ projectPath, agentId, disabled, refreshKe
         />
         <WildcardLibraryField
           token="@@Persona"
-          help="The persona body substituted for @@Persona. Built-ins seed the list; edits save to .clubhouse/personas/ and override the built-in."
+          help="The persona body substituted for @@Persona. Built-ins seed the list; save to this project or to your user-global library (~/.clubhouse/personas/) to reuse across projects. Project overrides user overrides built-in."
           noun="persona"
           value={form.persona}
           projectDefault={data.persona.projectDefault}
           options={personaOptions}
           disabled={disabled}
+          scopeOptions={personaScopeOptions}
+          initialScope={personaInitialScope}
           onChange={(id) => update({ persona: id })}
           loadContent={(id) => window.clubhouse.agentSettings.readSourcePersonaContent(projectPath, id)}
-          saveContent={(id, content) => window.clubhouse.agentSettings.writeSourcePersonaContent(projectPath, id, content)}
-          deleteItem={(id) => window.clubhouse.agentSettings.deleteSourcePersona(projectPath, id)}
+          saveContent={(id, content, scope) => window.clubhouse.agentSettings.writeSourcePersonaContent(projectPath, id, content, scope === 'user' ? 'user' : 'project')}
+          deleteItem={(id, scope) => window.clubhouse.agentSettings.deleteSourcePersona(projectPath, id, scope === 'user' ? 'user' : 'project')}
           onLibraryChanged={() => setInternalRefresh((n) => n + 1)}
         />
       </section>

--- a/src/renderer/features/assistant/content/personas/group-project-pm.md
+++ b/src/renderer/features/assistant/content/personas/group-project-pm.md
@@ -1,0 +1,91 @@
+# Role: Group Project PM
+
+You are a **group-project manager and delegator** running the shared group-project
+bulletin board. You plan, coordinate, dispatch, and actively operate the board so
+the team stays synchronized. You do NOT write code yourself — you delegate all
+implementation to executor agents.
+
+This persona **assumes you have the privileged group-project tools enabled** (admin
+mode). Run `list_members` and check your available tools first: if you do not see
+`wake_agent`, `sleep_agent`, `start_polling`, `stop_polling`, `shoulder_tap`,
+`broadcast`, `clear_agent`, `compact_agent`, `clear_topic`, or `delete_messages`,
+then privileged tools are not enabled for you — ask the human to enable them on your
+group-project binding in the Clubhouse UI, and operate with the core tools only
+(`post_bulletin`, `read_bulletin`, `read_topic`, `read_message`, `list_members`,
+`get_project_info`) until they are.
+
+## Responsibilities
+
+- Break large goals into discrete, well-scoped missions with testable acceptance criteria
+- Dispatch missions to the right agents and track them on the board
+- Keep the team awake/asleep and polling appropriately for the current workload
+- Keep the board healthy: prune stale channels and manage context growth
+- Unblock agents, including waking or shoulder-tapping non-responsive ones
+- Make prioritization and merge-gating decisions
+
+## Orient first
+
+1. `get_project_info` — read the project's instructions, channels, and conventions
+2. `list_members` — see who is `connected` vs `sleeping`, and confirm your tool access
+3. `read_bulletin` with `summary=true` — get a digest before drilling in with `read_topic`
+
+## Channels & communication
+
+- `general` — introduce yourself once, then project-wide announcements only
+- `control` — set up scoped work channels and tell agents where to poll
+  (e.g. "new channel #fix-login-bug, bold-falcon please follow")
+- `missions-<stream>` / work channels — post mission briefs with clear scope,
+  acceptance criteria, and branch naming; one agent per mission
+- `inbox-<agent-name>` — direct 1:1 asks to a specific agent
+- Post `decisions` to the relevant work channel when you make a call that affects it
+- Read efficiently: pass `since=<last-timestamp>` and a filtered `channels=[…]` list;
+  only `read_topic` channels whose `newMessageCount > 0`
+
+## Operating the team (privileged tools)
+
+**Wake / sleep** — match the awake roster to the work in flight.
+- `wake_agent` (`target_agent_id`, optional `message`, `resume`) to bring a sleeping
+  agent online, optionally handing it a mission and resuming its prior session
+- `sleep_agent` (`target_agent_id`) to gracefully stop an idle agent and free resources
+- Re-check `list_members` after lifecycle changes; do not leave agents idle-but-awake
+
+**Polling** — keep agents synchronized without babysitting.
+- After waking an agent, `start_polling` so it periodically reads its relevant channels
+  (Claude Code agents automate this as a `/loop` over `read_bulletin`)
+- `stop_polling` when an agent is going idle, finishing a stream, or being put to sleep
+- Stop polling before sleeping an agent so it doesn't churn
+
+**Shoulder tap** — for unresponsive, time-critical cases ONLY.
+- Post to the agent's `inbox-<name>` first; routine asks belong on the board
+- `shoulder_tap` (`target_agent_id`, `message`) injects an urgent, ephemeral nudge
+  straight into the agent — it is NOT recorded on the board. Use it only when an agent
+  is genuinely unresponsive and the matter is urgent
+- `broadcast` is reserved for rare, critical all-hands announcements
+
+## Board & context hygiene (do this periodically)
+
+The board auto-prunes (defaults ~100 messages/channel, ~500 total; protected channels
+like `general`, `control`, and `inbox-*` are preserved), but as PM you should actively
+keep things lean so agents spend tokens on signal, not noise:
+
+- **Periodically manage message size across all channels.** Sweep with
+  `read_bulletin` (use `summary=true`) and:
+  - `clear_topic` to retire a completed/abandoned work channel (it deletes the channel
+    and its messages; protected channels are recreated empty)
+  - `delete_messages` to remove specific stale or superseded messages by id
+- **Manage agents' own context** when their conversations get bloated:
+  - `compact_agent` to compress an agent's context without losing continuity (prefer this)
+  - `clear_agent` to fully reset an agent's context (use sparingly — it loses history)
+- You cannot change the board's retention limits from here; those are configured by the
+  human in the Clubhouse UI. Ask them to raise/lower limits if pruning isn't enough.
+
+## Rules
+
+1. **Never write code** — delegate all implementation to executor agents
+2. **One agent per mission** — check the board before assigning to avoid duplicate work
+3. **Clear acceptance criteria** — every mission has testable exit conditions
+4. **Right-size the roster** — wake only who you need; sleep idle agents; pair polling with wake/sleep
+5. **Board first, tap second** — use channels for routine coordination; `shoulder_tap` only when unresponsive and urgent
+6. **Keep it lean** — sweep channels and compact agent contexts on a regular cadence
+7. **Respect QA and design leads** — their approvals are required before merge
+8. **Status updates** — post regular summaries so the team stays aligned

--- a/src/renderer/features/assistant/content/personas/index.ts
+++ b/src/renderer/features/assistant/content/personas/index.ts
@@ -1,4 +1,5 @@
 import projectManager from './project-manager.md';
+import groupProjectPm from './group-project-pm.md';
 import qa from './qa.md';
 import uiLead from './ui-lead.md';
 import qualityAuditor from './quality-auditor.md';
@@ -21,6 +22,12 @@ export const PERSONA_TEMPLATES: PersonaTemplate[] = [
     name: 'Project Manager',
     description: 'Delegator and planner. Dispatches work via the group project board. Does not write code.',
     content: projectManager,
+  },
+  {
+    id: 'group-project-pm',
+    name: 'Group Project PM',
+    description: 'Project manager who actively operates the group-project board: dispatches work, wakes/sleeps agents, manages polling, shoulder-taps, and keeps channels lean. Assumes privileged (admin) tools.',
+    content: groupProjectPm,
   },
   {
     id: 'qa',

--- a/src/renderer/features/assistant/content/personas/personas.test.ts
+++ b/src/renderer/features/assistant/content/personas/personas.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { PERSONA_TEMPLATES, getPersonaTemplate, getPersonaIds } from './index';
 
 describe('persona templates', () => {
-  it('exports 9 persona templates', () => {
-    expect(PERSONA_TEMPLATES).toHaveLength(9);
+  it('exports 10 persona templates', () => {
+    expect(PERSONA_TEMPLATES).toHaveLength(10);
   });
 
   it('each template has required fields', () => {
@@ -27,10 +27,11 @@ describe('persona templates', () => {
     expect(getPersonaTemplate('nonexistent')).toBeUndefined();
   });
 
-  it('getPersonaIds returns all 9 IDs', () => {
+  it('getPersonaIds returns all 10 IDs', () => {
     const ids = getPersonaIds();
-    expect(ids).toHaveLength(9);
+    expect(ids).toHaveLength(10);
     expect(ids).toContain('project-manager');
+    expect(ids).toContain('group-project-pm');
     expect(ids).toContain('qa');
     expect(ids).toContain('ui-lead');
     expect(ids).toContain('quality-auditor');

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -339,7 +339,7 @@ export interface AgentWildcardSettings {
   mission: { override: string | null; projectDefault: string | null; resolved: string | null };
   persona: { override: string | null; projectDefault: string | null; resolved: string | null };
   missions: Array<{ id: string }>;
-  personas: Array<{ id: string; name: string; source: 'builtin' | 'disk' }>;
+  personas: Array<{ id: string; name: string; source: 'builtin' | 'user' | 'project' }>;
 }
 
 export interface ClubhouseModeSettings {


### PR DESCRIPTION
## Summary

Two pieces of persona work:

- **Item 11 — `group-project-pm` built-in persona.** A delegator/PM like `project-manager`, but with explicit, product-accurate instructions for actively *operating* the group-project board: dispatching work via channels, waking/sleeping agents, starting/stopping polling, shoulder-tapping non-responsive agents, and keeping the board lean (pruning channels, compacting agent contexts). It assumes the **privileged group-project tools** are enabled and tells the agent how to check/which to ask for if they aren't.
- **Item 12 — user-global persona library.** Personas can now live in `~/.clubhouse/personas/<id>.md` so a user authors a persona once and reuses it across **every** project, alongside the project-scoped `.clubhouse/personas/` from #1488.

## Item 11 details
- New `src/renderer/features/assistant/content/personas/group-project-pm.md` + registered in `PERSONA_TEMPLATES`.
- Written against the real subsystem: `post_bulletin`/`read_bulletin`/`read_topic`, `list_members`, `wake_agent`/`sleep_agent`, `start_polling`/`stop_polling`, `shoulder_tap`/`broadcast`, `clear_agent`/`compact_agent`, `clear_topic`/`delete_messages`, and the auto-retention/pruning model.
- Note: there is no literal "admin mode" toggle in code — privileged tools are gated per-binding via `disabledTools`. The persona frames "admin mode" as "privileged tools enabled" and explains how to verify.

## Item 12 details (scope: backend + reuse existing field, per product direction)
- **Storage:** new user-global scope at `~/.clubhouse/personas/` (consistent with `~/.clubhouse/group-projects`, `~/.clubhouse/agent-icons`), alongside project `.clubhouse/personas/`.
- **Resolution precedence everywhere: project → user-global → built-in.** `resolvePersonaContent`, `readPersonaForEdit`, and `listAvailablePersonas` (which now tags each entry's effective `source` as `builtin | user | project`).
- **Scope-aware service:** persona `list/read/write/delete` take a `scope: 'project' | 'user'` (default `project`, backward compatible) via a `personasDirFor` helper.
- **IPC/preload:** persona write/delete accept an optional `scope`; `AgentWildcardSettings.personas[].source` widened to `builtin | user | project`.
- **UI:** `WildcardLibraryField` gains an optional **Save scope** selector; the persona field offers **This project** vs **All my projects**, defaulting to the selected persona's current scope. Dropdown entries show a `· user` / `· project` source tag. Missions are unchanged (project-only).
- **Docs:** the `clubhouse-mode.md` self-edit guide documents the user-global library and the precedence rule, so UI edits and agent/readme edits stay equivalent.

No new settings screen and no agent-gallery changes this PR (deferred by design).

## Test Plan
- [x] `personas.test.ts` — count 9 → 10; `group-project-pm` present.
- [x] `agent-settings-service.test.ts` — persona `write`/`delete`/`read` honor `scope: 'user'` (paths under `~/.clubhouse/personas`); project scope unchanged.
- [x] `materialization-service.test.ts` — `resolvePersonaContent` precedence project > user > built-in (+ user-only fallback, project-wins); `listAvailablePersonas` tags `user` vs `project` and project shadows user; readme references `~/.clubhouse/personas/` + precedence.
- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 478 files / 12206 pass, 4 pre-existing skips.
- [x] `npm run lint` — 0 errors.

## Manual Validation
- [ ] Create an agent with the **Group Project PM** persona; confirm its instructions render and reference the real board tools.
- [ ] In a managed agent's **Wildcards → @@Persona** field: edit a persona, set **Save scope = All my projects**, save → confirm `~/.clubhouse/personas/<id>.md` is written; open a *different* project and confirm the persona appears in the dropdown tagged `· user`.
- [ ] Set **Save scope = This project** for the same id → confirm `.clubhouse/personas/<id>.md` is written and overrides the user-global one (dropdown shows `· project`).
- [ ] Delete with each scope → confirm only the targeted layer's file is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)