### PR TITLE
chore: bump version to 0.40.0-beta.6 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.40.0-beta.5",
+  "version": "0.40.0-beta.6",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Bug Fixes & Performance Improvements

# Bug Fixes
- Plugin loading fixed — "Cannot find module" errors for plugins with `./`-prefixed manifest entry points (automations, GH issue tracker, any plugin using `"main": "./dist/main.js"`)