### PR TITLE
feat(personas): apply persona to / extract pattern from agents (right-click)

### DIFF
--- a/src/main/ipc/agent-settings-handlers.ts
+++ b/src/main/ipc/agent-settings-handlers.ts
@@ -3,8 +3,11 @@ import { IPC } from '../../shared/ipc-channels';
 import * as agentSettings from '../services/agent-settings-service';
 import { SettingsConventions } from '../services/agent-settings-service';
 import { resolveOrchestrator } from '../services/agent-system';
-import { getDurableConfig } from '../services/agent-config';
-import { getAgentWildcards, listAvailablePersonas, materializeAgent, previewMaterialization, readPersonaForEdit, resetProjectAgentDefaults } from '../services/materialization-service';
+import { getDurableConfig, updateDurableConfig } from '../services/agent-config';
+import { extractAgentPattern, getAgentWildcards, listAvailablePersonas, materializeAgent, previewMaterialization, readLayeredPersonaRaw, readPersonaForEdit, resetProjectAgentDefaults, writeResolvedPersonaInstructions } from '../services/materialization-service';
+import { isClubhouseModeEnabled } from '../services/clubhouse-mode-settings';
+import { parsePersonaFile } from '../../shared/persona-pattern';
+import type { DurableConfigUpdates } from '../../shared/types';
 import { computeConfigDiff, propagateChanges } from '../services/config-diff-service';
 import { getProjectConfigBreakdown, removePluginInjectionItem } from '../services/config-provenance-service';
 import { appLog } from '../services/log-service';
@@ -327,6 +330,47 @@ export function registerAgentSettingsHandlers(): void {
     [stringArg(), stringArg(), stringArg({ optional: true })],
     async (_event, projectPath, personaId, scope) => {
       await agentSettings.deleteSourcePersona(projectPath, personaId, scope === 'user' ? 'user' : 'project');
+    },
+  ));
+
+  // Apply a persona (content + any front-matter settings) to an existing agent.
+  ipcMain.handle(IPC.AGENT.APPLY_PERSONA_TO_AGENT, withValidatedArgs(
+    [stringArg(), stringArg(), stringArg()],
+    async (_event, projectPath, agentId, personaId) => {
+      const agent = await getDurableConfig(projectPath, agentId);
+      if (!agent) return;
+
+      // Settings ride along in the persona file's front-matter (if any).
+      const raw = await readLayeredPersonaRaw(projectPath, personaId);
+      const { settings } = raw ? parsePersonaFile(raw) : { settings: {} };
+
+      const updates: DurableConfigUpdates = {
+        persona: personaId,
+        ...(settings as DurableConfigUpdates),
+      };
+      await updateDurableConfig(projectPath, agentId, updates);
+
+      const updated = await getDurableConfig(projectPath, agentId);
+      if (!updated) return;
+      const provider = await resolveOrchestrator(projectPath, updated.orchestrator);
+      if (isClubhouseModeEnabled(projectPath)) {
+        // Clubhouse mode rebuilds instructions from project defaults + persona.
+        await materializeAgent({ projectPath, agent: updated, provider });
+      } else {
+        // Otherwise write the resolved persona body straight to the instructions.
+        await writeResolvedPersonaInstructions({ projectPath, agent: updated, provider });
+      }
+    },
+  ));
+
+  // Extract an agent's instructions + settings into a reusable pattern payload.
+  ipcMain.handle(IPC.AGENT.EXTRACT_AGENT_PATTERN, withValidatedArgs(
+    [stringArg(), stringArg()],
+    async (_event, projectPath, agentId) => {
+      const agent = await getDurableConfig(projectPath, agentId);
+      if (!agent) return null;
+      const provider = await resolveOrchestrator(projectPath, agent.orchestrator);
+      return extractAgentPattern({ projectPath, agent, provider });
     },
   ));
 

--- a/src/main/services/materialization-service.test.ts
+++ b/src/main/services/materialization-service.test.ts
@@ -73,6 +73,9 @@ import {
   resolveMissionId,
   resolvePersonaId,
   resolvePersonaContent,
+  readPersonaForEdit,
+  extractAgentPattern,
+  writeResolvedPersonaInstructions,
   resolveAgentCommands,
   listAvailablePersonas,
   getAgentWildcards,
@@ -321,6 +324,54 @@ describe('materialization-service', () => {
       expect(resolveAgentCommands(testAgent, { buildCommand: 'npm run build', testCommand: 'npm test' })).toEqual({
         buildCommand: 'npm run build', testCommand: 'npm test', lintCommand: undefined,
       });
+    });
+  });
+
+  describe('persona pattern front-matter + apply/extract', () => {
+    it('resolvePersonaContent strips pattern front-matter to the body', async () => {
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p).replace(/\\/g, '/');
+        if (fp.startsWith('/project') && fp.endsWith('.clubhouse/personas/qa.md')) {
+          return '---\nmodel: "claude-opus-4-8"\n---\n# Role: QA';
+        }
+        throw new Error('ENOENT');
+      });
+      expect(await resolvePersonaContent('/project', 'qa')).toBe('# Role: QA');
+    });
+
+    it('readPersonaForEdit returns the raw file including front-matter', async () => {
+      const raw = '---\nmodel: "claude-opus-4-8"\n---\n# Role: QA';
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p).replace(/\\/g, '/');
+        if (fp.startsWith('/project') && fp.endsWith('.clubhouse/personas/qa.md')) return raw;
+        throw new Error('ENOENT');
+      });
+      expect(await readPersonaForEdit('/project', 'qa')).toBe(raw);
+    });
+
+    it('extractAgentPattern re-genericizes wildcards and captures settings', async () => {
+      mockSettingsFile(JSON.stringify({ defaults: {}, quickOverrides: {} }));
+      const agent = { ...testAgent, model: 'claude-opus-4-8', mcpIds: ['github'], freeAgentMode: true };
+      const provider = {
+        ...mockProvider,
+        readInstructions: vi.fn(async () => 'Agent bold-falcon at .clubhouse/agents/bold-falcon/'),
+      };
+      const { content, settings } = await extractAgentPattern({ projectPath: '/project', agent, provider });
+      expect(content).toBe('Agent @@AgentName at @@Path');
+      expect(settings).toEqual({ model: 'claude-opus-4-8', mcpIds: ['github'], freeAgentMode: true });
+    });
+
+    it('writeResolvedPersonaInstructions writes the resolved persona body', async () => {
+      const agent = { ...testAgent, persona: 'qa' };
+      vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+        const fp = String(p).replace(/\\/g, '/');
+        if (fp.endsWith('settings.json')) return JSON.stringify({ defaults: {}, quickOverrides: {} });
+        if (fp.endsWith('.clubhouse/personas/qa.md')) return '---\nmodel: "x"\n---\nPersona for @@AgentName';
+        throw new Error('ENOENT');
+      });
+      const provider = { ...mockProvider, writeInstructions: vi.fn() };
+      await writeResolvedPersonaInstructions({ projectPath: '/project', agent, provider });
+      expect(provider.writeInstructions).toHaveBeenCalledWith(agent.worktreePath, 'Persona for bold-falcon');
     });
   });
 

