### PR TITLE
fix(hooks): tear down orchestrator hooks for stopped durable agents + toggle UI fix

### DIFF
--- a/src/main/services/config-pipeline.test.ts
+++ b/src/main/services/config-pipeline.test.ts
@@ -25,6 +25,7 @@ import {
   getHooksConfigPath,
   isClubhouseHookEntry,
   stripClubhouseHooks,
+  stripClubhouseHooksFromFile,
   _resetForTesting,
 } from './config-pipeline';
 
@@ -34,6 +35,78 @@ describe('config-pipeline', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetForTesting();
+  });
+
+  describe('stripClubhouseHooksFromFile', () => {
+    it('returns false (no-op) when the file does not exist', async () => {
+      vi.mocked(pathExists).mockResolvedValueOnce(false);
+      const result = await stripClubhouseHooksFromFile('/p/dur/.github/hooks/hooks.json');
+      expect(result).toBe(false);
+      expect(fsp.writeFile).not.toHaveBeenCalled();
+      expect(fsp.unlink).not.toHaveBeenCalled();
+    });
+
+    it('returns false for an unreadable / non-JSON file without touching it', async () => {
+      vi.mocked(pathExists).mockResolvedValueOnce(true);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce('not json {');
+      const result = await stripClubhouseHooksFromFile('/p/dur/hooks.json');
+      expect(result).toBe(false);
+      expect(fsp.writeFile).not.toHaveBeenCalled();
+      expect(fsp.unlink).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the file has no Clubhouse hooks', async () => {
+      vi.mocked(pathExists).mockResolvedValueOnce(true);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce(JSON.stringify({
+        hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+      }));
+      const result = await stripClubhouseHooksFromFile('/p/dur/hooks.json');
+      expect(result).toBe(false);
+      expect(fsp.writeFile).not.toHaveBeenCalled();
+      expect(fsp.unlink).not.toHaveBeenCalled();
+    });
+
+    it('deletes the file when stripping leaves no settings (Claude-style)', async () => {
+      vi.mocked(pathExists).mockResolvedValueOnce(true);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce(JSON.stringify({
+        hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: CLUBHOUSE_HOOK_CMD }] }] },
+      }));
+      const result = await stripClubhouseHooksFromFile('/p/dur/.claude/settings.local.json');
+      expect(result).toBe(true);
+      expect(fsp.unlink).toHaveBeenCalledWith(path.resolve('/p/dur/.claude/settings.local.json'));
+      expect(fsp.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('writes back preserving sibling settings (Copilot-style version field)', async () => {
+      vi.mocked(pathExists).mockResolvedValueOnce(true);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce(JSON.stringify({
+        version: 1,
+        hooks: { preToolUse: [{ type: 'command', bash: CLUBHOUSE_HOOK_CMD }] },
+      }));
+      const result = await stripClubhouseHooksFromFile('/p/dur/.github/hooks/hooks.json');
+      expect(result).toBe(true);
+      expect(fsp.unlink).not.toHaveBeenCalled();
+      const written = JSON.parse(vi.mocked(fsp.writeFile).mock.calls[0][1] as string);
+      expect(written).toEqual({ version: 1 });
+    });
+
+    it('preserves user-authored hooks alongside the stripped Clubhouse entry', async () => {
+      vi.mocked(pathExists).mockResolvedValueOnce(true);
+      vi.mocked(fsp.readFile).mockResolvedValueOnce(JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { hooks: [{ type: 'command', command: CLUBHOUSE_HOOK_CMD }] },
+            { hooks: [{ type: 'command', command: 'echo user-hook' }] },
+          ],
+        },
+      }));
+      const result = await stripClubhouseHooksFromFile('/p/dur/settings.json');
+      expect(result).toBe(true);
+      const written = JSON.parse(vi.mocked(fsp.writeFile).mock.calls[0][1] as string);
+      expect(written.hooks.PreToolUse).toEqual([
+        { hooks: [{ type: 'command', command: 'echo user-hook' }] },
+      ]);
+    });
   });
 
   describe('snapshotFile', () => {

--- a/src/main/services/config-pipeline.ts
+++ b/src/main/services/config-pipeline.ts
@@ -179,6 +179,67 @@ export function stripClubhouseHooks(settings: Record<string, unknown>): Record<s
   return result;
 }
 
+/**
+ * Strip Clubhouse-injected hook entries from an on-disk JSON config file that
+ * belongs to a *stopped* agent — one with no live snapshot in this process.
+ *
+ * The per-orchestrator hook-server disable path uses the snapshot/restore
+ * pipeline for running agents, but stopped durable agents have no in-memory
+ * snapshot: their hook file still sits on disk and keeps firing after the
+ * toggle is turned off. This reconciles those files directly.
+ *
+ * Reads the current file, removes our hook entries (preserving user-authored
+ * hooks and sibling settings such as Copilot's `version`), and writes it back.
+ * If stripping collapses the file to an empty object, the file is deleted.
+ * No-ops (returns false) when the file is missing, not valid JSON, or contains
+ * no Clubhouse entries. Mutex-guarded so it serialises with snapshot/restore
+ * on the same path. Returns true only when an entry was actually removed.
+ */
+export function stripClubhouseHooksFromFile(filePath: string): Promise<boolean> {
+  return withMutex(async () => {
+    const absPath = path.resolve(filePath);
+    if (!(await pathExists(absPath))) return false;
+
+    let current: unknown;
+    try {
+      current = JSON.parse(await fsp.readFile(absPath, 'utf-8'));
+    } catch {
+      return false; // unreadable / not valid JSON — leave it untouched
+    }
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return false;
+
+    const settings = current as Record<string, unknown>;
+    const hooks = settings.hooks;
+    if (!hooks || typeof hooks !== 'object') return false;
+
+    const hadClubhouse = Object.values(hooks as Record<string, unknown>).some(
+      (entries) => Array.isArray(entries) && entries.some((e) => isClubhouseHookEntry(e)),
+    );
+    if (!hadClubhouse) return false;
+
+    const cleaned = stripClubhouseHooks(settings);
+    try {
+      if (Object.keys(cleaned).length === 0) {
+        await fsp.unlink(absPath);
+        appLog('core:config-pipeline', 'info', 'Stripped Clubhouse hooks from stopped agent (deleted, no remaining settings)', {
+          meta: { filePath: absPath },
+        });
+      } else {
+        await fsp.writeFile(absPath, JSON.stringify(cleaned, null, 2), 'utf-8');
+        appLog('core:config-pipeline', 'info', 'Stripped Clubhouse hooks from stopped agent', {
+          meta: { filePath: absPath },
+        });
+      }
+      return true;
+    } catch (err) {
+      appLog('core:config-pipeline', 'error', 'Failed to strip hooks from stopped agent config', {
+        meta: { filePath: absPath, error: err instanceof Error ? err.message : String(err) },
+      });
+      return false;
+    }
+  });
+}
+
 /** Check if a file path looks like a TOML config file. */
 function isTomlFile(filePath: string): boolean {
   return filePath.endsWith('.toml');

--- a/src/main/services/hook-server-toggle.test.ts
+++ b/src/main/services/hook-server-toggle.test.ts
@@ -18,10 +18,23 @@ vi.mock('../../shared/ipc-channels', () => ({
 }));
 
 const mockGetAllRegistrations = vi.fn();
+const mockReadProjectOrchestrator = vi.fn(() => Promise.resolve(undefined));
 vi.mock('./agent-registry', () => ({
   agentRegistry: {
     getAllRegistrations: () => mockGetAllRegistrations(),
   },
+  readProjectOrchestrator: (...args: unknown[]) => mockReadProjectOrchestrator(...args),
+  DEFAULT_ORCHESTRATOR: 'claude-code',
+}));
+
+const mockProjectStoreList = vi.fn(() => Promise.resolve([]));
+vi.mock('./project-store', () => ({
+  list: (...args: unknown[]) => mockProjectStoreList(...args),
+}));
+
+const mockListDurable = vi.fn(() => Promise.resolve([]));
+vi.mock('./agent-config', () => ({
+  listDurable: (...args: unknown[]) => mockListDurable(...args),
 }));
 
 const mockGetProvider = vi.fn();
@@ -34,10 +47,12 @@ vi.mock('../orchestrators', () => ({
 const mockSnapshotFile = vi.fn(() => Promise.resolve());
 const mockRestoreForAgent = vi.fn(() => Promise.resolve());
 const mockGetHooksConfigPath = vi.fn();
+const mockStripClubhouseHooksFromFile = vi.fn(() => Promise.resolve(true));
 vi.mock('./config-pipeline', () => ({
   snapshotFile: (...args: unknown[]) => mockSnapshotFile(...args),
   restoreForAgent: (...args: unknown[]) => mockRestoreForAgent(...args),
   getHooksConfigPath: (...args: unknown[]) => mockGetHooksConfigPath(...args),
+  stripClubhouseHooksFromFile: (...args: unknown[]) => mockStripClubhouseHooksFromFile(...args),
 }));
 
 const mockClearForAgent = vi.fn();
@@ -121,6 +136,125 @@ describe('hook-server-toggle', () => {
     });
   });
 
+  describe('applyDisabledForOrchestrator — stopped durable agents', () => {
+    const hookProvider = { id: 'copilot-cli', writeHooksConfig: vi.fn(() => Promise.resolve()) };
+
+    beforeEach(() => {
+      mockGetProvider.mockReturnValue(hookProvider);
+      mockIsHookCapable.mockReturnValue(true);
+      mockGetHooksConfigPath.mockImplementation(
+        (_provider: unknown, cwd: string) => `${cwd}/.github/hooks/hooks.json`,
+      );
+      mockStripClubhouseHooksFromFile.mockResolvedValue(true);
+    });
+
+    it('strips on-disk hooks for a stopped durable agent of the target orchestrator', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map()); // nothing running
+      mockProjectStoreList.mockResolvedValue([{ id: 'proj1', name: 'p', path: '/p' }]);
+      mockListDurable.mockResolvedValue([
+        { id: 'dur-a', name: 'a', color: '#fff', worktreePath: '/p/dur-a', orchestrator: 'copilot-cli' },
+      ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(mockStripClubhouseHooksFromFile).toHaveBeenCalledWith('/p/dur-a/.github/hooks/hooks.json');
+      expect(affected).toEqual(['dur-a']);
+      expect(mockBroadcastToAllWindows).toHaveBeenCalledWith(
+        'hook-server:agents-need-restart',
+        { reason: 'disabled', agentIds: ['dur-a'] },
+      );
+    });
+
+    it('skips a durable agent that is currently running (already handled, no double strip)', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['dur-a', { projectPath: '/p', cwd: '/p/dur-a', orchestrator: 'copilot-cli', runtime: 'pty' }],
+      ]));
+      mockProjectStoreList.mockResolvedValue([{ id: 'proj1', name: 'p', path: '/p' }]);
+      mockListDurable.mockResolvedValue([
+        { id: 'dur-a', name: 'a', color: '#fff', worktreePath: '/p/dur-a', orchestrator: 'copilot-cli' },
+      ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(mockRestoreForAgent).toHaveBeenCalledWith('dur-a');
+      expect(mockStripClubhouseHooksFromFile).not.toHaveBeenCalled();
+      expect(affected).toEqual(['dur-a']);
+    });
+
+    it('skips durable agents belonging to a different orchestrator', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      mockProjectStoreList.mockResolvedValue([{ id: 'proj1', name: 'p', path: '/p' }]);
+      mockListDurable.mockResolvedValue([
+        { id: 'dur-claude', name: 'c', color: '#fff', worktreePath: '/p/dur-claude', orchestrator: 'claude-code' },
+        { id: 'dur-copilot', name: 'c', color: '#fff', worktreePath: '/p/dur-copilot', orchestrator: 'copilot-cli' },
+      ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(mockStripClubhouseHooksFromFile).toHaveBeenCalledWith('/p/dur-copilot/.github/hooks/hooks.json');
+      expect(mockStripClubhouseHooksFromFile).not.toHaveBeenCalledWith('/p/dur-claude/.github/hooks/hooks.json');
+      expect(affected).toEqual(['dur-copilot']);
+    });
+
+    it('resolves a durable agent with no explicit orchestrator via the project setting', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      mockReadProjectOrchestrator.mockResolvedValueOnce('copilot-cli');
+      mockProjectStoreList.mockResolvedValue([{ id: 'proj1', name: 'p', path: '/p' }]);
+      mockListDurable.mockResolvedValue([
+        { id: 'dur-inherit', name: 'i', color: '#fff', worktreePath: '/p/dur-inherit' },
+      ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(affected).toEqual(['dur-inherit']);
+    });
+
+    it('does not count a durable agent whose file had no Clubhouse hooks', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      mockStripClubhouseHooksFromFile.mockResolvedValue(false);
+      mockProjectStoreList.mockResolvedValue([{ id: 'proj1', name: 'p', path: '/p' }]);
+      mockListDurable.mockResolvedValue([
+        { id: 'dur-a', name: 'a', color: '#fff', worktreePath: '/p/dur-a', orchestrator: 'copilot-cli' },
+      ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(affected).toEqual([]);
+      expect(mockBroadcastToAllWindows).not.toHaveBeenCalled();
+    });
+
+    it('does not reconcile durable agents for a non-hook-capable orchestrator', async () => {
+      mockIsHookCapable.mockReturnValue(false);
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      mockProjectStoreList.mockResolvedValue([{ id: 'proj1', name: 'p', path: '/p' }]);
+      mockListDurable.mockResolvedValue([
+        { id: 'dur-a', name: 'a', color: '#fff', worktreePath: '/p/dur-a', orchestrator: 'copilot-cli' },
+      ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(mockStripClubhouseHooksFromFile).not.toHaveBeenCalled();
+      expect(affected).toEqual([]);
+    });
+
+    it('continues when one project fails to list durable agents', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map());
+      mockProjectStoreList.mockResolvedValue([
+        { id: 'proj1', name: 'p1', path: '/p1' },
+        { id: 'proj2', name: 'p2', path: '/p2' },
+      ]);
+      mockListDurable
+        .mockRejectedValueOnce(new Error('corrupt agents.json'))
+        .mockResolvedValueOnce([
+          { id: 'dur-b', name: 'b', color: '#fff', worktreePath: '/p2/dur-b', orchestrator: 'copilot-cli' },
+        ]);
+
+      const affected = await applyDisabledForOrchestrator('copilot-cli');
+
+      expect(affected).toEqual(['dur-b']);
+    });
+  });
+
   describe('applyEnabledForOrchestrator', () => {
     const mockProvider = {
       id: 'claude-code',
@@ -201,6 +335,15 @@ describe('hook-server-toggle', () => {
         'hook-server:agents-need-restart',
         { reason: 'enabled', agentIds: ['agent-a'] },
       );
+    });
+
+    it('does not reach into durable configs (stopped agents get hooks via startup injection)', async () => {
+      mockGetAllRegistrations.mockReturnValue(new Map([
+        ['agent-a', { projectPath: '/p', cwd: '/p/a', orchestrator: 'claude-code', runtime: 'pty' }],
+      ]));
+      await applyEnabledForOrchestrator('claude-code');
+      expect(mockListDurable).not.toHaveBeenCalled();
+      expect(mockStripClubhouseHooksFromFile).not.toHaveBeenCalled();
     });
   });
 

--- a/src/main/services/hook-server-toggle.ts
+++ b/src/main/services/hook-server-toggle.ts
@@ -19,13 +19,16 @@
  * mid-task would lose work.  Restart is the user's call.
  */
 
-import { agentRegistry } from './agent-registry';
+import * as path from 'path';
+import { agentRegistry, readProjectOrchestrator, DEFAULT_ORCHESTRATOR } from './agent-registry';
 import { getProvider } from '../orchestrators';
 import { isHookCapable } from '../orchestrators';
 import { appLog } from './log-service';
 import * as configPipeline from './config-pipeline';
 import * as permissionQueue from './annex-permission-queue';
 import * as hookServer from './hook-server';
+import * as projectStore from './project-store';
+import * as agentConfig from './agent-config';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { IPC } from '../../shared/ipc-channels';
 
@@ -34,14 +37,19 @@ const NS = 'core:hook-server-toggle';
 /**
  * Apply the disabled state for a single orchestrator: resolve its pending
  * permissions, strip injected hooks from each of its running agents' configs,
+ * reconcile any STOPPED durable agents whose hook config is still on disk, then
  * broadcast restart-needed.  Other orchestrators' agents are left untouched.
  */
 export async function applyDisabledForOrchestrator(orchestratorId: string): Promise<string[]> {
   const registrations = agentRegistry.getAllRegistrations();
   const affectedAgentIds: string[] = [];
+  const runningCwds = new Set<string>();
 
+  // 1. Running agents — strip via the snapshot/restore pipeline (which preserves
+  //    user-authored settings) and release in-flight permissions.
   for (const [agentId, registration] of registrations) {
     if (registration.orchestrator !== orchestratorId) continue;
+    if (registration.cwd) runningCwds.add(path.resolve(registration.cwd));
 
     // Release this agent's in-flight permissions so curls return immediately;
     // `clearForAgent` resolves each pending entry as 'timeout', which the hook
@@ -58,6 +66,14 @@ export async function applyDisabledForOrchestrator(orchestratorId: string): Prom
     }
   }
 
+  // 2. Stopped durable agents — never in the registry, but their hook config is
+  //    still on disk and would keep firing after the disable (and is NOT
+  //    re-stripped on restart, since startup injection is gated on the now-off
+  //    toggle). Reconcile every matching durable agent that is not currently
+  //    running by stripping its on-disk hook file directly.
+  const stoppedIds = await reconcileStoppedDurableAgents(orchestratorId, runningCwds);
+  affectedAgentIds.push(...stoppedIds);
+
   appLog(NS, 'info', 'Hook server disabled for orchestrator — agents stripped of injected hooks', {
     meta: { orchestrator: orchestratorId, affectedAgentIds, agentCount: affectedAgentIds.length },
   });
@@ -70,6 +86,80 @@ export async function applyDisabledForOrchestrator(orchestratorId: string): Prom
   }
 
   return affectedAgentIds;
+}
+
+/**
+ * Sweep every project's durable agents and strip Clubhouse hook entries from
+ * the on-disk config of each STOPPED agent belonging to `orchestratorId`.
+ * Agents whose worktree is in `runningCwds` are skipped — they were already
+ * handled via the snapshot/restore pipeline. Returns the IDs that actually had
+ * hooks removed (so they can be folded into the "needs restart" broadcast).
+ *
+ * Best-effort: a failure reading one project or one agent's file is logged and
+ * skipped rather than aborting the whole reconciliation.
+ */
+async function reconcileStoppedDurableAgents(
+  orchestratorId: string,
+  runningCwds: Set<string>,
+): Promise<string[]> {
+  const affected: string[] = [];
+
+  const provider = getProvider(orchestratorId);
+  if (!provider || !isHookCapable(provider)) {
+    // Unknown or non-hook-capable orchestrator never wrote hooks to strip.
+    return affected;
+  }
+
+  let projects: Awaited<ReturnType<typeof projectStore.list>>;
+  try {
+    projects = await projectStore.list();
+  } catch (err) {
+    appLog(NS, 'warn', 'Durable agent reconciliation skipped — failed to list projects', {
+      meta: { orchestrator: orchestratorId, error: err instanceof Error ? err.message : String(err) },
+    });
+    return affected;
+  }
+
+  for (const project of projects) {
+    // A durable agent with no explicit orchestrator inherits the project's
+    // setting, falling back to the app default.
+    const projectOrchestrator = (await readProjectOrchestrator(project.path)) || DEFAULT_ORCHESTRATOR;
+
+    let durables: Awaited<ReturnType<typeof agentConfig.listDurable>>;
+    try {
+      durables = await agentConfig.listDurable(project.path);
+    } catch (err) {
+      appLog(NS, 'warn', 'Failed to list durable agents for project', {
+        meta: { projectPath: project.path, error: err instanceof Error ? err.message : String(err) },
+      });
+      continue;
+    }
+
+    for (const durable of durables) {
+      if (!durable.worktreePath) continue;
+      const effectiveOrchestrator = durable.orchestrator || projectOrchestrator;
+      if (effectiveOrchestrator !== orchestratorId) continue;
+      if (runningCwds.has(path.resolve(durable.worktreePath))) continue; // handled as a running agent
+
+      const hookConfigPath = configPipeline.getHooksConfigPath(provider, durable.worktreePath);
+      if (!hookConfigPath) continue;
+
+      try {
+        const stripped = await configPipeline.stripClubhouseHooksFromFile(hookConfigPath);
+        if (stripped) affected.push(durable.id);
+      } catch (err) {
+        appLog(NS, 'error', 'Failed to strip hooks for stopped durable agent', {
+          meta: {
+            agentId: durable.id,
+            orchestrator: orchestratorId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      }
+    }
+  }
+
+  return affected;
 }
 
 /**

--- a/src/renderer/features/settings/OrchestratorSettingsView.tsx
+++ b/src/renderer/features/settings/OrchestratorSettingsView.tsx
@@ -261,7 +261,7 @@ function AppAgentSettings() {
 
               {showExpansion && (
                 <div className="border-t border-surface-0 px-3 py-2.5 pl-8 space-y-2.5">
-                  <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center justify-between gap-3">
                     <div className="min-w-0">
                       <div className="text-xs text-ctp-text font-medium">Hook server</div>
                       <div className="text-[11px] text-ctp-subtext0 mt-0.5">
@@ -271,10 +271,12 @@ function AppAgentSettings() {
                         running agents, which need a restart to take full effect.
                       </div>
                     </div>
-                    <Toggle
-                      checked={hookServerOn}
-                      onChange={(v) => setHookServerEnabled(o.id, v)}
-                    />
+                    <div className="flex-shrink-0">
+                      <Toggle
+                        checked={hookServerOn}
+                        onChange={(v) => setHookServerEnabled(o.id, v)}
+                      />
+                    </div>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary

Fixes two related bugs in the per-orchestrator hook-server toggle (#1501). **P0 — hard block for GitHub Copilot.**

### Bug A — disable didn't reach stopped durable agents (primary)
`applyDisabledForOrchestrator()` only iterated **running** agents (`agentRegistry.getAllRegistrations()`). A stopped durable agent kept its Clubhouse hook entries on disk; since startup injection is gated on the now-off toggle (`agent-system.ts:360`), those entries were never re-stripped and kept firing — defeating the disable and hard-blocking Copilot.

- **New `config-pipeline.stripClubhouseHooksFromFile()`** — mutex-guarded on-disk strip that removes Clubhouse hook entries while preserving user-authored hooks and sibling settings (e.g. Copilot's `version` field). Deletes the file only if it collapses to `{}`. No-op when the file is missing, non-JSON, or has no Clubhouse entries.
- **`applyDisabledForOrchestrator` now sweeps every project's durable agents** (`projectStore.list()` → `agentConfig.listDurable()`) and reconciles each **stopped** agent of the target orchestrator, skipping ones already handled as running. Effective orchestrator is resolved via agent override → project setting → app default. Best-effort: a failure on one project/agent is logged and skipped.
- **Enable path unchanged** — restarted/stopped agents pick hooks back up via the normal startup injection once the toggle flips on. Added a regression test asserting enable never touches durable configs.

### Bug B — squished toggle
`OrchestratorSettingsView.tsx` — wrapped the hook-server `<Toggle>` in a `flex-shrink-0` div (Toggle takes no className) so it no longer gets squished by the long label at narrow widths. Mirrors the working "Prompt for Session Name" row.

## Acceptance criteria
1. ✅ Disable → a previously-run, now-stopped agent has its on-disk hook config stripped; restart does not re-inject (startup gate is already off).
2. ✅ Running agents still stripped via the snapshot/restore pipeline — no regression.
3. ✅ Re-enable restores hooks for new/restarted agents via startup injection.
4. ✅ Toggle row renders aligned at narrow widths.
5. ✅ Validated: `electron-forge package` build, `tsc --noEmit` typecheck, and `eslint` (0 errors) all clean.

## Tests
- `config-pipeline.test.ts`: on-disk strip — missing file, non-JSON, no-Clubhouse no-op, Claude-style delete, Copilot-style write-back preserving `version`, preserving user hooks.
- `hook-server-toggle.test.ts`: durable sweep — strips stopped agent, skips running agent (no double strip), filters by orchestrator, inherits project default, no-op when no Clubhouse hooks, skips non-hook-capable provider, continues past a failing project; enable doesn't touch durable configs.
- Full suite green: 5605 unit + 6738 component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)