### PR TITLE
fix(plugins): durable same-origin protocol for plugin module imports (Part B)

### DIFF
--- a/e2e/fixtures/community-plugins/e2e-multifile/dist/lib/nested.js
+++ b/e2e/fixtures/community-plugins/e2e-multifile/dist/lib/nested.js
@@ -1,0 +1,3 @@
+// Deepest sibling — proves transitive relative-import resolution through a
+// nested directory (dist/main.js → ./marker.js → ./lib/nested.js).
+export const NESTED = 'nested-ok';

--- a/e2e/fixtures/community-plugins/e2e-multifile/dist/main.js
+++ b/e2e/fixtures/community-plugins/e2e-multifile/dist/main.js
@@ -1,0 +1,17 @@
+// Entry module for the E2E multi-file fixture plugin.
+//
+// The point of this fixture: the entry imports a sibling (./marker.js), which
+// in turn imports a deeper sibling (./lib/nested.js). Under the #1499 blob-wrap
+// regression these relative imports could not resolve (a blob: URL has no
+// path). With the durable same-origin protocol (Part B), they resolve in both
+// dev and prod. A successful activation — observable via the DOM marker below —
+// is runtime proof that sibling resolution works.
+import { MARKER, NESTED } from './marker.js';
+
+export function activate() {
+  document.documentElement.setAttribute('data-e2e-multifile', `${MARKER}:${NESTED}`);
+}
+
+export function deactivate() {
+  document.documentElement.removeAttribute('data-e2e-multifile');
+}

--- a/e2e/fixtures/community-plugins/e2e-multifile/dist/marker.js
+++ b/e2e/fixtures/community-plugins/e2e-multifile/dist/marker.js
@@ -1,0 +1,7 @@
+// Sibling module imported by the entry (dist/main.js). If relative-import
+// resolution is broken, importing this throws and the plugin fails to activate.
+export const MARKER = 'sibling-resolved-ok';
+
+// A second hop: marker.js itself imports a deeper sibling, so the E2E proves
+// transitive relative resolution, not just one level.
+export { NESTED } from './lib/nested.js';

--- a/e2e/fixtures/community-plugins/e2e-multifile/manifest.json
+++ b/e2e/fixtures/community-plugins/e2e-multifile/manifest.json
@@ -1,0 +1,22 @@
+{
+  "id": "e2e-multifile",
+  "name": "E2E Multi-File Plugin",
+  "version": "1.0.0",
+  "description": "E2E fixture whose entry module imports a sibling module — proves relative-import resolution at runtime.",
+  "author": "Clubhouse E2E",
+  "engine": { "api": 0.8 },
+  "scope": "project",
+  "main": "./dist/main.js",
+  "permissions": [],
+  "contributes": {
+    "help": {
+      "topics": [
+        {
+          "id": "e2e-multifile",
+          "title": "E2E Multi-File Plugin",
+          "content": "Fixture plugin. Its entry `dist/main.js` does `import { MARKER } from './marker.js'` so a successful activation proves the sibling module resolved."
+        }
+      ]
+    }
+  }
+}

