### PR TITLE
fix(status): reconcile durable-agent status against live sessions on window reopen

### DIFF
--- a/src/main/ipc/agent-handlers.test.ts
+++ b/src/main/ipc/agent-handlers.test.ts
@@ -46,6 +46,7 @@ vi.mock('../services/agent-system', () => ({
   checkAvailability: vi.fn(async () => ({ available: true })),
   getAvailableOrchestrators: vi.fn(() => ['claude-code', 'aider']),
   isHeadlessAgent: vi.fn(() => false),
+  getRunningAgentIds: vi.fn((ids: string[]) => ids.filter((id) => id === 'running_one')),
 }));
 
 vi.mock('../services/headless-manager', () => ({
@@ -123,6 +124,7 @@ describe('agent-handlers', () => {
       IPC.AGENT.GET_TOOL_VERB, IPC.AGENT.GET_SUMMARY_INSTRUCTION,
       IPC.AGENT.READ_TRANSCRIPT, IPC.AGENT.GET_TRANSCRIPT_INFO,
       IPC.AGENT.READ_TRANSCRIPT_PAGE, IPC.AGENT.IS_HEADLESS_AGENT,
+      IPC.AGENT.GET_RUNNING_STATUSES,
     ];
     for (const channel of expectedChannels) {
       expect(handlers.has(channel)).toBe(true);
@@ -152,6 +154,13 @@ describe('agent-handlers', () => {
     const result = await handler({}, '/project');
     expect(agentConfig.listDurable).toHaveBeenCalledWith('/project');
     expect(result).toEqual([{ id: 'a1', name: 'Bot' }]);
+  });
+
+  it('GET_RUNNING_STATUSES delegates to agentSystem.getRunningAgentIds', async () => {
+    const handler = handlers.get(IPC.AGENT.GET_RUNNING_STATUSES)!;
+    const result = await handler({}, ['running_one', 'sleeping_two']);
+    expect(agentSystem.getRunningAgentIds).toHaveBeenCalledWith(['running_one', 'sleeping_two']);
+    expect(result).toEqual(['running_one']);
   });
 
   it('CREATE_DURABLE delegates to agentConfig.createDurable', async () => {

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -40,6 +40,18 @@ export function registerAgentHandlers(): void {
     },
   ));
 
+  // Returns the subset of the given agent IDs that currently have a live
+  // session (PTY / headless / structured) in the main process. The renderer
+  // calls this after (re)loading durable agents to reconcile status, so a
+  // reopened window shows running agents as 'running' immediately instead of
+  // waiting for the next poll tick or hook event.
+  ipcMain.handle(IPC.AGENT.GET_RUNNING_STATUSES, withValidatedArgs(
+    [arrayArg(stringArg())],
+    async (_event, agentIds) => {
+      return agentSystem.getRunningAgentIds(agentIds);
+    },
+  ));
+
   ipcMain.handle(
     IPC.AGENT.CREATE_DURABLE,
     withValidatedArgs(

--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -16,9 +16,11 @@ vi.mock('./config-pipeline', () => ({
 // Mock pty-manager
 const mockPtySpawn = vi.fn();
 const mockPtyGracefulKill = vi.fn();
+const mockPtyIsRunning = vi.fn(() => false);
 vi.mock('./pty-manager', () => ({
   spawn: (...args: unknown[]) => mockPtySpawn(...args),
   gracefulKill: (...args: unknown[]) => mockPtyGracefulKill(...args),
+  isRunning: (...args: unknown[]) => mockPtyIsRunning(...args),
 }));
 
 // Mock headless-manager
@@ -227,6 +229,8 @@ import {
   untrackAgent,
   isHeadlessAgent,
   isStructuredAgent,
+  isAgentRunning,
+  getRunningAgentIds,
   expandHome,
 } from './agent-system';
 import * as os from 'os';
@@ -2321,6 +2325,36 @@ describe('agent-system', () => {
         ['my-mcp'],
         testConfigs,
       );
+    });
+  });
+
+  describe('isAgentRunning / getRunningAgentIds', () => {
+    it('reports running when a PTY session is live', () => {
+      mockPtyIsRunning.mockImplementation((id: string) => id === 'pty_agent');
+      expect(isAgentRunning('pty_agent')).toBe(true);
+      expect(isAgentRunning('other')).toBe(false);
+    });
+
+    it('reports running for headless and structured sessions', () => {
+      mockIsHeadless.mockImplementation((id: string) => id === 'headless_agent');
+      mockIsStructuredSession.mockImplementation((id: string) => id === 'structured_agent');
+      expect(isAgentRunning('headless_agent')).toBe(true);
+      expect(isAgentRunning('structured_agent')).toBe(true);
+    });
+
+    it('reports not running when no manager has a session', () => {
+      expect(isAgentRunning('idle_agent')).toBe(false);
+    });
+
+    it('filters a candidate list to only the live agents', () => {
+      mockPtyIsRunning.mockImplementation((id: string) => id === 'a');
+      mockIsHeadless.mockImplementation((id: string) => id === 'b');
+      mockIsStructuredSession.mockImplementation((id: string) => id === 'c');
+      expect(getRunningAgentIds(['a', 'b', 'c', 'd'])).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns an empty array when none are running', () => {
+      expect(getRunningAgentIds(['x', 'y'])).toEqual([]);
     });
   });
 });

--- a/src/main/services/agent-system.ts
+++ b/src/main/services/agent-system.ts
@@ -76,6 +76,25 @@ export function isStructuredAgent(agentId: string): boolean {
   return structuredManager.isStructuredSession(agentId);
 }
 
+/**
+ * Whether an agent currently has a live session in the main process — a PTY,
+ * a headless run, or a structured session. Live sessions outlive the renderer
+ * window, so this is the source of truth when a reopened window reconciles
+ * status (see `getRunningAgentIds`).
+ */
+export function isAgentRunning(agentId: string): boolean {
+  return ptyManager.isRunning(agentId) || isHeadlessAgent(agentId) || isStructuredAgent(agentId);
+}
+
+/**
+ * Given a set of candidate agent IDs, return those with a live session. Used by
+ * the renderer to reconcile durable-agent status on window reopen so genuinely
+ * running agents don't briefly show as 'sleeping' until the next poll tick.
+ */
+export function getRunningAgentIds(agentIds: string[]): string[] {
+  return agentIds.filter(isAgentRunning);
+}
+
 export async function spawnAgent(inParams: SpawnAgentParams): Promise<void> {
   let params = inParams;
   const provider = await resolveOrchestrator(params.projectPath, params.orchestrator);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -93,6 +93,8 @@ const api = {
   agent: {
     listDurable: (projectPath: string) =>
       ipcRenderer.invoke(IPC.AGENT.LIST_DURABLE, projectPath),
+    getRunningStatuses: (agentIds: string[]): Promise<string[]> =>
+      ipcRenderer.invoke(IPC.AGENT.GET_RUNNING_STATUSES, agentIds),
     createDurable: (projectPath: string, name: string, color: string, model?: string, useWorktree?: boolean, orchestrator?: string, freeAgentMode?: boolean, mcpIds?: string[], mcpConfigs?: Record<string, Record<string, string>>, structuredMode?: boolean, persona?: string) =>
       ipcRenderer.invoke(IPC.AGENT.CREATE_DURABLE, projectPath, name, color, model, useWorktree, orchestrator, freeAgentMode, mcpIds, mcpConfigs, structuredMode, persona),
     deleteDurable: (projectPath: string, agentId: string) =>

--- a/src/renderer/stores/agent/agentCrudSlice.ts
+++ b/src/renderer/stores/agent/agentCrudSlice.ts
@@ -89,6 +89,36 @@ export function createCrudSlice(set: SetAgentState, get: GetAgentState): AgentCr
 
       set({ agents });
 
+      // Reconcile status against the main process's live sessions. Durable
+      // agents load as 'sleeping' (above), but their PTY/headless/structured
+      // sessions outlive the renderer window — on a window reopen the freshly
+      // loaded store would otherwise show genuinely-running agents as 'asleep'
+      // until the next poll tick or hook event. Upgrade 'sleeping' → 'running'
+      // for any loaded agent the main process reports as live (mirrors the
+      // remote-agent reconciliation in remoteProjectStore). Upgrade only —
+      // downgrades are left to the stale-status tick and hook events.
+      try {
+        const runningIds: string[] = await window.clubhouse.agent.getRunningStatuses(
+          configs.map((config) => config.id),
+        );
+        if (runningIds.length > 0) {
+          set((s) => {
+            let changed = false;
+            const next = { ...s.agents };
+            for (const id of runningIds) {
+              const agent = next[id];
+              if (agent && agent.status === 'sleeping') {
+                next[id] = { ...agent, status: 'running' };
+                changed = true;
+              }
+            }
+            return changed ? { agents: next } : s;
+          });
+        }
+      } catch {
+        // Non-fatal — status self-corrects on the next poll tick / hook event.
+      }
+
       // Load icons for agents that have them (in parallel)
       await Promise.all(
         configs

--- a/src/renderer/stores/agentStore.test.ts
+++ b/src/renderer/stores/agentStore.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal('window', {
     },
     agent: {
       listDurable: vi.fn().mockResolvedValue([]),
+      getRunningStatuses: vi.fn().mockResolvedValue([]),
       renameDurable: vi.fn().mockResolvedValue(undefined),
       updateDurable: vi.fn().mockResolvedValue(undefined),
       deleteDurable: vi.fn().mockResolvedValue(undefined),
@@ -1197,6 +1198,58 @@ describe('agentStore', () => {
       // Second load under project B (same path, different store ID)
       await getState().loadDurableAgents('proj_B', '/shared-path');
       expect(getState().agents['durable_dup'].projectId).toBe('proj_B');
+    });
+
+    it('reconciles status to running for agents the main process reports live', async () => {
+      const mockAgent = window.clubhouse.agent as any;
+      mockAgent.listDurable.mockResolvedValue([
+        { id: 'durable_live', name: 'live', color: 'indigo', createdAt: '2024-01-01' },
+        { id: 'durable_idle', name: 'idle', color: 'emerald', createdAt: '2024-01-01' },
+      ]);
+      // Main process reports only the first agent as having a live session.
+      mockAgent.getRunningStatuses.mockResolvedValue(['durable_live']);
+
+      await getState().loadDurableAgents('proj_1', '/project');
+
+      // Running agent reconciled immediately; genuinely-idle one stays sleeping.
+      expect(getState().agents['durable_live'].status).toBe('running');
+      expect(getState().agents['durable_idle'].status).toBe('sleeping');
+      expect(mockAgent.getRunningStatuses).toHaveBeenCalledWith(['durable_live', 'durable_idle']);
+    });
+
+    it('leaves all agents sleeping when none are reported running', async () => {
+      const mockAgent = window.clubhouse.agent as any;
+      mockAgent.listDurable.mockResolvedValue([
+        { id: 'durable_s1', name: 's1', color: 'indigo', createdAt: '2024-01-01' },
+      ]);
+      mockAgent.getRunningStatuses.mockResolvedValue([]);
+
+      await getState().loadDurableAgents('proj_1', '/project');
+      expect(getState().agents['durable_s1'].status).toBe('sleeping');
+    });
+
+    it('does not downgrade an agent already marked running', async () => {
+      seedAgent({ id: 'durable_run', projectId: 'proj_1', status: 'running' });
+      const mockAgent = window.clubhouse.agent as any;
+      mockAgent.listDurable.mockResolvedValue([
+        { id: 'durable_run', name: 'run', color: 'indigo', createdAt: '2024-01-01' },
+      ]);
+      // Main reports it as not live (e.g. a transient snapshot) — must not flip it.
+      mockAgent.getRunningStatuses.mockResolvedValue([]);
+
+      await getState().loadDurableAgents('proj_1', '/project');
+      expect(getState().agents['durable_run'].status).toBe('running');
+    });
+
+    it('survives a getRunningStatuses failure (non-fatal)', async () => {
+      const mockAgent = window.clubhouse.agent as any;
+      mockAgent.listDurable.mockResolvedValue([
+        { id: 'durable_err', name: 'err', color: 'indigo', createdAt: '2024-01-01' },
+      ]);
+      mockAgent.getRunningStatuses.mockRejectedValue(new Error('ipc down'));
+
+      await getState().loadDurableAgents('proj_1', '/project');
+      expect(getState().agents['durable_err'].status).toBe('sleeping');
     });
   });
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -37,6 +37,7 @@ export const IPC = {
   AGENT: {
     CREATE_DURABLE: 'agent:create-durable',
     LIST_DURABLE: 'agent:list-durable',
+    GET_RUNNING_STATUSES: 'agent:get-running-statuses',
     DELETE_DURABLE: 'agent:delete-durable',
     READ_INSTRUCTIONS: 'agent:read-instructions',
     SAVE_INSTRUCTIONS: 'agent:save-instructions',

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -67,6 +67,7 @@ vi.stubGlobal('clubhouse', {
   },
   agent: {
     listDurable: async () => [],
+    getRunningStatuses: async () => [],
     createDurable: asyncNoop,
     deleteDurable: asyncNoop,
     renameDurable: asyncNoop,


### PR DESCRIPTION
## Problem (P2)

After a headless window round-trip (close → reopen), durable agents that were **actually awake** showed as **"asleep"**, self-correcting only on the next ~10s poll tick.

**Root cause:** `loadDurableAgents()` (`agentCrudSlice.ts`) loads every durable agent as `status: 'sleeping'` and never reconciles against the main process's live sessions. PTY / headless / structured sessions live in the **main** process and outlive the renderer window, so on reopen the freshly-loaded store reads 'sleeping' until the `clearStaleStatuses` tick (`app-event-bridge.ts:567`) or a later hook event corrects it. Remote agents already reconcile (`remoteProjectStore.ts:369-376`); local agents had no equivalent.

## Fix

Mirror the remote-agent reconciliation for local durable agents:

1. **`agent-system.ts`** — lift the canonical predicate `isAgentRunning(id)` (`pty.isRunning || isHeadless || isStructured`) and add `getRunningAgentIds(ids)`.
2. **New IPC `agent:get-running-statuses`** — handler in `agent-handlers.ts` (validated `arrayArg(stringArg())`), preload `agent.getRunningStatuses(ids)`.
3. **`loadDurableAgents()`** — after loading, query the main process for which loaded agents are live and upgrade `sleeping → running`. **Upgrade-only** — downgrades stay the tick's/hook's job, so a transient snapshot can't flip a running agent to sleeping. Best-effort; an IPC failure is non-fatal (status self-corrects on the next tick). Covers the main window and popout views (all call `loadDurableAgents`).

## Acceptance criteria

1. ✅ Reopen with live agents → 'running' immediately, no transient 'asleep' (reconcile runs inside `loadDurableAgents`).
2. ✅ Genuinely-sleeping agents aren't in the running set → stay 'sleeping'.
3. ✅ No remote regression — remote agents live in a separate `remoteAgents` store slice, untouched.
4. ✅ Validated: `typecheck` ✓, `lint` ✓ (0 errors), full unit suite ✓ (12403 passed), webpack build (`package`) ✓.

## Tests

- `agent-system.test.ts` — `isAgentRunning` (pty/headless/structured) + `getRunningAgentIds` filtering.
- `agent-handlers.test.ts` — `GET_RUNNING_STATUSES` registered + delegates.
- `agentStore.test.ts` — reconcile upgrades only reported-live agents; leaves others sleeping; never downgrades an already-running agent; survives an IPC failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
