### PR TITLE
feat(canvas): zone wires — wire to a zone, auto-update, annex-reliable rendering (#7, #8)

### DIFF
--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -2163,7 +2163,8 @@ describe('annex-server', () => {
         path.join(__dirname, '../../renderer/plugins/builtin/canvas/canvas-store.ts'), 'utf-8',
       ));
       // hydrateFromRemote accepts wireDefinitions as third parameter
-      expect(source).toContain('hydrateFromRemote: (canvasData, activeId, remoteWireDefinitions?)');
+      // (and zone wire definitions as a fourth)
+      expect(source).toContain('hydrateFromRemote: (canvasData, activeId, remoteWireDefinitions?, remoteZoneWireDefinitions?)');
     });
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1198,6 +1198,8 @@ const api = {
       viewport: { panX: number; panY: number; zoom: number };
       nextZIndex: number;
       zoomedViewId: string | null;
+      wireDefinitions?: unknown[];
+      zoneWireDefinitions?: unknown[];
     } | null> =>
       ipcRenderer.invoke(IPC.WINDOW.GET_CANVAS_STATE, canvasId, scope, projectId),
     onRequestCanvasState: (callback: (requestId: string, canvasId: string, scope: string, projectId?: string) => void) => {
@@ -1222,6 +1224,8 @@ const api = {
       viewport: { panX: number; panY: number; zoom: number };
       nextZIndex: number;
       zoomedViewId: string | null;
+      wireDefinitions?: unknown[];
+      zoneWireDefinitions?: unknown[];
     }) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, state: Parameters<typeof callback>[0]) => callback(state);
       ipcRenderer.on(IPC.WINDOW.CANVAS_STATE_CHANGED, listener);

--- a/src/renderer/features/popout/PopoutCanvasView.tsx
+++ b/src/renderer/features/popout/PopoutCanvasView.tsx
@@ -13,6 +13,7 @@ import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { CanvasWorkspace } from '../../plugins/builtin/canvas/CanvasWorkspace';
 import type { CanvasView, CanvasViewType, Viewport, Position, Size } from '../../plugins/builtin/canvas/canvas-types';
 import { clampViewport } from '../../plugins/builtin/canvas/canvas-operations';
+import type { ZoneWireDefinition } from '../../plugins/builtin/canvas/zone-wire-store';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { createWidgetsAPI } from '../../plugins/plugin-api-ui';
@@ -186,6 +187,7 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
   // Popout uses live MCP bindings as wire definitions — persistence is handled
   // by the main window's canvas store via the wireDefinitions system.
   const popoutWireDefinitions = useMcpBindingStore((s) => s.bindings);
+  const [zoneWireDefinitions, setZoneWireDefinitions] = useState<ZoneWireDefinition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Guard against mutations firing before the initial IPC snapshot resolves.
@@ -226,6 +228,7 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
         setViews(snapshot.views as CanvasView[]);
         setViewport(clampViewport(snapshot.viewport));
         setZoomedViewId(snapshot.zoomedViewId);
+        setZoneWireDefinitions((snapshot.zoneWireDefinitions as ZoneWireDefinition[] | undefined) ?? []);
       } else {
         setError(`Canvas "${canvasId}" not found`);
       }
@@ -250,6 +253,7 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
       setViews(state.views as CanvasView[]);
       setViewport(clampViewport(state.viewport));
       setZoomedViewId(state.zoomedViewId);
+      setZoneWireDefinitions((state.zoneWireDefinitions as ZoneWireDefinition[] | undefined) ?? []);
     });
     return remove;
   }, [canvasId]);
@@ -264,6 +268,7 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
           setViews(snapshot.views as CanvasView[]);
           setViewport(clampViewport(snapshot.viewport));
           setZoomedViewId(snapshot.zoomedViewId);
+          setZoneWireDefinitions((snapshot.zoneWireDefinitions as ZoneWireDefinition[] | undefined) ?? []);
         }
       }).catch(() => { /* silent — main window may be busy */ });
     }, RECONCILE_INTERVAL_MS);
@@ -386,6 +391,9 @@ export function PopoutCanvasView({ canvasId, projectId }: PopoutCanvasViewProps)
         onAddWireDefinition={() => {}}
         onRemoveWireDefinition={() => {}}
         onUpdateWireDefinition={() => {}}
+        zoneWireDefinitions={zoneWireDefinitions}
+        onAddZoneWireDefinition={(wire) => ({ ...wire, id: '' })}
+        onRemoveZoneWireDefinition={() => {}}
         api={api}
         onViewportChange={handleViewportChange}
         onAddView={handleAddView}

--- a/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasWorkspace.tsx
@@ -19,8 +19,8 @@ import { WireDragOverlay } from './WireDragOverlay';
 import { WireConfigPopover } from './WireConfigPopover';
 import { CanvasMinimap } from './CanvasMinimap';
 import { useWiring, type ZoneWireCallback } from './useWiring';
-import { useZoneWireStore } from './zone-wire-store';
-import { expandZoneWires, reconcileZoneBindings } from './zone-wire-expansion';
+import type { ZoneWireDefinition } from './zone-wire-store';
+import { expandZoneWires, diffZoneBindings, type ExpandedBinding } from './zone-wire-expansion';
 import { useMcpBindingStore, type McpBindingEntry } from '../../../stores/mcpBindingStore';
 import { useMcpSettingsStore } from '../../../stores/mcpSettingsStore';
 import { useAnnexClientStore } from '../../../stores/annexClientStore';
