### PR TITLE
feat(blueprints): built-in Small/Large Squad canvas templates

### DIFF
--- a/src/renderer/features/blueprints/BlueprintGallery.test.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.test.tsx
@@ -150,17 +150,21 @@ describe('BlueprintGallery', () => {
     await waitFor(() => { expect(screen.getByText('Alpha')).toBeDefined(); });
 
     const grid = screen.getByTestId('blueprint-gallery-grid');
-    const cards = grid.querySelectorAll('[data-testid^="blueprint-card-"]');
-    // Default sort by name
-    expect(cards[0].textContent).toContain('Alpha');
-    expect(cards[1].textContent).toContain('Bravo');
-    expect(cards[2].textContent).toContain('Charlie');
+    // Built-in templates are always present; assert the relative ordering of the
+    // disk blueprints rather than absolute indices.
+    const orderOf = (name: string) => {
+      const cards = [...grid.querySelectorAll('[data-testid^="blueprint-card-"]')];
+      return cards.findIndex((c) => c.textContent?.includes(name));
+    };
 
-    // Sort by views
+    // Default sort by name: Alpha < Bravo < Charlie
+    expect(orderOf('Alpha')).toBeLessThan(orderOf('Bravo'));
+    expect(orderOf('Bravo')).toBeLessThan(orderOf('Charlie'));
+
+    // Sort by views (desc): Alpha (5) < Bravo (3) < Charlie (1)
     fireEvent.change(screen.getByTestId('blueprint-gallery-sort'), { target: { value: 'views' } });
-    const sorted = grid.querySelectorAll('[data-testid^="blueprint-card-"]');
-    expect(sorted[0].textContent).toContain('Alpha'); // 5 views
-    expect(sorted[2].textContent).toContain('Charlie'); // 1 view
+    expect(orderOf('Alpha')).toBeLessThan(orderOf('Bravo'));
+    expect(orderOf('Bravo')).toBeLessThan(orderOf('Charlie'));
   });
 
   // ── Preview panel ──────────────────────────────────────────────
