### PR TITLE
feat(mcp-notify): MCP agents notify user with toast UI

### DIFF
--- a/src/renderer/app-event-bridge.test.ts
+++ b/src/renderer/app-event-bridge.test.ts
@@ -198,6 +198,19 @@ vi.mock('./stores/notificationStore', () => ({
       })),
     },
   ),
+  isAgentVisible: vi.fn(() => false),
+}));
+
+vi.mock('./stores/toastStore', () => ({
+  useToastStore: Object.assign(
+    vi.fn(),
+    {
+      getState: vi.fn(() => ({
+        addToast: vi.fn(),
+        removeToast: vi.fn(),
+      })),
+    },
+  ),
 }));
 
 vi.mock('./stores/quickAgentStore', () => ({
@@ -288,6 +301,8 @@ import { initAppEventBridge } from './app-event-bridge';
 import { useAgentStore } from './stores/agentStore';
 import { useProjectStore } from './stores/projectStore';
 import { useUIStore } from './stores/uiStore';
+import { isAgentVisible } from './stores/notificationStore';
+import { useToastStore } from './stores/toastStore';
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -480,6 +495,111 @@ describe('initAppEventBridge', () => {
     }
 
     expect(mockPlaySound).not.toHaveBeenCalled();
+  });
+
+  it('shows toast notification when agent emits notification event and agent is not visible', () => {
+    const agent = createAgent('a1', 'proj-1');
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: agent },
+      activeAgentId: null,
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const mockAddToast = vi.fn();
+    vi.mocked(useToastStore.getState).mockReturnValue({
+      addToast: mockAddToast,
+      removeToast: vi.fn(),
+      toasts: [],
+    } as any);
+
+    vi.mocked(isAgentVisible).mockReturnValue(false);
+
+    const hookCallback = vi.mocked(window.clubhouse.agent.onHookEvent).mock.calls[0][0];
+    hookCallback('a1', {
+      kind: 'notification',
+      message: 'Agent completed successfully',
+      timestamp: Date.now(),
+    });
+
+    expect(mockAddToast).toHaveBeenCalledWith('Agent completed successfully', 'info');
+  });
+
+  it('does not show toast when agent is visible and emits notification event', () => {
+    const agent = createAgent('a1', 'proj-1');
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: agent },
+      activeAgentId: 'a1',
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const mockAddToast = vi.fn();
+    vi.mocked(useToastStore.getState).mockReturnValue({
+      addToast: mockAddToast,
+      removeToast: vi.fn(),
+      toasts: [],
+    } as any);
+
+    vi.mocked(isAgentVisible).mockReturnValue(true);
+
+    const hookCallback = vi.mocked(window.clubhouse.agent.onHookEvent).mock.calls[0][0];
+    hookCallback('a1', {
+      kind: 'notification',
+      message: 'Agent is still running',
+      timestamp: Date.now(),
+    });
+
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+
+  it('does not show toast when notification event has no message', () => {
+    const agent = createAgent('a1', 'proj-1');
+    vi.mocked(useAgentStore.getState).mockReturnValue({
+      agents: { a1: agent },
+      activeAgentId: null,
+      agentDetailedStatus: {},
+      agentIcons: {},
+      updateAgentStatus: vi.fn(),
+      handleHookEvent: vi.fn(),
+      removeAgent: vi.fn(),
+      clearStaleStatuses: vi.fn(),
+      setActiveAgent: vi.fn(),
+      restoreProjectAgent: vi.fn(),
+      openConfigChangesDialog: vi.fn(),
+      setSessionNamePrompt: vi.fn(),
+    } as any);
+
+    const mockAddToast = vi.fn();
+    vi.mocked(useToastStore.getState).mockReturnValue({
+      addToast: mockAddToast,
+      removeToast: vi.fn(),
+      toasts: [],
+    } as any);
+
+    const hookCallback = vi.mocked(window.clubhouse.agent.onHookEvent).mock.calls[0][0];
+    hookCallback('a1', {
+      kind: 'notification',
+      timestamp: Date.now(),
+    });
+
+    expect(mockAddToast).not.toHaveBeenCalled();
   });
 
 });

--- a/src/renderer/app-event-bridge.ts
+++ b/src/renderer/app-event-bridge.ts
@@ -13,7 +13,8 @@
 import { useAgentStore, consumeCancelled } from './stores/agentStore';
 import { useProjectStore } from './stores/projectStore';
 import { useUIStore } from './stores/uiStore';
