### PR TITLE
ci: pin Windows E2E runners to windows-2022 (fix VS2026 node-gyp breakage)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,7 +52,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        # Pin Windows to windows-2022 (VS2022). windows-latest rolled to the
+        # windows-2025 image (VS2026), which @electron/node-gyp can't detect,
+        # breaking the node-pty rebuild during `electron-forge package`.
+        os: [macos-latest, windows-2022, ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -92,7 +95,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        # Pin Windows to windows-2022 (VS2022). windows-latest rolled to the
+        # windows-2025 image (VS2026), which @electron/node-gyp can't detect,
+        # breaking the node-pty rebuild during `electron-forge package`.
+        os: [macos-latest, windows-2022, ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- GitHub's `windows-latest` label rolled to the **windows-2025** image (Visual Studio **2026**).
- electron-forge 7.11.1's bundled `@electron/node-gyp` can't detect VS2026, failing with `Could not find any Visual Studio installation to use` during the node-pty native rebuild in `electron-forge package`.
- This blocked the **E2E** and **Annex E2E** jobs on **every open PR** (#1503, #1504, #1505, …), unrelated to any mission's code.

## Root cause
node-pty must be rebuilt against Electron's ABI at package time. The rebuild runs `node-gyp`, which needs a Visual Studio toolchain it recognizes. The new `windows-2025`/VS2026 runner image is not yet supported by the bundled node-gyp, so the rebuild fails before any test runs. PR #1501 passed on 2026-06-09 because `windows-latest` still mapped to the VS2022 image then.

## Changes
- Pin the two jobs that actually package the app (`e2e`, `e2e-annex`) to `windows-2022` (VS2022), which node-gyp detects correctly.
- `typecheck` and `unit-and-component` keep `windows-latest` — they don't package, so the VS2026 image is fine for them.

## Why not skip the rebuild instead
Skipping node-pty's rebuild (e.g. `rebuildConfig.onlyModules: []`) ships a binary built for system Node, not Electron — the PTY fails to load at runtime and breaks E2E on **all** platforms. Pinning the toolchain is the correct fix.

## Test Plan
- [ ] `e2e (windows-2022)` builds the app (node-gyp finds VS2022) and runs Playwright
- [ ] `e2e-annex (windows-2022)` same
- [ ] macOS / Ubuntu E2E unchanged and green
- [ ] `typecheck` / `unit` unchanged and green on all OSes

## Coordination
Single source of truth for this CI fix, per agreement in #ghcp-quality with @curious-tapir (#1503) — no duplicate workflow edits in feature PRs. Once merged, open PRs rebase onto main and clear the Windows wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)