### PR TITLE
ci: pin release Windows build to windows-2022 (fix VS2026 node-gyp breakage)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,11 @@ jobs:
   build-windows:
     name: Build Windows (${{ matrix.arch }})
     needs: [verify-tag, validate-update-scripts]
-    runs-on: windows-latest
+    # Pin to windows-2022 (VS2022). windows-latest rolled to the windows-2025
+    # image (VS2026), which @electron/node-gyp can't detect, breaking the
+    # node-pty native rebuild during `electron-forge make`. Mirrors the E2E
+    # runner pin from #1509.
+    runs-on: windows-2022
     environment: release
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
The `v0.41.0-beta.1` release pipeline failed: **Build Windows (x64)** and **Build Windows (arm64)** both errored during the `node-pty` native rebuild.

Root cause is the same VS2026 breakage fixed by #1509 — GitHub's `windows-latest` label rolled to the **windows-2025** image (Visual Studio **2026**), which electron-forge's bundled `@electron/node-gyp` can't detect:

```
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
Error: Could not find any Visual Studio installation to use
✖ Preparing native dependencies [FAILED: node-gyp failed to rebuild 'node-pty']
```

#1509 pinned the **validate** workflow's packaging jobs (`e2e`, `e2e-annex`) to `windows-2022`, but the **release** workflow's `build-windows` job was missed and still ran on `windows-latest`.

## Changes
- Pin `build-windows` (`release.yml`) to `windows-2022` (VS2022), which node-gyp detects correctly.
- `validate-update-scripts` keeps `windows-latest` — it only runs vitest and never compiles native modules, so the VS2026 image is fine.

## Test Plan
- [ ] On the next `v*-beta.*` tag, `Build Windows (x64)` and `Build Windows (arm64)` rebuild `node-pty` against VS2022 and produce signed installers
- [ ] macOS / Linux build jobs unchanged
- [ ] `validate-update-scripts` unchanged and green

## Note (out of scope)
The macOS build jobs in the same run failed for an unrelated reason — the Apple Developer Program License Agreement needs to be re-accepted in the Apple Developer account. That's an account/portal action, not a code fix.