@@ -48,6 +48,10 @@ interface CanvasWorkspaceProps {
   onAddWireDefinition: (entry: McpBindingEntry) => void;
   onRemoveWireDefinition: (agentId: string, targetId: string) => void;
   onUpdateWireDefinition: (agentId: string, targetId: string, updates: Partial<McpBindingEntry>) => void;
+  /** Persisted zone-level wires (zone → target). Source of truth in canvas store. */
+  zoneWireDefinitions?: ZoneWireDefinition[];
+  onAddZoneWireDefinition?: (wire: Omit<ZoneWireDefinition, 'id'>) => ZoneWireDefinition;
+  onRemoveZoneWireDefinition?: (wireId: string) => void;
   api: PluginAPI;
   onViewportChange: (viewport: Viewport) => void;
   onAddView: (type: CanvasViewType, position: Position) => void;
@@ -88,6 +92,9 @@ export function CanvasWorkspace({
   onAddWireDefinition,
   onRemoveWireDefinition,
   onUpdateWireDefinition,
+  zoneWireDefinitions = [],
+  onAddZoneWireDefinition,
+  onRemoveZoneWireDefinition,
   api,
   onViewportChange,
   onAddView,
@@ -124,7 +131,6 @@ export function CanvasWorkspace({
   // ── MCP / wire store subscriptions ───────────────────────────────
   const mcpEnabled = !!useMcpSettingsStore((s) => s.enabled);
   const mcpBindings = useMcpBindingStore((s) => s.bindings);
-  const addZoneWire = useZoneWireStore((s) => s.addWire);
   const mcpBind = useMcpBindingStore((s) => s.bind);
 
   const mergedWireBindings = useMemo(() => {
@@ -133,14 +139,29 @@ export function CanvasWorkspace({
     return extras.length > 0 ? [...wireDefinitions, ...extras] : wireDefinitions;
   }, [wireDefinitions, mcpBindings]);
 
+  // Creating a zone wire only records the definition; the reconcile effect
+  // below expands it into per-agent MCP bindings and keeps them in sync as
+  // members join/leave the zone.
   const handleZoneWire: ZoneWireCallback = useCallback((sourceZoneId, targetId, targetType) => {
-    addZoneWire({ sourceZoneId, targetId, targetType });
-    const allWires = [...useZoneWireStore.getState().wires];
-    const expanded = expandZoneWires(allWires, views);
-    const current = useMcpBindingStore.getState().bindings;
-    const { toAdd } = reconcileZoneBindings(expanded, current);
+    onAddZoneWireDefinition?.({ sourceZoneId, targetId, targetType });
+  }, [onAddZoneWireDefinition]);
+
+  // Auto-reconcile zone-derived bindings whenever the zone wires or the canvas
+  // views (containment) change. This re-expands every zone wire and applies the
+  // delta against the previous expansion: new memberships are bound, departed
+  // memberships are unbound, and manual wires are never touched. It also runs on
+  // hydration, re-deriving runtime bindings from the persisted zone wires.
+  const prevExpandedRef = useRef<ExpandedBinding[]>([]);
+  useEffect(() => {
+    if (!mcpEnabled) return;
+    const desired = expandZoneWires(zoneWireDefinitions, views);
+    const currentKeys = new Set(
+      useMcpBindingStore.getState().bindings.map((b) => `${b.agentId}:${b.targetId}`),
+    );
+    const { toAdd, toRemove } = diffZoneBindings(prevExpandedRef.current, desired, currentKeys);
+    prevExpandedRef.current = desired;
     for (const b of toAdd) {
-      mcpBind(b.agentId, {
+      void mcpBind(b.agentId, {
         targetId: b.targetId,
         targetKind: b.targetKind,
         label: b.label,
@@ -148,7 +169,10 @@ export function CanvasWorkspace({
         targetName: b.targetName,
       });
     }
-  }, [views, addZoneWire, mcpBind]);
+    for (const b of toRemove) {
+      void useMcpBindingStore.getState().unbind(b.agentId, b.targetId);
+    }
+  }, [zoneWireDefinitions, views, mcpEnabled, mcpBind]);
 
   const handleAddWireDef = useCallback((entry: { agentId: string; targetId: string; targetKind: string; label: string; agentName?: string; targetName?: string; projectName?: string }) => {
     onAddWireDefinition(entry as McpBindingEntry);
@@ -503,9 +527,11 @@ export function CanvasWorkspace({
             <WireOverlay
               views={views}
               bindings={mergedWireBindings}
+              zoneWireDefinitions={zoneWireDefinitions}
               viewPositions={wireViewPositions}
               sleepingAgentIds={sleepingAgentIds}
               onWireClick={handleWireClick}
+              onZoneWireClick={onRemoveZoneWireDefinition}
               forceBidirectional={bidirectionalWires}
             />
           </div>

--- a/src/renderer/plugins/builtin/canvas/WireOverlay.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireOverlay.test.tsx
@@ -606,4 +606,72 @@ describe('WireOverlay', () => {
     const group = container.querySelector('[data-testid^="wire-group-"]');
     expect(group?.getAttribute('data-dimmed')).toBeNull();
   });
+
+  describe('zone wires', () => {
+    function makeZoneView(id: string, x = 0, y = 0): CanvasView {
+      return {
+        id, type: 'zone',
+        position: { x, y }, size: { width: 400, height: 300 },
+        title: id, displayName: id, zIndex: 0, metadata: {},
+        themeId: 'catppuccin-mocha', containedViewIds: [],
+      };
+    }
+
+    it('renders a single zone wire to the zone (not one per member)', () => {
+      const views: CanvasView[] = [
+        makeZoneView('z1', 0, 0),
+        makeAgentView('a1', 'agent-1', 700, 0),
+      ];
+      const { container } = render(
+        <WireOverlay
+          views={views}
+          bindings={[]}
+          zoneWireDefinitions={[{ id: 'zw1', sourceZoneId: 'z1', targetId: 'agent-1', targetType: 'agent' }]}
+        />,
+      );
+      const zonePaths = container.querySelectorAll('[data-testid^="zone-wire-path-"]');
+      expect(zonePaths).toHaveLength(1);
+      expect(container.querySelector('[data-testid="zone-wire-group-zw1"]')).not.toBeNull();
+    });
+
+    it('renders the SVG even when there are only zone wires and no bindings', () => {
+      const views: CanvasView[] = [makeZoneView('z1'), makeAgentView('a1', 'agent-1', 700, 0)];
+      const { container } = render(
+        <WireOverlay
+          views={views}
+          bindings={[]}
+          zoneWireDefinitions={[{ id: 'zw1', sourceZoneId: 'z1', targetId: 'agent-1', targetType: 'agent' }]}
+        />,
+      );
+      expect(container.querySelector('svg')).not.toBeNull();
+    });
+
+    it('invokes onZoneWireClick when a zone wire hitbox is clicked', () => {
+      const onZoneWireClick = vi.fn();
+      const views: CanvasView[] = [makeZoneView('z1'), makeAgentView('a1', 'agent-1', 700, 0)];
+      const { container } = render(
+        <WireOverlay
+          views={views}
+          bindings={[]}
+          zoneWireDefinitions={[{ id: 'zw1', sourceZoneId: 'z1', targetId: 'agent-1', targetType: 'agent' }]}
+          onZoneWireClick={onZoneWireClick}
+        />,
+      );
+      const hitbox = container.querySelector('[data-testid="zone-wire-hitbox-zw1"]') as SVGPathElement;
+      hitbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(onZoneWireClick).toHaveBeenCalledWith('zw1', expect.anything());
+    });
+
+    it('drops a zone wire whose target view is missing', () => {
+      const views: CanvasView[] = [makeZoneView('z1')];
+      const { container } = render(
+        <WireOverlay
+          views={views}
+          bindings={[]}
+          zoneWireDefinitions={[{ id: 'zw1', sourceZoneId: 'z1', targetId: 'agent-missing', targetType: 'agent' }]}
+        />,
+      );
+      expect(container.querySelector('svg')).toBeNull();
+    });
+  });
 });

--- a/src/renderer/plugins/builtin/canvas/WireOverlay.tsx
+++ b/src/renderer/plugins/builtin/canvas/WireOverlay.tsx
@@ -13,6 +13,8 @@ import type { EdgeMidpoint } from './wire-utils';
 import { WireFlowDots, WireFlowDotFilters } from './WireFlowDots';
 import { useWirePhysics } from './useWirePhysics';
 import { useWireActivity } from './useWireActivity';
+import type { ZoneWireDefinition } from './zone-wire-store';
+import { buildViewIndex as buildContractIndex, resolveZoneWireViews } from './wire-render-contract';
 
 /** CSS animations for wire glow — ambient is subtle, active is vivid */
 const WIRE_GLOW_KEYFRAMES = `
@@ -42,14 +44,66 @@ function isBidirectional(binding: McpBindingEntry, allBindings: McpBindingEntry[
 interface WireOverlayProps {
   views: CanvasView[];
   bindings: McpBindingEntry[];
+  /** Zone-level wires — rendered as a single visual wire to the zone. */
+  zoneWireDefinitions?: ZoneWireDefinition[];
   /** Optional per-view position overrides (e.g. during drag). */
   viewPositions?: Map<string, { x: number; y: number }>;
   /** Agent IDs whose status is sleeping or error — wires to/from them render dimmed. */
   sleepingAgentIds?: Set<string>;
   onWireClick?: (binding: McpBindingEntry, event: React.MouseEvent) => void;
+  /** Click handler for a zone wire (e.g. to remove it). Receives the wire id. */
+  onZoneWireClick?: (wireId: string, event: React.MouseEvent) => void;
   /** When true, all agent-to-agent wires render as bidirectional regardless of binding direction. */
   forceBidirectional?: boolean;
 }
+
+/** Zone wires use a distinct accent so the "bundle to a zone" reads differently. */
+const ZONE_WIRE_COLOR = 'rgb(var(--ctp-mauve, 203 166 247))';
+
+/** A single zone wire — a bundled connection drawn to the zone itself. */
+const ZoneWireGroup = React.memo(function ZoneWireGroup({
+  wireId,
+  path,
+  onZoneWireClick,
+}: {
+  wireId: string;
+  path: string;
+  onZoneWireClick?: (wireId: string, event: React.MouseEvent) => void;
+}) {
+  return (
+    <g data-testid={`zone-wire-group-${wireId}`} data-zone-wire="true">
+      {/* Invisible thick hitbox for click interaction */}
+      <path
+        d={path}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={10}
+        style={{ pointerEvents: onZoneWireClick ? 'stroke' : 'none', cursor: onZoneWireClick ? 'pointer' : 'default' }}
+        onClick={(e) => onZoneWireClick?.(wireId, e)}
+        data-testid={`zone-wire-hitbox-${wireId}`}
+      />
+      {/* Outer "bundle" stroke — wider, translucent */}
+      <path
+        d={path}
+        fill="none"
+        strokeWidth={6}
+        strokeLinecap="round"
+        style={{ stroke: ZONE_WIRE_COLOR, opacity: 0.25, pointerEvents: 'none' }}
+      />
+      {/* Inner dashed stroke */}
+      <path
+        d={path}
+        fill="none"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeDasharray="2 5"
+        markerEnd="url(#zone-wire-arrow)"
+        style={{ stroke: ZONE_WIRE_COLOR, pointerEvents: 'none' }}
+        data-testid={`zone-wire-path-${wireId}`}
+      />
+    </g>
+  );
+});
 
 /** Index maps for O(1) binding resolution instead of linear scans. */
 interface ViewIndex {
@@ -173,9 +227,11 @@ const WireGroup = React.memo(function WireGroup({
 export const WireOverlay = React.memo(function WireOverlay({
   views,
   bindings,
+  zoneWireDefinitions,
   viewPositions,
   sleepingAgentIds,
   onWireClick,
+  onZoneWireClick,
   forceBidirectional,
 }: WireOverlayProps) {
   const viewIndex = useMemo(() => {
@@ -183,6 +239,24 @@ export const WireOverlay = React.memo(function WireOverlay({
     for (const v of views) m.set(v.id, v);
     return buildViewIndex(m);
   }, [views]);
+
+  // Zone wires render as a single bundled wire to the zone, resolved via the
+  // shared wire rendering contract so local and annex paths agree.
+  const zoneWires = useMemo(() => {
+    if (!zoneWireDefinitions || zoneWireDefinitions.length === 0) return [];
+    const index = buildContractIndex(views);
+    const result: Array<{ id: string; path: string }> = [];
+    for (const wire of zoneWireDefinitions) {
+      const resolved = resolveZoneWireViews(wire, index);
+      if (!resolved) continue;
+      const { source, target } = resolved;
+      const srcPos = viewPositions?.get(source.id) ?? source.position;
+      const tgtPos = viewPositions?.get(target.id) ?? target.position;
+      const { path } = computeWirePath(viewRect(srcPos, source.size), viewRect(tgtPos, target.size));
+      result.push({ id: wire.id, path });
+    }
+    return result;
+  }, [zoneWireDefinitions, views, viewPositions]);
 
   const wires = useMemo(() => {
     // Track already-rendered pairs so bidirectional bindings only emit one wire
@@ -279,7 +353,7 @@ export const WireOverlay = React.memo(function WireOverlay({
     return result;
   }, [wires, wireOffsets]);
 
-  if (wires.length === 0) return null;
+  if (wires.length === 0 && zoneWires.length === 0) return null;
 
   return (
     <svg
@@ -301,11 +375,19 @@ export const WireOverlay = React.memo(function WireOverlay({
         <marker id="wire-arrow-rev-bidir" markerWidth="8" markerHeight="8" refX="1" refY="4" orient="auto" markerUnits="userSpaceOnUse">
           <path d="M 7 1 L 1 4 L 7 7" fill="none" style={{ stroke: BIDIR_COLOR }} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
         </marker>
+        {/* Zone wire arrowhead (mauve) */}
+        <marker id="zone-wire-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto" markerUnits="userSpaceOnUse">
+          <path d="M 1 1 L 7 4 L 1 7" fill="none" style={{ stroke: ZONE_WIRE_COLOR }} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </marker>
         {/* Wire path definitions (referenced by flow dots via <mpath>) */}
         {wires.map(({ key }) => (
           <path key={`def-${key}`} id={`wire-path-${key}`} d={resolvedPaths.get(key)!} fill="none" />
         ))}
       </defs>
+      {/* Zone wires drawn first so per-agent binding wires sit visually on top */}
+      {zoneWires.map(({ id, path }) => (
+        <ZoneWireGroup key={`zone-${id}`} wireId={id} path={path} onZoneWireClick={onZoneWireClick} />
+      ))}
       {wires.map(({ key, binding, bidir }) => (
         <WireGroup
           key={key}

--- a/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
@@ -1140,4 +1140,76 @@ describe('hydrateFromRemote', () => {
       expect(store.getState().wireDefinitions).toHaveLength(1);
     });
   });
+
+  describe('zone wire definitions', () => {
+    it('addZoneWireDefinition adds a wire and assigns an id; dedupes on (zone,target)', () => {
+      const w1 = store.getState().addZoneWireDefinition({ sourceZoneId: 'z1', targetId: 'durable_2', targetType: 'agent' });
+      expect(w1.id).toMatch(/^zw_/);
+      expect(store.getState().zoneWireDefinitions).toHaveLength(1);
+      // Same source+target → returns existing, no duplicate
+      const w2 = store.getState().addZoneWireDefinition({ sourceZoneId: 'z1', targetId: 'durable_2', targetType: 'agent' });
+      expect(w2.id).toBe(w1.id);
+      expect(store.getState().zoneWireDefinitions).toHaveLength(1);
+    });
+
+    it('removeZoneWireDefinition removes by id', () => {
+      const w = store.getState().addZoneWireDefinition({ sourceZoneId: 'z1', targetId: 'durable_2', targetType: 'agent' });
+      store.getState().removeZoneWireDefinition(w.id);
+      expect(store.getState().zoneWireDefinitions).toHaveLength(0);
+    });
+
+    it('persists and restores zone wires via saveCanvas/loadCanvas', async () => {
+      const storage = createMockStorage();
+      await store.getState().loadCanvas(storage);
+      store.getState().addZoneWireDefinition({ sourceZoneId: 'z1', targetId: 'durable_2', targetType: 'agent' });
+      await store.getState().saveCanvas(storage);
+
+      const store2 = createCanvasStore();
+      await store2.getState().loadCanvas(storage);
+      expect(store2.getState().zoneWireDefinitions).toHaveLength(1);
+      expect(store2.getState().zoneWireDefinitions[0].targetId).toBe('durable_2');
+    });
+
+    it('hydrateFromRemote restores zone wires from a remote snapshot', () => {
+      const zoneWires = [{ id: 'zw_1', sourceZoneId: 'z1', targetId: 'durable_2', targetType: 'agent' }];
+      store.getState().hydrateFromRemote(
+        [{ id: 'c1', name: 'C', views: [], viewport: { panX: 0, panY: 0, zoom: 1 }, nextZIndex: 0, zoomedViewId: null }],
+        'c1',
+        undefined,
+        zoneWires,
+      );
+      expect(store.getState().zoneWireDefinitions).toEqual(zoneWires);
+    });
+
+    it('removeZone removes zone wires sourced from or targeting the zone', () => {
+      store.getState().addView('zone', { x: 0, y: 0 });
+      const zone = store.getState().views.find((v) => v.type === 'zone')!;
+      store.setState({
+        zoneWireDefinitions: [
+          { id: 'zw_a', sourceZoneId: zone.id, targetId: 'durable_2', targetType: 'agent' },
+          { id: 'zw_b', sourceZoneId: 'other-zone', targetId: zone.id, targetType: 'zone' },
+          { id: 'zw_c', sourceZoneId: 'other-zone', targetId: 'durable_9', targetType: 'agent' },
+        ],
+      });
+      store.getState().removeZone(zone.id, false);
+      const ids = store.getState().zoneWireDefinitions.map((w) => w.id);
+      expect(ids).toEqual(['zw_c']);
+    });
+
+    it('removeView removes zone wires referencing the removed agent view', () => {
+      store.getState().addView('agent', { x: 0, y: 0 });
+      const agent = store.getState().views.find((v) => v.type === 'agent') as { id: string; agentId: string | null };
+      // Give the agent a stable agentId so the zone wire can reference it.
+      store.getState().updateView(agent.id, { agentId: 'durable_x' } as never);
+      store.setState({
+        zoneWireDefinitions: [
+          { id: 'zw_a', sourceZoneId: 'z1', targetId: 'durable_x', targetType: 'agent' },
+          { id: 'zw_b', sourceZoneId: 'z1', targetId: 'durable_keep', targetType: 'agent' },
+        ],
+      });
+      store.getState().removeView(agent.id);
+      const ids = store.getState().zoneWireDefinitions.map((w) => w.id);
+      expect(ids).toEqual(['zw_b']);
+    });
+  });
 });

--- a/src/renderer/plugins/builtin/canvas/canvas-store.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.ts
@@ -4,6 +4,7 @@ import { generateHubName } from '../../../../shared/name-generator';
 import type { CanvasView, CanvasViewType, CanvasInstance, CanvasInstanceData, AgentCanvasView, ZoneCanvasView, Position, Size, Viewport } from './canvas-types';
 import type { CanvasWidgetMetadata, CanvasWidgetFilter, CanvasWidgetHandle } from '../../../../shared/plugin-types';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
+import { generateZoneWireId, type ZoneWireDefinition } from './zone-wire-store';
 import {
   createView as createViewOp,
   createPluginView as createPluginViewOp,
@@ -33,7 +34,7 @@ export interface CanvasState {
   // Lifecycle
   loadCanvas: (storage: ScopedStorage) => Promise<void>;
   saveCanvas: (storage: ScopedStorage) => Promise<void>;
-  hydrateFromRemote: (canvasData: unknown[], activeCanvasId: string, wireDefinitions?: unknown[]) => void;
+  hydrateFromRemote: (canvasData: unknown[], activeCanvasId: string, wireDefinitions?: unknown[], zoneWireDefinitions?: unknown[]) => void;
 
   // Wire persistence — wireDefinitions is the canvas-owned source of truth for
   // wires, independent of the MCP binding runtime.  Wires survive agent sleep
@@ -44,6 +45,13 @@ export interface CanvasState {
   addWireDefinition: (entry: McpBindingEntry) => void;
   removeWireDefinition: (agentId: string, targetId: string) => void;
   updateWireDefinition: (agentId: string, targetId: string, updates: Partial<McpBindingEntry>) => void;
+
+  // Zone wire persistence — zone wires are conceptual wires from a zone to a
+  // target that expand into per-agent bindings. Persisted + synced alongside
+  // wireDefinitions so they survive reload and the annex round-trip.
+  zoneWireDefinitions: ZoneWireDefinition[];
+  addZoneWireDefinition: (wire: Omit<ZoneWireDefinition, 'id'>) => ZoneWireDefinition;
+  removeZoneWireDefinition: (wireId: string) => void;
 
   // Canvas tab management
   addCanvas: () => string;
@@ -118,6 +126,7 @@ export interface CanvasState {
 const STORAGE_KEY_INSTANCES = 'canvas-instances';
 const STORAGE_KEY_ACTIVE = 'canvas-active-id';
 const STORAGE_KEY_WIRES = 'canvas-wires';
+const STORAGE_KEY_ZONE_WIRES = 'canvas-zone-wires';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -185,6 +194,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
     selectedViewId: null,
     selectedViewIds: [],
     wireDefinitions: [],
+    zoneWireDefinitions: [],
     minimapAutoHide: true,
     elkAlgorithm: 'layered',
     elkDirection: 'RIGHT',
@@ -201,6 +211,21 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
 
     loadCanvas: async (storage) => {
       try {
+        // Restore zone wire definitions alongside the canvas. They expand into
+        // bindings at runtime (no MCP state of their own), so they belong with
+        // the canvas data rather than the MCP wire restore.
+        let loadedZoneWires: ZoneWireDefinition[] = [];
+        try {
+          const savedZoneWires = await storage.read(STORAGE_KEY_ZONE_WIRES) as ZoneWireDefinition[] | null;
+          if (savedZoneWires && Array.isArray(savedZoneWires)) {
+            loadedZoneWires = savedZoneWires.filter(
+              (w) => w && w.id && w.sourceZoneId && w.targetId && w.targetType,
+            );
+          }
+        } catch {
+          // ignore zone wire restore failure
+        }
+
         const savedInstances = await storage.read(STORAGE_KEY_INSTANCES) as CanvasInstanceData[] | null;
         if (savedInstances && Array.isArray(savedInstances) && savedInstances.length > 0) {
           const canvases: CanvasInstance[] = savedInstances.map((s): CanvasInstance => {
@@ -236,13 +261,13 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
             ? savedActive
             : canvases[0].id;
 
-          set({ canvases, activeCanvasId, loaded: true, ...syncDerivedState(canvases, activeCanvasId) });
+          set({ canvases, activeCanvasId, zoneWireDefinitions: loadedZoneWires, loaded: true, ...syncDerivedState(canvases, activeCanvasId) });
           return;
         }
 
         // Fresh start
         const canvas = createCanvasInstance();
-        set({ canvases: [canvas], activeCanvasId: canvas.id, loaded: true, ...syncDerivedState([canvas], canvas.id) });
+        set({ canvases: [canvas], activeCanvasId: canvas.id, zoneWireDefinitions: loadedZoneWires, loaded: true, ...syncDerivedState([canvas], canvas.id) });
       } catch {
         const canvas = createCanvasInstance();
         set({ canvases: [canvas], activeCanvasId: canvas.id, loaded: true, ...syncDerivedState([canvas], canvas.id) });
@@ -264,6 +289,16 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
       }));
       await storage.write(STORAGE_KEY_INSTANCES, data);
       await storage.write(STORAGE_KEY_ACTIVE, activeCanvasId);
+
+      // Persist zone wire definitions — the canvas-owned source of truth for
+      // zone-level wires. They survive reload and feed the annex snapshot.
+      const zoneData = get().zoneWireDefinitions.map((w) => ({
+        id: w.id,
+        sourceZoneId: w.sourceZoneId,
+        targetId: w.targetId,
+        targetType: w.targetType,
+      }));
+      await storage.write(STORAGE_KEY_ZONE_WIRES, zoneData);
     },
 
     loadWires: async (storage) => {
@@ -390,7 +425,24 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
       }));
     },
 
-    hydrateFromRemote: (canvasData, activeId, remoteWireDefinitions?) => {
+    addZoneWireDefinition: (wire) => {
+      // Deduplicate on (sourceZone, target) so re-dragging the same wire is a no-op.
+      const existing = get().zoneWireDefinitions.find(
+        (w) => w.sourceZoneId === wire.sourceZoneId && w.targetId === wire.targetId,
+      );
+      if (existing) return existing;
+      const newWire: ZoneWireDefinition = { ...wire, id: generateZoneWireId() };
+      set((state) => ({ zoneWireDefinitions: [...state.zoneWireDefinitions, newWire] }));
+      return newWire;
+    },
+
+    removeZoneWireDefinition: (wireId) => {
+      set((state) => ({
+        zoneWireDefinitions: state.zoneWireDefinitions.filter((w) => w.id !== wireId),
+      }));
+    },
+
+    hydrateFromRemote: (canvasData, activeId, remoteWireDefinitions?, remoteZoneWireDefinitions?) => {
       if (!canvasData || !Array.isArray(canvasData) || canvasData.length === 0) return;
       const existingState = get();
       const existingCanvasMap = new Map(existingState.canvases.map((c) => [c.id, c]));
@@ -435,7 +487,14 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         ? { wireDefinitions: remoteWireDefinitions as McpBindingEntry[] }
         : {};
 
-      set({ canvases, activeCanvasId: resolvedActive, loaded: true, wiresLoaded: true, ...wireUpdate, ...syncDerivedState(canvases, resolvedActive) });
+      // Restore zone wire definitions from remote state. Unlike bindings, an
+      // empty array is meaningful (all zone wires removed), so only skip when
+      // the field is absent entirely.
+      const zoneWireUpdate = remoteZoneWireDefinitions && Array.isArray(remoteZoneWireDefinitions)
+        ? { zoneWireDefinitions: remoteZoneWireDefinitions as ZoneWireDefinition[] }
+        : {};
+
+      set({ canvases, activeCanvasId: resolvedActive, loaded: true, wiresLoaded: true, ...wireUpdate, ...zoneWireUpdate, ...syncDerivedState(canvases, resolvedActive) });
     },
 
     // ── Canvas tab management ────────────────────────────────────
@@ -544,9 +603,22 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
       const wires = get().wireDefinitions;
       const filtered = wires.filter((w) => w.agentId !== wireId && w.targetId !== wireId);
 
+      // Remove orphaned zone wires referencing the removed view. The view may be
+      // referenced by its view id (zone/browser source/target) or by a resolved
+      // id (agentId / groupProjectId / queueId) when it is a wire target.
+      const removedIds = new Set<string>([viewId, wireId]);
+      const gpId = removedView?.metadata?.groupProjectId as string | undefined;
+      if (gpId) removedIds.add(gpId);
+      const queueId = removedView?.metadata?.queueId as string | undefined;
+      if (queueId) removedIds.add(queueId);
+      const zoneFiltered = get().zoneWireDefinitions.filter(
+        (w) => !removedIds.has(w.sourceZoneId) && !removedIds.has(w.targetId),
+      );
+
       set({
         ...canvasUpdate,
         wireDefinitions: filtered,
+        zoneWireDefinitions: zoneFiltered,
       });
     },
 
@@ -659,7 +731,15 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         (w) => !removedWireIds.has(w.agentId) && !removedWireIds.has(w.targetId),
       );
 
-      set({ ...canvasUpdate, wireDefinitions: filtered });
+      // Remove zone wires originating from or targeting this zone (and, when
+      // removeContents, any contained views identified above).
+      const removedZoneIds = new Set<string>(removedWireIds);
+      removedZoneIds.add(zoneId);
+      const zoneFiltered = state.zoneWireDefinitions.filter(
+        (w) => !removedZoneIds.has(w.sourceZoneId) && !removedZoneIds.has(w.targetId),
+      );
+
+      set({ ...canvasUpdate, wireDefinitions: filtered, zoneWireDefinitions: zoneFiltered });
     },
 
     updateZoneTheme: (zoneId, themeId) => {

--- a/src/renderer/plugins/builtin/canvas/canvas-sync.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-sync.ts
@@ -157,6 +157,16 @@ export function broadcastCanvasState(
         ...(w.disabledTools && w.disabledTools.length > 0 ? { disabledTools: w.disabledTools } : {}),
       }))
       : undefined,
+    // Zone wire definitions for annex controllers — zone wires render as a
+    // single visual wire to the zone and must survive the round-trip.
+    zoneWireDefinitions: state.zoneWireDefinitions.length > 0
+      ? state.zoneWireDefinitions.map((w) => ({
+        id: w.id,
+        sourceZoneId: w.sourceZoneId,
+        targetId: w.targetId,
+        targetType: w.targetType,
+      }))
+      : undefined,
   };
 
   window.clubhouse.window.broadcastCanvasState(snapshot);

--- a/src/renderer/plugins/builtin/canvas/main.test.ts
+++ b/src/renderer/plugins/builtin/canvas/main.test.ts
@@ -204,8 +204,8 @@ describe('canvas main', () => {
 
     // Auto-save effect should react to wireDefinitions, not bindings
     const autoSaveEffect = source.slice(
-      source.indexOf('wireDefinitions, minimapAutoHide, elkAlgorithm, elkDirection, layoutCenterId, loaded, wiresLoaded, scheduleSave'),
-      source.indexOf('wireDefinitions, minimapAutoHide, elkAlgorithm, elkDirection, layoutCenterId, loaded, wiresLoaded, scheduleSave') + 140,
+      source.indexOf('wireDefinitions, zoneWireDefinitions, minimapAutoHide, elkAlgorithm, elkDirection, layoutCenterId, loaded, wiresLoaded, scheduleSave'),
+      source.indexOf('wireDefinitions, zoneWireDefinitions, minimapAutoHide, elkAlgorithm, elkDirection, layoutCenterId, loaded, wiresLoaded, scheduleSave') + 160,
     );
     expect(autoSaveEffect).toBeTruthy();
   });

--- a/src/renderer/plugins/builtin/canvas/main.ts
+++ b/src/renderer/plugins/builtin/canvas/main.ts
@@ -158,6 +158,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   const loaded = store((s) => s.loaded);
   const wiresLoaded = store((s) => s.wiresLoaded);
   const wireDefinitions = store((s) => s.wireDefinitions);
+  const zoneWireDefinitions = store((s) => s.zoneWireDefinitions);
   const minimapAutoHide = store((s) => s.minimapAutoHide);
   const elkAlgorithm = store((s) => s.elkAlgorithm);
   const elkDirection = store((s) => s.elkDirection);
@@ -193,14 +194,14 @@ export function MainPanel({ api }: { api: PluginAPI }) {
     if (isRemoteApp && activeHostId) {
       const remoteState = useRemoteProjectStore.getState().remoteAppCanvasState[activeHostId];
       if (remoteState) {
-        store.getState().hydrateFromRemote(remoteState.canvases, remoteState.activeCanvasId, remoteState.wireDefinitions);
+        store.getState().hydrateFromRemote(remoteState.canvases, remoteState.activeCanvasId, remoteState.wireDefinitions, (remoteState as { zoneWireDefinitions?: unknown[] }).zoneWireDefinitions);
         return;
       }
     }
     if (isRemote && projectId) {
       const remoteState = useRemoteProjectStore.getState().remoteCanvasState[projectId];
       if (remoteState) {
-        store.getState().hydrateFromRemote(remoteState.canvases, remoteState.activeCanvasId, remoteState.wireDefinitions);
+        store.getState().hydrateFromRemote(remoteState.canvases, remoteState.activeCanvasId, remoteState.wireDefinitions, (remoteState as { zoneWireDefinitions?: unknown[] }).zoneWireDefinitions);
         return;
       }
     }
@@ -220,7 +221,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       const newState = state.remoteCanvasState[projectId];
       if (newState && newState !== prevState && store.getState().loaded) {
         prevState = newState;
-        store.getState().hydrateFromRemote(newState.canvases, newState.activeCanvasId, newState.wireDefinitions);
+        store.getState().hydrateFromRemote(newState.canvases, newState.activeCanvasId, newState.wireDefinitions, (newState as { zoneWireDefinitions?: unknown[] }).zoneWireDefinitions);
       }
     });
   }, [store, isRemote, projectId]);
@@ -233,7 +234,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       const newState = state.remoteAppCanvasState[activeHostId];
       if (newState && newState !== prevState && store.getState().loaded) {
         prevState = newState;
-        store.getState().hydrateFromRemote(newState.canvases, newState.activeCanvasId, newState.wireDefinitions);
+        store.getState().hydrateFromRemote(newState.canvases, newState.activeCanvasId, newState.wireDefinitions, (newState as { zoneWireDefinitions?: unknown[] }).zoneWireDefinitions);
       }
     });
   }, [store, isRemoteApp, activeHostId]);
@@ -263,7 +264,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
         saveTimerRef.current = null;
       }
     };
-  }, [canvases, views, viewport, zoomedViewId, wireDefinitions, minimapAutoHide, elkAlgorithm, elkDirection, layoutCenterId, loaded, wiresLoaded, scheduleSave]);
+  }, [canvases, views, viewport, zoomedViewId, wireDefinitions, zoneWireDefinitions, minimapAutoHide, elkAlgorithm, elkDirection, layoutCenterId, loaded, wiresLoaded, scheduleSave]);
 
   // ── Agent wake reconciliation ────────────────────────────────────
   // When an agent wakes up (bindings appear in MCP store that match wire
@@ -353,7 +354,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       isAppMode ? undefined : api.context.projectId,
       scope,
     );
-  }, [store, activeCanvasId, canvases, views, viewport, zoomedViewId, loaded, isAppMode, isRemote, isRemoteApp, api, scope]);
+  }, [store, activeCanvasId, canvases, views, viewport, zoomedViewId, wireDefinitions, zoneWireDefinitions, loaded, isAppMode, isRemote, isRemoteApp, api, scope]);
 
   // ── Remote mutation helper ──────────────────────────────────────
 
@@ -649,6 +650,9 @@ export function MainPanel({ api }: { api: PluginAPI }) {
             },
             onRemoveWireDefinition: (agentId: string, targetId: string) => store.getState().removeWireDefinition(agentId, targetId),
             onUpdateWireDefinition: (agentId: string, targetId: string, updates: Partial<McpBindingEntry>) => store.getState().updateWireDefinition(agentId, targetId, updates),
+            zoneWireDefinitions,
+            onAddZoneWireDefinition: (wire) => store.getState().addZoneWireDefinition(wire),
+            onRemoveZoneWireDefinition: (wireId: string) => store.getState().removeZoneWireDefinition(wireId),
             api,
             onViewportChange: handleViewportChange,
             onAddView: handleAddView,

--- a/src/renderer/plugins/builtin/canvas/remote-canvas-wire-sync.test.ts
+++ b/src/renderer/plugins/builtin/canvas/remote-canvas-wire-sync.test.ts
@@ -248,4 +248,59 @@ describe('remote canvas wire sync', () => {
       expect(namespaced[1].targetId).toBe('remote||sat-xyz||gp-123');
     });
   });
+
+  // ── Zone wire sync (item 8: survive the annex round-trip) ───────────
+
+  describe('broadcastCanvasState zone wire definitions', () => {
+    it('includes zoneWireDefinitions in the snapshot when zone wires exist', () => {
+      const canvasId = store.getState().activeCanvasId;
+      store.getState().addZoneWireDefinition({ sourceZoneId: 'z1', targetId: 'agent-2', targetType: 'agent' });
+
+      broadcastCanvasState(store, canvasId);
+
+      const snapshot = broadcastSpy.mock.calls[0][0];
+      expect(snapshot.zoneWireDefinitions).toHaveLength(1);
+      expect(snapshot.zoneWireDefinitions[0]).toEqual(expect.objectContaining({
+        sourceZoneId: 'z1', targetId: 'agent-2', targetType: 'agent',
+      }));
+    });
+
+    it('omits zoneWireDefinitions when no zone wires exist', () => {
+      broadcastCanvasState(store, store.getState().activeCanvasId);
+      expect(broadcastSpy.mock.calls[0][0].zoneWireDefinitions).toBeUndefined();
+    });
+  });
+
+  describe('zone wire namespacing', () => {
+    // Mirrors the zone-wire namespacing in annexClientStore's canvas:state handler.
+    function namespaceZoneWires(
+      wires: Array<{ id: string; sourceZoneId: string; targetId: string; targetType: string }>,
+      satelliteId: string,
+    ) {
+      const ns = (id: string) => id.startsWith('remote||') ? id : `remote||${satelliteId}||${id}`;
+      return wires.map((w) => {
+        const patched = { ...w };
+        if (patched.targetType === 'agent' || patched.targetType === 'group-project') {
+          patched.targetId = ns(patched.targetId);
+        }
+        return patched;
+      });
+    }
+
+    it('namespaces agent and group-project targets but not zone/browser/queue', () => {
+      const wires = [
+        { id: 'a', sourceZoneId: 'z1', targetId: 'agent-2', targetType: 'agent' },
+        { id: 'b', sourceZoneId: 'z1', targetId: 'gp-1', targetType: 'group-project' },
+        { id: 'c', sourceZoneId: 'z1', targetId: 'z2', targetType: 'zone' },
+        { id: 'd', sourceZoneId: 'z1', targetId: 'browser-1', targetType: 'browser' },
+      ];
+      const ns = namespaceZoneWires(wires, 'sat-1');
+      expect(ns[0].targetId).toBe('remote||sat-1||agent-2');
+      expect(ns[1].targetId).toBe('remote||sat-1||gp-1');
+      expect(ns[2].targetId).toBe('z2');
+      expect(ns[3].targetId).toBe('browser-1');
+      // sourceZoneId (a view id) is never namespaced
+      expect(ns.every((w) => w.sourceZoneId === 'z1')).toBe(true);
+    });
+  });
 });

--- a/src/renderer/plugins/builtin/canvas/wire-render-contract.test.ts
+++ b/src/renderer/plugins/builtin/canvas/wire-render-contract.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRenderedWires, resolveZoneWireViews, buildViewIndex } from './wire-render-contract';
+import type { AgentCanvasView, ZoneCanvasView, PluginCanvasView, CanvasView } from './canvas-types';
+import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
+import type { ZoneWireDefinition } from './zone-wire-store';
+
+function makeZone(id: string, containedViewIds: string[] = []): ZoneCanvasView {
+  return {
+    id, type: 'zone',
+    position: { x: 0, y: 0 }, size: { width: 600, height: 400 },
+    title: id, displayName: id, zIndex: 0, metadata: {},
+    themeId: 'catppuccin-mocha', containedViewIds,
+  };
+}
+
+function makeAgent(id: string, agentId: string): AgentCanvasView {
+  return {
+    id, type: 'agent',
+    position: { x: 50, y: 50 }, size: { width: 200, height: 200 },
+    title: id, displayName: id, zIndex: 1, metadata: {}, agentId,
+  };
+}
+
+function makeGroupProject(id: string, gpId: string): PluginCanvasView {
+  return {
+    id, type: 'plugin',
+    position: { x: 900, y: 50 }, size: { width: 200, height: 200 },
+    title: id, displayName: id, zIndex: 1, metadata: { groupProjectId: gpId },
+    pluginWidgetType: 'plugin:group-project:group-project', pluginId: 'group-project',
+  };
+}
+
+function binding(agentId: string, targetId: string, targetKind: McpBindingEntry['targetKind']): McpBindingEntry {
+  return { agentId, targetId, targetKind, label: targetId };
+}
+
+function zoneWire(id: string, sourceZoneId: string, targetId: string, targetType: ZoneWireDefinition['targetType']): ZoneWireDefinition {
+  return { id, sourceZoneId, targetId, targetType };
+}
+
+describe('resolveRenderedWires — binding wires', () => {
+  it('resolves an agent→agent binding to one wire with both endpoints', () => {
+    const a1 = makeAgent('v1', 'durable_1');
+    const a2 = makeAgent('v2', 'durable_2');
+    const wires = resolveRenderedWires([a1, a2], [binding('durable_1', 'durable_2', 'agent')], []);
+    expect(wires).toHaveLength(1);
+    expect(wires[0].kind).toBe('binding');
+    expect(wires[0].source.id).toBe('v1');
+    expect(wires[0].target.id).toBe('v2');
+    expect(wires[0].key).toBe('binding:durable_1--durable_2');
+  });
+
+  it('resolves an agent→group-project binding via groupProjectId', () => {
+    const a1 = makeAgent('v1', 'durable_1');
+    const gp = makeGroupProject('v2', 'gp_123');
+    const wires = resolveRenderedWires([a1, gp], [binding('durable_1', 'gp_123', 'group-project')], []);
+    expect(wires).toHaveLength(1);
+    expect(wires[0].target.id).toBe('v2');
+  });
+
+  it('drops a binding whose source or target view is missing (no throw)', () => {
+    const a1 = makeAgent('v1', 'durable_1');
+    expect(resolveRenderedWires([a1], [binding('durable_1', 'gp_missing', 'group-project')], [])).toHaveLength(0);
+    expect(resolveRenderedWires([a1], [binding('durable_missing', 'durable_1', 'agent')], [])).toHaveLength(0);
+  });
+});
+
+describe('resolveRenderedWires — zone wires', () => {
+  it('renders ONE wire to the zone, with the zone as an endpoint (not one per member)', () => {
+    const zone = makeZone('z1', ['v1', 'v2']);
+    const a1 = makeAgent('v1', 'durable_1');
+    const a2 = makeAgent('v2', 'durable_2');
+    const target = makeAgent('v3', 'durable_3');
+    const views: CanvasView[] = [zone, a1, a2, target];
+    const wires = resolveRenderedWires(views, [], [zoneWire('zw1', 'z1', 'durable_3', 'agent')]);
+    const zoneWires = wires.filter((w) => w.kind === 'zone');
+    expect(zoneWires).toHaveLength(1);
+    expect(zoneWires[0].source.id).toBe('z1');
+    expect(zoneWires[0].source.type).toBe('zone');
+    expect(zoneWires[0].target.id).toBe('v3');
+    expect(zoneWires[0].key).toBe('zone:zw1');
+  });
+
+  it('resolves zone→zone, zone→group-project targets', () => {
+    const z1 = makeZone('z1', []);
+    const z2 = makeZone('z2', []);
+    const gp = makeGroupProject('gpv', 'gp_9');
+    const views: CanvasView[] = [z1, z2, gp];
+    const w1 = resolveZoneWireViews(zoneWire('a', 'z1', 'z2', 'zone'), buildViewIndex(views));
+    expect(w1?.target.id).toBe('z2');
+    const w2 = resolveZoneWireViews(zoneWire('b', 'z1', 'gp_9', 'group-project'), buildViewIndex(views));
+    expect(w2?.target.id).toBe('gpv');
+  });
+
+  it('drops a zone wire whose source is not a zone or whose target is missing', () => {
+    const z1 = makeZone('z1', []);
+    const a1 = makeAgent('v1', 'durable_1');
+    // target missing
+    expect(resolveRenderedWires([z1], [], [zoneWire('zw1', 'z1', 'durable_x', 'agent')])).toHaveLength(0);
+    // source not a zone
+    expect(resolveZoneWireViews(zoneWire('zw2', 'v1', 'durable_1', 'agent'), buildViewIndex([a1]))).toBeNull();
+  });
+
+  it('emits binding wires before zone wires, deterministically', () => {
+    const a1 = makeAgent('v1', 'durable_1');
+    const a2 = makeAgent('v2', 'durable_2');
+    const zone = makeZone('z1', ['v1']);
+    const wires = resolveRenderedWires(
+      [a1, a2, zone],
+      [binding('durable_1', 'durable_2', 'agent')],
+      [zoneWire('zw1', 'z1', 'durable_2', 'agent')],
+    );
+    expect(wires.map((w) => w.kind)).toEqual(['binding', 'zone']);
+  });
+});

--- a/src/renderer/plugins/builtin/canvas/wire-render-contract.ts
+++ b/src/renderer/plugins/builtin/canvas/wire-render-contract.ts
@@ -1,0 +1,190 @@
+/**
+ * Wire rendering contract — the single source of truth for which wires are
+ * drawn on the canvas.
+ *
+ * ## The contract
+ *
+ * The set of rendered wires is a **pure function** of three synced inputs:
+ *   1. `views`               — the canvas views (agents, zones, plugin widgets…)
+ *   2. `wireDefinitions`     — persisted agent→target MCP-binding wires
+ *   3. `zoneWireDefinitions` — persisted zone-level wires
+ *
+ * Nothing else influences what is rendered. In particular, the *transient*
+ * runtime MCP binding store (`mcpBindingStore`) is NOT consulted for rendering.
+ * Runtime bindings come and go as agents sleep/wake and as the main process
+ * reconciles them; relying on them for rendering is exactly why wires
+ * "disappeared over the annex protocol while the tools still worked" — the
+ * controller/satellite never receives the runtime bindings, only the synced
+ * definitions.
+ *
+ * Because both the local window and the annex controller call this same
+ * function over the same snapshot (`wireDefinitions` + `zoneWireDefinitions`
+ * are both serialised in `CanvasStateSnapshot`), a wire that exists logically
+ * renders identically everywhere.
+ *
+ * ## Endpoint resolution (stable, in priority order)
+ *
+ * Binding wire (`kind: 'binding'`):
+ *   - source: agent view by `agentId`
+ *   - target: view by `id` → agent view by `agentId` → plugin view by
+ *     `metadata.groupProjectId` / `metadata.queueId`
+ *
+ * Zone wire (`kind: 'zone'`): rendered as a **single** wire to the zone itself
+ * (not one wire per contained agent). Under the hood the zone wire expands to
+ * per-agent bindings (see `zone-wire-expansion.ts`), but visually it is one
+ * wire that auto-tracks the zone as members are added/removed.
+ *   - source: zone view by `sourceZoneId`
+ *   - target by `targetType`:
+ *       'zone'          → zone view by `targetId`
+ *       'agent'         → agent view by `agentId` (== targetId)
+ *       'group-project' → plugin view by `metadata.groupProjectId`
+ *       'agent-queue'   → plugin view by `metadata.queueId`
+ *       'browser'       → view by `id`
+ *
+ * Any wire whose source or target cannot be resolved is silently dropped (it is
+ * not an error — the referenced view may simply not exist on this canvas yet).
+ *
+ * Every rendered wire carries a stable, unique `key` so React reconciliation
+ * and activity tracking are deterministic.
+ */
+
+import type { CanvasView, AgentCanvasView, ZoneCanvasView, PluginCanvasView } from './canvas-types';
+import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
+import type { ZoneWireDefinition } from './zone-wire-store';
+
+/** A wire resolved to concrete source/target views, ready to render. */
+export interface RenderedWire {
+  /** Stable unique key for React + activity tracking. */
+  key: string;
+  kind: 'binding' | 'zone';
+  source: CanvasView;
+  target: CanvasView;
+  /** Present when `kind === 'binding'`. */
+  binding?: McpBindingEntry;
+  /** Present when `kind === 'zone'`. */
+  zoneWire?: ZoneWireDefinition;
+}
+
+/** O(1) lookup indexes over the view list. */
+export interface ViewIndex {
+  byId: Map<string, CanvasView>;
+  byAgentId: Map<string, CanvasView>;
+  byGroupProjectId: Map<string, CanvasView>;
+  byQueueId: Map<string, CanvasView>;
+}
+
+export function buildViewIndex(views: CanvasView[]): ViewIndex {
+  const byId = new Map<string, CanvasView>();
+  const byAgentId = new Map<string, CanvasView>();
+  const byGroupProjectId = new Map<string, CanvasView>();
+  const byQueueId = new Map<string, CanvasView>();
+  for (const v of views) {
+    byId.set(v.id, v);
+    if (v.type === 'agent' && (v as AgentCanvasView).agentId) {
+      byAgentId.set((v as AgentCanvasView).agentId as string, v);
+    }
+    if (v.type === 'plugin') {
+      const gpId = v.metadata?.groupProjectId;
+      if (gpId) byGroupProjectId.set(gpId as string, v);
+      const qId = v.metadata?.queueId;
+      if (qId) byQueueId.set(qId as string, v);
+    }
+  }
+  return { byId, byAgentId, byGroupProjectId, byQueueId };
+}
+
+/** Resolve a binding wire's source + target views, or null if unresolvable. */
+export function resolveBindingWireViews(
+  binding: McpBindingEntry,
+  index: ViewIndex,
+): { source: CanvasView; target: CanvasView } | null {
+  const source = index.byAgentId.get(binding.agentId);
+  if (!source) return null;
+
+  let target = index.byId.get(binding.targetId);
+  if (!target && binding.targetKind === 'agent') {
+    target = index.byAgentId.get(binding.targetId);
+  }
+  if (!target && binding.targetKind === 'group-project') {
+    target = index.byGroupProjectId.get(binding.targetId);
+  }
+  if (!target && binding.targetKind === 'agent-queue') {
+    target = index.byQueueId.get(binding.targetId);
+  }
+  if (!target) return null;
+
+  return { source, target };
+}
+
+/** Resolve a zone wire's source zone + target views, or null if unresolvable. */
+export function resolveZoneWireViews(
+  wire: ZoneWireDefinition,
+  index: ViewIndex,
+): { source: ZoneCanvasView; target: CanvasView } | null {
+  const source = index.byId.get(wire.sourceZoneId);
+  if (!source || source.type !== 'zone') return null;
+
+  let target: CanvasView | undefined;
+  switch (wire.targetType) {
+    case 'zone':
+    case 'browser':
+      target = index.byId.get(wire.targetId);
+      break;
+    case 'agent':
+      target = index.byAgentId.get(wire.targetId) ?? index.byId.get(wire.targetId);
+      break;
+    case 'group-project':
+      target = index.byGroupProjectId.get(wire.targetId) ?? index.byId.get(wire.targetId);
+      break;
+    case 'agent-queue':
+      target = index.byQueueId.get(wire.targetId) ?? index.byId.get(wire.targetId);
+      break;
+  }
+  if (!target) return null;
+
+  return { source: source as ZoneCanvasView, target };
+}
+
+/**
+ * THE rendering contract: resolve every renderable wire from synced state.
+ *
+ * Returns binding wires first, then zone wires, each in input order, so output
+ * ordering is deterministic.
+ */
+export function resolveRenderedWires(
+  views: CanvasView[],
+  wireDefinitions: McpBindingEntry[],
+  zoneWireDefinitions: ZoneWireDefinition[] = [],
+): RenderedWire[] {
+  const index = buildViewIndex(views);
+  const out: RenderedWire[] = [];
+
+  for (const binding of wireDefinitions) {
+    const resolved = resolveBindingWireViews(binding, index);
+    if (!resolved) continue;
+    out.push({
+      key: `binding:${binding.agentId}--${binding.targetId}`,
+      kind: 'binding',
+      source: resolved.source,
+      target: resolved.target,
+      binding,
+    });
+  }
+
+  for (const wire of zoneWireDefinitions) {
+    const resolved = resolveZoneWireViews(wire, index);
+    if (!resolved) continue;
+    out.push({
+      key: `zone:${wire.id}`,
+      kind: 'zone',
+      source: resolved.source,
+      target: resolved.target,
+      zoneWire: wire,
+    });
+  }
+
+  return out;
+}
+
+// Re-export so callers (and the plugin's PluginCanvasView typing) stay co-located.
+export type { PluginCanvasView };

--- a/src/renderer/plugins/builtin/canvas/zone-wire-expansion.test.ts
+++ b/src/renderer/plugins/builtin/canvas/zone-wire-expansion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { expandZoneWires, reconcileZoneBindings } from './zone-wire-expansion';
+import { expandZoneWires, reconcileZoneBindings, diffZoneBindings, type ExpandedBinding } from './zone-wire-expansion';
 import type { AgentCanvasView, ZoneCanvasView, PluginCanvasView } from './canvas-types';
 import type { ZoneWireDefinition } from './zone-wire-store';
 
@@ -167,5 +167,49 @@ describe('reconcileZoneBindings', () => {
     // this individual binding is preserved
     expect(toRemove.length).toBe(1);
     expect(toRemove[0].targetId).toBe('a3');
+  });
+});
+
+describe('diffZoneBindings (containment auto-update)', () => {
+  const eb = (agentId: string, targetId: string): ExpandedBinding => ({
+    agentId, targetId, targetKind: 'agent', label: targetId, agentName: agentId, targetName: targetId,
+  });
+
+  it('adds bindings for an agent that joined the zone', () => {
+    const prev = [eb('durable_1', 'durable_t')];
+    const next = [eb('durable_1', 'durable_t'), eb('durable_2', 'durable_t')];
+    const current = new Set(['durable_1:durable_t']);
+    const { toAdd, toRemove } = diffZoneBindings(prev, next, current);
+    expect(toAdd.map((b) => b.agentId)).toEqual(['durable_2']);
+    expect(toRemove).toHaveLength(0);
+  });
+
+  it('removes bindings for an agent that left the zone', () => {
+    const prev = [eb('durable_1', 'durable_t'), eb('durable_2', 'durable_t')];
+    const next = [eb('durable_1', 'durable_t')];
+    const current = new Set(['durable_1:durable_t', 'durable_2:durable_t']);
+    const { toAdd, toRemove } = diffZoneBindings(prev, next, current);
+    expect(toAdd).toHaveLength(0);
+    expect(toRemove).toEqual([{ agentId: 'durable_2', targetId: 'durable_t' }]);
+  });
+
+  it('never removes a manual binding (one never in prevDesired)', () => {
+    // The zone wire is removed entirely: prev had one zone binding, next is empty.
+    const prev = [eb('durable_1', 'durable_t')];
+    const next: ExpandedBinding[] = [];
+    // current also contains a manual wire durable_9 -> durable_manual
+    const current = new Set(['durable_1:durable_t', 'durable_9:durable_manual']);
+    const { toAdd, toRemove } = diffZoneBindings(prev, next, current);
+    expect(toAdd).toHaveLength(0);
+    // Only the zone-derived binding is removed; the manual one is untouched.
+    expect(toRemove).toEqual([{ agentId: 'durable_1', targetId: 'durable_t' }]);
+  });
+
+  it('does not re-add a binding already present in current', () => {
+    const prev: ExpandedBinding[] = [];
+    const next = [eb('durable_1', 'durable_t')];
+    const current = new Set(['durable_1:durable_t']);
+    const { toAdd } = diffZoneBindings(prev, next, current);
+    expect(toAdd).toHaveLength(0);
   });
 });

--- a/src/renderer/plugins/builtin/canvas/zone-wire-expansion.ts
+++ b/src/renderer/plugins/builtin/canvas/zone-wire-expansion.ts
@@ -269,6 +269,34 @@ export function expandZoneWires(
 }
 
 /**
+ * Diff zone-derived bindings across a containment / zone-wire change.
+ *
+ * This is the auto-update mechanism: when an agent joins or leaves a zone, the
+ * zone's expansion changes and we must add the new bindings and remove the ones
+ * that no longer apply — without disturbing manually-created wires.
+ *
+ * Only bindings that were *previously* zone-derived (`prevDesired`) are eligible
+ * for removal, so manual wires (which never appear in `prevDesired`) are
+ * preserved. Bindings already present in `currentKeys` are not re-added.
+ */
+export function diffZoneBindings(
+  prevDesired: ExpandedBinding[],
+  newDesired: ExpandedBinding[],
+  currentKeys: Set<string>,
+): {
+  toAdd: ExpandedBinding[];
+  toRemove: Array<{ agentId: string; targetId: string }>;
+} {
+  const keyOf = (b: { agentId: string; targetId: string }) => `${b.agentId}:${b.targetId}`;
+  const newKeys = new Set(newDesired.map(keyOf));
+  const toAdd = newDesired.filter((b) => !currentKeys.has(keyOf(b)));
+  const toRemove = prevDesired
+    .filter((b) => !newKeys.has(keyOf(b)))
+    .map((b) => ({ agentId: b.agentId, targetId: b.targetId }));
+  return { toAdd, toRemove };
+}
+
+/**
  * Reconcile expanded zone bindings with current MCP bindings.
  * Returns lists of bindings to add and remove.
  */

--- a/src/renderer/plugins/builtin/canvas/zone-wire-store.ts
+++ b/src/renderer/plugins/builtin/canvas/zone-wire-store.ts
@@ -1,9 +1,15 @@
 /**
- * Zone wire store — manages zone-level wire definitions (conceptual wires
- * between zones and targets). These expand into individual MCP bindings.
+ * Zone wire definitions — conceptual wires between a zone and a target.
+ *
+ * A zone wire is "shorthand" for wiring every agent inside the zone to the
+ * target; it expands into individual MCP bindings (see `zone-wire-expansion.ts`)
+ * and renders as a single visual wire to the zone (see `wire-render-contract.ts`).
+ *
+ * The canvas store (`canvas-store.ts`) is the single source of truth for zone
+ * wires — it persists them to storage and serialises them in the annex
+ * snapshot so they survive the annex round-trip. This module only owns the
+ * shape and id generation.
  */
-
-import { create } from 'zustand';
 
 export interface ZoneWireDefinition {
   id: string;
@@ -15,51 +21,6 @@ export interface ZoneWireDefinition {
   targetType: 'zone' | 'agent' | 'group-project' | 'agent-queue' | 'browser';
 }
 
-interface ZoneWireState {
-  wires: ZoneWireDefinition[];
-  addWire: (wire: Omit<ZoneWireDefinition, 'id'>) => ZoneWireDefinition;
-  removeWire: (wireId: string) => void;
-  removeWiresForZone: (zoneId: string) => void;
-  removeWiresForTarget: (targetId: string) => void;
-  loadWires: (wires: ZoneWireDefinition[]) => void;
-}
-
-function generateWireId(): string {
+export function generateZoneWireId(): string {
   return `zw_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
 }
-
-export const useZoneWireStore = create<ZoneWireState>((set, get) => ({
-  wires: [],
-
-  addWire: (wire) => {
-    // Deduplicate: skip if identical source+target already exists
-    const existing = get().wires.find(
-      (w) => w.sourceZoneId === wire.sourceZoneId && w.targetId === wire.targetId,
-    );
-    if (existing) return existing;
-
-    const newWire: ZoneWireDefinition = { ...wire, id: generateWireId() };
-    set((s) => ({ wires: [...s.wires, newWire] }));
-    return newWire;
-  },
-
-  removeWire: (wireId) => {
-    set((s) => ({ wires: s.wires.filter((w) => w.id !== wireId) }));
-  },
-
-  removeWiresForZone: (zoneId) => {
-    set((s) => ({
-      wires: s.wires.filter((w) => w.sourceZoneId !== zoneId && w.targetId !== zoneId),
-    }));
-  },
-
-  removeWiresForTarget: (targetId) => {
-    set((s) => ({
-      wires: s.wires.filter((w) => w.targetId !== targetId && w.sourceZoneId !== targetId),
-    }));
-  },
-
-  loadWires: (wires) => {
-    set({ wires });
-  },
-}));

--- a/src/renderer/stores/annexClientStore.ts
+++ b/src/renderer/stores/annexClientStore.ts
@@ -434,6 +434,10 @@ export function initAnnexClientListener(): () => void {
             agentName?: string; targetName?: string; projectName?: string;
             instructions?: Record<string, string>; disabledTools?: string[];
           }>;
+          zoneWireDefinitions?: Array<{
+            id: string; sourceZoneId: string; targetId: string;
+            targetType: 'zone' | 'agent' | 'group-project' | 'agent-queue' | 'browser';
+          }>;
         };
 
         // Re-namespace agent/project IDs in views — the satellite stores
@@ -476,10 +480,23 @@ export function initAnnexClientListener(): () => void {
           return patched;
         });
 
+        // Re-namespace zone wires. Source is always a zone view id (view ids are
+        // not namespaced). The target is namespaced only when it is an agent or
+        // group-project id — those are namespaced in remoteAgents/view metadata;
+        // zone/browser targets are view ids and agent-queue ids stay verbatim.
+        const ns = (id: string) => id.startsWith('remote||') ? id : `remote||${satelliteId}||${id}`;
+        const namespacedZoneWires = cs.zoneWireDefinitions?.map((w) => {
+          const patched = { ...w };
+          if (patched.targetType === 'agent' || patched.targetType === 'group-project') {
+            patched.targetId = ns(patched.targetId);
+          }
+          return patched;
+        });
+
         // Helper to route canvas data to the correct store based on scope.
         // Deferred via requestIdleCallback to avoid blocking the event loop
         // with deep object cloning during rapid canvas:state bursts.
-        const commitCanvasData = (data: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] }) => {
+        const commitCanvasData = (data: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] }) => {
           const commit = () => {
             if (isAppLevel) {
               useRemoteProjectStore.getState().updateRemoteAppCanvasState(satelliteId, data);
@@ -497,7 +514,7 @@ export function initAnnexClientListener(): () => void {
         const existingStore = isAppLevel
           ? useRemoteProjectStore.getState().remoteAppCanvasState[satelliteId]
           : useRemoteProjectStore.getState().remoteCanvasState[nsProjId];
-        const existing = existingStore as { canvases: any[]; activeCanvasId: string; wireDefinitions?: unknown[] } | undefined;
+        const existing = existingStore as { canvases: any[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] } | undefined;
 
         if (cs.allCanvasTabs) {
           // Full tab metadata available — build complete canvas list.
@@ -522,6 +539,7 @@ export function initAnnexClientListener(): () => void {
             canvases,
             activeCanvasId: cs.activeCanvasId || cs.canvasId,
             wireDefinitions: namespacedWires,
+            zoneWireDefinitions: namespacedZoneWires,
           });
         } else if (existing) {
           // No tab metadata — merge single canvas into existing state
@@ -542,6 +560,7 @@ export function initAnnexClientListener(): () => void {
             canvases,
             activeCanvasId: existing.activeCanvasId,
             wireDefinitions: namespacedWires ?? existing.wireDefinitions,
+            zoneWireDefinitions: namespacedZoneWires ?? existing.zoneWireDefinitions,
           });
         } else {
           // First canvas state for this project/app
@@ -554,6 +573,7 @@ export function initAnnexClientListener(): () => void {
             }],
             activeCanvasId: cs.canvasId,
             wireDefinitions: namespacedWires,
+            zoneWireDefinitions: namespacedZoneWires,
           });
         }
       }

--- a/src/renderer/stores/remoteProjectStore.ts
+++ b/src/renderer/stores/remoteProjectStore.ts
@@ -94,10 +94,10 @@ interface RemoteProjectStoreState {
   remoteAgentIcons: Record<string, string>;
 
   /** Remote canvas state keyed by namespaced project ID */
-  remoteCanvasState: Record<string, { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] }>;
+  remoteCanvasState: Record<string, { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] }>;
 
   /** App-level (global) canvas state keyed by satelliteId */
-  remoteAppCanvasState: Record<string, { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] }>;
+  remoteAppCanvasState: Record<string, { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] }>;
 
   /** Remote group projects keyed by satelliteId */
   remoteGroupProjects: Record<string, unknown[]>;
