### PR TITLE
fix(agents): profile-aware orchestrator selector in AgentSettingsView

### DIFF
--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { Agent, QuickAgentDefaults, MaterializationPreview, McpCatalogArg, McpCatalogEntry, McpCatalogEntryWithState } from '../../../shared/types';
 import { AGENT_COLORS } from '../../../shared/name-generator';
 import { useModelOptions } from '../../hooks/useModelOptions';
+import { useEffectiveOrchestrators } from '../../hooks/useEffectiveOrchestrators';
+import { buildOrchestratorOptions } from './orchestrator-options';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useOrchestratorStore } from '../../stores/orchestratorStore';
@@ -140,9 +142,19 @@ export function AgentSettingsView({ agent }: Props) {
   const activeProject = projects.find((p) => p.id === activeProjectId);
   const worktreePath = agent.worktreePath || activeProject?.path || '';
   const { options: MODEL_OPTIONS } = useModelOptions();
-  const enabled = useOrchestratorStore((s) => s.enabled);
   const allOrchestrators = useOrchestratorStore((s) => s.allOrchestrators);
-  const enabledOrchestrators = allOrchestrators.filter((o) => enabled.includes(o.id));
+  // Resolve orchestrators the same way AddAgentDialog does — profile-aware and scoped
+  // to this agent's project — so the selector behaves consistently with agent creation.
+  const projectPath = projects.find((p) => p.id === agent.projectId)?.path;
+  const { effectiveOrchestrators } = useEffectiveOrchestrators(projectPath);
+  const agentOrchestrator = agent.orchestrator || 'claude-code';
+  // Always offer the agent's current orchestrator, even if it's disabled app-wide or
+  // missing from this machine's settings (e.g. a worktree-synced agent whose project
+  // profile wasn't synced). See buildOrchestratorOptions / #fix-orchestrator-selector AC #2.
+  const orchestratorOptions = useMemo(
+    () => buildOrchestratorOptions(effectiveOrchestrators, allOrchestrators, agentOrchestrator),
+    [effectiveOrchestrators, allOrchestrators, agentOrchestrator],
+  );
 
   // Tab state
   const [activeTab, setActiveTab] = useState<SettingsTab>('main');
@@ -320,7 +332,6 @@ export function AgentSettingsView({ agent }: Props) {
   };
 
   // Resolve orchestrator display name
-  const agentOrchestrator = agent.orchestrator || 'claude-code';
   const orchestratorInfo = allOrchestrators.find((o) => o.id === agentOrchestrator);
 
   // Resolve capabilities for the agent's orchestrator
@@ -358,7 +369,6 @@ export function AgentSettingsView({ agent }: Props) {
   }, []);
 
   // Quick Agent Defaults state
-  const projectPath = projects.find((p) => p.id === agent.projectId)?.path;
   const [qadSystemPrompt, setQadSystemPrompt] = useState('');
   const [qadAllowedTools, setQadAllowedTools] = useState('');
   const [qadDefaultModel, setQadDefaultModel] = useState('');
