### PR TITLE
fix(plugins): make community plugins with a JS main launch again (TS-downlevel + CORS + shim path)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,7 @@ import { loadPendingResume } from './services/restart-session-service';
 import { applyWindowSecurityGuards } from './window-security-guards';
 import { generateCspNonce, getCspNonce, buildProductionCsp } from './csp-nonce';
 import { initProtocolHandler } from './services/protocol-service';
-import { resolvePluginModulePath } from './plugin-protocol';
+import { resolvePluginModulePath, pluginModuleResponseHeaders } from './plugin-protocol';
 import { PLUGIN_PROTOCOL_SCHEME } from '../shared/plugin-protocol-url';
 import { getCommunityPluginsDir } from './services/plugin-discovery';
 import * as projectStore from './services/project-store';
@@ -281,16 +281,9 @@ app.on('ready', () => {
         (p) => fs.promises.realpath(p),
       );
       const source = await fs.promises.readFile(realPath, 'utf-8');
-      const headers: Record<string, string> = {
-        'content-type': 'text/javascript; charset=utf-8',
-      };
-      // Dev (renderer on http://localhost) imports cross-origin and needs CORS.
-      // Prod (renderer on file://) is same-origin and does not — scope ACAO to
-      // unpackaged builds to keep the prod posture tight (QA note, Part B).
-      if (!app.isPackaged) {
-        headers['access-control-allow-origin'] = '*';
-      }
-      return new Response(source, { headers });
+      // CORS header is required: importing this scheme is always cross-origin
+      // from the file://-or-http:// renderer. See pluginModuleResponseHeaders.
+      return new Response(source, { headers: pluginModuleResponseHeaders() });
     } catch (err) {
       appLog('core:plugins', 'warn', 'clubhouse-plugin: request denied', {
         meta: { url: request.url, error: err instanceof Error ? err.message : String(err) },

--- a/src/main/plugin-protocol.test.ts
+++ b/src/main/plugin-protocol.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as path from 'path';
-import { isPathWithinRoot, resolvePluginModulePath } from './plugin-protocol';
+import { isPathWithinRoot, resolvePluginModulePath, pluginModuleResponseHeaders } from './plugin-protocol';
 import { buildPluginModuleUrl } from '../shared/plugin-protocol-url';
 
 const ROOT = '/home/me/.clubhouse/plugins';
+
+describe('pluginModuleResponseHeaders', () => {
+  // Regression: a dynamic import() of clubhouse-plugin: is always cross-origin
+  // (renderer is file:// or http://localhost), so the response MUST carry an
+  // Access-Control-Allow-Origin header in EVERY build — not just unpackaged.
+  // Without it the packaged app fails with "Failed to fetch dynamically imported
+  // module" and no plugin with a JS main can launch.
+  it('always sets Access-Control-Allow-Origin (not gated on dev vs packaged)', () => {
+    expect(pluginModuleResponseHeaders()['access-control-allow-origin']).toBe('*');
+  });
+
+  it('serves the module as JavaScript', () => {
+    expect(pluginModuleResponseHeaders()['content-type']).toMatch(/text\/javascript/);
+  });
+});
 
 describe('isPathWithinRoot', () => {
   it('accepts the root and paths under it', () => {

--- a/src/main/plugin-protocol.ts
+++ b/src/main/plugin-protocol.ts
@@ -12,6 +12,27 @@ import * as path from 'path';
 import { parsePluginModuleUrl } from '../shared/plugin-protocol-url';
 
 /**
+ * HTTP response headers for serving a plugin module over the `clubhouse-plugin:`
+ * scheme.
+ *
+ * `Access-Control-Allow-Origin` is mandatory and must NOT be gated on
+ * packaged-vs-dev: a dynamic ESM `import()` of this scheme is ALWAYS
+ * cross-origin, because the renderer's origin is `file://` (prod) or
+ * `http://localhost` (dev) — never `clubhouse-plugin://`. Module fetches use
+ * CORS mode, so a response without this header is rejected by the browser with
+ * "Failed to fetch dynamically imported module", which breaks plugin loading in
+ * every build. (An earlier `!app.isPackaged` gate wrongly assumed prod was
+ * same-origin.) The served file is already validated within the plugins root by
+ * `resolvePluginModulePath`, so allowing any origin to read it is safe.
+ */
+export function pluginModuleResponseHeaders(): Record<string, string> {
+  return {
+    'content-type': 'text/javascript; charset=utf-8',
+    'access-control-allow-origin': '*',
+  };
+}
+
+/**
  * True iff `target` is the root itself or strictly underneath it. Compares
  * against `root + sep` so `/a/plugins-evil` does NOT match root `/a/plugins`.
  */

--- a/src/renderer/import-map.test.ts
+++ b/src/renderer/import-map.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+
+// Regression guard for the v0.40+ plugin-launch failure
+//   TypeError: Failed to fetch dynamically imported module
+// caused by the renderer import map pointing at the WRONG shim path.
+//
+// Layout of the packaged renderer output (forge webpack plugin):
+//   .webpack/renderer/index.html        ← NO: the entry is named 'main_window'
+//   .webpack/renderer/main_window/index.html   ← the actual document
+//   .webpack/renderer/shims/react.js           ← CopyWebpackPlugin: from src/renderer/shims → 'shims'
+//
+// Import-map addresses resolve against the *document's* URL, which is one level
+// deep (main_window/). So the map must use '../shims/…' to climb out to the
+// shims dir. './shims/…' resolves to main_window/shims/… which does not exist →
+// 404 → the plugin's whole module graph fails to fetch. (It only worked in dev,
+// where the dev server serves the entry without the main_window/ segment.)
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(path.join(here, 'index.html'), 'utf-8');
+
+function getImportMap(): Record<string, string> {
+  const m = html.match(/<script type="importmap"[^>]*>([\s\S]*?)<\/script>/);
+  if (!m) throw new Error('no importmap script block found in index.html');
+  return JSON.parse(m[1]).imports as Record<string, string>;
+}
+
+describe('renderer index.html import map', () => {
+  const imports = getImportMap();
+
+  it('maps the React bare specifiers plugins need', () => {
+    expect(Object.keys(imports).sort()).toEqual(
+      ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'].sort(),
+    );
+  });
+
+  it('points shims one level up (../shims), not at the main_window-relative ./shims', () => {
+    for (const [spec, addr] of Object.entries(imports)) {
+      expect(addr, `${spec} → ${addr}`).toMatch(/^\.\.\/shims\//);
+      expect(addr, `${spec} must not be main_window-relative`).not.toMatch(/^\.\/shims\//);
+    }
+  });
+
+  it('resolves each shim to .webpack/renderer/shims from the main_window document', () => {
+    // Simulate resolution against the real document URL.
+    const docUrl = new URL('https://app/.webpack/renderer/main_window/index.html');
+    for (const addr of Object.values(imports)) {
+      const resolved = new URL(addr, docUrl).pathname;
+      expect(resolved.startsWith('/.webpack/renderer/shims/')).toBe(true);
+    }
+  });
+});

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,14 +8,24 @@
     <!-- Import map for community plugin ESM imports.
          Plugins use native ESM dynamic import outside webpack, so bare specifiers
          like 'react' must be resolved via import map. These shim files
-         re-export from the globalThis references set by the renderer entry. -->
+         re-export from the globalThis references set by the renderer entry.
+
+         Paths are '../shims/…', NOT './shims/…': the webpack CopyWebpackPlugin
+         emits the shims at the renderer output ROOT (.webpack/renderer/shims),
+         while this document is the 'main_window' entry one level deeper
+         (.webpack/renderer/main_window/index.html). Import-map addresses resolve
+         against THIS document's URL, so a packaged build needs to climb out of
+         main_window/ to reach them — './shims' 404s in production (it only
+         happened to resolve in dev, where the entry is served without the
+         main_window/ path segment). A 404 here fails the plugin's whole module
+         graph with "Failed to fetch dynamically imported module". -->
     <script type="importmap" nonce="%%NONCE%%">
     {
       "imports": {
-        "react": "./shims/react.js",
-        "react-dom": "./shims/react-dom.js",
-        "react-dom/client": "./shims/react-dom-client.js",
-        "react/jsx-runtime": "./shims/react-jsx-runtime.js"
+        "react": "../shims/react.js",
+        "react-dom": "../shims/react-dom.js",
+        "react-dom/client": "../shims/react-dom-client.js",
+        "react/jsx-runtime": "../shims/react-jsx-runtime.js"
       }
     }
     </script>

--- a/src/renderer/plugins/dynamic-import.ts
+++ b/src/renderer/plugins/dynamic-import.ts
@@ -1,5 +1,6 @@
 import type { PluginModule } from '../../shared/plugin-types';
 import { PLUGIN_PROTOCOL_SCHEME, parsePluginModuleUrl } from '../../shared/plugin-protocol-url';
+import { nativeDynamicImport } from './native-import';
 
 /**
  * Dynamic import wrapper — in a separate module so tests can mock it.
@@ -20,18 +21,20 @@ import { PLUGIN_PROTOCOL_SCHEME, parsePluginModuleUrl } from '../../shared/plugi
  *   standing dev limitation; production uses the protocol. This is the approved
  *   dev posture: never weaken CSP or ship a broken dev path to force one route.)
  *
- * The webpackIgnore comment prevents webpack from statically analyzing the import().
+ * The actual `import()` lives in native-import.js (plain JS). It MUST stay there:
+ * under tsconfig's `module: "commonjs"`, ts-loader downlevels a TS `import()`
+ * into `require()` and drops the `webpackIgnore` comment, which throws
+ * `Cannot find module 'clubhouse-plugin://…'` and never reaches the protocol
+ * handler. See native-import.js for the full rationale.
  */
 
 /**
  * Indirection around the native dynamic import so tests can spy on it without
- * depending on the runtime's module resolver. The webpackIgnore comment still
- * suppresses webpack's static analysis.
+ * depending on the runtime's module resolver.
  * @internal — only the export name is internal; the behavior is production code.
  */
 export const _internals = {
-  rawImport: (specifier: string): Promise<PluginModule> =>
-    import(/* webpackIgnore: true */ specifier),
+  rawImport: (specifier: string): Promise<PluginModule> => nativeDynamicImport(specifier),
 };
 
 async function importViaBlob(filePath: string): Promise<PluginModule> {

--- a/src/renderer/plugins/native-import.d.ts
+++ b/src/renderer/plugins/native-import.d.ts
@@ -1,0 +1,10 @@
+import type { PluginModule } from '../../shared/plugin-types';
+
+/**
+ * Perform a genuine native ESM dynamic `import()` of `specifier`.
+ *
+ * Implemented in plain JavaScript (native-import.js) so ts-loader's commonjs
+ * downlevel does not turn the `import()` into a `require()`. See that file's
+ * header for the full rationale.
+ */
+export function nativeDynamicImport(specifier: string): Promise<PluginModule>;

--- a/src/renderer/plugins/native-import.js
+++ b/src/renderer/plugins/native-import.js
@@ -1,0 +1,25 @@
+// Native ESM dynamic import, deliberately isolated in a plain `.js` module.
+//
+// WHY THIS IS NOT A `.ts` FILE:
+// tsconfig.json sets `module: "commonjs"`, and the ts-loader webpack rule
+// (`test: /\.tsx?$/`) runs over every `.ts`/`.tsx` source. Under commonjs,
+// TypeScript *downlevels* a dynamic `import(x)` into
+// `Promise.resolve(x).then(s => require(s))` — and it strips the
+// `/* webpackIgnore */` magic comment in the process. The result is a webpack
+// `require()` of a runtime string, which throws
+// `Cannot find module 'clubhouse-plugin://…'` at load time and never performs a
+// real ESM fetch (so the main-process protocol handler is never reached). That
+// is exactly the regression that broke community-plugin loading from v0.40.
+//
+// Because the ts-loader rule only matches `.tsx?`, a `.js` file is parsed by
+// webpack directly: webpack honors the `webpackIgnore` magic comment and emits
+// a genuine native `import()`. This is CSP-safe (no `eval`/`new Function`, which
+// the production CSP forbids after the nonce migration) and keeps the
+// `clubhouse-plugin:` URL a real module request that Chromium dispatches to the
+// protocol handler.
+//
+// Keep this file tiny and `.js` — moving the `import()` back into TypeScript
+// re-introduces the downlevel bug. native-import.test.ts guards against that.
+export function nativeDynamicImport(specifier) {
+  return import(/* webpackIgnore: true */ specifier);
+}

--- a/src/renderer/plugins/native-import.test.ts
+++ b/src/renderer/plugins/native-import.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+import ts from 'typescript';
+
+// Regression guard for the v0.40+ plugin-launch failure:
+//   "Cannot find module 'clubhouse-plugin://plugin/v…/…/main.js'"
+//
+// Cause: a dynamic `import()` written in TypeScript and compiled under
+// tsconfig's `module: "commonjs"` is downleveled to `require()`, which dies on
+// the custom scheme and never reaches the protocol handler. The fix moves the
+// real `import()` into a plain `.js` file (native-import.js) that ts-loader does
+// not transform. These tests fail if anyone reverts that.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(path.join(here, rel), 'utf-8');
+
+describe('native dynamic import isolation', () => {
+  // Read the project's real module setting so the test tracks tsconfig.
+  const tsconfig = JSON.parse(read('../../../tsconfig.json'));
+  const projectModule: string = tsconfig.compilerOptions.module;
+
+  it('documents the hazard: TS downlevels import() to require() under the project module setting', () => {
+    const src = 'export const f = (s: string) => import(/* webpackIgnore: true */ s);';
+
+    const cjs = ts.transpileModule(src, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+    }).outputText;
+    // The bug, reproduced: import() is gone, replaced by a require() call.
+    expect(cjs).toMatch(/require\(/);
+    expect(cjs).not.toMatch(/\bimport\(/);
+
+    // Sanity: the project is configured with the module kind that triggers this.
+    expect(projectModule.toLowerCase()).toBe('commonjs');
+
+    // Contrast: an ESM target preserves the native import().
+    const esm = ts.transpileModule(src, {
+      compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+    }).outputText;
+    expect(esm).toMatch(/\bimport\(/);
+    expect(esm).not.toMatch(/require\(/);
+  });
+
+  it('keeps the real dynamic import in a plain .js module webpack does not transform', () => {
+    // The file must be .js (ts-loader rule is /\.tsx?$/), so webpack — not TS —
+    // parses it and honors the webpackIgnore magic comment, leaving a native
+    // import(). A .ts here would re-introduce the require() downlevel.
+    const js = read('./native-import.js');
+    expect(js).toMatch(/\bimport\(/);
+    expect(js).toMatch(/webpackIgnore/);
+    // CSP forbids unsafe-eval in production — the old indirect-eval shim is gone.
+    // Check executable code only (the header comment discusses these by name).
+    const jsCode = js
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    expect(jsCode).not.toMatch(/new Function|\beval\b/);
+  });
+
+  it('routes plugin module loading through the .js helper, never a TS-compiled import()', () => {
+    const loader = read('./dynamic-import.ts');
+    // Delegates to the native helper…
+    expect(loader).toMatch(/from '\.\/native-import'/);
+    expect(loader).toMatch(/nativeDynamicImport/);
+    // …and contains no bare dynamic import() call of its own (comments aside).
+    const codeOnly = loader
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+      .replace(/\/\/[^\n]*/g, ''); // line comments
+    expect(codeOnly).not.toMatch(/\bimport\s*\(/);
+  });
+});


### PR DESCRIPTION
## Summary
Community plugins that ship a JS `main` (e.g. **Automations**, **GitHub Issues**) have failed to launch since **v0.40**. Investigation + validation against a local package build found **three** independent, compounding regressions — all three are needed for a plugin to load. Verified working in a packaged build (Automations + GitHub Issues activate; no `Failed to load module` in `~/.clubhouse/logs`).

The failure was masked in dev/E2E because the dev renderer runs unpackaged and from `http://localhost` — every one of these bugs only bites the packaged `file://` build.

## The three bugs

### 1. TS-commonjs downlevels `import()` → `require()`  →  `Cannot find module 'clubhouse-plugin://…'`
`tsconfig` sets `module: "commonjs"`, so ts-loader compiles the dynamic `import(specifier)` in `dynamic-import.ts` into `Promise.resolve(specifier).then(s => require(s))`, discarding the `/* webpackIgnore */` comment. The shipped bundle confirmed it: `rawImport: e => Promise.resolve(\`${e}\`).then(e => r(n(56464)(e)))`, where webpack module `56464` is the *"Cannot find module"* thrower. It was a CJS `require()` of a URL string, never an ESM fetch — so the protocol handler was never reached.

**Fix:** move the real `import()` into a plain **`.js`** module (`native-import.js`). The ts-loader rule is `/\.tsx?$/`, so a `.js` file is parsed by webpack directly, which honors `webpackIgnore` and emits a genuine native `import()`. CSP-safe (no `eval`/`new Function`, which the production CSP forbids).

### 2. CORS  →  `Failed to fetch dynamically imported module`
The `clubhouse-plugin:` protocol handler only set `Access-Control-Allow-Origin` when `!app.isPackaged`. But a dynamic `import()` of that scheme is **always cross-origin** (renderer origin is `file://`/`http://localhost`, never `clubhouse-plugin://`), so the CORS-mode module fetch is rejected without ACAO. The `!app.isPackaged` gate (comment claimed "prod is same-origin") broke every shipped build.

**Fix:** header construction moved to a pure, unit-tested `pluginModuleResponseHeaders()` that always sets ACAO. The file is already path-validated within the plugins root, so `*` is safe.

### 3. Import-map shim path  →  also `Failed to fetch dynamically imported module`
The renderer import map resolved the react/react-dom shims via `./shims/…`, but the document is emitted at `.webpack/renderer/main_window/index.html` while CopyWebpackPlugin copies the shims to `.webpack/renderer/shims/`. Import-map addresses resolve against the document URL, so `./shims/…` → nonexistent `main_window/shims/…` (404), failing the plugin's module graph.

**Fix:** `./shims/…` → `../shims/…`.

## Verification
- **Packaged build validated by hand** — both plugins load; the log error is gone.
- **Production webpack compile** of `native-import.js` emits a native `import()` (no `require()` downlevel, no module `56464`).
- New regression tests, each confirmed to **fail on pre-fix code**:
  - `native-import.test.ts` — TS-downlevel hazard + helper-is-`.js` + loader delegates.
  - `plugin-protocol.test.ts` — ACAO always set (not gated on packaged).
  - `import-map.test.ts` — shims resolve to `.webpack/renderer/shims` from the `main_window` document.
- `tsc` clean, `eslint` clean, full `main`+`renderer` suites green (**11307 passing**).

## Test plan
- [ ] CI green
- [x] Manual: launch packaged app → Automations + GitHub Issues activate, no `Failed to load module` in `~/.clubhouse/logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)