### PR TITLE
fix(plugins): normalize ./ in manifest main + route all file:// imports via blob URL

### DIFF
--- a/src/renderer/plugins/dynamic-import.test.ts
+++ b/src/renderer/plugins/dynamic-import.test.ts
@@ -119,25 +119,54 @@ describe('dynamicImportModule', () => {
   describe('production mode (file: origin)', () => {
     beforeEach(() => {
       setupProdModeGlobals();
-      vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:unused');
+      vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
       vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
     });
 
-    it('does not call loadModuleSource for file: origin', async () => {
-      const loadModuleSource = vi.fn();
+    it('reads module source via IPC for file: origin (same as dev mode)', async () => {
+      const fakeModule: PluginModule = { activate: vi.fn() };
+      const { loadModuleSource } = setupDevModeGlobals(fakeModule);
+      // Override location back to production after setupDevModeGlobals set it to http:
+      setupProdModeGlobals();
+
+      const fn = await loadFn();
+      await fn('file:///Users/masonallen/.clubhouse/plugins/automations/dist/main.js').catch(() => {});
+
+      expect(loadModuleSource).toHaveBeenCalledWith(
+        '/Users/masonallen/.clubhouse/plugins/automations/dist/main.js',
+      );
+    });
+
+    it('creates a blob URL for file: origin — avoids ?v= query-param failure', async () => {
+      const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
       (window as any).clubhouse = { plugin: { loadModuleSource } };
 
       const fn = await loadFn();
-      await fn('file:///app/.webpack/renderer/plugin/main.js').catch(() => {});
+      await fn('file:///plugins/automations/dist/main.js?v=1780813375562').catch(() => {});
 
-      expect(loadModuleSource).not.toHaveBeenCalled();
+      expect(URL.createObjectURL).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'text/javascript' }),
+      );
     });
 
-    it('does not create a blob URL for file: origin', async () => {
-      const fn = await loadFn();
-      await fn('file:///app/.webpack/renderer/plugin/main.js').catch(() => {});
+    it('strips ?v= cache-busting query param from file path in production', async () => {
+      const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
+      (window as any).clubhouse = { plugin: { loadModuleSource } };
 
-      expect(URL.createObjectURL).not.toHaveBeenCalled();
+      const fn = await loadFn();
+      await fn('file:///plugins/automations/dist/main.js?v=1780813375562').catch(() => {});
+
+      expect(loadModuleSource).toHaveBeenCalledWith('/plugins/automations/dist/main.js');
+    });
+
+    it('revokes the blob URL after import in production (cleanup)', async () => {
+      const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
+      (window as any).clubhouse = { plugin: { loadModuleSource } };
+
+      const fn = await loadFn();
+      await fn('file:///plugins/automations/dist/main.js').catch(() => {});
+
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(FAKE_BLOB_URL);
     });
   });
 });

--- a/src/renderer/plugins/dynamic-import.ts
+++ b/src/renderer/plugins/dynamic-import.ts
@@ -3,16 +3,22 @@ import type { PluginModule } from '../../shared/plugin-types';
 /**
  * Dynamic import wrapper — in a separate module so tests can mock it.
  *
- * In dev mode the renderer is served from http://localhost (webpack dev server),
- * so Chromium's ES module loader blocks cross-origin import() of file:// URLs.
- * We work around this by reading the file via IPC and importing from a blob: URI,
- * which avoids the cross-origin restriction without requiring unsafe-eval or data:.
+ * All file:// imports are routed through IPC + blob URL for two reasons:
+ *
+ * 1. Dev mode (renderer on http://localhost): Chromium blocks cross-origin
+ *    import() of file:// URLs; blob: avoids this without unsafe-eval.
+ *
+ * 2. Production mode (renderer on file://): Chromium's ESM loader does not
+ *    support query parameters in file:// URLs, so passing ?v=… cache-busting
+ *    params directly to import() causes "Cannot find module" errors.  Routing
+ *    through a unique blob URL both strips the query param and provides the
+ *    same cache-busting guarantee in production.
  *
  * The webpackIgnore comment prevents webpack from statically analyzing the import().
  */
 export async function dynamicImportModule(url: string): Promise<PluginModule> {
-  if (url.startsWith('file:') && window.location.protocol !== 'file:') {
-    // Strip only the 'file://' scheme prefix, preserving the leading '/' for absolute paths.
+  if (url.startsWith('file:')) {
+    // Strip scheme prefix and any query params to get the filesystem path.
     const filePath = decodeURIComponent(
       url.replace(/^file:\/\//, '').replace(/\?.*$/, ''),
     );

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -1112,6 +1112,47 @@ describe('plugin-loader', () => {
       expect(importedUrl).toMatch(/^file:\/\/\/plugins\/comm-main\/dist\/index\.js\?v=\d+$/);
     });
 
+    it('normalizes ./ prefix in manifest main path', async () => {
+      // Regression: manifest.main of "./dist/main.js" was producing the path
+      // "pluginPath/./dist/main.js" which Chromium's ESM loader cannot resolve.
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      usePluginStore.getState().registerPlugin(
+        makeManifest({ id: 'comm-dotslash', main: './dist/main.js' }),
+        'community',
+        '/Users/masonallen/.clubhouse/plugins/automations',
+        'registered',
+      );
+
+      await activatePlugin('comm-dotslash', 'proj-1', '/p1');
+
+      const importedUrl = mockDynamicImport.mock.calls[0][0] as string;
+      // Must NOT contain "/./": the ./ prefix must be stripped before joining.
+      expect(importedUrl).not.toContain('/./');
+      expect(importedUrl).toMatch(
+        /^file:\/\/\/Users\/masonallen\/.clubhouse\/plugins\/automations\/dist\/main\.js\?v=\d+$/,
+      );
+    });
+
+    it('normalizes nested ./ prefix in manifest main — e.g. ./lib/index.js', async () => {
+      const mod: PluginModule = { activate: vi.fn() };
+      mockDynamicImport.mockResolvedValue(mod);
+
+      usePluginStore.getState().registerPlugin(
+        makeManifest({ id: 'comm-nested', main: './lib/index.js' }),
+        'community',
+        '/plugins/comm-nested',
+        'registered',
+      );
+
+      await activatePlugin('comm-nested', 'proj-1', '/p1');
+
+      const importedUrl = mockDynamicImport.mock.calls[0][0] as string;
+      expect(importedUrl).not.toContain('/./');
+      expect(importedUrl).toMatch(/^file:\/\/\/plugins\/comm-nested\/lib\/index\.js\?v=\d+$/);
+    });
+
     it('sets errored status when dynamic import fails', async () => {
       mockDynamicImport.mockRejectedValue(new Error('Module not found'));
 

--- a/src/renderer/plugins/plugin-loader.ts
+++ b/src/renderer/plugins/plugin-loader.ts
@@ -376,7 +376,9 @@ export async function activatePlugin(
       }
     } else {
       // Dynamic import for community plugins
-      const mainPath = entry.manifest.main || 'main.js';
+      // Strip leading "./" from manifest.main so joining doesn't create an
+      // unresolvable "./"-prefixed segment in the final file:// URL.
+      const mainPath = (entry.manifest.main || 'main.js').replace(/^\.\//, '');
       const fullModulePath = `${entry.pluginPath}/${mainPath}`;
 
       // Convert filesystem path to file:// URL for ESM import resolution.


### PR DESCRIPTION
## Summary
- Fixes critical plugin loading failure: `Cannot find module 'file:///..././ dist/main.js?v=...'`
- Two distinct root causes both addressed; affects automations plugin, GH issue tracker, and any plugin whose `manifest.json` uses a `./`-prefixed `main` entry

## Root Causes

### Bug 1 — `./` prefix in `manifest.main` not normalized (`plugin-loader.ts`)
When a plugin's `manifest.json` declares `"main": "./dist/main.js"`, the loader joined it directly with the plugin directory path:
```
/Users/masonallen/.clubhouse/plugins/automations  +  ./dist/main.js
→ /Users/masonallen/.clubhouse/plugins/automations/./dist/main.js   ← unresolvable
```
**Fix:** Strip the leading `./` before the path join: `mainPath.replace(/^\.\//, '')`.

### Bug 2 — `?v=` cache-busting query param breaks `file://` imports in production (`dynamic-import.ts`)
The `?v=<timestamp>` appended for cache-busting was only stripped in **dev mode** (webpack dev server on `http://`). In **production** (Electron renderer on `file://`), the raw URL with `?v=...` was passed straight to `import()`. Chromium's ESM loader does not support query parameters on `file://` URLs — it tries to find a file literally named `main.js?v=1780813375562`, which does not exist.

**Fix:** Remove the dev-only guard in `dynamicImportModule`. Route **all** `file://` imports through IPC + blob URL:
- The blob URL path already strips `?v=` before the IPC call
- Each blob URL is unique → cache-busting works in both dev and production
- No behavior change for dev mode; production now gets the same correct path

These two bugs compound: both must be present to produce the exact error shown in the issue.

## Changes
- `src/renderer/plugins/plugin-loader.ts` — strip `./` prefix from `manifest.main` before path join
- `src/renderer/plugins/dynamic-import.ts` — remove `window.location.protocol !== 'file:'` guard; always use blob URL for `file://` imports; updated doc comment

## Test Plan
- [x] `plugin-loader.test.ts` — new: `normalizes ./ prefix in manifest main path` — asserts no `/./` in the generated URL and that the path resolves to `dist/main.js` correctly
- [x] `plugin-loader.test.ts` — new: `normalizes nested ./ prefix in manifest main — e.g. ./lib/index.js`
- [x] `dynamic-import.test.ts` — updated production-mode suite: now expects IPC + blob URL to be called in `file:` origin (was asserting the opposite — the broken behavior)
- [x] `dynamic-import.test.ts` — new production tests: `reads module source via IPC`, `creates a blob URL`, `strips ?v= cache-busting query param`, `revokes blob URL after import`
- [x] All 139 tests in changed files pass; 9 pre-existing failures in unrelated renderer tests unchanged

## Manual Validation
1. Install a plugin whose `manifest.json` uses `"main": "./dist/main.js"` (e.g. automations, GH issue tracker)
2. Launch app — plugin should activate without the "Failed to load module: Cannot find module" error
3. Toggle plugin off → on — should reload cleanly without error
4. Reinstall from marketplace — should work without toggling