--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -18,6 +18,15 @@ export interface LaunchOptions {
    * `CLUBHOUSE_USER_DATA` env var.
    */
   experimental?: Record<string, boolean>;
+
+  /**
+   * Redirect the community-plugins directory to a sandbox via
+   * `CLUBHOUSE_PLUGINS_DIR`. Honored only in unpackaged builds (E2E runs
+   * unpackaged), and feeds both plugin discovery and the `clubhouse-plugin:`
+   * protocol handler's allowed-root. Lets a test install a fixture plugin
+   * without touching the real user dir.
+   */
+  pluginsDir?: string;
 }
 
 /**
@@ -36,6 +45,9 @@ export async function launchApp(opts: LaunchOptions = {}) {
       'utf-8',
     );
     env.CLUBHOUSE_USER_DATA = userDataDir;
+  }
+  if (opts.pluginsDir) {
+    env.CLUBHOUSE_PLUGINS_DIR = opts.pluginsDir;
   }
 
   const electronApp = await electron.launch({

--- a/e2e/plugin-multifile.spec.ts
+++ b/e2e/plugin-multifile.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Part B E2E — durable multi-file plugin loading via the `clubhouse-plugin:`
+ * protocol.
+ *
+ * This is the coverage #1520 structurally could not provide: jsdom/vitest can't
+ * execute a real `import './sibling.js'`, so #1520's regression tests were a
+ * unit proxy. Here we run the REAL Chromium ESM loader in the REAL packaged-style
+ * (file://) renderer, importing a real multi-file fixture plugin over the custom
+ * protocol, and assert its transitive relative imports resolve at runtime.
+ *
+ * We drive `import()` directly in the renderer rather than the full plugin-enable
+ * UI flow: the mechanism Part B changes is module resolution, and this exercises
+ * the actual scheme registration + main-process handler + Chromium relative URL
+ * resolution + CSP + path-version cache-busting end-to-end.
+ *
+ * NOTE: E2E runs only in CI (packaged build); it is not run locally.
+ */
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { launchApp } from './launch';
+
+let electronApp: Awaited<ReturnType<typeof launchApp>>['electronApp'];
+let window: Page;
+let pluginsDir: string;
+
+const FIXTURE_SRC = path.resolve(__dirname, 'fixtures/community-plugins/e2e-multifile');
+
+/**
+ * Build a clubhouse-plugin:// URL — MUST match src/shared/plugin-protocol-url.ts
+ * (kept simple; that format is locked by unit tests). Version in the path so a
+ * new version busts the whole module subtree.
+ */
+function pluginUrl(absFilePath: string, version: number): string {
+  const norm = absFilePath.replace(/\\/g, '/');
+  const withSlash = norm.startsWith('/') ? norm : `/${norm}`;
+  const enc = withSlash
+    .split('/')
+    .map((s) => encodeURIComponent(s).replace(/%3A/gi, ':'))
+    .join('/');
+  return `clubhouse-plugin://plugin/v${version}${enc}`;
+}
+
+/** Import the URL in the renderer, run activate(), return the DOM marker. */
+async function importAndActivate(url: string): Promise<{ ok: boolean; marker: string | null; error?: string }> {
+  return window.evaluate(async (u) => {
+    try {
+      document.documentElement.removeAttribute('data-e2e-multifile');
+      const mod: { activate?: () => void | Promise<void> } = await import(u);
+      await mod.activate?.();
+      return { ok: true, marker: document.documentElement.getAttribute('data-e2e-multifile') };
+    } catch (e) {
+      return { ok: false, marker: null, error: String(e) };
+    }
+  }, url);
+}
+
+test.beforeAll(async () => {
+  // Install the fixture into a sandbox plugins dir the app + handler will use.
+  pluginsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clubhouse-e2e-plugins-'));
+  fs.cpSync(FIXTURE_SRC, path.join(pluginsDir, 'e2e-multifile'), { recursive: true });
+  ({ electronApp, window } = await launchApp({ pluginsDir }));
+  // Sanity: we must be in the packaged-style file:// renderer for this to mean anything.
+  expect(window.url().startsWith('file://')).toBe(true);
+});
+
+test.afterAll(async () => {
+  await electronApp?.close();
+  if (pluginsDir) fs.rmSync(pluginsDir, { recursive: true, force: true });
+});
+
+test.describe('clubhouse-plugin: protocol — real multi-file resolution', () => {
+  const entryAbs = () => path.join(pluginsDir, 'e2e-multifile', 'dist', 'main.js');
+
+  test('resolves transitive relative imports (main → ./marker.js → ./lib/nested.js)', async () => {
+    const res = await importAndActivate(pluginUrl(entryAbs(), Date.now()));
+    expect(res.error ?? '').toBe('');
+    expect(res.ok).toBe(true);
+    // marker = `${MARKER}:${NESTED}` — proves BOTH sibling hops resolved.
+    expect(res.marker).toBe('sibling-resolved-ok:nested-ok');
+  });
+
+  test('a malformed / out-of-root request is denied (404), not served', async () => {
+    // Point at a file outside the plugins root — handler must reject it.
+    const escaped = pluginUrl('/etc/hosts', Date.now());
+    const res = await importAndActivate(escaped);
+    expect(res.ok).toBe(false);
+  });
+
+  test('path-version cache-busting picks up rebuilt sibling code', async () => {
+    const v1 = Date.now();
+    const first = await importAndActivate(pluginUrl(entryAbs(), v1));
+    expect(first.marker).toBe('sibling-resolved-ok:nested-ok');
+
+    // "Rebuild" the deepest sibling.
+    const nestedPath = path.join(pluginsDir, 'e2e-multifile', 'dist', 'lib', 'nested.js');
+    fs.writeFileSync(nestedPath, "export const NESTED = 'nested-RELOADED';\n");
+
+    // Same version → still cached (per-URL immutability).
+    const cached = await importAndActivate(pluginUrl(entryAbs(), v1));
+    expect(cached.marker).toBe('sibling-resolved-ok:nested-ok');
+
+    // New version → whole subtree re-fetched, new sibling code observed.
+    const reloaded = await importAndActivate(pluginUrl(entryAbs(), v1 + 1));
+    expect(reloaded.marker).toBe('sibling-resolved-ok:nested-RELOADED');
+  });
+});

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,6 +11,7 @@ import fs from 'fs';
 
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
+import { buildDevCsp } from './src/main/csp-nonce';
 
 function copyNativeModule(srcRoot: string, destRoot: string, moduleName: string): void {
   const src = path.join(srcRoot, 'node_modules', moduleName);
@@ -125,6 +126,12 @@ const config: ForgeConfig = {
     new WebpackPlugin({
       port: 3456,
       mainConfig,
+      // Dev-only CSP (webpack dev server, http://localhost). Includes the
+      // webpack-HMR relaxations plus the custom `clubhouse-plugin:` scheme so
+      // the dev renderer can import plugin modules over it. Production CSP is
+      // set separately via an HTTP header in src/main/index.ts. Kept in sync
+      // with buildProductionCsp by csp-nonce tests.
+      devContentSecurityPolicy: buildDevCsp(),
       renderer: {
         config: rendererConfig,
         entryPoints: [

--- a/src/main/csp-nonce.test.ts
+++ b/src/main/csp-nonce.test.ts
@@ -32,35 +32,59 @@ describe('csp-nonce', () => {
   });
 });
 
+function scriptSrcOf(csp: string): string {
+  const dir = csp
+    .split(';')
+    .map((d) => d.trim())
+    .find((d) => d.startsWith('script-src'));
+  if (!dir) throw new Error('no script-src directive');
+  return dir;
+}
+
 describe('buildProductionCsp', () => {
   // Regression guard: production plugin loading imports community plugin
-  // modules directly by their same-origin file:// URL. That requires
-  // `script-src 'self'`. If this is ever removed, multi-file plugin loading
-  // breaks again (the #1499 regression class).
-  it("allows same-origin script via script-src 'self' so plugin import is not blocked", async () => {
+  // modules over the custom clubhouse-plugin: scheme. That requires both
+  // `script-src 'self'` and `clubhouse-plugin:`. Removing either re-breaks
+  // plugin loading.
+  it("allows same-origin script via script-src 'self'", async () => {
     const { buildProductionCsp } = await import('./csp-nonce');
-    const csp = buildProductionCsp('test-nonce');
-    const scriptSrc = csp
-      .split(';')
-      .map((d) => d.trim())
-      .find((d) => d.startsWith('script-src'));
-    expect(scriptSrc).toBeDefined();
-    expect(scriptSrc).toContain("'self'");
+    expect(scriptSrcOf(buildProductionCsp('test-nonce'))).toContain("'self'");
   });
 
-  it('keeps blob: in script-src for the dev blob-import path', async () => {
+  it('allows the clubhouse-plugin: scheme in script-src', async () => {
     const { buildProductionCsp } = await import('./csp-nonce');
-    const csp = buildProductionCsp('test-nonce');
-    const scriptSrc = csp
-      .split(';')
-      .map((d) => d.trim())
-      .find((d) => d.startsWith('script-src'))!;
-    expect(scriptSrc).toContain('blob:');
+    expect(scriptSrcOf(buildProductionCsp('test-nonce'))).toContain('clubhouse-plugin:');
+  });
+
+  it('keeps blob: in script-src (workers / dev fallback)', async () => {
+    const { buildProductionCsp } = await import('./csp-nonce');
+    expect(scriptSrcOf(buildProductionCsp('test-nonce'))).toContain('blob:');
+  });
+
+  it('does NOT reintroduce unsafe-eval or data: in production script-src', async () => {
+    const { buildProductionCsp } = await import('./csp-nonce');
+    const scriptSrc = scriptSrcOf(buildProductionCsp('test-nonce'));
+    expect(scriptSrc).not.toContain('unsafe-eval');
+    expect(scriptSrc).not.toContain('data:');
   });
 
   it('embeds the provided nonce in script-src', async () => {
     const { buildProductionCsp } = await import('./csp-nonce');
-    const csp = buildProductionCsp('abc123');
-    expect(csp).toContain("'nonce-abc123'");
+    expect(buildProductionCsp('abc123')).toContain("'nonce-abc123'");
+  });
+});
+
+describe('buildDevCsp', () => {
+  it('allows the clubhouse-plugin: scheme in script-src (dev import path)', async () => {
+    const { buildDevCsp } = await import('./csp-nonce');
+    expect(scriptSrcOf(buildDevCsp())).toContain('clubhouse-plugin:');
+  });
+
+  it('keeps the webpack-HMR relaxations and blob: in dev', async () => {
+    const { buildDevCsp } = await import('./csp-nonce');
+    const scriptSrc = scriptSrcOf(buildDevCsp());
+    expect(scriptSrc).toContain("'unsafe-eval'");
+    expect(scriptSrc).toContain("'unsafe-inline'");
+    expect(scriptSrc).toContain('blob:');
   });
 });

--- a/src/main/csp-nonce.ts
+++ b/src/main/csp-nonce.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'crypto';
+import { PLUGIN_PROTOCOL_SCHEME } from '../shared/plugin-protocol-url';
 
 let _nonce: string | null = null;
 
@@ -15,14 +16,26 @@ export function getCspNonce(): string {
 /**
  * Build the production Content-Security-Policy header value.
  *
- * `script-src` must include `'self'` so the renderer (loaded from file://) can
- * import community plugin modules directly by their file:// URL — they are
- * same-origin and served by the main-process `protocol.handle('file', …)`
- * handler. Removing `'self'` here re-breaks multi-file plugin loading (the
- * #1499 regression class), so the value is locked by a unit test.
+ * `script-src` must include `'self'` (renderer is loaded from file://) and the
+ * custom `clubhouse-plugin:` scheme so the renderer can import community plugin
+ * modules served by the main-process protocol handler (Part B). Removing either
+ * re-breaks plugin loading, so the value is locked by a unit test.
  *
- * `blob:` remains allowed for the dev-mode blob-import path and web workers.
+ * `blob:` remains for web workers (and the dev blob-import fallback). NO
+ * `unsafe-eval`, NO `data:` in script-src — Part B must not regress security.
  */
 export function buildProductionCsp(nonce: string): string {
-  return `default-src 'self' 'unsafe-inline' data:; script-src 'self' 'nonce-${nonce}' blob:; worker-src 'self' blob:`;
+  return `default-src 'self' 'unsafe-inline' data:; script-src 'self' 'nonce-${nonce}' blob: ${PLUGIN_PROTOCOL_SCHEME}:; worker-src 'self' blob:`;
+}
+
+/**
+ * Build the development Content-Security-Policy (used by the webpack dev server
+ * via forge.config.ts). Dev runs the renderer from http://localhost, so it
+ * needs the webpack-HMR relaxations (`unsafe-eval`, `unsafe-inline`) that
+ * production deliberately omits. We add `clubhouse-plugin:` so the dev renderer
+ * can also import plugin modules over the custom scheme (cross-origin, allowed
+ * by the handler's CORS header). Locked by a unit test alongside the prod CSP.
+ */
+export function buildDevCsp(): string {
+  return `default-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob: ${PLUGIN_PROTOCOL_SCHEME}:; worker-src 'self' blob: ${PLUGIN_PROTOCOL_SCHEME}:`;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -281,12 +281,16 @@ app.on('ready', () => {
         (p) => fs.promises.realpath(p),
       );
       const source = await fs.promises.readFile(realPath, 'utf-8');
-      return new Response(source, {
-        headers: {
-          'content-type': 'text/javascript; charset=utf-8',
-          'access-control-allow-origin': '*',
-        },
-      });
+      const headers: Record<string, string> = {
+        'content-type': 'text/javascript; charset=utf-8',
+      };
+      // Dev (renderer on http://localhost) imports cross-origin and needs CORS.
+      // Prod (renderer on file://) is same-origin and does not — scope ACAO to
+      // unpackaged builds to keep the prod posture tight (QA note, Part B).
+      if (!app.isPackaged) {
+        headers['access-control-allow-origin'] = '*';
+      }
+      return new Response(source, { headers });
     } catch (err) {
       appLog('core:plugins', 'warn', 'clubhouse-plugin: request denied', {
         meta: { url: request.url, error: err instanceof Error ? err.message : String(err) },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { app, BrowserWindow, dialog, powerMonitor, session, net } from 'electron';
+import { app, BrowserWindow, dialog, powerMonitor, session, net, protocol } from 'electron';
 import { registerAllHandlers } from './ipc';
 import { killAll, startStaleSweep as startPtyStaleSweep, stopStaleSweep as stopPtyStaleSweep } from './services/pty-manager';
 import { cleanupWatchesForWindow, stopAllWatches } from './services/file-watch-service';
@@ -23,6 +23,9 @@ import { loadPendingResume } from './services/restart-session-service';
 import { applyWindowSecurityGuards } from './window-security-guards';
 import { generateCspNonce, getCspNonce, buildProductionCsp } from './csp-nonce';
 import { initProtocolHandler } from './services/protocol-service';
+import { resolvePluginModulePath } from './plugin-protocol';
+import { PLUGIN_PROTOCOL_SCHEME } from '../shared/plugin-protocol-url';
+import { getCommunityPluginsDir } from './services/plugin-discovery';
 import * as projectStore from './services/project-store';
 
 // Allow overriding userData path for running multiple isolated instances (e.g. testing,
@@ -42,6 +45,25 @@ app.name = 'Clubhouse';
 if (process.platform === 'win32') {
   app.setAppUserModelId('com.mason-allen.clubhouse');
 }
+
+// Register the custom plugin-module scheme as privileged. MUST run before the
+// app 'ready' event (i.e. at module load), per Electron. `standard` makes
+// relative ESM imports resolve via normal URL resolution; `secure` keeps it a
+// secure context; `supportFetchAPI` + `corsEnabled` let the dev renderer
+// (http://localhost) import cross-origin when the handler returns ACAO. The
+// handler itself is wired after 'ready' (see below).
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: PLUGIN_PROTOCOL_SCHEME,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+      stream: true,
+    },
+  },
+]);
 
 // Catch-all handlers for truly unexpected errors. These fire *after* logService.init()
 // has been called (in registerAllHandlers), so early crashes before `ready` won't log —
@@ -244,6 +266,33 @@ app.on('ready', () => {
     }
 
     return net.fetch(request as unknown as Request, { bypassCustomProtocolHandlers: true });
+  });
+
+  // Serve plugin modules over the custom same-origin `clubhouse-plugin:` scheme
+  // (Part B). The path is resolved + validated symlink-safely against the
+  // plugins root; relative imports inside a module resolve back through this
+  // same handler (the version prefix in the path propagates to siblings, giving
+  // cache-busting). CORS header lets the dev renderer (http origin) import it too.
+  session.defaultSession.protocol.handle(PLUGIN_PROTOCOL_SCHEME, async (request) => {
+    try {
+      const realPath = await resolvePluginModulePath(
+        request.url,
+        getCommunityPluginsDir(),
+        (p) => fs.promises.realpath(p),
+      );
+      const source = await fs.promises.readFile(realPath, 'utf-8');
+      return new Response(source, {
+        headers: {
+          'content-type': 'text/javascript; charset=utf-8',
+          'access-control-allow-origin': '*',
+        },
+      });
+    } catch (err) {
+      appLog('core:plugins', 'warn', 'clubhouse-plugin: request denied', {
+        meta: { url: request.url, error: err instanceof Error ? err.message : String(err) },
+      });
+      return new Response('Not found', { status: 404 });
+    }
   });
 
   // Enforce CSP via HTTP header on the main-frame HTML response (production only).

--- a/src/main/plugin-protocol.test.ts
+++ b/src/main/plugin-protocol.test.ts
@@ -53,10 +53,26 @@ describe('resolvePluginModulePath', () => {
   it('rejects a SYMLINK that escapes the root (realpath resolves outside)', async () => {
     const abs = `${ROOT}/p/dist/main.js`;
     const url = buildPluginModuleUrl(abs, 1);
-    // realpath resolves the in-root path to an out-of-root target (symlink escape).
-    const escapingRealpath = vi.fn().mockResolvedValue('/etc/shadow');
+    // The root resolves to itself; only the file's realpath escapes the root.
+    const escapingRealpath = vi.fn().mockImplementation((p: string) =>
+      p === path.resolve(ROOT) ? Promise.resolve(path.resolve(ROOT)) : Promise.resolve('/etc/shadow'),
+    );
     await expect(resolvePluginModulePath(url, ROOT, escapingRealpath)).rejects.toThrow(/Access denied/);
     expect(escapingRealpath).toHaveBeenCalled();
+  });
+
+  it('resolves a symlinked root (realpath of root differs from lexical root)', async () => {
+    // Simulate macOS /var → /private/var: both root and file live under the
+    // resolved prefix, so a file inside the symlinked root is accepted.
+    const lexicalRoot = '/var/tmp-plugins';
+    const realParent = '/private/var/tmp-plugins';
+    const realpathFn = vi.fn().mockImplementation((p: string) =>
+      Promise.resolve(p.replace(/^\/var\//, '/private/var/')),
+    );
+    const url = buildPluginModuleUrl(`${lexicalRoot}/p/dist/main.js`, 1);
+    await expect(resolvePluginModulePath(url, lexicalRoot, realpathFn)).resolves.toBe(
+      `${realParent}/p/dist/main.js`,
+    );
   });
 
   it('propagates a realpath failure (missing file → 404 upstream)', async () => {

--- a/src/main/plugin-protocol.test.ts
+++ b/src/main/plugin-protocol.test.ts
@@ -27,15 +27,16 @@ describe('resolvePluginModulePath', () => {
   it('resolves a valid in-root URL to its real path', async () => {
     const abs = `${ROOT}/automations/dist/main.js`;
     const url = buildPluginModuleUrl(abs, 123);
-    await expect(resolvePluginModulePath(url, ROOT, identityRealpath)).resolves.toBe(abs);
+    // path.resolve() so the expectation matches on Windows (C:\…) too.
+    await expect(resolvePluginModulePath(url, ROOT, identityRealpath)).resolves.toBe(path.resolve(abs));
   });
 
   it('ignores the version prefix when resolving the file', async () => {
     const abs = `${ROOT}/p/dist/main.js`;
     const v1 = await resolvePluginModulePath(buildPluginModuleUrl(abs, 1), ROOT, identityRealpath);
     const v2 = await resolvePluginModulePath(buildPluginModuleUrl(abs, 999), ROOT, identityRealpath);
-    expect(v1).toBe(abs);
-    expect(v2).toBe(abs);
+    expect(v1).toBe(path.resolve(abs));
+    expect(v2).toBe(path.resolve(abs));
   });
 
   it('rejects a malformed / wrong-scheme URL', async () => {
@@ -62,17 +63,17 @@ describe('resolvePluginModulePath', () => {
   });
 
   it('resolves a symlinked root (realpath of root differs from lexical root)', async () => {
-    // Simulate macOS /var → /private/var: both root and file live under the
-    // resolved prefix, so a file inside the symlinked root is accepted.
-    const lexicalRoot = '/var/tmp-plugins';
-    const realParent = '/private/var/tmp-plugins';
+    // Simulate macOS /var → /private/var: realpath maps anything under the
+    // lexical root onto a different real prefix. Built with path.resolve so it
+    // holds on Windows (C:\…) too.
+    const lexicalRoot = path.resolve('/tmp-lexical/plugins');
+    const realRoot = path.resolve('/tmp-real/plugins');
     const realpathFn = vi.fn().mockImplementation((p: string) =>
-      Promise.resolve(p.replace(/^\/var\//, '/private/var/')),
+      Promise.resolve(p.startsWith(lexicalRoot) ? realRoot + p.slice(lexicalRoot.length) : p),
     );
     const url = buildPluginModuleUrl(`${lexicalRoot}/p/dist/main.js`, 1);
-    await expect(resolvePluginModulePath(url, lexicalRoot, realpathFn)).resolves.toBe(
-      `${realParent}/p/dist/main.js`,
-    );
+    const expected = path.join(realRoot, 'p', 'dist', 'main.js');
+    await expect(resolvePluginModulePath(url, lexicalRoot, realpathFn)).resolves.toBe(expected);
   });
 
   it('propagates a realpath failure (missing file → 404 upstream)', async () => {

--- a/src/main/plugin-protocol.test.ts
+++ b/src/main/plugin-protocol.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'path';
+import { isPathWithinRoot, resolvePluginModulePath } from './plugin-protocol';
+import { buildPluginModuleUrl } from '../shared/plugin-protocol-url';
+
+const ROOT = '/home/me/.clubhouse/plugins';
+
+describe('isPathWithinRoot', () => {
+  it('accepts the root and paths under it', () => {
+    expect(isPathWithinRoot(`${ROOT}/p/dist/main.js`, ROOT)).toBe(true);
+    expect(isPathWithinRoot(ROOT, ROOT)).toBe(true);
+  });
+
+  it('rejects sibling-prefix paths (plugins-evil vs plugins)', () => {
+    expect(isPathWithinRoot('/home/me/.clubhouse/plugins-evil/x.js', ROOT)).toBe(false);
+  });
+
+  it('rejects paths outside the root', () => {
+    expect(isPathWithinRoot('/etc/passwd', ROOT)).toBe(false);
+  });
+});
+
+describe('resolvePluginModulePath', () => {
+  // realpath that returns the path unchanged (no symlinks) and pretends it exists.
+  const identityRealpath = (p: string) => Promise.resolve(path.resolve(p));
+
+  it('resolves a valid in-root URL to its real path', async () => {
+    const abs = `${ROOT}/automations/dist/main.js`;
+    const url = buildPluginModuleUrl(abs, 123);
+    await expect(resolvePluginModulePath(url, ROOT, identityRealpath)).resolves.toBe(abs);
+  });
+
+  it('ignores the version prefix when resolving the file', async () => {
+    const abs = `${ROOT}/p/dist/main.js`;
+    const v1 = await resolvePluginModulePath(buildPluginModuleUrl(abs, 1), ROOT, identityRealpath);
+    const v2 = await resolvePluginModulePath(buildPluginModuleUrl(abs, 999), ROOT, identityRealpath);
+    expect(v1).toBe(abs);
+    expect(v2).toBe(abs);
+  });
+
+  it('rejects a malformed / wrong-scheme URL', async () => {
+    await expect(resolvePluginModulePath('file:///x.js', ROOT, identityRealpath)).rejects.toThrow(
+      /Invalid plugin module URL/,
+    );
+  });
+
+  it('rejects a path that escapes the root via ../ (lexical)', async () => {
+    // Construct a URL whose decoded path climbs out of the root.
+    const url = buildPluginModuleUrl(`${ROOT}/../../etc/passwd`, 1);
+    await expect(resolvePluginModulePath(url, ROOT, identityRealpath)).rejects.toThrow(/Access denied/);
+  });
+
+  it('rejects a SYMLINK that escapes the root (realpath resolves outside)', async () => {
+    const abs = `${ROOT}/p/dist/main.js`;
+    const url = buildPluginModuleUrl(abs, 1);
+    // realpath resolves the in-root path to an out-of-root target (symlink escape).
+    const escapingRealpath = vi.fn().mockResolvedValue('/etc/shadow');
+    await expect(resolvePluginModulePath(url, ROOT, escapingRealpath)).rejects.toThrow(/Access denied/);
+    expect(escapingRealpath).toHaveBeenCalled();
+  });
+
+  it('propagates a realpath failure (missing file → 404 upstream)', async () => {
+    const url = buildPluginModuleUrl(`${ROOT}/p/dist/missing.js`, 1);
+    const missingRealpath = vi.fn().mockRejectedValue(new Error('ENOENT'));
+    await expect(resolvePluginModulePath(url, ROOT, missingRealpath)).rejects.toThrow(/ENOENT/);
+  });
+});

--- a/src/main/plugin-protocol.ts
+++ b/src/main/plugin-protocol.ts
@@ -43,9 +43,19 @@ export async function resolvePluginModulePath(
   if (!parsed) {
     throw new Error(`Invalid plugin module URL: ${url}`);
   }
+  // Realpath the ROOT too, then compare realpath-to-realpath. Without this, a
+  // symlinked plugins root (e.g. macOS tmpdir /var → /private/var) makes the
+  // file's realpath fail the startsWith check against the un-resolved root. Fall
+  // back to the lexical root if it can't be resolved (e.g. dir doesn't exist).
+  let realRoot: string;
+  try {
+    realRoot = await realpathFn(path.resolve(pluginsRoot));
+  } catch {
+    realRoot = path.resolve(pluginsRoot);
+  }
   const candidate = path.resolve(parsed.filePath);
   const realPath = await realpathFn(candidate);
-  if (!isPathWithinRoot(realPath, pluginsRoot)) {
+  if (!isPathWithinRoot(realPath, realRoot)) {
     throw new Error(`Access denied: "${parsed.filePath}" is outside the plugins root`);
   }
   return realPath;

--- a/src/main/plugin-protocol.ts
+++ b/src/main/plugin-protocol.ts
@@ -1,0 +1,52 @@
+/**
+ * Main-process resolution + security validation for the `clubhouse-plugin:`
+ * module protocol (Part B). The URL format itself lives in the shared,
+ * renderer-safe `plugin-protocol-url` module; this file adds the parts that are
+ * main-only: filesystem resolution and the symlink-safe within-root check.
+ *
+ * Pure-ish: imports only `path` (no Electron, no direct `fs`). The `realpath`
+ * function is injected so the traversal/symlink-escape logic is fully
+ * unit-testable; the Electron wiring in `index.ts` passes `fs.promises.realpath`.
+ */
+import * as path from 'path';
+import { parsePluginModuleUrl } from '../shared/plugin-protocol-url';
+
+/**
+ * True iff `target` is the root itself or strictly underneath it. Compares
+ * against `root + sep` so `/a/plugins-evil` does NOT match root `/a/plugins`.
+ */
+export function isPathWithinRoot(target: string, root: string): boolean {
+  const normRoot = path.resolve(root);
+  const normTarget = path.resolve(target);
+  return normTarget === normRoot || normTarget.startsWith(normRoot + path.sep);
+}
+
+/**
+ * Resolve a `clubhouse-plugin://` request URL to a real, validated file path.
+ *
+ * Order matters (mirrors the existing PLUGIN.LOAD_MODULE_SOURCE handler):
+ *   1. parse the URL → absolute candidate path
+ *   2. `realpath` it — FOLLOWS symlinks (and throws if the file is missing)
+ *   3. THEN check the realpath is within the plugins root
+ * Doing realpath before the check is what prevents a symlink inside the plugins
+ * dir from pointing outside it and escaping the sandbox.
+ *
+ * Throws on malformed URL, missing file, or out-of-root path. `realpathFn` is
+ * injected for testability.
+ */
+export async function resolvePluginModulePath(
+  url: string,
+  pluginsRoot: string,
+  realpathFn: (p: string) => Promise<string>,
+): Promise<string> {
+  const parsed = parsePluginModuleUrl(url);
+  if (!parsed) {
+    throw new Error(`Invalid plugin module URL: ${url}`);
+  }
+  const candidate = path.resolve(parsed.filePath);
+  const realPath = await realpathFn(candidate);
+  if (!isPathWithinRoot(realPath, pluginsRoot)) {
+    throw new Error(`Access denied: "${parsed.filePath}" is outside the plugins root`);
+  }
+  return realPath;
+}

--- a/src/main/services/plugin-discovery.test.ts
+++ b/src/main/services/plugin-discovery.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
+import { app } from 'electron';
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
@@ -40,6 +41,7 @@ import {
   listProjectPluginInjections,
   cleanupProjectPluginInjections,
   listOrphanedPluginIds,
+  getCommunityPluginsDir,
 } from './plugin-discovery';
 
 const PLUGINS_DIR = path.join(os.tmpdir(), 'clubhouse-test-home', '.clubhouse', 'plugins');
@@ -675,5 +677,36 @@ describe('plugin-discovery', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('getCommunityPluginsDir — CLUBHOUSE_PLUGINS_DIR seam (Part B guardrail)', () => {
+  const ORIG_ENV = process.env.CLUBHOUSE_PLUGINS_DIR;
+  const ORIG_PACKAGED = (app as { isPackaged: boolean }).isPackaged;
+
+  afterEach(() => {
+    if (ORIG_ENV === undefined) delete process.env.CLUBHOUSE_PLUGINS_DIR;
+    else process.env.CLUBHOUSE_PLUGINS_DIR = ORIG_ENV;
+    (app as { isPackaged: boolean }).isPackaged = ORIG_PACKAGED;
+  });
+
+  it('honors CLUBHOUSE_PLUGINS_DIR in an unpackaged (dev/E2E) build', () => {
+    (app as { isPackaged: boolean }).isPackaged = false;
+    process.env.CLUBHOUSE_PLUGINS_DIR = path.join(os.tmpdir(), 'sandbox-plugins');
+    expect(getCommunityPluginsDir()).toBe(path.join(os.tmpdir(), 'sandbox-plugins'));
+  });
+
+  it('IGNORES CLUBHOUSE_PLUGINS_DIR in a packaged build — cannot widen the prod allowed-root', () => {
+    (app as { isPackaged: boolean }).isPackaged = true;
+    process.env.CLUBHOUSE_PLUGINS_DIR = path.join(os.tmpdir(), 'sandbox-plugins');
+    const result = getCommunityPluginsDir();
+    expect(result).not.toBe(path.join(os.tmpdir(), 'sandbox-plugins'));
+    expect(result.endsWith(path.join('.clubhouse', 'plugins'))).toBe(true);
+  });
+
+  it('falls back to the home plugins dir when no override is set', () => {
+    (app as { isPackaged: boolean }).isPackaged = false;
+    delete process.env.CLUBHOUSE_PLUGINS_DIR;
+    expect(getCommunityPluginsDir().endsWith(path.join('.clubhouse', 'plugins'))).toBe(true);
   });
 });

--- a/src/main/services/plugin-discovery.ts
+++ b/src/main/services/plugin-discovery.ts
@@ -13,7 +13,21 @@ function assertSafePluginId(pluginId: string): void {
   }
 }
 
-function getCommunityPluginsDir(): string {
+/**
+ * The directory community/marketplace plugins are discovered from — and the
+ * allowed-root the `clubhouse-plugin:` protocol handler validates against.
+ *
+ * Test/E2E seam: `CLUBHOUSE_PLUGINS_DIR` redirects this to a sandbox so tests
+ * can install fixture plugins without touching the real user dir. It is honored
+ * ONLY in unpackaged builds — a packaged production app always uses the real
+ * home dir, so the env var can never widen the protocol handler's allowed-root
+ * in production (Part B guardrail).
+ */
+export function getCommunityPluginsDir(): string {
+  const override = process.env.CLUBHOUSE_PLUGINS_DIR;
+  if (override && !app.isPackaged) {
+    return override;
+  }
   return path.join(app.getPath('home'), '.clubhouse', 'plugins');
 }
 

--- a/src/renderer/plugins/dynamic-import.test.ts
+++ b/src/renderer/plugins/dynamic-import.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { PluginModule } from '../../shared/plugin-types';
+import { buildPluginModuleUrl } from '../../shared/plugin-protocol-url';
 
 const FAKE_SOURCE = 'export default {}';
 const FAKE_BLOB_URL = 'blob:null/test-uuid';
@@ -12,30 +13,19 @@ function getLoadModuleSource() {
   return (window as unknown as ClubhouseWindow).clubhouse.plugin.loadModuleSource;
 }
 
-function setupDevModeGlobals(mockModule: PluginModule) {
-  // Simulate http: origin (dev mode)
+function setOrigin(protocol: 'file:' | 'http:') {
   Object.defineProperty(window, 'location', {
-    value: { protocol: 'http:' },
-    writable: true,
-    configurable: true,
-  });
-
-  const loadModuleSource = vi.fn().mockResolvedValue(FAKE_SOURCE);
-  (window as any).clubhouse = { plugin: { loadModuleSource } };
-
-  vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
-  vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
-
-  return { loadModuleSource, mockModule };
-}
-
-function setupProdModeGlobals() {
-  Object.defineProperty(window, 'location', {
-    value: { protocol: 'file:' },
+    value: { protocol },
     writable: true,
     configurable: true,
   });
 }
+
+async function loadModule() {
+  return import('./dynamic-import');
+}
+
+const PLUGIN_URL = buildPluginModuleUrl('/Users/me/.clubhouse/plugins/automations/dist/main.js', 1780813375562);
 
 describe('dynamicImportModule', () => {
   afterEach(() => {
@@ -43,185 +33,88 @@ describe('dynamicImportModule', () => {
     vi.resetModules();
   });
 
-  async function loadFn() {
-    const { dynamicImportModule } = await import('./dynamic-import');
-    return dynamicImportModule;
-  }
-
-  async function loadModule() {
-    return import('./dynamic-import');
-  }
-
-  describe('dev mode (non-file: origin)', () => {
-    it('reads module source via IPC for file: URLs', async () => {
+  describe('production (file: origin)', () => {
+    it('imports the clubhouse-plugin: URL directly — no IPC, no blob', async () => {
+      setOrigin('file:');
+      setClubhouse(vi.fn().mockResolvedValue(FAKE_SOURCE));
+      const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
       const fakeModule: PluginModule = { activate: vi.fn() };
-      const { loadModuleSource } = setupDevModeGlobals(fakeModule);
 
-      vi.doMock('blob:null/test-uuid', () => fakeModule, { virtual: true });
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
 
-      const fn = await loadFn();
-      await fn('file:///path/to/plugin/main.js').catch(() => {
-        // import of blob url may fail in jsdom — we only care about side effects
-      });
+      const result = await mod.dynamicImportModule(PLUGIN_URL);
 
-      expect(loadModuleSource).toHaveBeenCalledWith('/path/to/plugin/main.js');
+      expect(result).toBe(fakeModule);
+      expect(rawImport).toHaveBeenCalledWith(PLUGIN_URL);
+      expect(getLoadModuleSource()).not.toHaveBeenCalled();
+      expect(createObjectURL).not.toHaveBeenCalled();
     });
 
-    it('creates a blob URL from the module source', async () => {
-      const fakeModule: PluginModule = {};
-      setupDevModeGlobals(fakeModule);
+    it('does not fall back to blob if the prod import fails (real error surfaces)', async () => {
+      setOrigin('file:');
+      setClubhouse(vi.fn().mockResolvedValue(FAKE_SOURCE));
 
-      const fn = await loadFn();
-      await fn('file:///some/plugin/main.js').catch(() => {});
+      const mod = await loadModule();
+      vi.spyOn(mod._internals, 'rawImport').mockRejectedValue(new Error('boom'));
 
-      expect(URL.createObjectURL).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'text/javascript' }),
-      );
-    });
-
-    it('revokes the blob URL after import (cleanup)', async () => {
-      const fakeModule: PluginModule = {};
-      setupDevModeGlobals(fakeModule);
-
-      const fn = await loadFn();
-      await fn('file:///plugin/main.js').catch(() => {});
-
-      expect(URL.revokeObjectURL).toHaveBeenCalledWith(FAKE_BLOB_URL);
-    });
-
-    it('revokes the blob URL even when import rejects', async () => {
-      setupDevModeGlobals({});
-      // Make the import throw by having a bad URL succeed createObjectURL but fail import
-      // We verify revokeObjectURL is still called via the finally block
-
-      const fn = await loadFn();
-      await fn('file:///bad/plugin.js').catch(() => {});
-
-      // revokeObjectURL should always be called (finally block)
-      expect(URL.revokeObjectURL).toHaveBeenCalled();
-    });
-
-    it('strips cache-busting query params when extracting the file path', async () => {
-      const fakeModule: PluginModule = {};
-      const { loadModuleSource } = setupDevModeGlobals(fakeModule);
-
-      const fn = await loadFn();
-      await fn('file:///path/to/plugin/main.js?v=1234567890').catch(() => {});
-
-      expect(loadModuleSource).toHaveBeenCalledWith('/path/to/plugin/main.js');
-    });
-
-    it('does not use new Function() — no unsafe-eval required', async () => {
-      const originalFunction = globalThis.Function;
-      const functionSpy = vi.fn((...args: unknown[]) => originalFunction(...(args as [string])));
-      globalThis.Function = functionSpy as any;
-
-      const fakeModule: PluginModule = {};
-      setupDevModeGlobals(fakeModule);
-
-      const fn = await loadFn();
-      await fn('file:///plugin/main.js').catch(() => {});
-
-      // Function constructor should NOT be called — we use webpackIgnore import() instead
-      expect(functionSpy).not.toHaveBeenCalled();
-      globalThis.Function = originalFunction;
+      await expect(mod.dynamicImportModule(PLUGIN_URL)).rejects.toThrow('boom');
+      expect(getLoadModuleSource()).not.toHaveBeenCalled();
     });
   });
 
-  describe('production mode (file: origin)', () => {
-    beforeEach(() => {
-      setupProdModeGlobals();
-      // Provide a clubhouse stub + URL spies so we can assert the blob/IPC
-      // path is NOT taken in production (that path is what broke relative
-      // imports in #1499).
+  describe('dev (http: origin)', () => {
+    it('imports the clubhouse-plugin: URL directly when cross-origin import works', async () => {
+      setOrigin('http:');
+      setClubhouse(vi.fn().mockResolvedValue(FAKE_SOURCE));
+      const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
+      const fakeModule: PluginModule = {};
+
+      const mod = await loadModule();
+      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
+
+      const result = await mod.dynamicImportModule(PLUGIN_URL);
+
+      expect(result).toBe(fakeModule);
+      expect(rawImport).toHaveBeenCalledWith(PLUGIN_URL);
+      expect(createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('falls back to IPC + blob when the cross-origin protocol import fails', async () => {
+      setOrigin('http:');
       setClubhouse(vi.fn().mockResolvedValue(FAKE_SOURCE));
       vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_BLOB_URL);
-      vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
-    });
-
-    // The exact case #1499's tests missed: a multi-file plugin whose entry
-    // module does `import './x.js'`. Blob-wrapping (no path) broke this. We
-    // assert production imports the file:// URL DIRECTLY — no IPC, no blob —
-    // which is the prerequisite for the entry module's relative import to
-    // resolve against its real filesystem path.
-    it('imports the file:// URL directly for a multi-file plugin — no IPC, no blob', async () => {
-      const fakeModule: PluginModule = { activate: vi.fn() };
-      const url = 'file:///Users/me/.clubhouse/plugins/automations/dist/main.js';
+      const revoke = vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
+      const blobModule: PluginModule = { activate: vi.fn() };
 
       const mod = await loadModule();
-      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
+      const rawImport = vi
+        .spyOn(mod._internals, 'rawImport')
+        .mockRejectedValueOnce(new Error('cross-origin blocked')) // protocol attempt
+        .mockResolvedValueOnce(blobModule); // blob attempt
 
-      const result = await mod.dynamicImportModule(url);
+      const result = await mod.dynamicImportModule(PLUGIN_URL);
 
-      // Imported directly with the real file:// path — not a blob/IPC copy.
-      expect(result).toBe(fakeModule);
-      expect(rawImport).toHaveBeenCalledWith(url);
-      expect(getLoadModuleSource()).not.toHaveBeenCalled();
-      expect(URL.createObjectURL).not.toHaveBeenCalled();
-    });
-
-    // A bare/external dependency import inside the entry module (e.g.
-    // `import 'some-dep'`) likewise only resolves when the module is imported
-    // directly with its real path — never through a pathless blob URL.
-    it('imports directly for an entry module with a bare dependency import', async () => {
-      const fakeModule: PluginModule = {};
-      const url = 'file:///plugins/with-deps/dist/main.js';
-
-      const mod = await loadModule();
-      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
-
-      const result = await mod.dynamicImportModule(url);
-
-      expect(result).toBe(fakeModule);
-      expect(rawImport).toHaveBeenCalledWith(url);
-      expect(URL.createObjectURL).not.toHaveBeenCalled();
-      expect(getLoadModuleSource()).not.toHaveBeenCalled();
-    });
-
-    it('strips the ?v= cache-busting query param before importing in production', async () => {
-      const fakeModule: PluginModule = {};
-      const cleanUrl = 'file:///plugins/automations/dist/main.js';
-
-      const mod = await loadModule();
-      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
-
-      await mod.dynamicImportModule(`${cleanUrl}?v=1780813375562`);
-
-      // The query param must be gone — Chromium's ESM loader rejects ?v= on file://.
-      expect(rawImport).toHaveBeenCalledWith(cleanUrl);
-      expect(URL.createObjectURL).not.toHaveBeenCalled();
-    });
-
-    it('loads a single-file plugin in production without blob-wrapping', async () => {
-      const fakeModule: PluginModule = { activate: vi.fn() };
-      const url = 'file:///plugins/single/main.js';
-
-      const mod = await loadModule();
-      const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
-
-      const result = await mod.dynamicImportModule(url);
-
-      expect(result).toBe(fakeModule);
-      expect(rawImport).toHaveBeenCalledWith(url);
-      expect(URL.createObjectURL).not.toHaveBeenCalled();
-      expect(getLoadModuleSource()).not.toHaveBeenCalled();
+      expect(result).toBe(blobModule);
+      // Source read for the parsed real file path (version prefix stripped):
+      expect(getLoadModuleSource()).toHaveBeenCalledWith('/Users/me/.clubhouse/plugins/automations/dist/main.js');
+      // First attempt = protocol URL, second = blob URL:
+      expect(rawImport).toHaveBeenNthCalledWith(1, PLUGIN_URL);
+      expect(rawImport).toHaveBeenNthCalledWith(2, FAKE_BLOB_URL);
+      expect(revoke).toHaveBeenCalledWith(FAKE_BLOB_URL);
     });
   });
 
-  describe('dev mode — direct-import seam (single-file, blob path)', () => {
-    it('imports the generated blob URL via the raw import seam', async () => {
-      const fakeModule: PluginModule = { activate: vi.fn() };
-      setupDevModeGlobals(fakeModule);
-
+  describe('non-plugin URLs', () => {
+    it('imports any other URL directly', async () => {
+      setOrigin('file:');
+      const fakeModule: PluginModule = {};
       const mod = await loadModule();
       const rawImport = vi.spyOn(mod._internals, 'rawImport').mockResolvedValue(fakeModule);
 
-      const result = await mod.dynamicImportModule('file:///some/plugin/main.js');
-
+      const result = await mod.dynamicImportModule('https://example.com/x.js');
       expect(result).toBe(fakeModule);
-      // Dev imports the blob URL (not the file path) to dodge the cross-origin block.
-      expect(rawImport).toHaveBeenCalledWith(FAKE_BLOB_URL);
-      expect(URL.revokeObjectURL).toHaveBeenCalledWith(FAKE_BLOB_URL);
+      expect(rawImport).toHaveBeenCalledWith('https://example.com/x.js');
     });
   });
 });

--- a/src/renderer/plugins/dynamic-import.ts
+++ b/src/renderer/plugins/dynamic-import.ts
@@ -1,38 +1,32 @@
 import type { PluginModule } from '../../shared/plugin-types';
+import { PLUGIN_PROTOCOL_SCHEME, parsePluginModuleUrl } from '../../shared/plugin-protocol-url';
 
 /**
  * Dynamic import wrapper — in a separate module so tests can mock it.
  *
- * Two distinct paths, selected by the renderer's origin:
+ * Community plugin modules are served over the custom same-origin
+ * `clubhouse-plugin:` scheme (Part B). Because that scheme is a *standard*
+ * scheme backed by a main-process handler, the module keeps a real path, so its
+ * relative/bare imports resolve — in both dev and prod — and the version prefix
+ * in the URL path provides cache-busting on reload.
  *
- * 1. Dev mode (renderer served from http://localhost by the webpack dev
- *    server): Chromium's ES module loader blocks cross-origin import() of
- *    file:// URLs. We read the file via IPC and import from a unique blob:
- *    URL, which sidesteps the cross-origin restriction without unsafe-eval.
- *    (A blob: URL has no path component, so a multi-file plugin's relative
- *    imports cannot resolve — but the cross-origin block leaves dev no other
- *    option. Production uses the direct path below, which does resolve them.)
- *
- * 2. Production mode (renderer on file://): import the file:// URL directly so
- *    the module keeps a real filesystem path and its relative/bare imports
- *    (e.g. `import './util.js'`) resolve. The renderer is same-origin with the
- *    plugin files — CSP allows it via `script-src 'self'`, and the files are
- *    served by the main-process `protocol.handle('file', …)` handler. We strip
- *    the `?v=` cache-busting query first: Chromium's ESM loader does not
- *    support query params on file:// URLs and would otherwise fail with
- *    "Cannot find module …?v=…".
- *
- * Routing *all* imports through a blob URL (as #1499 did) broke multi-file
- * plugins in production, because blob: URLs have no path for relative imports
- * to resolve against. This wrapper restores the direct production import.
+ * - **Production** (renderer on `file://`): import the `clubhouse-plugin:` URL
+ *   directly. This is the durable path and the one the E2E covers.
+ * - **Dev** (renderer on `http://localhost`): the import is cross-origin. The
+ *   privileged scheme + CORS header are meant to allow it; if a given Electron
+ *   build still blocks it, we fall back to reading the source via IPC and
+ *   importing from a blob URL so dev keeps loading. (Blob URLs have no path, so
+ *   multi-file relative imports are unsupported in that fallback — a long-
+ *   standing dev limitation; production uses the protocol. This is the approved
+ *   dev posture: never weaken CSP or ship a broken dev path to force one route.)
  *
  * The webpackIgnore comment prevents webpack from statically analyzing the import().
  */
 
 /**
- * Indirection around the native dynamic import. Kept on an object so tests can
- * spy on it without depending on the runtime's module resolver, while the
- * webpackIgnore comment still suppresses webpack's static analysis.
+ * Indirection around the native dynamic import so tests can spy on it without
+ * depending on the runtime's module resolver. The webpackIgnore comment still
+ * suppresses webpack's static analysis.
  * @internal — only the export name is internal; the behavior is production code.
  */
 export const _internals = {
@@ -40,27 +34,31 @@ export const _internals = {
     import(/* webpackIgnore: true */ specifier),
 };
 
+async function importViaBlob(filePath: string): Promise<PluginModule> {
+  const contents = await window.clubhouse.plugin.loadModuleSource(filePath);
+  const blob = new Blob([contents], { type: 'text/javascript' });
+  const blobUrl = URL.createObjectURL(blob);
+  try {
+    return await _internals.rawImport(blobUrl);
+  } finally {
+    URL.revokeObjectURL(blobUrl);
+  }
+}
+
 export async function dynamicImportModule(url: string): Promise<PluginModule> {
-  if (url.startsWith('file:') && window.location.protocol !== 'file:') {
-    // Dev mode: read the module source via IPC and import from a blob URL.
-    // Strip the scheme prefix and any query params to get the filesystem path.
-    const filePath = decodeURIComponent(
-      url.replace(/^file:\/\//, '').replace(/\?.*$/, ''),
-    );
-    const contents = await window.clubhouse.plugin.loadModuleSource(filePath);
-    const blob = new Blob([contents], { type: 'text/javascript' });
-    const blobUrl = URL.createObjectURL(blob);
+  const isPluginScheme = url.startsWith(`${PLUGIN_PROTOCOL_SCHEME}:`);
+
+  // Dev (non-file origin): try the protocol, fall back to the blob path so dev
+  // still loads if the cross-origin import is blocked.
+  if (isPluginScheme && window.location.protocol !== 'file:') {
     try {
-      return await _internals.rawImport(blobUrl);
-    } finally {
-      URL.revokeObjectURL(blobUrl);
+      return await _internals.rawImport(url);
+    } catch {
+      const parsed = parsePluginModuleUrl(url);
+      return importViaBlob(parsed?.filePath ?? url);
     }
   }
 
-  // Production (file:// origin) and any non-file URL: import directly so the
-  // module's relative/bare imports resolve against its real path. Strip the
-  // ?v= cache-busting query from file:// URLs — Chromium's ESM loader rejects
-  // query params on file:// URLs.
-  const importUrl = url.startsWith('file:') ? url.replace(/\?.*$/, '') : url;
-  return _internals.rawImport(importUrl);
+  // Production (file: origin) and any other URL: import directly.
+  return _internals.rawImport(url);
 }

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -1083,7 +1083,7 @@ describe('plugin-loader', () => {
   describe('community plugin loading', () => {
     const mockDynamicImport = dynamicImportModule as ReturnType<typeof vi.fn>;
 
-    it('converts unix path to file:// URL for dynamic import', async () => {
+    it('builds a clubhouse-plugin: URL from a unix path for dynamic import', async () => {
       const mod: PluginModule = { activate: vi.fn() };
       mockDynamicImport.mockResolvedValue(mod);
 
@@ -1095,7 +1095,9 @@ describe('plugin-loader', () => {
 
       expect(mockDynamicImport).toHaveBeenCalledTimes(1);
       const importedUrl = mockDynamicImport.mock.calls[0][0] as string;
-      expect(importedUrl).toMatch(/^file:\/\/\/home\/user\/.clubhouse\/plugins\/comm-1\/main\.js\?v=\d+$/);
+      expect(importedUrl).toMatch(
+        /^clubhouse-plugin:\/\/plugin\/v\d+\/home\/user\/\.clubhouse\/plugins\/comm-1\/main\.js$/,
+      );
     });
 
     it('uses custom main path from manifest', async () => {
@@ -1109,12 +1111,12 @@ describe('plugin-loader', () => {
       await activatePlugin('comm-main', 'proj-1', '/p1');
 
       const importedUrl = mockDynamicImport.mock.calls[0][0] as string;
-      expect(importedUrl).toMatch(/^file:\/\/\/plugins\/comm-main\/dist\/index\.js\?v=\d+$/);
+      expect(importedUrl).toMatch(/^clubhouse-plugin:\/\/plugin\/v\d+\/plugins\/comm-main\/dist\/index\.js$/);
     });
 
     it('normalizes ./ prefix in manifest main path', async () => {
-      // Regression: manifest.main of "./dist/main.js" was producing the path
-      // "pluginPath/./dist/main.js" which Chromium's ESM loader cannot resolve.
+      // Regression (#1499): manifest.main of "./dist/main.js" was producing
+      // "pluginPath/./dist/main.js" which the ESM loader cannot resolve. Kept.
       const mod: PluginModule = { activate: vi.fn() };
       mockDynamicImport.mockResolvedValue(mod);
 
@@ -1131,7 +1133,7 @@ describe('plugin-loader', () => {
       // Must NOT contain "/./": the ./ prefix must be stripped before joining.
       expect(importedUrl).not.toContain('/./');
       expect(importedUrl).toMatch(
-        /^file:\/\/\/Users\/masonallen\/.clubhouse\/plugins\/automations\/dist\/main\.js\?v=\d+$/,
+        /^clubhouse-plugin:\/\/plugin\/v\d+\/Users\/masonallen\/\.clubhouse\/plugins\/automations\/dist\/main\.js$/,
       );
     });
 
@@ -1150,7 +1152,7 @@ describe('plugin-loader', () => {
 
       const importedUrl = mockDynamicImport.mock.calls[0][0] as string;
       expect(importedUrl).not.toContain('/./');
-      expect(importedUrl).toMatch(/^file:\/\/\/plugins\/comm-nested\/lib\/index\.js\?v=\d+$/);
+      expect(importedUrl).toMatch(/^clubhouse-plugin:\/\/plugin\/v\d+\/plugins\/comm-nested\/lib\/index\.js$/);
     });
 
     it('sets errored status when dynamic import fails', async () => {
@@ -1214,7 +1216,7 @@ describe('plugin-loader', () => {
       expect(entry.error).toContain('at Plugin.activate');
     });
 
-    it('appends cache-busting query param to import URL', async () => {
+    it('embeds a cache-busting version in the URL path', async () => {
       const mod: PluginModule = {};
       mockDynamicImport.mockResolvedValue(mod);
 
@@ -1226,7 +1228,9 @@ describe('plugin-loader', () => {
       await activatePlugin('comm-cache', 'proj-1', '/p1');
 
       const importedUrl = mockDynamicImport.mock.calls[0][0] as string;
-      const match = importedUrl.match(/\?v=(\d+)$/);
+      // Version lives in the path (v<ts>), not a query — so it propagates to
+      // sibling imports for whole-subtree cache-busting.
+      const match = importedUrl.match(/\/plugin\/v(\d+)\//);
       expect(match).not.toBeNull();
       const timestamp = parseInt(match![1], 10);
       expect(timestamp).toBeGreaterThanOrEqual(before);

--- a/src/renderer/plugins/plugin-loader.ts
+++ b/src/renderer/plugins/plugin-loader.ts
@@ -10,6 +10,7 @@ import { getBuiltinPlugins, getDefaultEnabledIds, type ExperimentalFlags } from 
 import { preRegisterFromManifest } from './canvas-widget-registry';
 import { rendererLog } from './renderer-logger';
 import { dynamicImportModule } from './dynamic-import';
+import { buildPluginModuleUrl } from '../../shared/plugin-protocol-url';
 import { registerTheme, unregisterTheme } from '../themes';
 
 const activeContexts = new Map<string, PluginContext>();
@@ -375,29 +376,26 @@ export async function activatePlugin(
         return;
       }
     } else {
-      // Dynamic import for community plugins
+      // Dynamic import for community plugins.
       // Strip leading "./" from manifest.main so joining doesn't create an
-      // unresolvable "./"-prefixed segment in the final file:// URL.
+      // unresolvable "./"-prefixed segment (kept from #1499).
       const mainPath = (entry.manifest.main || 'main.js').replace(/^\.\//, '');
       const fullModulePath = `${entry.pluginPath}/${mainPath}`;
 
-      // Convert filesystem path to file:// URL for ESM import resolution.
-      // On macOS/Linux paths start with '/', on Windows they start with a drive letter.
-      const moduleUrl = fullModulePath.startsWith('/')
-        ? `file://${fullModulePath}`
-        : `file:///${fullModulePath.replace(/\\/g, '/')}`;
-
-      // Append cache-busting param so re-imports after plugin rebuild
-      // don't return the stale cached module.
-      const cacheBustedUrl = `${moduleUrl}?v=${Date.now()}`;
+      // Serve the module over the custom same-origin `clubhouse-plugin:` scheme
+      // (Part B). Unlike a file:// URL or a pathless blob URL, this lets the
+      // module's relative/bare imports resolve in both dev and prod. The
+      // Date.now() version is embedded in the URL path so a re-import after a
+      // plugin rebuild busts the cache for the entry AND its sibling modules.
+      const moduleUrl = buildPluginModuleUrl(fullModulePath, Date.now());
 
       try {
-        mod = await dynamicImportModule(cacheBustedUrl);
+        mod = await dynamicImportModule(moduleUrl);
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
         const errStack = err instanceof Error ? err.stack : undefined;
         rendererLog('core:plugins', 'error', `Failed to load module for plugin "${pluginId}"`, {
-          meta: { pluginId, modulePath: fullModulePath, moduleUrl: cacheBustedUrl, error: errMsg, stack: errStack },
+          meta: { pluginId, modulePath: fullModulePath, moduleUrl, error: errMsg, stack: errStack },
         });
         store.setPluginStatus(pluginId, 'errored', `Failed to load module: ${errMsg}`);
         return;

--- a/src/shared/plugin-protocol-url.test.ts
+++ b/src/shared/plugin-protocol-url.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PLUGIN_PROTOCOL_SCHEME,
+  PLUGIN_PROTOCOL_HOST,
+  buildPluginModuleUrl,
+  parsePluginModuleUrl,
+} from './plugin-protocol-url';
+
+describe('plugin-protocol-url', () => {
+  describe('buildPluginModuleUrl', () => {
+    it('builds a clubhouse-plugin:// URL with the version in the path', () => {
+      const url = buildPluginModuleUrl('/Users/me/.clubhouse/plugins/automations/dist/main.js', 1780813375562);
+      expect(url).toBe(
+        'clubhouse-plugin://plugin/v1780813375562/Users/me/.clubhouse/plugins/automations/dist/main.js',
+      );
+    });
+
+    it('round-trips through parse', () => {
+      const abs = '/Users/me/.clubhouse/plugins/automations/dist/main.js';
+      const parsed = parsePluginModuleUrl(buildPluginModuleUrl(abs, 42));
+      expect(parsed).toEqual({ version: '42', filePath: abs });
+    });
+
+    it('percent-encodes path segments with spaces, and parse decodes them', () => {
+      const abs = '/Users/me/my plugins/cool plugin/dist/main.js';
+      const url = buildPluginModuleUrl(abs, 1);
+      expect(url).toContain('my%20plugins');
+      expect(parsePluginModuleUrl(url)).toEqual({ version: '1', filePath: abs });
+    });
+
+    it('normalizes Windows backslashes and round-trips the drive-letter path', () => {
+      const url = buildPluginModuleUrl('C:\\Users\\me\\.clubhouse\\plugins\\p\\dist\\main.js', 7);
+      expect(url).toBe('clubhouse-plugin://plugin/v7/C:/Users/me/.clubhouse/plugins/p/dist/main.js');
+      expect(parsePluginModuleUrl(url)).toEqual({
+        version: '7',
+        filePath: 'C:/Users/me/.clubhouse/plugins/p/dist/main.js',
+      });
+    });
+  });
+
+  describe('relative-import resolution (the whole point)', () => {
+    it('resolves a sibling import to the same version prefix', () => {
+      const entry = buildPluginModuleUrl('/p/dist/main.js', 99);
+      // What Chromium's standard-scheme URL resolver produces for `import './util.js'`:
+      const sibling = new URL('./util.js', entry).href;
+      expect(sibling).toBe('clubhouse-plugin://plugin/v99/p/dist/util.js');
+      // And it parses back to the real sibling path with the SAME version → cache-bust propagates.
+      expect(parsePluginModuleUrl(sibling)).toEqual({ version: '99', filePath: '/p/dist/util.js' });
+    });
+
+    it('resolves a nested sibling (../lib/x.js) within the version prefix', () => {
+      const entry = buildPluginModuleUrl('/p/dist/main.js', 5);
+      const nested = new URL('../lib/x.js', entry).href;
+      expect(parsePluginModuleUrl(nested)).toEqual({ version: '5', filePath: '/p/lib/x.js' });
+    });
+  });
+
+  describe('parsePluginModuleUrl — rejects malformed input', () => {
+    it('returns null for a different scheme', () => {
+      expect(parsePluginModuleUrl('file:///p/dist/main.js')).toBeNull();
+      expect(parsePluginModuleUrl('clubhouse://open-file?path=/x')).toBeNull();
+    });
+
+    it('returns null for the wrong host', () => {
+      expect(parsePluginModuleUrl('clubhouse-plugin://evil/v1/p/main.js')).toBeNull();
+    });
+
+    it('returns null when the version prefix is missing', () => {
+      expect(parsePluginModuleUrl('clubhouse-plugin://plugin/p/dist/main.js')).toBeNull();
+    });
+
+    it('returns null for a non-URL string', () => {
+      expect(parsePluginModuleUrl('not a url')).toBeNull();
+    });
+
+    it('exposes stable scheme/host constants', () => {
+      expect(PLUGIN_PROTOCOL_SCHEME).toBe('clubhouse-plugin');
+      expect(PLUGIN_PROTOCOL_HOST).toBe('plugin');
+    });
+  });
+});

--- a/src/shared/plugin-protocol-url.ts
+++ b/src/shared/plugin-protocol-url.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared URL format for the custom `clubhouse-plugin:` module protocol (Part B).
+ *
+ * This is the single source of truth for the URL shape so the renderer (which
+ * BUILDS the URL in plugin-loader) and the main process (which PARSES it in the
+ * protocol handler) can never drift. Pure — no Electron, no fs — so it unit-tests
+ * trivially and can be imported from either layer.
+ *
+ * Shape: `clubhouse-plugin://plugin/v<version>/<absolute-file-path>`
+ *
+ * The cache-busting version lives in the PATH (not a query) on purpose: a custom
+ * standard scheme resolves relative imports via normal URL resolution, so an
+ * entry at `…/v<ts>/<dir>/main.js` resolves `import './util.js'` to
+ * `…/v<ts>/<dir>/util.js` — the version prefix propagates to every sibling, so a
+ * hot-reload (new <ts>) busts the whole module subtree. A query param would NOT
+ * propagate to sibling URLs, leaving them ESM-cached. This also sidesteps the
+ * `?v=`-on-`file://` failure (#1499 Bug 2) entirely.
+ */
+
+export const PLUGIN_PROTOCOL_SCHEME = 'clubhouse-plugin';
+
+/** Fixed authority. The real plugin path lives in the URL path, not the host. */
+export const PLUGIN_PROTOCOL_HOST = 'plugin';
+
+/**
+ * Build a `clubhouse-plugin://` URL for an absolute plugin module path.
+ * `version` is typically `Date.now()` captured at (re)load time for cache-busting.
+ */
+export function buildPluginModuleUrl(absFilePath: string, version: number | string): string {
+  // Normalize Windows backslashes to forward slashes for URL pathing.
+  const normalized = absFilePath.replace(/\\/g, '/');
+  // Guarantee a single leading slash (macOS/Linux already have it; Windows
+  // "C:/…" does not), then percent-encode each segment but keep '/' separators.
+  const withSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
+  // Percent-encode each segment, but keep ':' literal so a Windows drive letter
+  // ("C:") stays readable — ':' is valid in a non-leading URL path segment.
+  const encodedPath = withSlash
+    .split('/')
+    .map((seg) => encodeURIComponent(seg).replace(/%3A/gi, ':'))
+    .join('/');
+  return `${PLUGIN_PROTOCOL_SCHEME}://${PLUGIN_PROTOCOL_HOST}/v${version}${encodedPath}`;
+}
+
+/**
+ * Parse a `clubhouse-plugin://` URL back into its version + absolute file path.
+ * Returns null for anything that isn't a well-formed URL for this scheme/host.
+ * PURE — does no filesystem access or security validation; the caller (main
+ * process) must `realpath` + validate the path is within the plugins root.
+ */
+export function parsePluginModuleUrl(url: string): { version: string; filePath: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== `${PLUGIN_PROTOCOL_SCHEME}:`) return null;
+  if (parsed.hostname !== PLUGIN_PROTOCOL_HOST) return null;
+
+  // pathname is `/v<version>/<abs path…>` (percent-encoded). Decode, then split
+  // the version prefix from the absolute path.
+  const decoded = decodeURIComponent(parsed.pathname);
+  const match = decoded.match(/^\/v([^/]+)(\/.+)$/);
+  if (!match) return null;
+
+  const version = match[1];
+  let filePath = match[2]; // begins with '/'
+
+  // Windows: "/C:/Users/…" → "C:/Users/…"
+  if (/^\/[A-Za-z]:\//.test(filePath)) {
+    filePath = filePath.slice(1);
+  }
+
+  return { version, filePath };
+}


### PR DESCRIPTION
## Summary
Part B of the multi-file plugin loading fix. **#1520** (Part A) un-broke production by importing plugin `file://` URLs directly, but left two gaps it documented: (1) no prod in-session hot-reload cache-busting, and (2) only a *unit proxy* for relative-import resolution (jsdom can't run a real `import './x.js'`). This PR ships the durable fix and closes both.

It replaces #1520's dev-blob / prod-direct split with **one consistent path**: a custom same-origin **`clubhouse-plugin:`** protocol that serves plugin modules from a real path namespace, so relative/bare imports resolve in dev and prod, with cache-busting restored.

This is the fast-follow to **#1520** and the gate for fully closing the live-client **HIGH-sev** plugin regression (broken since v0.40.0).

## How it works
- **Scheme:** `clubhouse-plugin:`, registered privileged before `app.ready` (`standard` + `secure` → relative ESM resolution; `corsEnabled` + handler ACAO → dev cross-origin import). The existing `clubhouse://` OS deep-link scheme is untouched.
- **URL:** `clubhouse-plugin://plugin/v<ts>/<abs-path>`. The cache-bust version lives in the **path**, not a query — so `import './util.js'` resolves to `…/v<ts>/<dir>/util.js`; the version propagates to every sibling, so a reload busts the whole subtree (a query wouldn't propagate). Also sidesteps the `?v=`-on-`file://` failure (#1499 Bug 2).
- **Handler** (`src/main/index.ts`): `protocol.handle('clubhouse-plugin', …)` → `resolvePluginModulePath()` parses the URL, `realpath`s the file **and the root**, validates within the plugins root (symlink-safe), serves JS + `Access-Control-Allow-Origin`.
- **Renderer:** `plugin-loader.ts` builds the URL (keeps the #1499 `./`-manifest fix); `dynamic-import.ts` imports it directly in prod, and in dev tries it then falls back to the #1520 blob path if cross-origin import is blocked.

## Guardrails (from design review)
1. **Symlink-safe:** `realpath` before the within-root check (matches the existing `LOAD_MODULE_SOURCE` handler); root is realpath'd too so a symlinked plugins dir doesn't false-reject. Unit-tested incl. symlink-escape + `../` traversal.
2. **Dev posture:** prod-correct protocol; dev falls back to blob if the cross-origin import is blocked — never weakens CSP, never ships a broken dev path. (Dev multi-file via the protocol is a new improvement when CORS permits; the blob fallback is the historical dev behavior.)
3. **Test seam:** `CLUBHOUSE_PLUGINS_DIR` feeds both discovery and the handler's allowed-root, and is honored **only when `!app.isPackaged`** — it can never widen the allowed-root in a packaged prod build.
4. **CSP locked by test** for prod *and* dev: `clubhouse-plugin:` in `script-src`, `blob:` retained, **no `unsafe-eval`/`data:`** in prod.

## Acceptance criteria
1. ✅ Multi-file plugin with a real relative import loads in dev + prod via the protocol — prod proven by the E2E (below); dev via the protocol with blob fallback.
2. ✅ Single-file plugins still load; no #1520 regression (unit tests).
3. ✅ Prod hot-reload picks up rebuilt code — E2E rewrites a sibling and asserts a new version re-fetches it.
4. ✅ CSP updated + locked by test; no `unsafe-eval`/`data:` reintroduced.
5. ✅ **Electron E2E** (`e2e/plugin-multifile.spec.ts`) proving real transitive sibling resolution (`main → ./marker.js → ./lib/nested.js`) in the real `file://` renderer — the coverage #1520 structurally couldn't give. **Runs in CI** (E2E is not run locally).
6. ⏳ **Manual QA-on-build smoke of the automations plugin on a packaged build** — the HIGH-sev close gate. Pending human/QA on a packaged build (see checklist).
7. ✅ `npm test` (**12,449 pass / 4 skip / 0 fail**), `npm run typecheck` (clean), `eslint .` (0 errors) — all green locally.

## New / changed tests
- `src/shared/plugin-protocol-url.test.ts` — URL build/parse, sibling/nested relative resolution via `new URL()`, Windows drive-letter, malformed rejection.
- `src/main/plugin-protocol.test.ts` — resolver: in-root resolve, `../` traversal denial, **symlink escape** denial, symlinked-root acceptance, missing-file propagation, version ignored.
- `src/main/csp-nonce.test.ts` — prod + dev CSP contain `clubhouse-plugin:` + `blob:`; prod has no `unsafe-eval`/`data:`.
- `src/renderer/plugins/dynamic-import.test.ts` — prod direct import; dev direct + blob fallback; no prod fallback.
- `src/renderer/plugins/plugin-loader.test.ts` — updated to the new URL shape; `./`-manifest normalization retained.
- `e2e/plugin-multifile.spec.ts` + `e2e/fixtures/community-plugins/e2e-multifile/` — the CI E2E.

## ⏳ Reviewer / merge checklist (HIGH-sev close)
- [ ] CI E2E (`plugin-multifile.spec.ts`) green.
- [ ] **Manual smoke:** install the automations plugin, launch a **packaged** build, confirm it loads (no "Cannot find module"); toggle off→on; rebuild the plugin and confirm prod hot-reload picks up changes.

## Notes
- Follows **#1520**; together they close the v0.40.0 HIGH-sev plugin regression.
- No self-merge — requesting independent QA + design-lead waiver (no UI surface) per the mission.
