### PR TITLE
chore: bump version to 0.41.0-beta.2 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.41.0-beta.1",
+  "version": "0.41.0-beta.2",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Agent Personas & Workflow Improvements

# New Features
- Redesigned built-in agent personas into focused, skill-bundled packs, added a group-pm-polling skill, and renamed "extract pattern" to "extract persona"
- Added built-in Small and Large Squad canvas blueprint templates
- Open files and folders directly from clubhouse:// deep links
- MCP agents now notify you with a toast popup

# Bug Fixes
- Fixed loading of third-party multi-file plugins and made plugin module imports more reliable
- Drag-and-drop agent reordering now works on the first try, without selecting an agent first
- Fixed the orchestrator selector in agent settings to respect the active profile
- Durable agent status now stays accurate after reopening the window, and hooks for stopped agents are cleaned up
- Fixed group project creation silently failing on a fresh Mac
- Improved terminal paste reliability