### PR TITLE
test(ghcp): Mission 2c — parity & coverage audit + targeted tests

### DIFF
--- a/src/main/orchestrators/copilot-cli-provider.test.ts
+++ b/src/main/orchestrators/copilot-cli-provider.test.ts
@@ -340,6 +340,61 @@ describe('CopilotCliProvider', () => {
       expect(result.args).not.toContain('--agent');
       expect(result.args).not.toContain('--source');
     });
+
+    // Session resume. Copilot CLI cannot resume in prompt mode (-p), so the
+    // provider only appends resume flags for interactive (no mission/systemPrompt)
+    // spawns. This guard (copilot-cli-provider.ts:157) was previously untested and
+    // is the highest-risk silent-failure path in the provider.
+    it('adds --continue when resume is set without a sessionId', async () => {
+      const result = await provider.buildSpawnCommand({ cwd: '/project', resume: true });
+      expect(result.args).toContain('--continue');
+      expect(result.args).not.toContain('--resume');
+    });
+
+    it('adds --resume <sessionId> when resume is set with a sessionId', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        resume: true,
+        sessionId: 'sess-123',
+      });
+      expect(result.args).toContain('--resume');
+      expect(result.args[result.args.indexOf('--resume') + 1]).toBe('sess-123');
+      expect(result.args).not.toContain('--continue');
+    });
+
+    it('does not add resume flags when resume is false', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        resume: false,
+        sessionId: 'sess-123',
+      });
+      expect(result.args).not.toContain('--resume');
+      expect(result.args).not.toContain('--continue');
+    });
+
+    it('suppresses resume flags when a mission is set (prompt mode cannot resume)', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        resume: true,
+        sessionId: 'sess-123',
+        mission: 'Fix the bug',
+      });
+      expect(result.args).not.toContain('--resume');
+      expect(result.args).not.toContain('--continue');
+      // Mission is still passed through prompt mode.
+      expect(result.args).toContain('-p');
+    });
+
+    it('suppresses resume flags when a systemPrompt is set (prompt mode cannot resume)', async () => {
+      const result = await provider.buildSpawnCommand({
+        cwd: '/project',
+        resume: true,
+        systemPrompt: 'You are helpful',
+      });
+      expect(result.args).not.toContain('--resume');
+      expect(result.args).not.toContain('--continue');
+      expect(result.args).toContain('-p');
+    });
   });
 
   describe('buildAgentFileArgs (AgentFileCapable)', () => {
@@ -734,6 +789,42 @@ describe('CopilotCliProvider', () => {
       const pIdx = result!.args.indexOf('-p');
       expect(result!.args[pIdx + 1]).toContain('Be thorough');
       expect(result!.args[pIdx + 1]).toContain('Fix bug');
+    });
+
+    // Parity gap (Mission 2c): unlike the Claude Code provider, GHCP's headless
+    // path hard-codes blanket --allow-all and ignores fine-grained permission /
+    // tool-filtering options. These tests lock in the current behavior so any
+    // future change to close the gap is a deliberate, reviewed decision rather
+    // than a silent regression.
+    it('ignores permissionMode and always uses blanket --allow-all in headless', async () => {
+      const result = await provider.buildHeadlessCommand({
+        cwd: '/project',
+        mission: 'Fix bug',
+        permissionMode: 'skip-all',
+      });
+      expect(result!.args).toContain('--allow-all');
+      // permissionMode does not change the headless flag set.
+      expect(result!.args).not.toContain('--allow-all-tools');
+    });
+
+    it('does not emit --allow-tool for allowedTools in headless (blanket allow-all)', async () => {
+      const result = await provider.buildHeadlessCommand({
+        cwd: '/project',
+        mission: 'Fix bug',
+        allowedTools: ['read', 'edit'],
+      });
+      expect(result!.args).not.toContain('--allow-tool');
+      expect(result!.args).toContain('--allow-all');
+    });
+
+    it('does not emit --disallowedTools for disallowedTools in headless (parity gap vs Claude Code)', async () => {
+      const result = await provider.buildHeadlessCommand({
+        cwd: '/project',
+        mission: 'Fix bug',
+        disallowedTools: ['shell'],
+      } as Parameters<typeof provider.buildHeadlessCommand>[0]);
+      expect(result!.args).not.toContain('--disallowedTools');
+      expect(result!.args).not.toContain('--disallow-tool');
     });
   });
 


### PR DESCRIPTION
## Mission 2c: GHCP Quality Deep Dive

GHCP↔Claude Code parity audit + targeted tests closing the highest-risk coverage gaps.

**Scope note (per human review):** the parity audit is **not** checked in as a doc. The findings are filed as GitHub issues (repo convention); this PR carries the **tests** only.

### What's here
**Targeted tests** (`copilot-cli-provider.test.ts`, +8 tests):
- **Resume-suppression guard** (previously untested): 5 tests — `--continue` / `--resume <id>` / `resume:false` no-op / suppression in prompt mode (mission & systemPrompt).
- **Headless parity gaps**: 3 tests pinning that headless ignores `permissionMode`/`allowedTools`/`disallowedTools` — so closing those gaps is deliberate, not a silent regression.

### Parity gaps → issues
- #1513 [MEDIUM] GHCP headless ignores permissionMode/allowedTools/disallowedTools
- #1514 [LOW] GHCP silently drops resume when mission/systemPrompt set
- #1515 [LOW] Claude Code lacks agent-file loading (--agent/--source) GHCP has

Gaps deemed non-actionable (intentional/cosmetic/moot) were not filed: MCP-injection mechanism difference (intentional), hook event schema (moot — hooks default-off for GHCP), tool-verb display strings (cosmetic), paste-submit timing (intentional, Mission 2b).

### Results
- 117 provider tests pass · `tsc --noEmit` clean · `eslint` clean (all three gates)
- Coverage delta (orchestrators scope): branch 48.1% → 51.4%

### Acceptance criteria
- [x] Parity audit complete; gaps listed + prioritized (now tracked as #1513–#1515)
- [x] Test coverage report generated (branch 48.1%→51.4%)
- [x] New test suite added (hermetic; live-token CI deferred — no secrets story)
- [x] Key gaps addressed (resume guard + headless behavior now tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)