-import { useNotificationStore } from './stores/notificationStore';
+import { useNotificationStore, isAgentVisible } from './stores/notificationStore';
+import { useToastStore } from './stores/toastStore';
 import { useQuickAgentStore } from './stores/quickAgentStore';
 import { useClubhouseModeStore } from './stores/clubhouseModeStore';
 import { useCommandPaletteStore } from './stores/commandPaletteStore';
@@ -370,6 +371,14 @@ function initHookEventListener(): () => void {
       if (event.kind === 'permission_resolved') {
         const soundEvent = event.message === 'allow' ? 'permission-granted' : 'permission-denied';
         useSoundStore.getState().playSound(soundEvent as SoundEvent, agent.projectId);
+      }
+
+      // Show toast notification when agent emits a notification event (respects active focus)
+      if (event.kind === 'notification' && event.message) {
+        // Only show toast if agent is not actively being viewed
+        if (!isAgentVisible(agentId, agent.projectId)) {
+          useToastStore.getState().addToast(event.message, 'info');
+        }
       }
 
       // Emit plugin events for agent lifecycle

--- a/src/renderer/stores/notificationStore.ts
+++ b/src/renderer/stores/notificationStore.ts
@@ -22,7 +22,7 @@ function cachedCollectLeaves(tree: PaneNode): LeafPane[] {
   return cached;
 }
 
-function isAgentVisible(agentId: string, projectId: string): boolean {
+export function isAgentVisible(agentId: string, projectId: string): boolean {
   if (!document.hasFocus()) return false;
 
   const { explorerTab } = useUIStore.getState();


### PR DESCRIPTION
## Summary

Implement notification toast UI for MCP agents. Agents can now emit notification events with custom text that displays as in-app toasts when the user is not actively viewing that agent's tab.

- **Respects active focus**: suppresses toast if agent tab is currently active
- **Custom messages**: agents control notification text via event.message
- **Uses existing UI**: integrates with toastStore for consistent look/feel
- **Fully tested**: 3 new test cases cover all scenarios

## Changes

- `src/renderer/app-event-bridge.ts`: Added handler for `notification` hook event kind
  - Checks if agent is visible using `isAgentVisible()` 
  - Shows toast only if agent is NOT visible (respects focus)
  - Uses `useToastStore.addToast()` for in-app notification
  
- `src/renderer/stores/notificationStore.ts`: Exported `isAgentVisible()` function
  - Allows reuse in app-event-bridge for focus checking
  - Checks document focus, explorerTab, activeProjectId, and agent pane visibility
  
- `src/renderer/app-event-bridge.test.ts`: Added comprehensive test coverage
  - `shows toast notification when agent emits notification event and agent is not visible`
  - `does not show toast when agent is visible and emits notification event`
  - `does not show toast when notification event has no message`

## Acceptance Criteria

- ✅ MCP agents can emit notify events
- ✅ Toast UI implemented (in-app toast using toastStore)
- ✅ Respects active focus (no toast if agent tab is active)
- ✅ Text customizable by agent (uses event.message field)
- ✅ Tests pass (16/16 in app-event-bridge.test.ts)
- ✅ Full validation passes (12,314 tests, 0 lint errors)

## Test Plan

- [x] Unit tests for notification toast handler (3 test cases)
- [x] Hook event listener correctly routes notification events
- [x] Toast shows when agent not visible
- [x] Toast suppressed when agent is visible
- [x] Toast not shown if event.message is empty
- [x] All 486 test files pass (12,314 tests)
- [x] TypeScript and linting clean (0 errors, pre-existing warnings only)

## Manual Validation

To verify the feature works end-to-end:

1. Spawn an MCP agent that emits notification events
2. While the agent's tab/pane is active → verify no toast appears
3. Switch to a different tab → trigger agent notification → verify toast appears with correct message
4. Check toast auto-dismisses after standard timeout (5 seconds)
5. Verify toast appears in the correct location (z-index 300, above modals)

## Implementation Notes

- Uses the existing `notification` HookEventKind (already defined in shared types)
- Leverages existing `isAgentVisible()` logic from notificationStore (exported for reuse)
- Toast type is 'info' (matches agent action type, not error)
- Message field is required (toast not shown if empty)
- Integrates seamlessly with existing app-event-bridge hook handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)