### PR TITLE
fix(plugins): restore multi-file plugin loading broken by #1499

### DIFF
--- a/src/main/csp-nonce.test.ts
+++ b/src/main/csp-nonce.test.ts
@@ -31,3 +31,36 @@ describe('csp-nonce', () => {
     expect(a).not.toBe(b);
   });
 });
+
+describe('buildProductionCsp', () => {
+  // Regression guard: production plugin loading imports community plugin
+  // modules directly by their same-origin file:// URL. That requires
+  // `script-src 'self'`. If this is ever removed, multi-file plugin loading
+  // breaks again (the #1499 regression class).
+  it("allows same-origin script via script-src 'self' so plugin import is not blocked", async () => {
+    const { buildProductionCsp } = await import('./csp-nonce');
+    const csp = buildProductionCsp('test-nonce');
+    const scriptSrc = csp
+      .split(';')
+      .map((d) => d.trim())
+      .find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).toContain("'self'");
+  });
+
+  it('keeps blob: in script-src for the dev blob-import path', async () => {
+    const { buildProductionCsp } = await import('./csp-nonce');
+    const csp = buildProductionCsp('test-nonce');
+    const scriptSrc = csp
+      .split(';')
+      .map((d) => d.trim())
+      .find((d) => d.startsWith('script-src'))!;
+    expect(scriptSrc).toContain('blob:');
+  });
+
+  it('embeds the provided nonce in script-src', async () => {
+    const { buildProductionCsp } = await import('./csp-nonce');
+    const csp = buildProductionCsp('abc123');
+    expect(csp).toContain("'nonce-abc123'");
+  });
+});

--- a/src/main/csp-nonce.ts
+++ b/src/main/csp-nonce.ts
@@ -11,3 +11,18 @@ export function getCspNonce(): string {
   if (!_nonce) throw new Error('CSP nonce not initialized — call generateCspNonce() first');
   return _nonce;
 }