--- a/src/main/services/materialization-service.ts
+++ b/src/main/services/materialization-service.ts
@@ -2,7 +2,8 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { pathExists } from './fs-utils';
 import { AgentWildcardSettings, DurableAgentConfig, MaterializationPreview, ProjectAgentDefaults, SourceControlProvider } from '../../shared/types';
-import { WildcardContext, replaceWildcards } from '../../shared/wildcard-replacer';
+import { WildcardContext, replaceWildcards, unreplaceWildcards } from '../../shared/wildcard-replacer';
+import { PatternSettings, stripPersonaFrontMatter } from '../../shared/persona-pattern';
 import { OrchestratorProvider } from '../orchestrators/types';
 import {
   readProjectAgentDefaults,
@@ -268,6 +269,20 @@ export async function resolvePersonaContent(
   projectPath: string,
   personaId: string | undefined,
 ): Promise<string | undefined> {
+  const raw = await readLayeredPersonaRaw(projectPath, personaId);
+  // Strip any pattern front-matter so only the markdown body is substituted.
+  return raw === undefined ? undefined : stripPersonaFrontMatter(raw);
+}
+
+/**
+ * Read the raw persona file content (front-matter included) layered by scope:
+ * project (.clubhouse/personas) → user (~/.clubhouse/personas) → built-in.
+ * Returns undefined when none exists.
+ */
+export async function readLayeredPersonaRaw(
+  projectPath: string,
+  personaId: string | undefined,
+): Promise<string | undefined> {
   if (!personaId) return undefined;
   const project = await readSourcePersonaContent(projectPath, personaId, 'project');
   if (project) return project;
@@ -348,13 +363,88 @@ export async function listAvailablePersonas(
 }
 
 /**
- * Read persona content for editing in the UI: the effective layered content
- * (project → user → built-in) as a starting point. Returns empty string when
- * none exists.
+ * Read persona content for editing in the UI: the effective layered RAW content
+ * (project → user → built-in), front-matter included so pattern settings
+ * round-trip through the editor. Returns empty string when none exists.
  */
 export async function readPersonaForEdit(projectPath: string, personaId: string): Promise<string> {
-  const resolved = await resolvePersonaContent(projectPath, personaId);
-  return resolved ?? '';
+  const raw = await readLayeredPersonaRaw(projectPath, personaId);
+  return raw ?? '';
+}
+
+// ── Apply / extract persona patterns ─────────────────────────────────────
+
+/** Pick the pattern-settings subset from an agent's durable config. */
+function pickPatternSettings(agent: DurableAgentConfig): PatternSettings {
+  const s: PatternSettings = {};
+  if (agent.model) s.model = agent.model;
+  if (agent.orchestrator) s.orchestrator = agent.orchestrator;
+  if (agent.mcpIds && agent.mcpIds.length > 0) s.mcpIds = agent.mcpIds;
+  if (agent.mcpConfigs && Object.keys(agent.mcpConfigs).length > 0) s.mcpConfigs = agent.mcpConfigs;
+  if (agent.freeAgentMode) s.freeAgentMode = true;
+  if (agent.structuredMode) s.structuredMode = true;
+  if (agent.mission) s.mission = agent.mission;
+  if (agent.buildCommand) s.buildCommand = agent.buildCommand;
+  if (agent.testCommand) s.testCommand = agent.testCommand;
+  if (agent.lintCommand) s.lintCommand = agent.lintCommand;
+  if (agent.sourceControlProvider) s.sourceControlProvider = agent.sourceControlProvider;
+  return s;
+}
+
+/**
+ * Extract a reusable pattern from an agent: its instruction content (with this
+ * agent's resolved values turned back into @@wildcards so the pattern is
+ * portable) plus the pattern-settings subset of its config. The persona/mission
+ * content is intentionally NOT folded into the wildcard context here — the
+ * instructions themselves become the persona body.
+ */
+export async function extractAgentPattern(params: {
+  projectPath: string;
+  agent: DurableAgentConfig;
+  provider: OrchestratorProvider;
+}): Promise<{ content: string; settings: PatternSettings }> {
+  const { projectPath, agent, provider } = params;
+  const defaults = await readProjectAgentDefaults(projectPath);
+  const scp = await resolveSourceControlProvider(projectPath, agent);
+  const commands = resolveAgentCommands(agent, defaults);
+  // No mission/persona content in the context: we re-genericize only identity,
+  // commands, and provider so the body isn't accidentally collapsed to a token.
+  const ctx = buildWildcardContext(agent, projectPath, scp, commands);
+
+  let instructions = '';
+  if (agent.worktreePath) {
+    try {
+      instructions = await provider.readInstructions(agent.worktreePath);
+    } catch {
+      instructions = '';
+    }
+  }
+  const content = instructions ? unreplaceWildcards(instructions, ctx) : '';
+  return { content, settings: pickPatternSettings(agent) };
+}
+
+/**
+ * Write the agent's resolved persona body to its instructions (overwrite).
+ * Used when applying a persona outside Clubhouse mode, where materialization
+ * does not run on wake. Mirrors the persona-only branch of materializeAgent.
+ */
+export async function writeResolvedPersonaInstructions(params: {
+  projectPath: string;
+  agent: DurableAgentConfig;
+  provider: OrchestratorProvider;
+}): Promise<void> {
+  const { projectPath, agent, provider } = params;
+  if (!agent.worktreePath) return;
+  const defaults = await readProjectAgentDefaults(projectPath);
+  const personaId = resolvePersonaId(agent, defaults);
+  const personaContent = await resolvePersonaContent(projectPath, personaId);
+  if (!personaContent) return;
+  const scp = await resolveSourceControlProvider(projectPath, agent);
+  const commands = resolveAgentCommands(agent, defaults);
+  const missionId = resolveMissionId(agent, defaults);
+  const missionContent = missionId ? await readSourceMissionContent(projectPath, missionId) : undefined;
+  const ctx = buildWildcardContext(agent, projectPath, scp, commands, missionContent, personaContent);
+  await provider.writeInstructions(agent.worktreePath, replaceWildcards(personaContent, ctx));
 }
 
 /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -404,6 +404,10 @@ const api = {
       ipcRenderer.invoke(IPC.AGENT.WRITE_SOURCE_PERSONA_CONTENT, projectPath, personaId, content, scope),
     deleteSourcePersona: (projectPath: string, personaId: string, scope?: 'project' | 'user'): Promise<void> =>
       ipcRenderer.invoke(IPC.AGENT.DELETE_SOURCE_PERSONA, projectPath, personaId, scope),
+    applyPersonaToAgent: (projectPath: string, agentId: string, personaId: string): Promise<void> =>
+      ipcRenderer.invoke(IPC.AGENT.APPLY_PERSONA_TO_AGENT, projectPath, agentId, personaId),
+    extractAgentPattern: (projectPath: string, agentId: string): Promise<{ content: string; settings: import('../shared/persona-pattern').PatternSettings } | null> =>
+      ipcRenderer.invoke(IPC.AGENT.EXTRACT_AGENT_PATTERN, projectPath, agentId),
     createSkill: (basePath: string, name: string, isSource: boolean, projectPath?: string) =>
       ipcRenderer.invoke(IPC.AGENT.CREATE_SKILL, basePath, name, isSource, projectPath),
     createAgentTemplate: (basePath: string, name: string, isSource: boolean, projectPath?: string) =>

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -9,6 +9,8 @@ import { AddAgentDialog } from './AddAgentDialog';
 import { AgentGalleryDialog } from './AgentGalleryDialog';
 import { TemplateConfigDialog, type TemplateConfig } from './TemplateConfigDialog';
 import { DeleteAgentDialog } from './DeleteAgentDialog';
+import { ApplyPersonaDialog } from './ApplyPersonaDialog';
+import { ExtractPatternDialog } from './ExtractPatternDialog';
 import { QuickAgentGhostCompact } from './QuickAgentGhost';
 import { useModelOptions } from '../../hooks/useModelOptions';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
@@ -72,6 +74,8 @@ function AgentListInner() {
   const spawnDurableAgent = useAgentStore((s) => s.spawnDurableAgent);
   const loadDurableAgents = useAgentStore((s) => s.loadDurableAgents);
   const deleteDialogAgent = useAgentStore((s) => s.deleteDialogAgent);
+  const applyPersonaDialogAgent = useAgentStore((s) => s.applyPersonaDialogAgent);
+  const extractPatternDialogAgent = useAgentStore((s) => s.extractPatternDialogAgent);
   const reorderAgents = useAgentStore((s) => s.reorderAgents);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const projects = useProjectStore((s) => s.projects);
@@ -750,6 +754,8 @@ function AgentListInner() {
         />
       )}
       {deleteDialogAgent && <DeleteAgentDialog />}
+      {applyPersonaDialogAgent && <ApplyPersonaDialog />}
+      {extractPatternDialogAgent && <ExtractPatternDialog />}
     </div>
   );
 }

--- a/src/renderer/features/agents/AgentListItem.tsx
+++ b/src/renderer/features/agents/AgentListItem.tsx
@@ -135,6 +135,8 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
   const spawnDurableAgent = useAgentStore((s) => s.spawnDurableAgent);
   const openAgentSettings = useAgentStore((s) => s.openAgentSettings);
   const openDeleteDialog = useAgentStore((s) => s.openDeleteDialog);
+  const openApplyPersonaDialog = useAgentStore((s) => s.openApplyPersonaDialog);
+  const openExtractPatternDialog = useAgentStore((s) => s.openExtractPatternDialog);
   const localDetailed = useAgentStore((s) => s.agentDetailedStatus[agent.id]);
   const remoteDetailed = useRemoteProjectStore((s) => s.remoteAgentDetailedStatus[agent.id]);
   const detailed = isRemote ? remoteDetailed : localDetailed;
@@ -206,6 +208,14 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
   const handleDelete = useCallback(() => {
     openDeleteDialog(agent.id);
   }, [agent.id, openDeleteDialog]);
+
+  const handleApplyPersona = useCallback(() => {
+    openApplyPersonaDialog(agent.id);
+  }, [agent.id, openApplyPersonaDialog]);
+
+  const handleExtractPattern = useCallback(() => {
+    openExtractPatternDialog(agent.id);
+  }, [agent.id, openExtractPatternDialog]);
 
   const handlePopOut = useCallback(async () => {
     await window.clubhouse.window.createPopout({
@@ -309,6 +319,39 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
       });
     }
 
+    // Priority 4b: Apply persona / Extract pattern (local durable agents)
+    if (isDurable && !isRemote) {
+      list.push({
+        id: 'apply-persona',
+        label: 'Apply persona…',
+        icon: (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <line x1="19" y1="8" x2="19" y2="14" />
+            <line x1="22" y1="11" x2="16" y2="11" />
+          </svg>
+        ),
+        hoverColor: 'hover:text-ctp-accent',
+        visible: true,
+        handler: handleApplyPersona,
+      });
+      list.push({
+        id: 'extract-pattern',
+        label: 'Extract pattern…',
+        icon: (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        ),
+        hoverColor: 'hover:text-ctp-accent',
+        visible: true,
+        handler: handleExtractPattern,
+      });
+    }
+
     // Priority 5: Delete / Remove (lowest — collapses first)
     if (isDurable && agent.status !== 'running') {
       list.push({
@@ -331,7 +374,7 @@ export function AgentListItem({ agent, isActive, isThinking, onSelect, onSpawnQu
     }
 
     return list;
-  }, [agent.status, agent.kind, isDurable, isCreating, onSpawnQuickChild, handleStopOrRemove, handleWake, handleWakeAndResume, handlePopOut, handleSpawnChild, handleSettings, handleDelete]);
+  }, [agent.status, agent.kind, isDurable, isRemote, isCreating, onSpawnQuickChild, handleStopOrRemove, handleWake, handleWakeAndResume, handlePopOut, handleSpawnChild, handleSettings, handleDelete, handleApplyPersona, handleExtractPattern]);
 
   // ── Responsive action collapse ─────────────────────────────────
 

--- a/src/renderer/features/agents/ApplyPersonaDialog.test.tsx
+++ b/src/renderer/features/agents/ApplyPersonaDialog.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ApplyPersonaDialog } from './ApplyPersonaDialog';
+import { useAgentStore } from '../../stores/agentStore';
+import { useProjectStore } from '../../stores/projectStore';
+
+const mockClose = vi.fn();
+const mockLoadDurable = vi.fn().mockResolvedValue(undefined);
+
+function resetStores(overrides: Record<string, any> = {}) {
+  useAgentStore.setState({
+    applyPersonaDialogAgent: 'agent-1',
+    closeApplyPersonaDialog: mockClose,
+    loadDurableAgents: mockLoadDurable,
+    agents: {
+      'agent-1': {
+        id: 'agent-1', projectId: 'proj-1', name: 'bold-falcon',
+        kind: 'durable', status: 'sleeping', color: 'indigo',
+        worktreePath: '/worktrees/bold-falcon',
+      },
+    },
+    ...overrides,
+  });
+  useProjectStore.setState({
+    projects: [{ id: 'proj-1', name: 'my-project', path: '/home/user/project', color: 'indigo' }],
+    activeProjectId: 'proj-1',
+  });
+}
+
+describe('ApplyPersonaDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    window.clubhouse.agentSettings.listSourcePersonas = vi.fn().mockResolvedValue([
+      { id: 'qa', name: 'Quality Assurance', source: 'builtin' },
+      { id: 'my-pattern', name: 'My Pattern', source: 'user' },
+    ]);
+    window.clubhouse.agentSettings.readSourcePersonaContent = vi.fn().mockResolvedValue(
+      '---\nmodel: "claude-opus-4-8"\nmcpIds: ["github"]\n---\n# Role: My Pattern',
+    );
+    window.clubhouse.agentSettings.applyPersonaToAgent = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('renders nothing when no agent is selected', () => {
+    resetStores({ applyPersonaDialogAgent: null });
+    const { container } = render(<ApplyPersonaDialog />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('lists available personas', async () => {
+    render(<ApplyPersonaDialog />);
+    await waitFor(() => {
+      expect(screen.getByText('Quality Assurance')).toBeInTheDocument();
+      expect(screen.getByText('My Pattern · user')).toBeInTheDocument();
+    });
+  });
+
+  it('previews the settings a persona will overwrite', async () => {
+    render(<ApplyPersonaDialog />);
+    await screen.findByText('My Pattern · user');
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'my-pattern' } });
+    await waitFor(() => {
+      expect(screen.getByText(/model:/)).toBeInTheDocument();
+      expect(screen.getByText(/claude-opus-4-8/)).toBeInTheDocument();
+    });
+  });
+
+  it('applies the selected persona and closes', async () => {
+    render(<ApplyPersonaDialog />);
+    await screen.findByText('Quality Assurance');
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'qa' } });
+    fireEvent.click(screen.getByText('Apply persona'));
+    await waitFor(() => {
+      expect(window.clubhouse.agentSettings.applyPersonaToAgent).toHaveBeenCalledWith(
+        '/home/user/project', 'agent-1', 'qa',
+      );
+      expect(mockLoadDurable).toHaveBeenCalledWith('proj-1', '/home/user/project');
+      expect(mockClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/features/agents/ApplyPersonaDialog.tsx
+++ b/src/renderer/features/agents/ApplyPersonaDialog.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Modal } from '../../components/Modal';
+import { useAgentStore } from '../../stores/agentStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { parsePersonaFile, PatternSettings, PATTERN_SETTING_KEYS } from '../../../shared/persona-pattern';
+
+interface PersonaOption {
+  id: string;
+  name: string;
+  source: 'builtin' | 'user' | 'project';
+}
+
+/** Human-readable summary of a settings value for the confirmation preview. */
+function formatSettingValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(', ');
+  if (value && typeof value === 'object') return Object.keys(value).join(', ');
+  return String(value);
+}
+
+/**
+ * "Apply persona" dialog — pick an existing persona (built-in / user / project)
+ * and apply it to the right-clicked agent, overwriting its persona, instructions,
+ * and any settings the persona carries in its front-matter.
+ */
+export function ApplyPersonaDialog() {
+  const applyPersonaDialogAgent = useAgentStore((s) => s.applyPersonaDialogAgent);
+  const closeApplyPersonaDialog = useAgentStore((s) => s.closeApplyPersonaDialog);
+  const agents = useAgentStore((s) => s.agents);
+  const loadDurableAgents = useAgentStore((s) => s.loadDurableAgents);
+  const { projects, activeProjectId } = useProjectStore();
+  const activeProject = projects.find((p) => p.id === activeProjectId);
+
+  const agent = applyPersonaDialogAgent ? agents[applyPersonaDialogAgent] : null;
+
+  const [personas, setPersonas] = useState<PersonaOption[]>([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [previewSettings, setPreviewSettings] = useState<PatternSettings>({});
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState('');
+
+  const projectPath = activeProject?.path;
+
+  // Load the available personas when the dialog opens.
+  useEffect(() => {
+    if (!applyPersonaDialogAgent || !projectPath) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await window.clubhouse.agentSettings.listSourcePersonas(projectPath);
+        if (!cancelled) setPersonas(list);
+      } catch {
+        if (!cancelled) setPersonas([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [applyPersonaDialogAgent, projectPath]);
+
+  // Preview the settings carried by the selected persona's front-matter.
+  useEffect(() => {
+    if (!selectedId || !projectPath) { setPreviewSettings({}); return; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await window.clubhouse.agentSettings.readSourcePersonaContent(projectPath, selectedId);
+        if (!cancelled) setPreviewSettings(parsePersonaFile(raw).settings);
+      } catch {
+        if (!cancelled) setPreviewSettings({});
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [selectedId, projectPath]);
+
+  const settingKeys = useMemo(
+    () => PATTERN_SETTING_KEYS.filter((k) => previewSettings[k] !== undefined),
+    [previewSettings],
+  );
+
+  if (!agent || !projectPath || !applyPersonaDialogAgent) return null;
+
+  const handleApply = async () => {
+    if (!selectedId) return;
+    setApplying(true);
+    setError('');
+    try {
+      await window.clubhouse.agentSettings.applyPersonaToAgent(projectPath, applyPersonaDialogAgent, selectedId);
+      if (activeProject) await loadDurableAgents(activeProject.id, projectPath);
+      closeApplyPersonaDialog();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to apply persona.');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <Modal open onClose={closeApplyPersonaDialog} title={`Apply persona to ${agent.name}`} width="w-[440px]">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-xs text-ctp-subtext0 mb-1">Persona</label>
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="w-full bg-surface-0 border border-surface-2 rounded px-2 py-1.5 text-sm text-ctp-text focus-ring"
+          >
+            <option value="">Select a persona…</option>
+            {personas.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}{p.source !== 'builtin' ? ` · ${p.source}` : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {selectedId && (
+          <div className="text-xs text-ctp-subtext0 bg-ctp-mantle border border-surface-0 rounded-lg px-3 py-2 space-y-1">
+            <p>
+              Applying overwrites <span className="text-ctp-text">{agent.name}</span>&apos;s persona and instructions.
+            </p>
+            {settingKeys.length > 0 ? (
+              <div>
+                <p className="text-ctp-subtext0/80">It also overwrites these settings:</p>
+                <ul className="mt-1 space-y-0.5">
+                  {settingKeys.map((k) => (
+                    <li key={k} className="font-mono text-ctp-subtext0">
+                      {k}: <span className="text-ctp-text">{formatSettingValue(previewSettings[k])}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <p className="text-ctp-subtext0/80">This persona carries no extra settings (instructions only).</p>
+            )}
+            {agent.status === 'running' && (
+              <p className="text-ctp-warning">Agent is running — changes take effect on its next wake.</p>
+            )}
+          </div>
+        )}
+
+        {error && <p className="text-xs text-ctp-error">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={closeApplyPersonaDialog}
+            disabled={applying}
+            className="text-xs px-3 py-1.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text cursor-pointer transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleApply}
+            disabled={!selectedId || applying}
+            className="text-xs px-3 py-1.5 rounded bg-ctp-accent text-white hover:bg-ctp-accent/80 cursor-pointer transition-colors disabled:opacity-50"
+          >
+            {applying ? 'Applying…' : 'Apply persona'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/renderer/features/agents/ExtractPatternDialog.test.tsx
+++ b/src/renderer/features/agents/ExtractPatternDialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ExtractPatternDialog } from './ExtractPatternDialog';
+import { useAgentStore } from '../../stores/agentStore';
+import { useProjectStore } from '../../stores/projectStore';
+
+const mockClose = vi.fn();
+
+function resetStores(overrides: Record<string, any> = {}) {
+  useAgentStore.setState({
+    extractPatternDialogAgent: 'agent-1',
+    closeExtractPatternDialog: mockClose,
+    agents: {
+      'agent-1': {
+        id: 'agent-1', projectId: 'proj-1', name: 'Bold Falcon',
+        kind: 'durable', status: 'sleeping', color: 'indigo',
+        worktreePath: '/worktrees/bold-falcon',
+      },
+    },
+    ...overrides,
+  });
+  useProjectStore.setState({
+    projects: [{ id: 'proj-1', name: 'my-project', path: '/home/user/project', color: 'indigo' }],
+    activeProjectId: 'proj-1',
+  });
+}
+
+describe('ExtractPatternDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    window.clubhouse.agentSettings.extractAgentPattern = vi.fn().mockResolvedValue({
+      content: 'Agent @@AgentName',
+      settings: { model: 'claude-opus-4-8', mcpIds: ['github'] },
+    });
+    window.clubhouse.agentSettings.writeSourcePersonaContent = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('renders nothing when no agent is selected', () => {
+    resetStores({ extractPatternDialogAgent: null });
+    const { container } = render(<ExtractPatternDialog />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('prefills the extracted content, settings, and a slugified id', async () => {
+    render(<ExtractPatternDialog />);
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Agent @@AgentName')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('bold-falcon')).toBeInTheDocument(); // slug of "Bold Falcon"
+      expect(screen.getByText(/model/)).toBeInTheDocument();
+    });
+  });
+
+  it('saves the pattern with front-matter to the user library by default', async () => {
+    render(<ExtractPatternDialog />);
+    await screen.findByDisplayValue('Agent @@AgentName');
+    fireEvent.click(screen.getByText('Save pattern'));
+    await waitFor(() => {
+      expect(window.clubhouse.agentSettings.writeSourcePersonaContent).toHaveBeenCalled();
+    });
+    const call = (window.clubhouse.agentSettings.writeSourcePersonaContent as any).mock.calls[0];
+    expect(call[0]).toBe('/home/user/project');
+    expect(call[1]).toBe('bold-falcon');
+    expect(call[2]).toContain('model: "claude-opus-4-8"');
+    expect(call[2]).toContain('Agent @@AgentName');
+    expect(call[3]).toBe('user');
+  });
+});

--- a/src/renderer/features/agents/ExtractPatternDialog.tsx
+++ b/src/renderer/features/agents/ExtractPatternDialog.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Modal } from '../../components/Modal';
+import { useAgentStore } from '../../stores/agentStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { serializePersonaFile, PatternSettings, PATTERN_SETTING_KEYS } from '../../../shared/persona-pattern';
+
+const ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+function slugify(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9._-]/g, '');
+}
+
+function formatSettingValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(', ');
+  if (value && typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * "Extract pattern" dialog — capture the right-clicked agent's instructions
+ * (re-genericized with @@wildcards) and a chosen subset of its settings into a
+ * reusable persona file, saved to the user-global or project persona library.
+ */
+export function ExtractPatternDialog() {
+  const extractPatternDialogAgent = useAgentStore((s) => s.extractPatternDialogAgent);
+  const closeExtractPatternDialog = useAgentStore((s) => s.closeExtractPatternDialog);
+  const agents = useAgentStore((s) => s.agents);
+  const { projects, activeProjectId } = useProjectStore();
+  const activeProject = projects.find((p) => p.id === activeProjectId);
+
+  const agent = extractPatternDialogAgent ? agents[extractPatternDialogAgent] : null;
+  const projectPath = activeProject?.path;
+
+  const [content, setContent] = useState('');
+  const [settings, setSettings] = useState<PatternSettings>({});
+  const [checked, setChecked] = useState<Set<string>>(new Set());
+  const [id, setId] = useState('');
+  const [scope, setScope] = useState<'user' | 'project'>('user');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  // Load the extracted pattern when the dialog opens.
+  useEffect(() => {
+    if (!extractPatternDialogAgent || !projectPath) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const result = await window.clubhouse.agentSettings.extractAgentPattern(projectPath, extractPatternDialogAgent);
+        if (cancelled) return;
+        const s = (result?.settings ?? {}) as PatternSettings;
+        setContent(result?.content ?? '');
+        setSettings(s);
+        setChecked(new Set(PATTERN_SETTING_KEYS.filter((k) => s[k] !== undefined)));
+      } catch {
+        if (!cancelled) { setContent(''); setSettings({}); setChecked(new Set()); }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [extractPatternDialogAgent, projectPath]);
+
+  // Seed the default id from the agent name when the dialog opens.
+  useEffect(() => {
+    if (agent) setId(slugify(agent.name));
+  }, [agent]);
+
+  const presentKeys = useMemo(
+    () => PATTERN_SETTING_KEYS.filter((k) => settings[k] !== undefined),
+    [settings],
+  );
+
+  if (!agent || !projectPath || !extractPatternDialogAgent) return null;
+
+  const toggle = (key: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    const trimmed = id.trim();
+    if (!trimmed) { setError('Enter an id for the pattern.'); return; }
+    if (!ID_PATTERN.test(trimmed)) { setError('Use only letters, numbers, dots, dashes, and underscores.'); return; }
+    setSaving(true);
+    setError('');
+    try {
+      const chosen: PatternSettings = {};
+      for (const key of PATTERN_SETTING_KEYS) {
+        if (checked.has(key) && settings[key] !== undefined) {
+          (chosen as Record<string, unknown>)[key] = settings[key];
+        }
+      }
+      const file = serializePersonaFile(chosen, content);
+      await window.clubhouse.agentSettings.writeSourcePersonaContent(projectPath, trimmed, file, scope);
+      closeExtractPatternDialog();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save pattern.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal open onClose={closeExtractPatternDialog} title={`Extract pattern from ${agent.name}`} width="w-[520px]">
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="block text-xs text-ctp-subtext0 mb-1">Pattern id</label>
+            <input
+              type="text"
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder="my-pattern"
+              className="w-full bg-surface-0 border border-surface-2 rounded px-2 py-1.5 text-sm text-ctp-text placeholder:text-ctp-overlay0 focus-ring"
+            />
+          </div>
+          <div className="w-44">
+            <label className="block text-xs text-ctp-subtext0 mb-1">Save to</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value as 'user' | 'project')}
+              className="w-full bg-surface-0 border border-surface-2 rounded px-2 py-1.5 text-sm text-ctp-text focus-ring"
+            >
+              <option value="user">All my projects</option>
+              <option value="project">This project</option>
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs text-ctp-subtext0 mb-1">Instructions (persona body)</label>
+          <textarea
+            value={loading ? 'Loading…' : content}
+            onChange={(e) => setContent(e.target.value)}
+            disabled={loading || saving}
+            spellCheck={false}
+            placeholder="This agent has no instructions to capture."
+            className="w-full h-44 bg-surface-0 text-ctp-text text-sm font-mono rounded-lg p-2 resize-y border border-surface-1 focus-ring"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs text-ctp-subtext0 mb-1">Settings to include</label>
+          {presentKeys.length === 0 ? (
+            <p className="text-xs text-ctp-subtext0/60">This agent has no extra settings to capture.</p>
+          ) : (
+            <div className="grid grid-cols-2 gap-1">
+              {presentKeys.map((k) => (
+                <label key={k} className="flex items-center gap-2 text-xs text-ctp-text cursor-pointer py-0.5">
+                  <input
+                    type="checkbox"
+                    checked={checked.has(k)}
+                    onChange={() => toggle(k)}
+                    className="w-3.5 h-3.5 rounded border-surface-2 bg-surface-0 accent-ctp-accent"
+                  />
+                  <span className="font-mono truncate" title={`${k}: ${formatSettingValue(settings[k])}`}>
+                    {k} <span className="text-ctp-subtext0/70">= {formatSettingValue(settings[k])}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {error && <p className="text-xs text-ctp-error">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={closeExtractPatternDialog}
+            disabled={saving}
+            className="text-xs px-3 py-1.5 rounded bg-surface-1 text-ctp-subtext0 hover:bg-surface-2 hover:text-ctp-text cursor-pointer transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || loading}
+            className="text-xs px-3 py-1.5 rounded bg-ctp-accent text-white hover:bg-ctp-accent/80 cursor-pointer transition-colors disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save pattern'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/renderer/stores/agent/agentUISlice.ts
+++ b/src/renderer/stores/agent/agentUISlice.ts
@@ -5,6 +5,8 @@ export function createUISlice(set: SetAgentState, get: GetAgentState): AgentUISl
     activeAgentId: null,
     agentSettingsOpenFor: null,
     deleteDialogAgent: null,
+    applyPersonaDialogAgent: null,
+    extractPatternDialogAgent: null,
     configChangesDialogAgent: null,
     configChangesProjectPath: null,
     sessionNamePromptFor: null,
@@ -42,6 +44,14 @@ export function createUISlice(set: SetAgentState, get: GetAgentState): AgentUISl
     openDeleteDialog: (agentId) => set({ deleteDialogAgent: agentId }),
 
     closeDeleteDialog: () => set({ deleteDialogAgent: null }),
+
+    openApplyPersonaDialog: (agentId) => set({ applyPersonaDialogAgent: agentId }),
+
+    closeApplyPersonaDialog: () => set({ applyPersonaDialogAgent: null }),
+
+    openExtractPatternDialog: (agentId) => set({ extractPatternDialogAgent: agentId }),
+
+    closeExtractPatternDialog: () => set({ extractPatternDialogAgent: null }),
 
     openConfigChangesDialog: (agentId, projectPath) =>
       set({

--- a/src/renderer/stores/agent/types.ts
+++ b/src/renderer/stores/agent/types.ts
@@ -13,6 +13,10 @@ export interface AgentUISlice {
   activeAgentId: string | null;
   agentSettingsOpenFor: string | null;
   deleteDialogAgent: string | null;
+  /** Agent ID for the "Apply persona" dialog, or null when closed. */
+  applyPersonaDialogAgent: string | null;
+  /** Agent ID for the "Extract pattern" dialog, or null when closed. */
+  extractPatternDialogAgent: string | null;
   configChangesDialogAgent: string | null;
   configChangesProjectPath: string | null;
   /** Agent ID that should be prompted for a session name (set on quit if setting enabled) */
@@ -24,6 +28,10 @@ export interface AgentUISlice {
   closeAgentSettings: () => void;
   openDeleteDialog: (agentId: string) => void;
   closeDeleteDialog: () => void;
+  openApplyPersonaDialog: (agentId: string) => void;
+  closeApplyPersonaDialog: () => void;
+  openExtractPatternDialog: (agentId: string) => void;
+  closeExtractPatternDialog: () => void;
   openConfigChangesDialog: (agentId: string, projectPath: string) => void;
   closeConfigChangesDialog: () => void;
   setSessionNamePrompt: (agentId: string | null) => void;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -115,6 +115,8 @@ export const IPC = {
     READ_SOURCE_PERSONA_CONTENT: 'agent:read-source-persona-content',
     WRITE_SOURCE_PERSONA_CONTENT: 'agent:write-source-persona-content',
     DELETE_SOURCE_PERSONA: 'agent:delete-source-persona',
+    APPLY_PERSONA_TO_AGENT: 'agent:apply-persona-to-agent',
+    EXTRACT_AGENT_PATTERN: 'agent:extract-agent-pattern',
     GET_PROJECT_CONFIG_BREAKDOWN: 'agent:get-project-config-breakdown',
     REMOVE_PLUGIN_INJECTION_ITEM: 'agent:remove-plugin-injection-item',
     COMPUTE_CONFIG_DIFF: 'agent:compute-config-diff',

--- a/src/shared/persona-pattern.test.ts
+++ b/src/shared/persona-pattern.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePersonaFile,
+  serializePersonaFile,
+  stripPersonaFrontMatter,
+  PatternSettings,
+} from './persona-pattern';
+
+describe('persona-pattern', () => {
+  describe('parse / serialize round-trip', () => {
+    it('round-trips settings including nested mcpConfigs', () => {
+      const settings: PatternSettings = {
+        model: 'claude-opus-4-8',
+        orchestrator: 'claude-code',
+        mcpIds: ['github', 'linear'],
+        mcpConfigs: { github: { token: 'x' } },
+        freeAgentMode: true,
+        structuredMode: false,
+        mission: 'implement-and-ship',
+        buildCommand: 'npm run build',
+        sourceControlProvider: 'azure-devops',
+      };
+      const body = '# Role: Reviewer\n\nDo the thing.';
+      const file = serializePersonaFile(settings, body);
+      const parsed = parsePersonaFile(file);
+      expect(parsed.settings).toEqual(settings);
+      expect(parsed.body).toBe(body);
+    });
+
+    it('emits no front-matter when there are no settings', () => {
+      const body = '# Just content';
+      expect(serializePersonaFile({}, body)).toBe(body);
+      expect(parsePersonaFile(body)).toEqual({ settings: {}, body });
+    });
+
+    it('omits empty arrays and empty objects', () => {
+      const file = serializePersonaFile({ mcpIds: [], mcpConfigs: {}, model: 'x' }, 'body');
+      expect(file).toContain('model: "x"');
+      expect(file).not.toContain('mcpIds');
+      expect(file).not.toContain('mcpConfigs');
+    });
+  });
+
+  describe('parsePersonaFile', () => {
+    it('treats a file without front-matter as pure body', () => {
+      const raw = '# Role\n\nNo front-matter here.';
+      expect(parsePersonaFile(raw)).toEqual({ settings: {}, body: raw });
+    });
+
+    it('tolerates hand-edited unquoted scalar values', () => {
+      const raw = '---\nmodel: claude-opus-4-8\nfreeAgentMode: true\n---\n# Body';
+      const { settings, body } = parsePersonaFile(raw);
+      expect(settings.model).toBe('claude-opus-4-8');
+      expect(settings.freeAgentMode).toBe(true);
+      expect(body).toBe('# Body');
+    });
+
+    it('ignores unknown keys and comment lines', () => {
+      const raw = '---\n# a comment\nmodel: "x"\nbogusKey: "y"\n---\nbody';
+      const { settings } = parsePersonaFile(raw);
+      expect(settings.model).toBe('x');
+      expect((settings as Record<string, unknown>).bogusKey).toBeUndefined();
+    });
+  });
+
+  describe('stripPersonaFrontMatter', () => {
+    it('removes the front-matter block', () => {
+      const raw = '---\nmodel: "x"\n---\n\n# Role: QA';
+      expect(stripPersonaFrontMatter(raw)).toBe('# Role: QA');
+    });
+
+    it('returns the input unchanged when there is no front-matter', () => {
+      const raw = '# Role: QA\n\nbody';
+      expect(stripPersonaFrontMatter(raw)).toBe(raw);
+    });
+  });
+});

--- a/src/shared/persona-pattern.ts
+++ b/src/shared/persona-pattern.ts
@@ -1,0 +1,102 @@
+import { SourceControlProvider } from './types';
+
+/**
+ * The reusable agent-settings bundle a persona "pattern" can carry, stored as
+ * YAML front-matter at the top of a persona .md file. Every field is optional;
+ * only the ones present are applied when the persona is applied to an agent.
+ *
+ * These keys mirror the per-agent overrides on DurableConfigUpdates so a pattern
+ * applies cleanly via updateDurableConfig.
+ */
+export interface PatternSettings {
+  model?: string;
+  orchestrator?: string;
+  mcpIds?: string[];
+  mcpConfigs?: Record<string, Record<string, string>>;
+  freeAgentMode?: boolean;
+  structuredMode?: boolean;
+  mission?: string;
+  buildCommand?: string;
+  testCommand?: string;
+  lintCommand?: string;
+  sourceControlProvider?: SourceControlProvider;
+}
+
+/** Ordered list of the keys a pattern may carry (used by extract UI + apply). */
+export const PATTERN_SETTING_KEYS: Array<keyof PatternSettings> = [
+  'model',
+  'orchestrator',
+  'mcpIds',
+  'mcpConfigs',
+  'freeAgentMode',
+  'structuredMode',
+  'mission',
+  'buildCommand',
+  'testCommand',
+  'lintCommand',
+  'sourceControlProvider',
+];
+
+const FRONT_MATTER_RE = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n)+/;
+
+/**
+ * Split a persona file into its YAML front-matter settings and markdown body.
+ * Front-matter lines are `key: <value>`, where `<value>` is JSON when possible
+ * (so arrays/objects round-trip exactly) and otherwise treated as a raw string
+ * (tolerates hand-edited unquoted scalars like `model: claude-opus-4-8`).
+ * Files without front-matter parse to `{ settings: {}, body: <whole file> }`.
+ */
+export function parsePersonaFile(raw: string): { settings: PatternSettings; body: string } {
+  const match = raw.match(FRONT_MATTER_RE);
+  if (!match) return { settings: {}, body: raw };
+
+  const body = raw.slice(match[0].length);
+  const settings: Record<string, unknown> = {};
+  const known = new Set<string>(PATTERN_SETTING_KEYS as string[]);
+
+  for (const line of match[1].split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf(':');
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    if (!known.has(key)) continue;
+    const rawValue = trimmed.slice(idx + 1).trim();
+    if (rawValue === '') continue;
+    try {
+      settings[key] = JSON.parse(rawValue);
+    } catch {
+      // Tolerate unquoted scalar strings.
+      settings[key] = rawValue;
+    }
+  }
+
+  return { settings: settings as PatternSettings, body };
+}
+
+/**
+ * Return just the persona body (front-matter stripped). Used at materialization
+ * so only the markdown content is substituted for @@Persona.
+ */
+export function stripPersonaFrontMatter(raw: string): string {
+  const match = raw.match(FRONT_MATTER_RE);
+  return match ? raw.slice(match[0].length) : raw;
+}
+
+/**
+ * Serialize settings + body into a persona file. When there are no settings the
+ * body is returned unchanged (no front-matter), keeping content-only personas
+ * clean. Values are JSON-encoded so arrays and nested objects round-trip.
+ */
+export function serializePersonaFile(settings: PatternSettings, body: string): string {
+  const lines: string[] = [];
+  for (const key of PATTERN_SETTING_KEYS) {
+    const value = settings[key];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) continue;
+    lines.push(`${key}: ${JSON.stringify(value)}`);
+  }
+  if (lines.length === 0) return body;
+  return `---\n${lines.join('\n')}\n---\n\n${body}`;
+}

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -160,6 +160,8 @@ vi.stubGlobal('clubhouse', {
     readSourcePersonaContent: async () => '',
     writeSourcePersonaContent: asyncNoop,
     deleteSourcePersona: asyncNoop,
+    applyPersonaToAgent: asyncNoop,
+    extractAgentPattern: async () => ({ content: '', settings: {} }),
     createSkill: asyncNoop,
     createAgentTemplate: asyncNoop,
     readPermissions: async () => ({}),


### PR DESCRIPTION
## Summary

Two right-click actions on agents in the list, for mapping many agents onto common patterns:

- **Apply persona** — pick an existing persona (built-in / user / project) and apply it to the agent. It overwrites the agent's persona, instructions, and any settings the persona carries. A confirmation previews exactly what will change.
- **Extract pattern** — capture the agent's instructions (re-genericized with `@@wildcards`) plus a chosen subset of its settings into a reusable persona file, saved to your user-global library (default) or this project.

## What a "pattern" is

A pattern is just a persona `.md` file with **optional YAML front-matter** carrying a settings bundle. The front-matter is stripped at materialization, so only the body substitutes for `@@Persona` — built-ins (no front-matter) are unaffected.

```
---
model: "claude-opus-4-8"
mcpIds: ["github"]
freeAgentMode: true
mission: "implement-and-ship"
---
# Role: ...        ← this body is the @@Persona content
```

Captured settings: `model`, `orchestrator`, `mcpIds`, `mcpConfigs`, `freeAgentMode`, `structuredMode`, `mission`, `buildCommand`, `testCommand`, `lintCommand`, `sourceControlProvider`. Front-matter values are JSON-encoded (dependency-free parse, handles nested `mcpConfigs`).

## Changes
- **shared/persona-pattern.ts** — `PatternSettings` + `parsePersonaFile` / `serializePersonaFile` / `stripPersonaFrontMatter`.
- **materialization** — `resolvePersonaContent` strips front-matter; `readPersonaForEdit` returns the raw file (so the persona editor round-trips settings); `readLayeredPersonaRaw`; `extractAgentPattern` (reads instructions, `unreplaceWildcards` to re-genericize, captures settings); `writeResolvedPersonaInstructions` (apply path outside Clubhouse mode).
- **IPC / preload** — `applyPersonaToAgent`, `extractAgentPattern`. Apply orchestrates in the handler: `updateDurableConfig({ persona, ...settings })`, then `materializeAgent` (Clubhouse mode) or write resolved instructions (otherwise).
- **renderer** — `agentUISlice` dialog state/actions; two context-menu items (local durable agents only); `ApplyPersonaDialog` (picker + settings preview + overwrite confirm) and `ExtractPatternDialog` (editable content + per-setting checkboxes + id + user/project scope), mounted in `AgentList`.

## Behavior notes
- **Overwrite** semantics (not append), per design — re-applying doesn't stack.
- Applying to a **running** agent is allowed; the dialog notes changes take effect on next wake.
- Single-agent apply via right-click (bulk multi-apply intentionally deferred).
- Menu items hidden for remote agents (apply/extract are local-only this PR).

## Test Plan
- [x] `persona-pattern.test.ts` — serialize/parse round-trip incl. nested `mcpConfigs`; strip; no front-matter → pure body; tolerant of unquoted scalars; unknown keys ignored.
- [x] `materialization-service.test.ts` — `resolvePersonaContent` strips front-matter; `readPersonaForEdit` returns raw; `extractAgentPattern` re-genericizes wildcards + captures settings; `writeResolvedPersonaInstructions` writes resolved body.
- [x] `ApplyPersonaDialog.test.tsx` — lists personas, previews settings, applies + reloads + closes.
- [x] `ExtractPatternDialog.test.tsx` — prefills content/settings/slugified id; saves serialized front-matter to user scope.
- [x] `npx tsc --noEmit` clean; `npm test` 483 files / 12252 pass (4 pre-existing skips); `npm run lint` 0 errors.

## Manual Validation
- [ ] Right-click an agent → **Apply persona…** → pick a built-in (e.g. QA) → confirm overwrite → instructions/persona update (immediately in Clubhouse mode; on next wake otherwise).
- [ ] Apply a user pattern that carries settings → verify model/MCPs/etc. update on the agent.
- [ ] Right-click an agent → **Extract pattern…** → tweak content + uncheck a setting → Save to "All my projects" → confirm `~/.clubhouse/personas/<id>.md` has front-matter + body; open another project and apply it.
- [ ] Confirm the agent's name/path appear as `@@AgentName`/`@@Path` in the extracted content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)