@@ -909,7 +919,7 @@ export function AgentSettingsView({ agent }: Props) {
               </div>
 
               {/* Orchestrator */}
-              {enabledOrchestrators.length > 1 ? (
+              {orchestratorOptions.length > 1 ? (
                 <div>
                   <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Orchestrator</span>
                   <select
@@ -918,15 +928,15 @@ export function AgentSettingsView({ agent }: Props) {
                     disabled={agent.status === 'running'}
                     className="mt-1 w-full bg-surface-0 border border-surface-2 rounded px-2 py-1 text-sm text-ctp-text focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    {enabledOrchestrators.map((o) => (
+                    {orchestratorOptions.map((o) => (
                       <option key={o.id} value={o.id}>{o.displayName}</option>
                     ))}
                   </select>
                 </div>
-              ) : orchestratorInfo ? (
+              ) : (orchestratorInfo || orchestratorOptions[0]) ? (
                 <div>
                   <span className="text-xs text-ctp-subtext0 uppercase tracking-wider">Orchestrator</span>
-                  <p className="mt-1 text-sm text-ctp-text">{orchestratorInfo.displayName}</p>
+                  <p className="mt-1 text-sm text-ctp-text">{(orchestratorInfo || orchestratorOptions[0]).displayName}</p>
                 </div>
               ) : null}
 

--- a/src/renderer/features/agents/orchestrator-options.test.ts
+++ b/src/renderer/features/agents/orchestrator-options.test.ts
@@ -22,19 +22,22 @@ describe('buildOrchestratorOptions', () => {
     expect(opts).toHaveLength(2);
   });
 
-  it('prepends the current orchestrator (from the global list) when it is not in the effective set', () => {
+  it('prepends the current orchestrator (from the global list) with a (disabled) suffix when not in the effective set', () => {
     // Worktree-synced agent on codex-cli, but the profile only enables claude-code.
     const opts = buildOrchestratorOptions([claudeCode], allOrchestrators, 'codex-cli');
     expect(opts.map((o) => o.id)).toEqual(['codex-cli', 'claude-code']);
-    expect(opts[0].displayName).toBe('Codex CLI');
+    // Suffixed so the user understands why a non-enabled orchestrator appears.
+    expect(opts[0].displayName).toBe('Codex CLI (disabled)');
+    // Other options are unchanged.
+    expect(opts[1].displayName).toBe('Claude Code');
   });
 
-  it('renders a selectable option even when the current orchestrator is unknown to this machine', () => {
+  it('renders a selectable (not installed) option when the current orchestrator is unknown to this machine', () => {
     // Agent synced with an orchestrator absent from app settings entirely.
     const opts = buildOrchestratorOptions([claudeCode], [claudeCode], 'mystery-cli');
     expect(opts.map((o) => o.id)).toEqual(['mystery-cli', 'claude-code']);
     // A real <option> can render — the synthesized entry carries a label and safe caps.
-    expect(opts[0].displayName).toBe('mystery-cli');
+    expect(opts[0].displayName).toBe('mystery-cli (not installed)');
     expect(opts[0].capabilities.permissions).toBe(false);
   });
 

--- a/src/renderer/features/agents/orchestrator-options.test.ts
+++ b/src/renderer/features/agents/orchestrator-options.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildOrchestratorOptions } from './orchestrator-options';
+import type { OrchestratorInfo } from '../../../shared/types';
+
+const caps = { headless: true, structuredOutput: true, hooks: true, sessionResume: true, permissions: true, structuredMode: false };
+
+const claudeCode: OrchestratorInfo = { id: 'claude-code', displayName: 'Claude Code', shortName: 'CC', capabilities: caps };
+const codexCli: OrchestratorInfo = { id: 'codex-cli', displayName: 'Codex CLI', shortName: 'CX', capabilities: caps };
+const copilotCli: OrchestratorInfo = { id: 'copilot-cli', displayName: 'Copilot CLI', shortName: 'CP', capabilities: caps };
+
+const allOrchestrators = [claudeCode, codexCli, copilotCli];
+
+describe('buildOrchestratorOptions', () => {
+  it('returns the effective orchestrators unchanged when the current one is already present', () => {
+    const opts = buildOrchestratorOptions([claudeCode, codexCli], allOrchestrators, 'claude-code');
+    expect(opts.map((o) => o.id)).toEqual(['claude-code', 'codex-cli']);
+  });
+
+  it('does not duplicate the current orchestrator', () => {
+    const opts = buildOrchestratorOptions([claudeCode, codexCli], allOrchestrators, 'codex-cli');
+    expect(opts.filter((o) => o.id === 'codex-cli')).toHaveLength(1);
+    expect(opts).toHaveLength(2);
+  });
+
+  it('prepends the current orchestrator (from the global list) when it is not in the effective set', () => {
+    // Worktree-synced agent on codex-cli, but the profile only enables claude-code.
+    const opts = buildOrchestratorOptions([claudeCode], allOrchestrators, 'codex-cli');
+    expect(opts.map((o) => o.id)).toEqual(['codex-cli', 'claude-code']);
+    expect(opts[0].displayName).toBe('Codex CLI');
+  });
+
+  it('renders a selectable option even when the current orchestrator is unknown to this machine', () => {
+    // Agent synced with an orchestrator absent from app settings entirely.
+    const opts = buildOrchestratorOptions([claudeCode], [claudeCode], 'mystery-cli');
+    expect(opts.map((o) => o.id)).toEqual(['mystery-cli', 'claude-code']);
+    // A real <option> can render — the synthesized entry carries a label and safe caps.
+    expect(opts[0].displayName).toBe('mystery-cli');
+    expect(opts[0].capabilities.permissions).toBe(false);
+  });
+
+  it('still surfaces a single option (current orchestrator) when nothing is effective', () => {
+    // Empty effective set must not strand the agent with no selector data.
+    const opts = buildOrchestratorOptions([], allOrchestrators, 'claude-code');
+    expect(opts.map((o) => o.id)).toEqual(['claude-code']);
+  });
+
+  it('does not mutate the input array', () => {
+    const effective = [claudeCode];
+    buildOrchestratorOptions(effective, allOrchestrators, 'codex-cli');
+    expect(effective.map((o) => o.id)).toEqual(['claude-code']);
+  });
+});

--- a/src/renderer/features/agents/orchestrator-options.ts
+++ b/src/renderer/features/agents/orchestrator-options.ts
@@ -1,0 +1,35 @@
+import type { OrchestratorInfo } from '../../../shared/types';
+
+/**
+ * Builds the list of orchestrator options shown in an agent's settings selector.
+ *
+ * Starts from the profile-aware effective orchestrators (parity with AddAgentDialog),
+ * then guarantees the agent's *currently-selected* orchestrator is always present —
+ * even when it's disabled app-wide or absent from this machine's settings (e.g. a
+ * worktree-synced agent whose project/profile wasn't synced). This keeps the selector
+ * showing the real value and always usable. See #fix-orchestrator-selector AC #2.
+ */
+export function buildOrchestratorOptions(
+  effectiveOrchestrators: OrchestratorInfo[],
+  allOrchestrators: OrchestratorInfo[],
+  agentOrchestrator: string,
+): OrchestratorInfo[] {
+  const opts = [...effectiveOrchestrators];
+  if (!opts.some((o) => o.id === agentOrchestrator)) {
+    const current = allOrchestrators.find((o) => o.id === agentOrchestrator);
+    opts.unshift(current ?? {
+      id: agentOrchestrator,
+      displayName: agentOrchestrator,
+      shortName: agentOrchestrator,
+      capabilities: {
+        headless: false,
+        structuredOutput: false,
+        hooks: false,
+        sessionResume: false,
+        permissions: false,
+        structuredMode: false,
+      },
+    });
+  }
+  return opts;
+}

--- a/src/renderer/features/agents/orchestrator-options.ts
+++ b/src/renderer/features/agents/orchestrator-options.ts
@@ -8,6 +8,10 @@ import type { OrchestratorInfo } from '../../../shared/types';
  * even when it's disabled app-wide or absent from this machine's settings (e.g. a
  * worktree-synced agent whose project/profile wasn't synced). This keeps the selector
  * showing the real value and always usable. See #fix-orchestrator-selector AC #2.
+ *
+ * The prepended option's displayName is suffixed so users understand why it's there:
+ * `(disabled)` when it's a known orchestrator that isn't currently enabled/in-profile,
+ * `(not installed)` when it's unknown to this machine entirely (synthesized).
  */
 export function buildOrchestratorOptions(
   effectiveOrchestrators: OrchestratorInfo[],
@@ -17,19 +21,21 @@ export function buildOrchestratorOptions(
   const opts = [...effectiveOrchestrators];
   if (!opts.some((o) => o.id === agentOrchestrator)) {
     const current = allOrchestrators.find((o) => o.id === agentOrchestrator);
-    opts.unshift(current ?? {
-      id: agentOrchestrator,
-      displayName: agentOrchestrator,
-      shortName: agentOrchestrator,
-      capabilities: {
-        headless: false,
-        structuredOutput: false,
-        hooks: false,
-        sessionResume: false,
-        permissions: false,
-        structuredMode: false,
-      },
-    });
+    opts.unshift(current
+      ? { ...current, displayName: `${current.displayName} (disabled)` }
+      : {
+        id: agentOrchestrator,
+        displayName: `${agentOrchestrator} (not installed)`,
+        shortName: agentOrchestrator,
+        capabilities: {
+          headless: false,
+          structuredOutput: false,
+          hooks: false,
+          sessionResume: false,
+          permissions: false,
+          structuredMode: false,
+        },
+      });
   }
   return opts;
 }


### PR DESCRIPTION
## Problem (P1)

The orchestrator selector dropdown was missing in **AgentSettingsView** — users couldn't change an agent's orchestrator. Reproduced on a worktree-synced agent whose project/profile isn't fully present in the local app settings.

**Root cause:** `AgentSettingsView.tsx:912` gated the dropdown on `enabledOrchestrators.length > 1`, derived from the **global** enabled list (`useOrchestratorStore`) — *not* the profile-aware `useEffectiveOrchestrators` hook that `AddAgentDialog` already uses. When ≤1 orchestrator was globally enabled (or a profile restricted it, or settings weren't synced into a worktree), the control fell back to static text / nothing → no way to change the orchestrator. The change handler (`handleOrchestratorChange`) was already correct.

## Fix

- Resolve options via `useEffectiveOrchestrators(projectPath)`, matching the agent-creation flow — profile-aware and scoped to the agent's project.
- New pure helper `buildOrchestratorOptions()` **always includes the agent's currently-selected orchestrator**, even when it's disabled app-wide or absent from settings, so the `<select>` always reflects the real value and stays usable for worktree-synced agents.
- Show the dropdown whenever there is >1 distinct option; fall back to static text only when there is genuinely a single option (nothing to choose).
- Immediate-reflection on change preserved (no regression of `b2ad07d7`).

### Product decision (flagged in #fix-orchestrator-selector)
Kept parity with the creation flow: the list shows the profile-aware **enabled** orchestrators, *not* every CLI-available-but-globally-disabled one — letting users pick an app-disabled orchestrator would be inconsistent and surprising. The sole exception is the agent's *current* orchestrator, which is always shown so its state is never misrepresented.

## Acceptance criteria
1. ✅ For a project/agent with >1 orchestrator available, the dropdown renders and changing it persists + reflects immediately (no `b2ad07d7` regression).
2. ✅ A worktree-synced agent with a profile-restricted / absent-in-settings project still gets a working selector (current orchestrator is always an option).
3. ✅ Validated: `typecheck` (clean), `lint` (0 errors), `package` build (success).

## Tests
New `orchestrator-options.test.ts` (6 cases): current-in-set passthrough, no duplication, prepend-when-missing, unknown-orchestrator synthesis, empty-effective-set, and input immutability. Full renderer suite (6744 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)