+
+/**
+ * Build the production Content-Security-Policy header value.
+ *
+ * `script-src` must include `'self'` so the renderer (loaded from file://) can
+ * import community plugin modules directly by their file:// URL — they are
+ * same-origin and served by the main-process `protocol.handle('file', …)`
+ * handler. Removing `'self'` here re-breaks multi-file plugin loading (the
+ * #1499 regression class), so the value is locked by a unit test.
+ *
+ * `blob:` remains allowed for the dev-mode blob-import path and web workers.
+ */
+export function buildProductionCsp(nonce: string): string {
+  return `default-src 'self' 'unsafe-inline' data:; script-src 'self' 'nonce-${nonce}' blob:; worker-src 'self' blob:`;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,7 +21,7 @@ import { preWarmShellEnvironment } from './util/shell';
 import { initializeRipgrep } from './services/search-service';
 import { loadPendingResume } from './services/restart-session-service';
 import { applyWindowSecurityGuards } from './window-security-guards';
-import { generateCspNonce, getCspNonce } from './csp-nonce';
+import { generateCspNonce, getCspNonce, buildProductionCsp } from './csp-nonce';
 import { initProtocolHandler } from './services/protocol-service';
 import * as projectStore from './services/project-store';
 
@@ -254,7 +254,7 @@ app.on('ready', () => {
         responseHeaders: {
           ...details.responseHeaders,
           'Content-Security-Policy': [
-            `default-src 'self' 'unsafe-inline' data:; script-src 'self' 'nonce-${getCspNonce()}' blob:; worker-src 'self' blob:`,
+            buildProductionCsp(getCspNonce()),
           ],
         },
       });

--- a/src/renderer/plugins/dynamic-import.test.ts
+++ b/src/renderer/plugins/dynamic-import.test.ts
@@ -4,6 +4,14 @@ import type { PluginModule } from '../../shared/plugin-types';
 const FAKE_SOURCE = 'export default {}';
 const FAKE_BLOB_URL = 'blob:null/test-uuid';
 
+type ClubhouseWindow = { clubhouse: { plugin: { loadModuleSource: ReturnType<typeof vi.fn> } } };
+function setClubhouse(loadModuleSource: ReturnType<typeof vi.fn>) {
+  (window as unknown as ClubhouseWindow).clubhouse = { plugin: { loadModuleSource } };
+}
+function getLoadModuleSource() {
+  return (window as unknown as ClubhouseWindow).clubhouse.plugin.loadModuleSource;
+}
+
 function setupDevModeGlobals(mockModule: PluginModule) {
   // Simulate http: origin (dev mode)
   Object.defineProperty(window, 'location', {
@@ -126,7 +134,7 @@ describe('dynamicImportModule', () => {
       // Provide a clubhouse stub + URL spies so we can assert the blob/IPC
       // path is NOT taken in production (that path is what broke relative
       // imports in #1499).
-      (window as any).clubhouse = { plugin: { loadModuleSource: vi.fn().mockResolvedValue(FAKE_SOURCE) } };
+      setClubhouse(vi.fn().mockResolvedValue(FAKE_SOURCE));
       vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
       vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
     });
@@ -148,7 +156,7 @@ describe('dynamicImportModule', () => {
       // Imported directly with the real file:// path — not a blob/IPC copy.
       expect(result).toBe(fakeModule);
       expect(rawImport).toHaveBeenCalledWith(url);
-      expect((window as any).clubhouse.plugin.loadModuleSource).not.toHaveBeenCalled();
+      expect(getLoadModuleSource()).not.toHaveBeenCalled();
       expect(URL.createObjectURL).not.toHaveBeenCalled();
     });
 
@@ -167,7 +175,7 @@ describe('dynamicImportModule', () => {
       expect(result).toBe(fakeModule);
       expect(rawImport).toHaveBeenCalledWith(url);
       expect(URL.createObjectURL).not.toHaveBeenCalled();
-      expect((window as any).clubhouse.plugin.loadModuleSource).not.toHaveBeenCalled();
+      expect(getLoadModuleSource()).not.toHaveBeenCalled();
     });
 
     it('strips the ?v= cache-busting query param before importing in production', async () => {
@@ -196,7 +204,7 @@ describe('dynamicImportModule', () => {
       expect(result).toBe(fakeModule);
       expect(rawImport).toHaveBeenCalledWith(url);
       expect(URL.createObjectURL).not.toHaveBeenCalled();
-      expect((window as any).clubhouse.plugin.loadModuleSource).not.toHaveBeenCalled();
+      expect(getLoadModuleSource()).not.toHaveBeenCalled();
     });
   });
 

--- a/src/renderer/plugins/dynamic-import.test.ts
+++ b/src/renderer/plugins/dynamic-import.test.ts
@@ -40,6 +40,10 @@ describe('dynamicImportModule', () => {
     return dynamicImportModule;
   }
 
+  async function loadModule() {
+    return import('./dynamic-import');
+  }
+
   describe('dev mode (non-file: origin)', () => {
     it('reads module source via IPC for file: URLs', async () => {
       const fakeModule: PluginModule = { activate: vi.fn() };
@@ -119,53 +123,96 @@ describe('dynamicImportModule', () => {
   describe('production mode (file: origin)', () => {
     beforeEach(() => {
       setupProdModeGlobals();
+      // Provide a clubhouse stub + URL spies so we can assert the blob/IPC
+      // path is NOT taken in production (that path is what broke relative
+      // imports in #1499).
+      (window as any).clubhouse = { plugin: { loadModuleSource: vi.fn().mockResolvedValue(FAKE_SOURCE) } };
       vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
       vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
     });
 
-    it('reads module source via IPC for file: origin (same as dev mode)', async () => {
+    // The exact case #1499's tests missed: a multi-file plugin whose entry
+    // module does `import './x.js'`. Blob-wrapping (no path) broke this. We
+    // assert production imports the file:// URL DIRECTLY — no IPC, no blob —
+    // which is the prerequisite for the entry module's relative import to
+    // resolve against its real filesystem path.
+    it('imports the file:// URL directly for a multi-file plugin — no IPC, no blob', async () => {
       const fakeModule: PluginModule = { activate: vi.fn() };
-      const { loadModuleSource } = setupDevModeGlobals(fakeModule);
-      // Override location back to production after setupDevModeGlobals set it to http:
-      setupProdModeGlobals();
+      const url = 'file:///Users/me/.clubhouse/plugins/automations/dist/main.js';
 
-      const fn = await loadFn();
-      await fn('file:///Users/masonallen/.clubhouse/plugins/automations/dist/main.js').catch(() => {});
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
 
-      expect(loadModuleSource).toHaveBeenCalledWith(
-        '/Users/masonallen/.clubhouse/plugins/automations/dist/main.js',
-      );
+      const result = await mod.dynamicImportModule(url);
+
+      // Imported directly with the real file:// path — not a blob/IPC copy.
+      expect(result).toBe(fakeModule);
+      expect(rawImport).toHaveBeenCalledWith(url);
+      expect((window as any).clubhouse.plugin.loadModuleSource).not.toHaveBeenCalled();
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
     });
 
-    it('creates a blob URL for file: origin — avoids ?v= query-param failure', async () => {
-      const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
-      (window as any).clubhouse = { plugin: { loadModuleSource } };
+    // A bare/external dependency import inside the entry module (e.g.
+    // `import 'some-dep'`) likewise only resolves when the module is imported
+    // directly with its real path — never through a pathless blob URL.
+    it('imports directly for an entry module with a bare dependency import', async () => {
+      const fakeModule: PluginModule = {};
+      const url = 'file:///plugins/with-deps/dist/main.js';
 
-      const fn = await loadFn();
-      await fn('file:///plugins/automations/dist/main.js?v=1780813375562').catch(() => {});
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
 
-      expect(URL.createObjectURL).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'text/javascript' }),
-      );
+      const result = await mod.dynamicImportModule(url);
+
+      expect(result).toBe(fakeModule);
+      expect(rawImport).toHaveBeenCalledWith(url);
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
+      expect((window as any).clubhouse.plugin.loadModuleSource).not.toHaveBeenCalled();
     });
 
-    it('strips ?v= cache-busting query param from file path in production', async () => {
-      const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
-      (window as any).clubhouse = { plugin: { loadModuleSource } };
+    it('strips the ?v= cache-busting query param before importing in production', async () => {
+      const fakeModule: PluginModule = {};
+      const cleanUrl = 'file:///plugins/automations/dist/main.js';
 
-      const fn = await loadFn();
-      await fn('file:///plugins/automations/dist/main.js?v=1780813375562').catch(() => {});
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
 
-      expect(loadModuleSource).toHaveBeenCalledWith('/plugins/automations/dist/main.js');
+      await mod.dynamicImportModule(`${cleanUrl}?v=1780813375562`);
+
+      // The query param must be gone — Chromium's ESM loader rejects ?v= on file://.
+      expect(rawImport).toHaveBeenCalledWith(cleanUrl);
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
     });
 
-    it('revokes the blob URL after import in production (cleanup)', async () => {
-      const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
-      (window as any).clubhouse = { plugin: { loadModuleSource } };
+    it('loads a single-file plugin in production without blob-wrapping', async () => {
+      const fakeModule: PluginModule = { activate: vi.fn() };
+      const url = 'file:///plugins/single/main.js';
 
-      const fn = await loadFn();
-      await fn('file:///plugins/automations/dist/main.js').catch(() => {});
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
 
+      const result = await mod.dynamicImportModule(url);
+
+      expect(result).toBe(fakeModule);
+      expect(rawImport).toHaveBeenCalledWith(url);
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
+      expect((window as any).clubhouse.plugin.loadModuleSource).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dev mode — direct-import seam (single-file, blob path)', () => {
+    it('imports the generated blob URL via the raw import seam', async () => {
+      const fakeModule: PluginModule = { activate: vi.fn() };
+      setupDevModeGlobals(fakeModule);
+
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
+
+      const result = await mod.dynamicImportModule('file:///some/plugin/main.js');
+
+      expect(result).toBe(fakeModule);
+      // Dev imports the blob URL (not the file path) to dodge the cross-origin block.
+      expect(rawImport).toHaveBeenCalledWith(FAKE_BLOB_URL);
       expect(URL.revokeObjectURL).toHaveBeenCalledWith(FAKE_BLOB_URL);
     });
   });

--- a/src/renderer/plugins/dynamic-import.ts
+++ b/src/renderer/plugins/dynamic-import.ts
@@ -3,22 +3,47 @@ import type { PluginModule } from '../../shared/plugin-types';
 /**
  * Dynamic import wrapper — in a separate module so tests can mock it.
  *
- * All file:// imports are routed through IPC + blob URL for two reasons:
+ * Two distinct paths, selected by the renderer's origin:
  *
- * 1. Dev mode (renderer on http://localhost): Chromium blocks cross-origin
- *    import() of file:// URLs; blob: avoids this without unsafe-eval.
+ * 1. Dev mode (renderer served from http://localhost by the webpack dev
+ *    server): Chromium's ES module loader blocks cross-origin import() of
+ *    file:// URLs. We read the file via IPC and import from a unique blob:
+ *    URL, which sidesteps the cross-origin restriction without unsafe-eval.
+ *    (A blob: URL has no path component, so a multi-file plugin's relative
+ *    imports cannot resolve — but the cross-origin block leaves dev no other
+ *    option. Production uses the direct path below, which does resolve them.)
  *
- * 2. Production mode (renderer on file://): Chromium's ESM loader does not
- *    support query parameters in file:// URLs, so passing ?v=… cache-busting
- *    params directly to import() causes "Cannot find module" errors.  Routing
- *    through a unique blob URL both strips the query param and provides the
- *    same cache-busting guarantee in production.
+ * 2. Production mode (renderer on file://): import the file:// URL directly so
+ *    the module keeps a real filesystem path and its relative/bare imports
+ *    (e.g. `import './util.js'`) resolve. The renderer is same-origin with the
+ *    plugin files — CSP allows it via `script-src 'self'`, and the files are
+ *    served by the main-process `protocol.handle('file', …)` handler. We strip
+ *    the `?v=` cache-busting query first: Chromium's ESM loader does not
+ *    support query params on file:// URLs and would otherwise fail with
+ *    "Cannot find module …?v=…".
+ *
+ * Routing *all* imports through a blob URL (as #1499 did) broke multi-file
+ * plugins in production, because blob: URLs have no path for relative imports
+ * to resolve against. This wrapper restores the direct production import.
  *
  * The webpackIgnore comment prevents webpack from statically analyzing the import().
  */
+
+/**
+ * Indirection around the native dynamic import. Kept on an object so tests can
+ * spy on it without depending on the runtime's module resolver, while the
+ * webpackIgnore comment still suppresses webpack's static analysis.
+ * @internal — only the export name is internal; the behavior is production code.
+ */
+export const _internals = {
+  rawImport: (specifier: string): Promise<PluginModule> =>
+    import(/* webpackIgnore: true */ specifier),
+};
+
 export async function dynamicImportModule(url: string): Promise<PluginModule> {
-  if (url.startsWith('file:')) {
-    // Strip scheme prefix and any query params to get the filesystem path.
+  if (url.startsWith('file:') && window.location.protocol !== 'file:') {
+    // Dev mode: read the module source via IPC and import from a blob URL.
+    // Strip the scheme prefix and any query params to get the filesystem path.
     const filePath = decodeURIComponent(
       url.replace(/^file:\/\//, '').replace(/\?.*$/, ''),
     );
@@ -26,11 +51,16 @@ export async function dynamicImportModule(url: string): Promise<PluginModule> {
     const blob = new Blob([contents], { type: 'text/javascript' });
     const blobUrl = URL.createObjectURL(blob);
     try {
-      return await import(/* webpackIgnore: true */ blobUrl);
+      return await _internals.rawImport(blobUrl);
     } finally {
       URL.revokeObjectURL(blobUrl);
     }
   }
 
-  return import(/* webpackIgnore: true */ url);
+  // Production (file:// origin) and any non-file URL: import directly so the
+  // module's relative/bare imports resolve against its real path. Strip the
+  // ?v= cache-busting query from file:// URLs — Chromium's ESM loader rejects
+  // query params on file:// URLs.
+  const importUrl = url.startsWith('file:') ? url.replace(/\?.*$/, '') : url;
+  return _internals.rawImport(importUrl);
 }


### PR DESCRIPTION
## Summary
Restores **multi-file third-party plugin loading**, broken in production since **v0.40.0** by #1499 (HIGH severity, hitting a live client).

`#1499` removed the dev-only guard in `dynamic-import.ts` and routed **all** `file://` plugin imports through IPC + a **blob URL**. A `blob:` URL has **no path component**, so any relative or bare import inside a plugin's entry module (e.g. `import './util.js'`) resolved against `blob:file:///<uuid>` → nothing → `Failed to load module: Cannot find module`. Single-file plugins kept working; any plugin with >1 module broke.

## Root cause
`src/renderer/plugins/dynamic-import.ts` blob-wrapped every `file:` URL regardless of origin. Production (renderer on `file://`) is same-origin with the plugin files, so it can — and pre-#1499 did — import them directly with their real path, which is what lets relative/bare imports resolve.

> Note: the pre-#1499 production path was `import(url)` with the `?v=` cache-buster **still attached** — that was #1499's *Bug 2* (Chromium's ESM loader rejects query params on `file://`). So the old guard could not simply be restored verbatim; the fix strips `?v=` **and** imports directly.

## Fix (Part A — production direct `file://` import)
- `dynamic-import.ts`: keep the **dev** (`http:` origin) blob path — it dodges Chromium's cross-origin block on `file://` imports — but in **production** (`file:` origin) strip the `?v=` query and `import()` the `file://` URL **directly**, preserving the real path so relative/bare imports resolve.
- The #1499 `./`-manifest normalization in `plugin-loader.ts` is **kept** (not reverted).
- Added a tiny `_internals.rawImport` seam so the direct-import path is unit-testable (asserts the exact specifier — proving `?v=` stripping).
- Extracted the production CSP to `buildProductionCsp()` and locked `script-src 'self'` (required for same-origin `file://` plugin import) + `blob:` with tests.

### CSP verification
Production CSP is `script-src 'self' 'nonce-…' blob:`; the renderer loads from `file://` and the `protocol.handle('file', …)` handler (#1431) serves the modules, so the same-origin direct import is permitted. CSP does **not** block it. Locked by `buildProductionCsp` tests.

## Part B (custom same-origin protocol) — fast-follow, **not in this PR**
The durable fix (serve modules via a custom privileged scheme so relative imports + cache-busting work in dev *and* prod) requires registering a privileged scheme, a main-process handler, CSP changes, and a plugin-loader URL change — non-trivial and only meaningfully verifiable via Electron E2E. Per the brief's guidance, **Part A ships now to un-break the client; Part B will be a separate PR.** Trade-off: with `?v=` stripped, in-session production hot-reload may return the ESM-cached module (dev is unaffected — blob is always fresh). Pre-#1499 production couldn't load multi-file plugins at all, so this is strictly better; Part B restores prod cache-busting.

## New / updated regression tests
`src/renderer/plugins/dynamic-import.test.ts`:
- **multi-file plugin with relative import — production** imports the `file://` URL directly, no IPC, no blob (the exact case #1499's tests missed)
- **bare/external dependency import** in entry module — direct import
- **`?v=` stripping** in production (asserts the exact cleaned specifier)
- **single-file plugin** — production
- **dev blob path** still imports the generated blob URL (via the seam) and revokes it
- rewrote the prod-mode tests that previously asserted the #1499 (blob) behavior

`src/main/csp-nonce.test.ts`:
- `buildProductionCsp` keeps `script-src 'self'` (plugin import not blocked) + `blob:`, and embeds the nonce

`plugin-loader.test.ts` `./` + nested `./lib/index.js` normalization tests remain green (file untouched).

## Validation
- `npm test` — **12,430 passed, 4 skipped, 0 failures** (490 files)
- `npm run typecheck` — clean
- `eslint .` — 0 errors (2 pre-existing `any` warnings in the test file, not introduced here)

## Review
No self-merge — requesting **QA** + **design-lead** approval per the mission brief.

## Known limitations (tracked → Part B)
- **Production hot-reload cache:** with `?v=` stripped, re-importing the same `file://` module within a session returns the ESM-cached copy, so in-session hot-reload of a community plugin won't pick up on-disk changes in **production**. Dev is unaffected (blob URLs are always unique). Production multi-file plugins were fully broken before this PR, so this is strictly better; the durable fix (unique same-origin URLs via a custom protocol) lands in **Part B** (separate fast-follow PR).
