### PR TITLE
fix: group-project creation silently fails on fresh Mac (P1)

### DIFF
--- a/src/main/ipc/group-project-handlers.test.ts
+++ b/src/main/ipc/group-project-handlers.test.ts
@@ -160,13 +160,19 @@ describe('group-project-handlers', () => {
     expect(vi.mocked(ipcMain.handle).mock.calls.length).toBe(callCount);
   });
 
-  it('does not register when MCP is disabled', () => {
+  it('registers handlers even when MCP is disabled (regression: fresh-Mac silent create failure)', () => {
+    // Group-project creation is a local feature and must not depend on the MCP
+    // bridge being enabled. Previously this early-returned, leaving
+    // group-project:create unregistered so the renderer's invoke() rejected and
+    // creation silently no-op'd on fresh installs.
     vi.mocked(isMcpEnabledForAny).mockReturnValue(false);
     handlers.clear();
     vi.mocked(ipcMain.handle).mockClear();
     _resetHandlersForTesting();
     registerGroupProjectHandlers();
-    expect(ipcMain.handle).not.toHaveBeenCalled();
+    expect(ipcMain.handle).toHaveBeenCalled();
+    expect(handlers.has(IPC.GROUP_PROJECT.CREATE)).toBe(true);
+    expect(handlers.has(IPC.GROUP_PROJECT.LIST)).toBe(true);
   });
 
   it('subscribes to registry onChange for broadcast', () => {

--- a/src/main/ipc/group-project-handlers.ts
+++ b/src/main/ipc/group-project-handlers.ts
@@ -9,7 +9,6 @@ import { getBulletinBoard, destroyBulletinBoard } from '../services/group-projec
 import { initGroupProjectLifecycle } from '../services/group-project-lifecycle';
 import { executeShoulderTap } from '../services/group-project-shoulder-tap';
 import * as annexEventBus from '../services/annex-event-bus';
-import { isMcpEnabledForAny } from '../services/mcp-settings';
 import { appLog } from '../services/log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { withValidatedArgs, stringArg, objectArg, numberArg, booleanArg } from './validation';
@@ -39,8 +38,17 @@ export function _resetHandlersForTesting(): void {
 
 export function registerGroupProjectHandlers(): void {
   if (handlersRegistered) return;
-  if (!isMcpEnabledForAny()) return;
 
+  // NOTE: Group-project creation and its bulletin board are local features and
+  // must work regardless of whether the Clubhouse MCP bridge is enabled. Gating
+  // registration on isMcpEnabledForAny() previously meant that on a fresh install
+  // (MCP + Clubhouse Mode both default-off) NONE of these IPC handlers — including
+  // group-project:create — were registered, so the renderer's invoke() rejected
+  // with "No handler registered" and project creation silently no-op'd. The MCP
+  // bridge / tool exposure is gated separately in registerMcpBindingHandlers(),
+  // so registering these handlers unconditionally does not expose anything
+  // external. initGroupProjectLifecycle() is idempotent and its bindingManager
+  // subscription stays dormant until an agent actually binds to a project.
   handlersRegistered = true;
 
   // Tool registration is handled centrally in registerMcpBindingHandlers().

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
@@ -615,3 +615,24 @@ describe('GroupProjectCanvasWidget — admin star + toggle', () => {
     expect(source).toContain('getProjectAdmins(project?.metadata)');
   });
 });
+
+// ── Creation form surfaces errors (regression: silent create failure) ──
+
+describe('GroupProjectCanvasWidget — CreationForm error surfacing', () => {
+  it('handleCreate catches errors instead of only using try/finally', () => {
+    // Previously handleCreate wrapped create() in try/finally with no catch, so
+    // a rejected IPC call (e.g. unregistered group-project:create handler on a
+    // fresh Mac) became an unhandled rejection and the card silently reset.
+    expect(source).toMatch(/const handleCreate = useCallback\(async \(\) => \{[\s\S]*?\} catch \(err\) \{/);
+  });
+
+  it('stores and renders the create error in an alert region', () => {
+    expect(source).toContain("setError(`Couldn't create project: ${message}`)");
+    expect(source).toContain('role="alert"');
+    expect(source).toMatch(/\{error &&/);
+  });
+
+  it('clears the error when the user edits the name', () => {
+    expect(source).toMatch(/onChange=\{\(e\) => \{ setName\(e\.target\.value\); if \(error\) setError\(null\); \}\}/);
+  });
+});

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -98,6 +98,7 @@ function CreationForm({
 }) {
   const [name, setName] = useState('');
   const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const create = useGroupProjectStore((s) => s.create);
   const loadProjects = useGroupProjectStore((s) => s.loadProjects);
   const loaded = useGroupProjectStore((s) => s.loaded);
@@ -110,9 +111,18 @@ function CreationForm({
     const trimmed = name.trim();
     if (!trimmed || creating) return;
     setCreating(true);
+    setError(null);
     try {
       const project = await create(trimmed);
       onUpdateMetadata({ groupProjectId: project.id, name: project.name });
+    } catch (err) {
+      // Surface the failure instead of silently resetting the card. The most
+      // common cause is an unregistered IPC handler ("No handler registered for
+      // 'group-project:create'"), but disk/permission errors during the registry
+      // flush surface here too.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[group-project] create failed:', message);
+      setError(`Couldn't create project: ${message}`);
     } finally {
       setCreating(false);
     }
@@ -133,7 +143,7 @@ function CreationForm({
       <input
         type="text"
         value={name}
-        onChange={(e) => setName(e.target.value)}
+        onChange={(e) => { setName(e.target.value); if (error) setError(null); }}
         onKeyDown={handleKeyDown}
         placeholder="Project name..."
         className="w-full px-3 py-1.5 text-sm bg-surface-0 border border-surface-2 rounded-md text-ctp-text placeholder:text-ctp-overlay0 focus-ring"
@@ -146,6 +156,11 @@ function CreationForm({
       >
         {creating ? 'Creating...' : 'Create'}
       </button>
+      {error && (
+        <div role="alert" className="w-full text-xs text-ctp-red bg-ctp-red/10 border border-ctp-red/30 rounded-md px-3 py-1.5">
+          {error}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## P1: Group-project creation silently fails on a fresh Mac

**Repro:** Open the New Group Project card, type a name, hit Create → nothing happens, the name reverts, the card resets. Works on other machines; not reliably reproducible locally.

### Root cause (confirmed from code)

`registerGroupProjectHandlers()` is called **exactly once at app startup** (`src/main/ipc/index.ts:64`) and is never re-run on settings change. It bailed early at `group-project-handlers.ts:42`:

```ts
if (!isMcpEnabledForAny()) return;
```

So whether the group-project IPC handlers — including `group-project:create` and `group-project:list` — exist for the whole session is decided **once, by the MCP state at boot time**.

**Why this manifests as the repro (a boot-ordering bug):**
- On a fresh Mac, the first launch has MCP + Clubhouse Mode off (defaults), so at boot `isMcpEnabledForAny()` is `false` → **all** group-project handlers are skipped for that session.
- The user then enables MCP in Settings to use Group Projects. The renderer's "MCP Required" gate (`GroupProjectCanvasWidget.tsx:51`, keyed on the global `enabled` flag) clears, so the **CreationForm now renders**.
- User types a name and hits Create → store `create()` → `ipcRenderer.invoke('group-project:create', …)`. The handler was never registered (boot skipped it, and registration never re-runs), so Electron rejects with `Error: No handler registered for 'group-project:create'`.
- Neither the store's `create()` nor the widget's `handleCreate()` had a `catch` (only `try/finally`), so the rejection became an unhandled promise rejection: `creating` reset to `false`, `onUpdateMetadata` never fired, the card silently reset = the exact repro.

"Works on other machines" = MCP was already enabled at *their* last boot, so the handlers registered. Restarting the app after enabling MCP would also have masked it — a classic "works after a restart" smell.

### Fix
1. **Main** — register the group-project IPC handlers **unconditionally** at startup. Creating a project and its bulletin board is a local feature and must not depend on the MCP bridge being on at boot. The bridge / tool exposure is gated separately in `registerMcpBindingHandlers()`, and `initGroupProjectLifecycle()` is idempotent with a `bindingManager` subscription that stays dormant until an agent binds — so unconditional registration exposes nothing external and has no side effects when MCP is off. Handlers are now always present regardless of when MCP is toggled.
2. **Renderer** — `handleCreate()` now **catches** and surfaces the error in the UI (a `role="alert"` region) instead of silently resetting. This covers both the unregistered-handler case and the secondary registry-flush / permission failure modes. The error clears when the user edits the name.

### Tests
- Updated the handler registration test (which previously asserted the buggy early-return) to verify handlers register regardless of MCP state, asserting `CREATE` + `LIST` are present.
- Added renderer regression tests for the `catch` + error surfacing + error-clear-on-edit.

### Validation
- `npm run typecheck` ✓ (no `build` script exists in this repo — `tsc --noEmit` is the compile check)
- `npm test` ✓ — 489 files, 12394 passed / 4 skipped
- `npm run lint` ✓ — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
