### PR TITLE
feat(group-project): admin role + gated set_project_info tool (#9, #10)

### DIFF
--- a/src/main/ipc/mcp-binding-handlers.ts
+++ b/src/main/ipc/mcp-binding-handlers.ts
@@ -15,6 +15,7 @@ import { registerAssistantTools } from '../services/clubhouse-mcp/tools/assistan
 import { registerCanvasCommandHandler } from '../services/clubhouse-mcp/canvas-command';
 import { registerCommandPaletteHandler } from '../services/clubhouse-mcp/command-palette-bridge';
 import { agentRegistry } from '../services/agent-registry';
+import { bootstrapGroupProjectAdmin } from '../services/group-project-admin-service';
 import { appLog } from '../services/log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { withValidatedArgs, stringArg, objectArg, arrayArg } from './validation';
@@ -90,6 +91,12 @@ export function registerMcpBindingHandlers(): void {
       }
       assertValidTargetKind(target.targetKind);
       const isNew = bindingManager.bind(agentId as string, target as { targetId: string; targetKind: BindingTargetKind; label: string; agentName?: string; targetName?: string; projectName?: string });
+      // Bootstrap the project lead: the first agent to join a group project
+      // becomes its admin (no-op once an admin exists). The registry change
+      // invalidates the scoped tool cache so role gating applies immediately.
+      if (target.targetKind === 'group-project') {
+        void bootstrapGroupProjectAdmin(target.targetId, agentId as string);
+      }
       if (!isNew) {
         // Duplicate binding — notifyChange was skipped by bind(), so the
         // renderer's mcpBindingStore won't receive a BINDINGS_CHANGED event.

--- a/src/main/services/clubhouse-mcp/mcp-adapter.test.ts
+++ b/src/main/services/clubhouse-mcp/mcp-adapter.test.ts
@@ -27,6 +27,7 @@ vi.mock('../group-project-registry', () => ({
   groupProjectRegistry: {
     getAll: vi.fn().mockReturnValue([]),
     getSync: vi.fn().mockReturnValue(undefined),
+    onChange: vi.fn().mockReturnValue(() => {}),
     _resetForTesting: vi.fn(),
   },
 }));

--- a/src/main/services/clubhouse-mcp/tool-registry.test.ts
+++ b/src/main/services/clubhouse-mcp/tool-registry.test.ts
@@ -14,6 +14,7 @@ vi.mock('fs/promises', () => ({
 import { registerToolTemplate, registerGlobalTool, getScopedToolList, callTool, buildToolName, buildToolKey, parseToolName, shortHash, invalidateToolListCache, sanitizeWireInstruction, _resetForTesting } from './tool-registry';
 import { bindingManager } from './binding-manager';
 import { agentRegistry } from '../agent-registry';
+import { groupProjectRegistry } from '../group-project-registry';
 import type { McpBinding } from './types';
 
 function makeBinding(overrides: Partial<McpBinding> & { agentId: string; targetId: string; targetKind: McpBinding['targetKind'] }): McpBinding {
@@ -725,8 +726,9 @@ describe('ToolRegistry', () => {
     });
   });
 
-  describe('group-project tool gating (wire-level only)', () => {
+  describe('group-project tool gating (admin role + wire-level)', () => {
     beforeEach(() => {
+      groupProjectRegistry._resetForTesting();
       registerToolTemplate('group-project', 'list_members', { description: 'List', inputSchema: { type: 'object' } }, vi.fn());
       registerToolTemplate('group-project', 'shoulder_tap', { description: 'Tap', inputSchema: { type: 'object' } }, vi.fn());
       registerToolTemplate('group-project', 'broadcast', { description: 'Broadcast', inputSchema: { type: 'object' } }, vi.fn());
@@ -736,7 +738,11 @@ describe('ToolRegistry', () => {
       registerToolTemplate('group-project', 'compact_agent', { description: 'Compact agent', inputSchema: { type: 'object' } }, vi.fn());
     });
 
-    it('exposes all group-project tools when no wire-level disabledTools', () => {
+    it('exposes all group-project tools to an admin with no wire-level disabledTools', () => {
+      groupProjectRegistry._setForTesting({
+        id: 'gp_test_1', name: 'TestProj', description: '', instructions: '',
+        createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['agent-1'] },
+      });
       bindingManager.bind('agent-1', {
         targetId: 'gp_test_1', targetKind: 'group-project', label: 'GP', targetName: 'TestProj',
       });
@@ -767,7 +773,11 @@ describe('ToolRegistry', () => {
       expect(suffixes).not.toContain('compact_agent');
     });
 
-    it('can disable individual tools without affecting others', () => {
+    it('an admin wire can disable individual tools without affecting others', () => {
+      groupProjectRegistry._setForTesting({
+        id: 'gp_test_3', name: 'TestProj', description: '', instructions: '',
+        createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['agent-1'] },
+      });
       bindingManager.bind('agent-1', {
         targetId: 'gp_test_3', targetKind: 'group-project', label: 'GP', targetName: 'TestProj',
       });

--- a/src/main/services/clubhouse-mcp/tool-registry.ts
+++ b/src/main/services/clubhouse-mcp/tool-registry.ts
@@ -6,6 +6,8 @@
 import type { McpToolDefinition, McpToolResult, McpBinding, BindingTargetKind } from './types';
 import { bindingManager } from './binding-manager';
 import { agentRegistry } from '../agent-registry';
+import { groupProjectRegistry } from '../group-project-registry';
+import { deniedGroupProjectTools } from '../../../shared/group-project-admin';
 import { appLog } from '../log-service';
 
 /** Check if a value matches a JSON Schema type (handles array vs object correctly). */
@@ -206,13 +208,24 @@ export function getScopedToolList(agentId: string): McpToolDefinition[] {
     // When target agent is sleeping (not in registry), only expose status tools.
     const isTargetSleeping = binding.targetKind === 'agent' && !agentRegistry.get(binding.targetId);
 
+    // For group projects, the project's admin role governs the privileged
+    // toolset (admins get them, non-admins don't), combined with any per-wire
+    // disables. For all other targets, only per-wire disables apply.
+    const deniedTools = binding.targetKind === 'group-project'
+      ? deniedGroupProjectTools(
+          groupProjectRegistry.getSync(binding.targetId)?.metadata,
+          binding.agentId,
+          binding.disabledTools,
+        )
+      : new Set<string>(binding.disabledTools ?? []);
+
     for (const template of templates) {
       if (isTargetSleeping && template.nameSuffix !== 'get_status') {
         continue;
       }
 
-      // Skip tools disabled at the wire level
-      if (binding.disabledTools?.includes(template.nameSuffix)) {
+      // Skip tools disabled by role gating and/or at the wire level
+      if (deniedTools.has(template.nameSuffix)) {
         continue;
       }
 
@@ -359,6 +372,11 @@ export async function callTool(
 
   return template.handler(binding.targetId, agentId, args);
 }
+
+// Admin membership lives in group-project metadata (not in bindingManager, so
+// its version counter doesn't change). Refresh scoped tool lists whenever a
+// group project changes so role-based gating takes effect immediately.
+groupProjectRegistry.onChange(() => invalidateToolListCache());
 
 /** For testing: clear all registered templates and global tools. */
 export function _resetForTesting(): void {

--- a/src/main/services/clubhouse-mcp/tools/command-integration.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/command-integration.test.ts
@@ -28,6 +28,8 @@ vi.mock('../../agent-registry', () => ({
 vi.mock('../../group-project-registry', () => ({
   groupProjectRegistry: {
     getAll: vi.fn().mockReturnValue([]),
+    getSync: vi.fn().mockReturnValue(null),
+    onChange: vi.fn().mockReturnValue(() => {}),
     _resetForTesting: vi.fn(),
   },
 }));

--- a/src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts
+++ b/src/main/services/clubhouse-mcp/tools/group-project-tools.test.ts
@@ -101,7 +101,11 @@ describe('GroupProjectTools', () => {
     registerGroupProjectTools();
   });
 
-  it('registers all 16 tools by default (gating is per-wire only)', () => {
+  it('exposes all 17 tools to an admin member', () => {
+    groupProjectRegistry._setForTesting({
+      id: 'gp_123', name: 'My Project', description: '', instructions: '',
+      createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['agent-1'] },
+    });
     bindingManager.bind('agent-1', {
       targetId: 'gp_123',
       targetKind: 'group-project',
@@ -111,7 +115,7 @@ describe('GroupProjectTools', () => {
     });
 
     const tools = getScopedToolList('agent-1');
-    expect(tools).toHaveLength(16);
+    expect(tools).toHaveLength(17);
 
     const suffixes = tools.map(t => t.name.split('__').pop());
     expect(suffixes).toContain('list_members');
@@ -130,6 +134,25 @@ describe('GroupProjectTools', () => {
     expect(suffixes).toContain('compact_agent');
     expect(suffixes).toContain('clear_topic');
     expect(suffixes).toContain('delete_messages');
+    expect(suffixes).toContain('set_project_info');
+  });
+
+  it('exposes only the 6 core tools to a non-admin member', () => {
+    groupProjectRegistry._setForTesting({
+      id: 'gp_core', name: 'Core', description: '', instructions: '',
+      createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['someone-else'] },
+    });
+    bindingManager.bind('agent-1', {
+      targetId: 'gp_core', targetKind: 'group-project', label: 'Core', agentName: 'robin',
+    });
+
+    const suffixes = getScopedToolList('agent-1').map(t => t.name.split('__').pop());
+    expect(suffixes.sort()).toEqual(
+      ['get_project_info', 'list_members', 'post_bulletin', 'read_bulletin', 'read_message', 'read_topic'].sort(),
+    );
+    for (const priv of ['shoulder_tap', 'broadcast', 'wake_agent', 'sleep_agent', 'delete_messages', 'set_project_info']) {
+      expect(suffixes).not.toContain(priv);
+    }
   });
 
   it('hides tools disabled at the wire level', () => {
@@ -432,8 +455,9 @@ describe('GroupProjectTools', () => {
     agentRegistry.untrack('agent-1');
   });
 
-  it('shoulder_tap and broadcast are always available (no project-level flag needed)', async () => {
+  it('shoulder_tap and broadcast are available to an admin member', async () => {
     const project = await groupProjectRegistry.create('TapProj');
+    await groupProjectRegistry.update(project.id, { metadata: { admins: ['agent-1'] } });
 
     bindingManager.bind('agent-1', {
       targetId: project.id,
@@ -638,7 +662,11 @@ describe('GroupProjectTools', () => {
 
   /* ---------- Agent Control Tools (wake, sleep, start/stop polling) ---------- */
 
-  it('wake_agent, sleep_agent, start_polling, stop_polling are available when enabled', () => {
+  it('wake_agent, sleep_agent, start_polling, stop_polling are available to an admin', () => {
+    groupProjectRegistry._setForTesting({
+      id: 'gp_123', name: 'My Project', description: '', instructions: '',
+      createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['agent-1'] },
+    });
     bindingManager.bind('agent-1', {
       targetId: 'gp_123',
       targetKind: 'group-project',
@@ -1141,7 +1169,11 @@ describe('GroupProjectTools', () => {
 
   /* ---------- Agent deletion tools ---------- */
 
-  it('clear_topic and delete_messages are always available (wire-level gating only)', () => {
+  it('clear_topic and delete_messages are available to an admin (message curation)', () => {
+    groupProjectRegistry._setForTesting({
+      id: 'gp_123', name: 'GP', description: '', instructions: '',
+      createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['agent-1'] },
+    });
     bindingManager.bind('agent-1', {
       targetId: 'gp_123',
       targetKind: 'group-project',
@@ -1246,6 +1278,75 @@ describe('GroupProjectTools', () => {
     const remaining = JSON.parse(readResult.content[0].text!);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].body).toBe('keep me');
+  });
+
+  describe('set_project_info', () => {
+    it('updates description and instructions for an admin', async () => {
+      const project = await groupProjectRegistry.create('InfoEditProj');
+      await groupProjectRegistry.update(project.id, { metadata: { admins: ['agent-1'] } });
+      bindingManager.bind('agent-1', {
+        targetId: project.id, targetKind: 'group-project', label: 'IE', agentName: 'lead', targetName: 'InfoEditProj',
+      });
+
+      const binding = makeBinding({ agentId: 'agent-1', targetId: project.id, targetName: 'InfoEditProj' });
+      const name = buildToolName(binding, 'set_project_info');
+      const result = await callTool('agent-1', name, {
+        description: 'New purpose', instructions: 'Follow these rules',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text!);
+      expect(parsed.description).toBe('New purpose');
+      expect(parsed.instructions).toBe('Follow these rules');
+      const updated = await groupProjectRegistry.get(project.id);
+      expect(updated?.description).toBe('New purpose');
+      expect(updated?.instructions).toBe('Follow these rules');
+    });
+
+    it('leaves omitted fields unchanged', async () => {
+      const project = await groupProjectRegistry.create('PartialProj');
+      await groupProjectRegistry.update(project.id, {
+        description: 'orig desc', instructions: 'orig instr', metadata: { admins: ['agent-1'] },
+      });
+      bindingManager.bind('agent-1', {
+        targetId: project.id, targetKind: 'group-project', label: 'PP', agentName: 'lead', targetName: 'PartialProj',
+      });
+
+      const binding = makeBinding({ agentId: 'agent-1', targetId: project.id, targetName: 'PartialProj' });
+      const name = buildToolName(binding, 'set_project_info');
+      await callTool('agent-1', name, { instructions: 'updated instr' });
+
+      const updated = await groupProjectRegistry.get(project.id);
+      expect(updated?.description).toBe('orig desc');
+      expect(updated?.instructions).toBe('updated instr');
+    });
+
+    it('is rejected for a non-admin caller (defense in depth)', async () => {
+      const project = await groupProjectRegistry.create('GuardProj');
+      await groupProjectRegistry.update(project.id, { metadata: { admins: ['someone-else'] } });
+      bindingManager.bind('agent-1', {
+        targetId: project.id, targetKind: 'group-project', label: 'GP', agentName: 'member', targetName: 'GuardProj',
+      });
+
+      const binding = makeBinding({ agentId: 'agent-1', targetId: project.id, targetName: 'GuardProj' });
+      const name = buildToolName(binding, 'set_project_info');
+      const result = await callTool('agent-1', name, { description: 'hijack' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('admin');
+    });
+
+    it('is hidden from a non-admin’s scoped tool list', () => {
+      groupProjectRegistry._setForTesting({
+        id: 'gp_hidden', name: 'H', description: '', instructions: '',
+        createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['someone-else'] },
+      });
+      bindingManager.bind('agent-1', {
+        targetId: 'gp_hidden', targetKind: 'group-project', label: 'H', agentName: 'member',
+      });
+      const suffixes = getScopedToolList('agent-1').map(t => t.name.split('__').pop());
+      expect(suffixes).not.toContain('set_project_info');
+    });
   });
 
   describe('clear_agent', () => {

--- a/src/main/services/clubhouse-mcp/tools/group-project-tools.ts
+++ b/src/main/services/clubhouse-mcp/tools/group-project-tools.ts
@@ -7,6 +7,7 @@ import { bindingManager } from '../binding-manager';
 import { mcpAdapter } from '../mcp-adapter';
 import { getBulletinBoard } from '../../group-project-bulletin';
 import { groupProjectRegistry } from '../../group-project-registry';
+import { isProjectAdmin } from '../../../../shared/group-project-admin';
 import { isAgentAlive, injectPtyMessage } from '../../group-project-lifecycle';
 import * as ptyManager from '../../pty-manager';
 import { executeShoulderTap } from '../../group-project-shoulder-tap';
@@ -1059,6 +1060,53 @@ export function registerGroupProjectTools(): void {
 
       return {
         content: [{ type: 'text', text: JSON.stringify({ deleted: deletedCount, requested: messageIds.length }) }],
+      };
+    },
+  });
+
+  // group__<name>_<hash>__set_project_info
+  mcpAdapter.registerMcpCommand({
+    id: 'group-project.set_project_info',
+    category: 'group-project',
+    label: 'Set Project Info',
+    mcp: { targetKind: 'group-project', nameSuffix: 'set_project_info' },
+    description:
+      'Update the group project description and/or instructions (project-lead tool).\n\n' +
+      'The description explains the purpose of the group; the instructions are directives ' +
+      'every member must follow (returned by get_project_info). Provide either or both — ' +
+      'omitted fields are left unchanged. Returns the updated { description, instructions }.\n\n' +
+      'This is a privileged, admin-only tool; it is only available to project leads.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        description: { type: 'string', description: 'New project description (purpose of the group).' },
+        instructions: { type: 'string', description: 'New project instructions (rules members must follow).' },
+      },
+    },
+    handler: async (targetId: string, agentId: string, args: Record<string, unknown>): Promise<McpToolResult> => {
+      const project = await groupProjectRegistry.get(targetId);
+      if (!project) {
+        return { content: [{ type: 'text', text: `Group project ${targetId} not found.` }], isError: true };
+      }
+      // Defense in depth: the tool is already role-gated out of non-admins' tool
+      // lists, but reject here too in case it is ever invoked directly.
+      if (!isProjectAdmin(project.metadata, agentId)) {
+        return { content: [{ type: 'text', text: 'Only a project admin can update the project description or instructions.' }], isError: true };
+      }
+
+      const description = optionalString(args, 'description');
+      const instructions = optionalString(args, 'instructions');
+      if (description === undefined && instructions === undefined) {
+        return { content: [{ type: 'text', text: 'Provide at least one of description or instructions.' }], isError: true };
+      }
+
+      const updated = await groupProjectRegistry.update(targetId, {
+        ...(description !== undefined ? { description } : {}),
+        ...(instructions !== undefined ? { instructions } : {}),
+      });
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ description: updated?.description, instructions: updated?.instructions }) }],
       };
     },
   });

--- a/src/main/services/group-project-admin-service.test.ts
+++ b/src/main/services/group-project-admin-service.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bootstrapGroupProjectAdmin } from './group-project-admin-service';
+import { groupProjectRegistry } from './group-project-registry';
+import { getProjectAdmins } from '../../shared/group-project-admin';
+
+describe('bootstrapGroupProjectAdmin', () => {
+  beforeEach(() => {
+    groupProjectRegistry._resetForTesting();
+  });
+
+  it('makes the first joining agent the project admin', async () => {
+    groupProjectRegistry._setForTesting({
+      id: 'gp_1', name: 'P', description: '', instructions: '',
+      createdAt: '2020-01-01T00:00:00Z', metadata: {},
+    });
+    await bootstrapGroupProjectAdmin('gp_1', 'agent-first');
+    expect(getProjectAdmins(groupProjectRegistry.getSync('gp_1')?.metadata)).toEqual(['agent-first']);
+  });
+
+  it('is a no-op when an admin already exists', async () => {
+    groupProjectRegistry._setForTesting({
+      id: 'gp_1', name: 'P', description: '', instructions: '',
+      createdAt: '2020-01-01T00:00:00Z', metadata: { admins: ['existing-lead'] },
+    });
+    await bootstrapGroupProjectAdmin('gp_1', 'agent-second');
+    expect(getProjectAdmins(groupProjectRegistry.getSync('gp_1')?.metadata)).toEqual(['existing-lead']);
+  });
+
+  it('does nothing for an unknown project', async () => {
+    await expect(bootstrapGroupProjectAdmin('gp_missing', 'agent')).resolves.toBeUndefined();
+  });
+});

--- a/src/main/services/group-project-admin-service.ts
+++ b/src/main/services/group-project-admin-service.ts
@@ -1,0 +1,19 @@
+/**
+ * Group-project admin bootstrap.
+ *
+ * Standard pattern: the first agent to join a group project becomes its admin
+ * (project lead). Additional admins can be assigned later via the UI. This runs
+ * when an agent binds to a group project and is a no-op once any admin exists.
+ */
+
+import { groupProjectRegistry } from './group-project-registry';
+import { getProjectAdmins } from '../../shared/group-project-admin';
+
+/** Make `agentId` the project lead iff the project currently has no admins. */
+export async function bootstrapGroupProjectAdmin(targetId: string, agentId: string): Promise<void> {
+  // Ensure the registry is loaded before inspecting metadata.
+  const project = await groupProjectRegistry.get(targetId);
+  if (!project) return;
+  if (getProjectAdmins(project.metadata).length > 0) return;
+  await groupProjectRegistry.update(targetId, { metadata: { admins: [agentId] } });
+}

--- a/src/main/services/group-project-registry.ts
+++ b/src/main/services/group-project-registry.ts
@@ -172,6 +172,12 @@ class GroupProjectRegistry {
     return () => { this.listeners.delete(listener); };
   }
 
+  /** For testing: seed a project directly into the in-memory cache. */
+  _setForTesting(project: GroupProject): void {
+    this.loaded = true;
+    this.projects.set(project.id, project);
+  }
+
   /** For testing: reset all state. */
   _resetForTesting(): void {
     if (this.flushTimer) clearTimeout(this.flushTimer);

--- a/src/renderer/plugins/builtin/canvas/main.test.ts
+++ b/src/renderer/plugins/builtin/canvas/main.test.ts
@@ -233,12 +233,14 @@ describe('canvas main', () => {
     expect(source).toContain('mcpBinding.bind');
   });
 
-  it('group-project wire defaults use shared migration-aware helper (structural)', () => {
+  it('group-project privileged access is governed by admin role, not a per-wire default (structural)', () => {
     const fs = require('fs');
     const path = require('path');
     const source = fs.readFileSync(path.resolve(__dirname, 'main.ts'), 'utf-8');
 
-    expect(source).toContain('getDefaultGroupProjectDisabledToolsFromMetadata');
+    // New group-project wires no longer pre-disable privileged tools — the
+    // project's admin role sets the baseline (see shared/group-project-admin.ts).
+    expect(source).not.toContain('getDefaultGroupProjectDisabledToolsFromMetadata');
     expect(source).not.toContain("const allAdvanced = ['shoulder_tap'");
   });
 

--- a/src/renderer/plugins/builtin/canvas/main.ts
+++ b/src/renderer/plugins/builtin/canvas/main.ts
@@ -16,9 +16,7 @@ import { useMcpBindingStore, type McpBindingEntry } from '../../../stores/mcpBin
 import { usePluginStore } from '../../plugin-store';
 import { useAgentStore } from '../../../stores/agentStore';
 import { useProjectStore } from '../../../stores/projectStore';
-import { useGroupProjectStore } from '../../../stores/groupProjectStore';
 import { ExportBlueprintDialog } from '../../../features/blueprints/ExportBlueprintDialog';
-import { getDefaultGroupProjectDisabledToolsFromMetadata } from '../../../../shared/group-project-permissions';
 
 /**
  * Collect the real IDs a canvas view participates in for MCP bindings.
@@ -635,17 +633,10 @@ export function MainPanel({ api }: { api: PluginAPI }) {
             selectedViewIds,
             wireDefinitions,
             onAddWireDefinition: (entry: McpBindingEntry) => {
-              let wireEntry = entry;
-              if (entry.targetKind === 'group-project' && !entry.disabledTools?.length) {
-                const { projects } = useGroupProjectStore.getState();
-                const project = projects.find(p => p.id === entry.targetId);
-                const disabledTools = getDefaultGroupProjectDisabledToolsFromMetadata(project?.metadata);
-                if (disabledTools.length > 0) {
-                  wireEntry = { ...entry, disabledTools };
-                  void window.clubhouse.mcpBinding.setDisabledTools(entry.agentId, entry.targetId, disabledTools);
-                }
-              }
-              store.getState().addWireDefinition(wireEntry);
+              // Group-project privileged-tool access is governed by the project's
+              // admin role (see shared/group-project-admin.ts), not by a per-wire
+              // default — so new wires start clean and the role sets the baseline.
+              store.getState().addWireDefinition(entry);
             },
             onRemoveWireDefinition: (agentId: string, targetId: string) => store.getState().removeWireDefinition(agentId, targetId),
             onUpdateWireDefinition: (agentId: string, targetId: string, updates: Partial<McpBindingEntry>) => store.getState().updateWireDefinition(agentId, targetId, updates),

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
@@ -594,3 +594,24 @@ describe('GroupProjectCanvasWidget — snapshot data richness', () => {
     expect(serverSource).toContain("type: 'group-project:list'");
   });
 });
+
+// ── Admin (project lead) role in the agent list ─────────────────────
+
+describe('GroupProjectCanvasWidget — admin star + toggle', () => {
+  it('renders a StarIcon for members who are project admins', () => {
+    expect(source).toContain('function StarIcon');
+    expect(source).toMatch(/admin && <StarIcon/);
+  });
+
+  it('toggles admin membership via the project metadata.admins list', () => {
+    expect(source).toContain('handleToggleAdmin');
+    expect(source).toMatch(/update\(groupProjectId, \{ metadata: \{ admins: next \} \}\)/);
+    // Uses the shared add/remove helpers
+    expect(source).toContain('addAdmin(project?.metadata');
+    expect(source).toContain('removeAdmin(project?.metadata');
+  });
+
+  it('computes the admin list from project metadata via the shared helper', () => {
+    expect(source).toContain('getProjectAdmins(project?.metadata)');
+  });
+});

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -8,6 +8,7 @@ import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { useAgentStore } from '../../../stores/agentStore';
 import { useRemoteProjectStore } from '../../../stores/remoteProjectStore';
 import { pollingStartMsg, pollingStopMsg, pollingNudgeMsg } from '../../../../shared/polling-messages';
+import { getProjectAdmins, isProjectAdmin, addAdmin, removeAdmin } from '../../../../shared/group-project-admin';
 import { useMcpSettingsStore } from '../../../stores/mcpSettingsStore';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
 import { useGroupProjectContext, type GroupProjectContextValue, type GroupProjectMember } from './useGroupProjectContext';
@@ -233,6 +234,15 @@ function ProjectCard({
   const totalMessages = topics.reduce((sum, t) => sum + t.messageCount, 0);
   const totalNew = topics.reduce((sum, t) => sum + t.newMessageCount, 0);
 
+  const admins = getProjectAdmins(project?.metadata);
+  const handleToggleAdmin = useCallback(async (agentId: string) => {
+    const next = isProjectAdmin(project?.metadata, agentId)
+      ? removeAdmin(project?.metadata, agentId)
+      : addAdmin(project?.metadata, agentId);
+    await update(groupProjectId, { metadata: { admins: next } });
+    onUpdateMetadata({ admins: next });
+  }, [project?.metadata, groupProjectId, update, onUpdateMetadata]);
+
   const handleTogglePolling = useCallback(async () => {
     const newVal = !pollingEnabled;
     await update(groupProjectId, { metadata: { pollingEnabled: newVal } });
@@ -316,17 +326,28 @@ function ProjectCard({
         </div>
       )}
 
-      {/* Agent list */}
+      {/* Agent list — click a member to toggle their project-lead (admin) role.
+          Admins show a star and get the privileged group-project tools. */}
       {members.length > 0 && (
         <div className="flex flex-wrap gap-1.5 mt-1">
-          {members.map((m) => (
-            <span
-              key={m.agentId}
-              className="px-2 py-0.5 text-xs bg-surface-0 text-ctp-subtext1 rounded-full"
-            >
-              {m.agentName || m.agentId}
-            </span>
-          ))}
+          {members.map((m) => {
+            const admin = admins.includes(m.agentId);
+            return (
+              <button
+                key={m.agentId}
+                onClick={(e) => { e.stopPropagation(); void handleToggleAdmin(m.agentId); }}
+                title={admin ? 'Project lead — click to remove admin' : 'Click to make project lead (admin)'}
+                className={`flex items-center gap-1 px-2 py-0.5 text-xs rounded-full transition-colors ${
+                  admin
+                    ? 'bg-ctp-accent/20 text-ctp-accent'
+                    : 'bg-surface-0 text-ctp-subtext1 hover:bg-surface-1'
+                }`}
+              >
+                {admin && <StarIcon size={9} filled />}
+                {m.agentName || m.agentId}
+              </button>
+            );
+          })}
         </div>
       )}
 
@@ -1261,6 +1282,14 @@ function ShieldIcon({ size = 14 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  );
+}
+
+function StarIcon({ size = 14, filled = false }: { size?: number; filled?: boolean }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
     </svg>
   );
 }

--- a/src/shared/group-project-admin.test.ts
+++ b/src/shared/group-project-admin.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getProjectAdmins,
+  isProjectAdmin,
+  addAdmin,
+  removeAdmin,
+  deniedGroupProjectTools,
+} from './group-project-admin';
+import {
+  GROUP_PROJECT_PRIVILEGED_TOOL_SUFFIXES,
+  GROUP_PROJECT_CORE_TOOL_SUFFIXES,
+} from './group-project-permissions';
+
+describe('group-project admin helpers', () => {
+  it('getProjectAdmins reads the admins array defensively', () => {
+    expect(getProjectAdmins(undefined)).toEqual([]);
+    expect(getProjectAdmins({})).toEqual([]);
+    expect(getProjectAdmins({ admins: 'nope' })).toEqual([]);
+    expect(getProjectAdmins({ admins: ['a', 1, 'b'] })).toEqual(['a', 'b']);
+  });
+
+  it('isProjectAdmin checks membership', () => {
+    expect(isProjectAdmin({ admins: ['a'] }, 'a')).toBe(true);
+    expect(isProjectAdmin({ admins: ['a'] }, 'b')).toBe(false);
+    expect(isProjectAdmin(undefined, 'a')).toBe(false);
+  });
+
+  it('addAdmin is idempotent; removeAdmin filters', () => {
+    expect(addAdmin({ admins: ['a'] }, 'b')).toEqual(['a', 'b']);
+    expect(addAdmin({ admins: ['a'] }, 'a')).toEqual(['a']);
+    expect(removeAdmin({ admins: ['a', 'b'] }, 'a')).toEqual(['b']);
+    expect(removeAdmin(undefined, 'a')).toEqual([]);
+  });
+});
+
+describe('deniedGroupProjectTools (role-based gating)', () => {
+  const adminMeta = { admins: ['lead'] };
+
+  it('denies all privileged tools to a non-admin', () => {
+    const denied = deniedGroupProjectTools(adminMeta, 'member');
+    for (const t of GROUP_PROJECT_PRIVILEGED_TOOL_SUFFIXES) expect(denied.has(t)).toBe(true);
+    for (const t of GROUP_PROJECT_CORE_TOOL_SUFFIXES) expect(denied.has(t)).toBe(false);
+  });
+
+  it('grants all privileged tools to an admin', () => {
+    const denied = deniedGroupProjectTools(adminMeta, 'lead');
+    for (const t of GROUP_PROJECT_PRIVILEGED_TOOL_SUFFIXES) expect(denied.has(t)).toBe(false);
+  });
+
+  it('per-wire disabledTools restrict an admin further', () => {
+    const denied = deniedGroupProjectTools(adminMeta, 'lead', ['broadcast', 'post_bulletin']);
+    expect(denied.has('broadcast')).toBe(true);   // privileged removed by the wire
+    expect(denied.has('post_bulletin')).toBe(true); // core removed by the wire
+    expect(denied.has('wake_agent')).toBe(false);   // still granted
+  });
+
+  it('a non-admin with no metadata is denied privileged but keeps core', () => {
+    const denied = deniedGroupProjectTools(undefined, 'member');
+    expect(denied.has('wake_agent')).toBe(true);
+    expect(denied.has('list_members')).toBe(false);
+  });
+});

--- a/src/shared/group-project-admin.ts
+++ b/src/shared/group-project-admin.ts
@@ -1,0 +1,58 @@
+/**
+ * Group-project admin role.
+ *
+ * A group project has zero or more *admins* (project leads) recorded as agent
+ * ids in `project.metadata.admins`. The standard pattern is a single project
+ * manager, but multiple admins are allowed.
+ *
+ * Role model (see {@link deniedGroupProjectTools}):
+ *  - Non-admin members get the core tools only (read/post/list/info).
+ *  - Admins additionally get the privileged tools (wake/sleep, polling,
+ *    broadcast, shoulder_tap, clear/compact, message curation, set_project_info).
+ *  - The role sets the baseline; per-wire `disabledTools` restrict further for
+ *    anyone (an admin can have specific tools removed on their wire).
+ */
+
+import { GROUP_PROJECT_PRIVILEGED_TOOL_SUFFIXES } from './group-project-permissions';
+
+/** Read the admin agent-id list from a group project's metadata. */
+export function getProjectAdmins(metadata?: Record<string, unknown>): string[] {
+  const admins = metadata?.admins;
+  if (!Array.isArray(admins)) return [];
+  return admins.filter((a): a is string => typeof a === 'string');
+}
+
+/** Whether `agentId` is an admin of the project described by `metadata`. */
+export function isProjectAdmin(metadata: Record<string, unknown> | undefined, agentId: string): boolean {
+  return getProjectAdmins(metadata).includes(agentId);
+}
+
+/** Add `agentId` to the admin list (idempotent). Returns the new list. */
+export function addAdmin(metadata: Record<string, unknown> | undefined, agentId: string): string[] {
+  const admins = getProjectAdmins(metadata);
+  return admins.includes(agentId) ? admins : [...admins, agentId];
+}
+
+/** Remove `agentId` from the admin list. Returns the new list. */
+export function removeAdmin(metadata: Record<string, unknown> | undefined, agentId: string): string[] {
+  return getProjectAdmins(metadata).filter((a) => a !== agentId);
+}
+
+/**
+ * The set of tool suffixes denied for `agentId` on a group-project wire.
+ *
+ * - Per-wire `disabledTools` always apply (a wire can restrict anyone further).
+ * - Non-admins are additionally denied every privileged tool (role baseline);
+ *   admins keep the privileged set unless a wire explicitly disables one.
+ */
+export function deniedGroupProjectTools(
+  metadata: Record<string, unknown> | undefined,
+  agentId: string,
+  wireDisabledTools?: string[],
+): Set<string> {
+  const denied = new Set<string>(wireDisabledTools ?? []);
+  if (!isProjectAdmin(metadata, agentId)) {
+    for (const t of GROUP_PROJECT_PRIVILEGED_TOOL_SUFFIXES) denied.add(t);
+  }
+  return denied;
+}

--- a/src/shared/group-project-permissions.ts
+++ b/src/shared/group-project-permissions.ts
@@ -18,6 +18,7 @@ export const GROUP_PROJECT_PRIVILEGED_TOOL_SUFFIXES = [
   'compact_agent',
   'clear_topic',
   'delete_messages',
+  'set_project_info',
 ] as const;
 
 export const GROUP_PROJECT_TOOL_SUFFIXES = [


### PR DESCRIPTION
## Summary
- **#9 — `set_project_info` tool:** a new privileged MCP tool that lets a project lead set the group's description/instructions. Being privileged, it is admin-gated.
- **#10 — project admin role:** declare a project lead (admin) who gets the privileged toolset (wake/sleep, polling, broadcast, shoulder_tap, clear/compact, message curation, set_project_info). One admin by default, multiple allowed. Admins show a ⭐ in the agent list.

## Role model
`project.metadata.admins: string[]` holds the admin agent ids (`src/shared/group-project-admin.ts`).

- **Non-admins** get the 6 core tools (list/read/post/info).
- **Admins** additionally get the 10 privileged tools.
- The **role is the baseline**; per-wire `disabledTools` restrict further for anyone (an admin can have specific tools removed on their wire).
- Enforced in `tool-registry.getScopedToolList` via `deniedGroupProjectTools(metadata, agentId, wireDisabled)`. The scoped-tool cache is invalidated on any group-project change so role edits apply immediately.

## Bootstrap & migration
- The **first agent to join** a group project is bootstrapped as its admin (`mcp-binding-handlers` BIND → `group-project-admin-service`). On reload, persisted wires re-bind and bootstrap an admin for pre-existing projects.
- New group-project wires **no longer pre-disable** privileged tools — the role now sets the baseline, so the renderer auto-default application was removed. (Pre-existing wires that persisted `disabledTools` keep them; a lead can clear them or the per-wire dialog still applies.)

## UI
- Member pills in the group-project card show a ⭐ for admins; clicking a member toggles their admin role via `metadata.admins`.

## Changes
- `shared/group-project-admin.ts` (new): role helpers + `deniedGroupProjectTools`.
- `shared/group-project-permissions.ts`: `set_project_info` added to the privileged set.
- `main/services/clubhouse-mcp/tool-registry.ts`: role-based gating + cache invalidation on registry change.
- `main/services/clubhouse-mcp/tools/group-project-tools.ts`: `set_project_info` handler (admin-checked).
- `main/services/group-project-admin-service.ts` (new) + `mcp-binding-handlers.ts`: first-member admin bootstrap.
- `main/services/group-project-registry.ts`: `_setForTesting` helper.
- `renderer/.../GroupProjectCanvasWidget.tsx`: ⭐ badge + admin toggle.
- `renderer/.../canvas/main.ts`: drop auto default-disabled application.

## Test Plan
- [x] `shared/group-project-admin.test.ts` — role matrix (admin grants privileged, non-admin denied, wire restricts further).
- [x] `group-project-admin-service.test.ts` — first-member bootstrap, no-op when admin exists, unknown project.
- [x] `group-project-tools.test.ts` — `set_project_info` (admin update / partial / non-admin reject / hidden from non-admin); admin vs non-admin scoped tool lists; updated existing gating tests to the role model.
- [x] `tool-registry.test.ts` — role + wire gating.
- [x] `GroupProjectCanvasWidget.test.ts` — star + toggle.
- [x] `npm run typecheck` clean; `eslint` 0 errors; full suite **12247 passed**.

## Manual Validation
- Wire two agents to a group project; the first becomes admin (⭐). Confirm the admin sees privileged tools and `set_project_info`, the other sees only core tools.
- Click the non-admin pill to promote them; confirm their tool list gains the privileged set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)