### PR TITLE
chore: bump version to 0.40.0-beta.5 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.40.0-beta.4",
+  "version": "0.40.0-beta.5",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Persona System & Group Project Improvements

# New Features
- Personas are now first-class on-disk files with a per-agent wildcard settings form, a user-global persona library reusable across projects, a new Group Project PM persona, and right-click actions to apply a persona to an agent or extract a reusable pattern from one
- Group projects gained an admin role (project lead) that gates privileged tools, plus a new set_project_info tool for setting the group's description/instructions; admins are marked with a star
- Canvas wires can now connect to a zone — zone wires persist, render as a single bundled wire, auto-update as agents join or leave the zone, and render reliably over the annex protocol

# Bug Fixes
- Monaco editors no longer render white when using custom or plugin themes, and the Git view no longer loses the selected file on transient status reads
- Completed quick agents now move to the Completed footer instead of lingering nested under their parent durable agent
- Right-clicking a project and choosing Settings now opens that project's settings, and leaving and returning to settings restores the last-viewed section
- Drag-to-reorder now works in the durable agent list
- Large plaintext pastes from TextEdit now work via a native clipboard fallback