@@ -127,10 +127,10 @@ interface RemoteProjectStoreState {
   removeRemoteAgent: (satelliteId: string, agentId: string) => void;
 
   /** Update canvas state for a remote project. */
-  updateRemoteCanvasState: (namespacedProjectId: string, state: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] }) => void;
+  updateRemoteCanvasState: (namespacedProjectId: string, state: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] }) => void;
 
   /** Update app-level (global scope) canvas state for a satellite. */
-  updateRemoteAppCanvasState: (satelliteId: string, state: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] }) => void;
+  updateRemoteAppCanvasState: (satelliteId: string, state: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] }) => void;
 
   /** Update a remote group project (create/update/delete). */
   updateRemoteGroupProject: (satelliteId: string, action: string, project: unknown) => void;
@@ -240,8 +240,8 @@ function namespaceCanvasViews(satelliteId: string, views: unknown[]): unknown[] 
 /** Namespace views inside an entire canvas state object (canvases + views). */
 function namespaceCanvasData(
   satelliteId: string,
-  data: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] },
-): { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] } {
+  data: { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] },
+): { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] } {
   const canvases = (data.canvases as Array<{ views?: unknown[] } & Record<string, unknown>>).map((canvas) => {
     if (!canvas.views || !Array.isArray(canvas.views)) return canvas;
     return { ...canvas, views: namespaceCanvasViews(satelliteId, canvas.views) };
@@ -310,7 +310,7 @@ export const useRemoteProjectStore = create<RemoteProjectStoreState>((set, get) 
     // Namespace canvas state by project ID, including agentId/projectId
     // fields within each canvas view so they match the namespaced IDs
     // used in remoteAgents.
-    const newCanvasState: Record<string, { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[] }> = {};
+    const newCanvasState: Record<string, { canvases: unknown[]; activeCanvasId: string; wireDefinitions?: unknown[]; zoneWireDefinitions?: unknown[] }> = {};
     if (snapshot.canvasState) {
       for (const [projId, cs] of Object.entries(snapshot.canvasState)) {
         const typed = cs as { canvases: Array<{ views?: unknown[] } & Record<string, unknown>>; activeCanvasId: string; wireDefinitions?: unknown[] };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1146,6 +1146,14 @@ export interface CanvasStateSnapshot {
     instructions?: Record<string, string>;
     disabledTools?: string[];
   }>;
+  /** Zone wire definitions for remote canvas sync — ensures zone wires (and
+   *  their single visual wire to the zone) survive the annex round-trip. */
+  zoneWireDefinitions?: Array<{
+    id: string;
+    sourceZoneId: string;
+    targetId: string;
+    targetType: 'zone' | 'agent' | 'group-project' | 'agent-queue' | 'browser';
+  }>;
 }
 
 // --- Session Resume on Update types ---


### PR DESCRIPTION
## Summary
- **#7 — Wire to a zone now works end to end.** Zone wires are persisted, render as a single visual wire to the zone, and auto-update as agents/cards join or leave the zone.
- **#8 — Wires no longer disappear over the annex protocol.** A new single wire rendering contract derives rendered wires purely from synced state, and zone wires are serialized + namespaced over annex.

## Background
Zone wiring logic already existed (`isValidWireTarget`, `expandZoneWires`, the agent→zone inversion in `useWiring`), but it was invisible and fragile:
- Zone wires were never *rendered* — `WireOverlay` only drew per-agent bindings, so dragging to a zone appeared to do nothing → "can't wire to a zone".
- Zone-expanded bindings lived only in the transient `mcpBindingStore` (never persisted/synced), and reconciliation ran once at creation and ignored removals → no auto-update, and wires vanished on reload/annex while the tools kept working.
- There was no defined contract for what renders, which the mobile/annex devs flagged as unreliable.

## Changes
**New wire rendering contract** (`wire-render-contract.ts`)
- `resolveRenderedWires(views, wireDefinitions, zoneWireDefinitions)` is the single source of truth for what renders, derived purely from synced state — never from transient runtime MCP bindings (the root cause of wires disappearing on the controller/satellite while tools still worked).
- Zone wires resolve to **one** wire whose endpoint is the zone rect.

**Persist + sync zone wires** (`canvas-store.ts`, `canvas-sync.ts`, `shared/types.ts`)
- `zoneWireDefinitions` added to the canvas store with CRUD, storage load/save, `hydrateFromRemote`, and cleanup when a zone or referenced view is removed.
- Serialized in `CanvasStateSnapshot` / `broadcastCanvasState` and namespaced in the annex `canvas:state` handler (`annexClientStore.ts`) — agent/group-project targets get namespaced; zone/browser/queue ids stay verbatim.

**Render + auto-reconcile** (`WireOverlay.tsx`, `CanvasWorkspace.tsx`, `main.ts`, `PopoutCanvasView.tsx`)
- `WireOverlay` renders zone wires as a distinct mauve "bundle" wire to the zone, with a click handler to remove.
- `diffZoneBindings` reconciles expanded per-agent bindings on every containment/zone-wire change: new memberships bound, departed ones unbound, manual wires never touched. Also re-derives runtime bindings on hydration.

## Test Plan
- [x] `wire-render-contract.test.ts` — binding + zone endpoint resolution, single-wire-to-zone, missing-target drops, ordering
- [x] `zone-wire-expansion.test.ts` — `diffZoneBindings` add/remove/preserve-manual/no-double-add
- [x] `canvas-store.test.ts` — zone wire CRUD, persistence round-trip, hydrate, removeZone/removeView cleanup
- [x] `remote-canvas-wire-sync.test.ts` — broadcast includes/omits zone wires, namespacing rules
- [x] `WireOverlay.test.tsx` — single zone wire rendered, SVG present with only zone wires, click handler, missing target dropped
- [x] `npm run typecheck` clean; `eslint` 0 errors; full suite `12223 passed`

## Manual Validation
- Drag a wire from an agent onto a zone → one wire connects to the zone; add/remove an agent in the zone and confirm bindings update without re-wiring.
- Open the canvas over annex/mobile and confirm zone wires remain visible after the round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)