@@ -190,13 +194,15 @@ describe('BlueprintGallery', () => {
 
   // ── Empty state ────────────────────────────────────────────────
 
-  it('shows helpful empty state with export guidance', async () => {
+  it('shows built-in squad templates even when no disk blueprints exist', async () => {
     state.blueprintGalleryOpen = true;
     mockBlueprintList.mockResolvedValue([]);
 
     render(<BlueprintGallery />);
-    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-empty')).toBeDefined(); });
-    expect(screen.getByText('No blueprints yet')).toBeDefined();
+    // Built-in templates always lead the list, so the gallery is never empty.
+    await waitFor(() => { expect(screen.getByText('Small Squad')).toBeDefined(); });
+    expect(screen.getByText('Large Squad')).toBeDefined();
+    expect(screen.queryByText('No blueprints yet')).toBeNull();
   });
 
   it('shows search-specific empty state when no results', async () => {

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -7,6 +7,11 @@ import { parseAnyBlueprint, buildWireDefinitionsFromResult } from './parse-bluep
 import { getProjectCanvasStore, useAppCanvasStore } from '../../plugins/builtin/canvas/main';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAgentStore } from '../../stores/agentStore';
+import {
+  listBuiltinBlueprintSummaries,
+  getBuiltinBlueprint,
+  isBuiltinBlueprintPath,
+} from './builtin-blueprints';
 
 // ── Fuzzy search ─────────────────────────────────────────────────────
 
@@ -66,15 +71,26 @@ export function BlueprintGallery() {
     setSelected(null);
     setPreviewData(null);
     setDeleteConfirm(null);
+    // Built-in squad templates always lead the list; disk blueprints follow.
+    const builtins = listBuiltinBlueprintSummaries();
     window.clubhouse.blueprint.list()
-      .then(setBlueprints)
-      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .then((disk) => setBlueprints([...builtins, ...disk]))
+      .catch((err) => {
+        // Disk scan failure shouldn't hide the built-in templates.
+        setBlueprints(builtins);
+        setError(err instanceof Error ? err.message : String(err));
+      })
       .finally(() => setLoading(false));
   }, [isOpen]);
 
   // Fetch full data when a card is selected for preview
   useEffect(() => {
     if (!selected) { setPreviewData(null); return; }
+    if (isBuiltinBlueprintPath(selected.filePath)) {
+      const manifest = getBuiltinBlueprint(selected.filePath);
+      setPreviewData(manifest ? (manifest as unknown as Record<string, unknown>) : null);
+      return;
+    }
     window.clubhouse.blueprint.read(selected.filePath)
       .then(setPreviewData)
       .catch(() => setPreviewData(null));
@@ -90,7 +106,10 @@ export function BlueprintGallery() {
   const handleImport = useCallback(async (bp: BlueprintSummary) => {
     setImporting(bp.filePath);
     try {
-      const data = await window.clubhouse.blueprint.read(bp.filePath);
+      // Built-in templates resolve from the in-memory registry; disk blueprints are read from file.
+      const data = isBuiltinBlueprintPath(bp.filePath)
+        ? (getBuiltinBlueprint(bp.filePath) as unknown as Record<string, unknown> | undefined)
+        : await window.clubhouse.blueprint.read(bp.filePath);
       if (!data) throw new Error('Failed to read blueprint file');
 
       const store = activeProjectId
@@ -183,6 +202,8 @@ export function BlueprintGallery() {
   }, [activeProjectId, close]);
 
   const handleDelete = useCallback(async (bp: BlueprintSummary) => {
+    // Built-in templates are not file-backed and cannot be deleted.
+    if (isBuiltinBlueprintPath(bp.filePath)) return;
     const deleted = await window.clubhouse.blueprint.delete(bp.filePath);
     if (deleted) {
       setBlueprints((prev) => prev.filter((b) => b.filePath !== bp.filePath));
@@ -300,6 +321,7 @@ export function BlueprintGallery() {
                     onImport={() => handleImport(bp)}
                     onDelete={() => setDeleteConfirm(bp.filePath)}
                     importing={importing === bp.filePath}
+                    canDelete={!isBuiltinBlueprintPath(bp.filePath)}
                   />
                 ))}
               </div>
@@ -367,6 +389,7 @@ function BlueprintCard({
   onImport,
   onDelete,
   importing,
+  canDelete = true,
 }: {
   blueprint: BlueprintSummary;
   isSelected: boolean;
@@ -374,6 +397,7 @@ function BlueprintCard({
   onImport: () => void;
   onDelete: () => void;
   importing: boolean;
+  canDelete?: boolean;
 }) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -434,14 +458,18 @@ function BlueprintCard({
           >
             Import
           </button>
-          <div className="border-t border-surface-0 my-1" />
-          <button
-            onClick={() => { setContextMenu(null); onDelete(); }}
-            className="w-full text-left px-3 py-1.5 hover:bg-ctp-error/10 text-ctp-error"
-            data-testid="blueprint-card-delete"
-          >
-            Delete Blueprint
-          </button>
+          {canDelete && (
+            <>
+              <div className="border-t border-surface-0 my-1" />
+              <button
+                onClick={() => { setContextMenu(null); onDelete(); }}
+                className="w-full text-left px-3 py-1.5 hover:bg-ctp-error/10 text-ctp-error"
+                data-testid="blueprint-card-delete"
+              >
+                Delete Blueprint
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/features/blueprints/builtin-blueprints.test.ts
+++ b/src/renderer/features/blueprints/builtin-blueprints.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createSmallSquadBlueprint,
+  createLargeSquadBlueprint,
+  BUILTIN_BLUEPRINTS,
+  getBuiltinBlueprint,
+  listBuiltinBlueprintSummaries,
+  builtinBlueprintFilePath,
+  isBuiltinBlueprintPath,
+  BUILTIN_BLUEPRINT_PREFIX,
+} from './builtin-blueprints';
+import { validateManifest, importBlueprint } from './blueprint-import';
+
+describe('built-in blueprints', () => {
+  describe('Small Squad', () => {
+    const bp = createSmallSquadBlueprint();
+
+    it('has Group PM + 3 Developers + 1 QA (5 agents)', () => {
+      expect(bp.agents).toHaveLength(5);
+      const names = bp.agents!.map((a) => a.name);
+      expect(names).toEqual(['Group PM', 'Developer 1', 'Developer 2', 'Developer 3', 'QA 1']);
+    });
+
+    it('has one agent view per agent', () => {
+      expect(bp.canvas.views).toHaveLength(5);
+      expect(bp.canvas.views.every((v) => v.type === 'agent')).toBe(true);
+    });
+
+    it('wires the Group PM to every other agent bidirectionally', () => {
+      expect(bp.canvas.wires).toHaveLength(4);
+      expect(bp.canvas.wires.every((w) => w.sourceRef === 'agent_gp')).toBe(true);
+      expect(bp.canvas.wires.every((w) => w.bidirectional === true)).toBe(true);
+    });
+
+    it('is a valid manifest', () => {
+      expect(validateManifest(bp)).toEqual({ valid: true, errors: [] });
+    });
+  });
+
+  describe('Large Squad', () => {
+    const bp = createLargeSquadBlueprint();
+
+    it('has Group PM + 6 Developers + 2 QA (9 agents)', () => {
+      expect(bp.agents).toHaveLength(9);
+      const devs = bp.agents!.filter((a) => a.name.startsWith('Developer'));
+      const qas = bp.agents!.filter((a) => a.name.startsWith('QA'));
+      expect(devs).toHaveLength(6);
+      expect(qas).toHaveLength(2);
+    });
+
+    it('has 9 agent views and 8 PM fan-out wires', () => {
+      expect(bp.canvas.views).toHaveLength(9);
+      expect(bp.canvas.wires).toHaveLength(8);
+    });
+
+    it('is a valid manifest', () => {
+      expect(validateManifest(bp)).toEqual({ valid: true, errors: [] });
+    });
+  });
+
+  describe('agent definitions', () => {
+    it('developers run in worktrees with implementation skills', () => {
+      const bp = createSmallSquadBlueprint();
+      const dev = bp.agents!.find((a) => a.name === 'Developer 1')!;
+      expect(dev.useWorktree).toBe(true);
+      expect(dev.skills).toContain('mission');
+      expect(dev.skills).toContain('create-pr');
+    });
+
+    it('QA has review/test skills', () => {
+      const bp = createSmallSquadBlueprint();
+      const qa = bp.agents!.find((a) => a.name === 'QA 1')!;
+      expect(qa.skills).toContain('code-review');
+      expect(qa.skills).toContain('test');
+    });
+
+    it('uses unique refIds across views and agents', () => {
+      const bp = createLargeSquadBlueprint();
+      const viewRefs = bp.canvas.views.map((v) => v.refId);
+      const agentRefs = bp.agents!.map((a) => a.refId);
+      expect(new Set(viewRefs).size).toBe(viewRefs.length);
+      expect(new Set(agentRefs).size).toBe(agentRefs.length);
+    });
+
+    it('is deterministic (stable createdAt across calls)', () => {
+      expect(createSmallSquadBlueprint().createdAt).toBe(createSmallSquadBlueprint().createdAt);
+    });
+  });
+
+  describe('registry + resolution', () => {
+    it('exposes both built-in templates', () => {
+      expect(BUILTIN_BLUEPRINTS.map((b) => b.id)).toEqual(['small-squad', 'large-squad']);
+    });
+
+    it('resolves a manifest by id', () => {
+      expect(getBuiltinBlueprint('small-squad')?.name).toBe('Small Squad');
+      expect(getBuiltinBlueprint('large-squad')?.name).toBe('Large Squad');
+    });
+
+    it('resolves a manifest by builtin:// path', () => {
+      const path = builtinBlueprintFilePath('small-squad');
+      expect(path).toBe(`${BUILTIN_BLUEPRINT_PREFIX}small-squad`);
+      expect(getBuiltinBlueprint(path)?.name).toBe('Small Squad');
+    });
+
+    it('returns undefined for unknown ids', () => {
+      expect(getBuiltinBlueprint('nonexistent')).toBeUndefined();
+    });
+
+    it('identifies built-in paths', () => {
+      expect(isBuiltinBlueprintPath('builtin://small-squad')).toBe(true);
+      expect(isBuiltinBlueprintPath('/Users/x/.clubhouse/blueprints/foo.json')).toBe(false);
+    });
+  });
+
+  describe('gallery summaries', () => {
+    it('produces a summary per built-in with correct counts', () => {
+      const summaries = listBuiltinBlueprintSummaries();
+      expect(summaries).toHaveLength(2);
+
+      const small = summaries.find((s) => s.name === 'Small Squad')!;
+      expect(small.filePath).toBe('builtin://small-squad');
+      expect(small.source).toBe('Built-in');
+      expect(small.viewCount).toBe(5);
+      expect(small.agentCount).toBe(5);
+      expect(small.wireCount).toBe(4);
+      expect(small.agentNames).toContain('Group PM');
+
+      const large = summaries.find((s) => s.name === 'Large Squad')!;
+      expect(large.agentCount).toBe(9);
+      expect(large.wireCount).toBe(8);
+    });
+  });
+
+  describe('import into canvas', () => {
+    it('creates agent stub views for a fresh project (no existing agents)', () => {
+      const bp = createSmallSquadBlueprint();
+      const result = importBlueprint(bp, [], []);
+
+      // 5 agent views, all unmatched stubs (nothing to bind to yet)
+      expect(result.canvas.views).toHaveLength(5);
+      expect(result.stubs).toHaveLength(5);
+      expect(result.stubs.every((s) => s.badge === 'not_found')).toBe(true);
+      expect(result.canvas.views.every((v) => v.type === 'agent')).toBe(true);
+
+      // Wires are carried through as pending until agents are bound
+      expect(result.pendingWires).toHaveLength(4);
+    });
+  });
+});

--- a/src/renderer/features/blueprints/builtin-blueprints.ts
+++ b/src/renderer/features/blueprints/builtin-blueprints.ts
@@ -1,0 +1,223 @@
+// ── Built-in Blueprint Templates ───────────────────────────────────
+//
+// Ships preconfigured squad blueprints that appear in the Blueprint Gallery
+// alongside user/project blueprints. Selecting one creates a canvas with
+// agent stub cards (Group PM + developers + QA) wired to the PM, which the
+// user then binds to existing agents or creates fresh.
+//
+// These are in-memory manifests (not file-backed). They are surfaced to the
+// gallery via listBuiltinBlueprintSummaries() and identified by a synthetic
+// `builtin://<id>` filePath so the import path can resolve them without disk IO.
+
+import type {
+  BlueprintManifest,
+  BlueprintAgentDef,
+  BlueprintView,
+  BlueprintWire,
+} from '../../../shared/blueprint-types';
+import type { BlueprintSummary } from '../../../shared/blueprint-summary';
+
+/** Synthetic filePath prefix marking a blueprint as built-in (not on disk). */
+export const BUILTIN_BLUEPRINT_PREFIX = 'builtin://';
+
+/**
+ * Fixed creation timestamp for built-in templates. Kept constant (rather than
+ * `Date.now()`) so the manifests are deterministic and snapshot-testable.
+ */
+const BUILTIN_CREATED_AT = '2026-06-13T00:00:00.000Z';
+
+const GRID_SPACING = 320;
+const COLS_PER_ROW = 3;
+const AGENT_VIEW_SIZE = { width: 280, height: 220 };
+
+// ── Agent def builders ──────────────────────────────────────────────
+
+function groupPMAgent(): BlueprintAgentDef {
+  return {
+    refId: 'agent_gp',
+    name: 'Group PM',
+    orchestrator: 'claude',
+    skills: [],
+  };
+}
+
+function devAgent(n: number): BlueprintAgentDef {
+  return {
+    refId: `agent_dev_${n}`,
+    name: `Developer ${n}`,
+    orchestrator: 'claude',
+    skills: ['mission', 'build', 'test', 'validate-changes', 'create-pr'],
+    useWorktree: true,
+  };
+}
+
+function qaAgent(n: number): BlueprintAgentDef {
+  return {
+    refId: `agent_qa_${n}`,
+    name: `QA ${n}`,
+    orchestrator: 'claude',
+    skills: ['test', 'code-review', 'validate-changes'],
+  };
+}
+
+// ── Layout ──────────────────────────────────────────────────────────
+
+/** Grid positions for `count` cards: 3 per row, top-down. */
+function gridPositions(count: number): { x: number; y: number }[] {
+  const positions: { x: number; y: number }[] = [];
+  for (let i = 0; i < count; i++) {
+    positions.push({
+      x: (i % COLS_PER_ROW) * GRID_SPACING,
+      y: Math.floor(i / COLS_PER_ROW) * GRID_SPACING,
+    });
+  }
+  return positions;
+}
+
+function agentView(def: BlueprintAgentDef, position: { x: number; y: number }): BlueprintView {
+  return {
+    refId: def.refId,
+    type: 'agent',
+    displayName: def.name,
+    agentRef: def.refId,
+    position,
+    size: { ...AGENT_VIEW_SIZE },
+  };
+}
+
+/** Bidirectional wires from the Group PM to every other agent. */
+function pmFanoutWires(pmRefId: string, otherRefIds: string[]): BlueprintWire[] {
+  return otherRefIds.map((targetRef) => ({
+    sourceRef: pmRefId,
+    targetRef,
+    bidirectional: true,
+  }));
+}
+
+// ── Manifest assembly ───────────────────────────────────────────────
+
+function buildSquadManifest(
+  id: string,
+  name: string,
+  description: string,
+  agents: BlueprintAgentDef[],
+): BlueprintManifest {
+  const positions = gridPositions(agents.length);
+  const views = agents.map((def, i) => agentView(def, positions[i]));
+  const [pm, ...rest] = agents;
+  const wires = pmFanoutWires(pm.refId, rest.map((a) => a.refId));
+
+  return {
+    id: `blueprint_${id}`,
+    name,
+    description,
+    version: '1.0.0',
+    schemaVersion: 1,
+    createdAt: BUILTIN_CREATED_AT,
+    createdBy: 'system',
+    canvas: {
+      views,
+      wires,
+      layout: { algorithm: 'layered', direction: 'DOWN' },
+    },
+    agents,
+  };
+}
+
+/**
+ * Small Squad — Group PM + 3 Developers + 1 QA (5 agents).
+ * Ideal for focused feature work.
+ */
+export function createSmallSquadBlueprint(): BlueprintManifest {
+  const agents = [
+    groupPMAgent(),
+    devAgent(1),
+    devAgent(2),
+    devAgent(3),
+    qaAgent(1),
+  ];
+  return buildSquadManifest(
+    'small-squad',
+    'Small Squad',
+    'Group PM + 3 Developers + 1 QA. Ideal for focused feature work.',
+    agents,
+  );
+}
+
+/**
+ * Large Squad — Group PM + 6 Developers + 2 QA (9 agents).
+ * Ideal for larger projects with parallel workstreams.
+ */
+export function createLargeSquadBlueprint(): BlueprintManifest {
+  const agents = [
+    groupPMAgent(),
+    devAgent(1),
+    devAgent(2),
+    devAgent(3),
+    devAgent(4),
+    devAgent(5),
+    devAgent(6),
+    qaAgent(1),
+    qaAgent(2),
+  ];
+  return buildSquadManifest(
+    'large-squad',
+    'Large Squad',
+    'Group PM + 6 Developers + 2 QA. Ideal for larger projects and parallel workstreams.',
+    agents,
+  );
+}
+
+// ── Registry ────────────────────────────────────────────────────────
+
+interface BuiltinBlueprintEntry {
+  id: string;
+  factory: () => BlueprintManifest;
+}
+
+export const BUILTIN_BLUEPRINTS: BuiltinBlueprintEntry[] = [
+  { id: 'small-squad', factory: createSmallSquadBlueprint },
+  { id: 'large-squad', factory: createLargeSquadBlueprint },
+];
+
+/** The synthetic filePath for a built-in blueprint id. */
+export function builtinBlueprintFilePath(id: string): string {
+  return `${BUILTIN_BLUEPRINT_PREFIX}${id}`;
+}
+
+/** True if a filePath refers to a built-in blueprint. */
+export function isBuiltinBlueprintPath(filePath: string): boolean {
+  return filePath.startsWith(BUILTIN_BLUEPRINT_PREFIX);
+}
+
+/** Resolve a built-in blueprint manifest by id or `builtin://`-prefixed path. */
+export function getBuiltinBlueprint(idOrPath: string): BlueprintManifest | undefined {
+  const id = idOrPath.startsWith(BUILTIN_BLUEPRINT_PREFIX)
+    ? idOrPath.slice(BUILTIN_BLUEPRINT_PREFIX.length)
+    : idOrPath;
+  const entry = BUILTIN_BLUEPRINTS.find((b) => b.id === id);
+  return entry ? entry.factory() : undefined;
+}
+
+/** Convert a manifest into a gallery summary. */
+function toSummary(manifest: BlueprintManifest, id: string): BlueprintSummary {
+  const views = manifest.canvas.views;
+  const agentViews = views.filter((v) => v.type === 'agent');
+  return {
+    filePath: builtinBlueprintFilePath(id),
+    name: manifest.name,
+    description: manifest.description,
+    viewCount: views.length,
+    agentCount: agentViews.length,
+    wireCount: manifest.canvas.wires.length,
+    version: manifest.schemaVersion,
+    source: 'Built-in',
+    createdAt: manifest.createdAt,
+    agentNames: (manifest.agents ?? []).map((a) => a.name),
+  };
+}
+
+/** Gallery summaries for all built-in blueprints. */
+export function listBuiltinBlueprintSummaries(): BlueprintSummary[] {
+  return BUILTIN_BLUEPRINTS.map((entry) => toSummary(entry.factory(), entry.id));
+}


### PR DESCRIPTION
## Summary
- Adds built-in canvas blueprint templates so new canvas creation offers ready-made squad setups (Mission 3b).
- **Small Squad**: Group PM + 3 Developers + 1 QA (5 agents)
- **Large Squad**: Group PM + 6 Developers + 2 QA (9 agents)

## Changes
- **`builtin-blueprints.ts`** (new): in-memory `BlueprintManifest` factories built on the canonical `shared/blueprint-types`. Agents are laid out on a grid; the Group PM fans bidirectional wires to every dev/QA. Developers run in worktrees with `mission`/`build`/`test`/`validate-changes`/`create-pr` skills; QA gets `test`/`code-review`/`validate-changes`. Deterministic `createdAt` for snapshot stability. Exposes a registry, `getBuiltinBlueprint()`, and `listBuiltinBlueprintSummaries()`.
- **`BlueprintGallery.tsx`**: built-ins lead the gallery list (identified by a synthetic `builtin://<id>` path), render their preview from the in-memory manifest, import via the **existing** `manifestImportBlueprint` path (creating agent stub cards the user binds/creates), and are not deletable. Built-ins still show if the disk scan fails.

## Design notes
- Reuses the existing blueprint import pipeline rather than adding a parallel one. Importing a squad creates a canvas of **agent stub cards** (badge `not_found` on a fresh project) that the user binds to existing agents or creates — consistent with how disk blueprints already behave. This is what "agents spun up per template" maps to in the current architecture.

## Test Plan
- [x] `builtin-blueprints.test.ts` (18 cases): squad composition, view/wire counts, manifest validity (`validateManifest`), agent skills/worktree flags, unique refIds, determinism, registry/path resolution, gallery summaries, and a real `importBlueprint` producing 5 stub views + 4 pending wires.
- [x] Updated 2 existing gallery tests for the always-present built-ins (sort ordering asserted relatively; empty-state test now verifies built-ins appear when disk is empty).
- [x] `npm run typecheck` clean
- [x] `npm test` — 12,329 passed, 4 skipped, 0 failures
- [x] `npm run lint` — 0 errors

## Manual Validation
- Open the Blueprint Gallery → Small Squad and Large Squad appear first with correct view/agent/wire counts and a layout preview; importing creates the squad canvas; built-ins have no Delete option.