### PR TITLE
fix(macOS): prevent PTY worker starvation

### DIFF
--- a/e2e/agent-real-cli.spec.ts
+++ b/e2e/agent-real-cli.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect, _electron as electron, Page } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { launchApp } from './launch';
+import { addProject } from './smoke-helpers';
+
+type ElectronApp = Awaited<ReturnType<typeof electron.launch>>;
+
+const RUN_REAL_CLI = process.env.CLUBHOUSE_REAL_CLI_E2E === '1';
+const FIXTURE_DIR = path.resolve(__dirname, 'fixtures/project-agent-transition');
+const AGENTS_DIR = path.join(FIXTURE_DIR, '.clubhouse');
+const AGENTS_JSON = path.join(AGENTS_DIR, 'agents.json');
+const SLEEPER_ID = 'real_cli_sleeping_agent';
+const SLEEPER_NAME = 'real-cli-sleeper';
+const SLEEPER_BRANCH = `${SLEEPER_NAME}/standby`;
+const SLEEPER_WORKTREE = path.join(AGENTS_DIR, SLEEPER_NAME);
+const CREATED_NAME = `real-cli-created-${Date.now()}`;
+const CREATED_BRANCH = `${CREATED_NAME}/standby`;
+const CREATED_WORKTREE = path.join(AGENTS_DIR, CREATED_NAME);
+const PACKAGED_EXECUTABLE = path.resolve(
+  __dirname,
+  '..',
+  'out',
+  `Clubhouse-darwin-${process.arch}`,
+  'Clubhouse.app',
+  'Contents',
+  'MacOS',
+  'clubhouse',
+);
+
+let electronApp: ElectronApp;
+let window: Page;
+let createdAgentId: string | null = null;
+
+function runGit(args: string[]): void {
+  execFileSync('git', args, { cwd: FIXTURE_DIR, stdio: 'pipe' });
+}
+
+function removeWorktree(worktreePath: string, branch: string): void {
+  try {
+    runGit(['worktree', 'remove', worktreePath, '--force']);
+  } catch {
+    fs.rmSync(worktreePath, { recursive: true, force: true });
+    try { runGit(['worktree', 'prune']); } catch { /* best effort */ }
+  }
+  try { runGit(['branch', '-D', branch]); } catch { /* already absent */ }
+}
+
+function prepareSleepingAgent(): void {
+  fs.mkdirSync(AGENTS_DIR, { recursive: true });
+  removeWorktree(SLEEPER_WORKTREE, SLEEPER_BRANCH);
+  removeWorktree(CREATED_WORKTREE, CREATED_BRANCH);
+  runGit(['worktree', 'add', '-b', SLEEPER_BRANCH, SLEEPER_WORKTREE, 'HEAD']);
+  fs.writeFileSync(
+    AGENTS_JSON,
+    JSON.stringify(
+      [{
+        id: SLEEPER_ID,
+        name: SLEEPER_NAME,
+        color: 'green',
+        branch: SLEEPER_BRANCH,
+        worktreePath: SLEEPER_WORKTREE,
+        createdAt: new Date().toISOString(),
+        orchestrator: 'copilot-cli',
+        freeAgentMode: true,
+      }],
+      null,
+      2,
+    ),
+    'utf-8',
+  );
+}
+
+async function ptyBuffer(agentId: string): Promise<string> {
+  return window.evaluate(
+    async (id) => window.clubhouse.pty.getBuffer(id),
+    agentId,
+  );
+}
+
+async function assertCopilotRunning(agentId: string): Promise<void> {
+  await expect.poll(
+    async () => (await ptyBuffer(agentId)).length,
+    { timeout: 30_000 },
+  ).toBeGreaterThan(1_000);
+}
+
+async function assertFilesystemResponsive(): Promise<void> {
+  const responsive = await window.evaluate(async (projectPath) => {
+    try {
+      await Promise.race([
+        window.clubhouse.project.readMcpCatalog(projectPath),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('filesystem IPC timeout')), 3_000);
+        }),
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  }, FIXTURE_DIR);
+  expect(responsive).toBe(true);
+}
+
+test.skip(!RUN_REAL_CLI || process.platform !== 'darwin', 'Set CLUBHOUSE_REAL_CLI_E2E=1 on macOS to run');
+
+test.beforeAll(async () => {
+  expect(fs.existsSync(PACKAGED_EXECUTABLE)).toBe(true);
+  prepareSleepingAgent();
+  ({ electronApp, window } = await launchApp({
+    experimental: {},
+    executablePath: PACKAGED_EXECUTABLE,
+  }));
+  expect(await electronApp.evaluate(() => process.env.UV_THREADPOOL_SIZE)).toBeUndefined();
+  await addProject(electronApp, window, FIXTURE_DIR);
+  await expect(
+    window.locator(`[data-testid="agent-item-${SLEEPER_ID}"]`),
+  ).toBeVisible({ timeout: 15_000 });
+});
+
+test.afterAll(async () => {
+  if (window && !window.isClosed()) {
+    await window.evaluate(async (agentIds) => {
+      for (const agentId of agentIds) {
+        window.clubhouse.pty.write(agentId, '/exit\r');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      await Promise.allSettled(agentIds.map((agentId) => window.clubhouse.pty.kill(agentId)));
+    }, [createdAgentId, SLEEPER_ID].filter((id): id is string => Boolean(id))).catch(() => {});
+  }
+  await electronApp?.close();
+  removeWorktree(CREATED_WORKTREE, CREATED_BRANCH);
+  removeWorktree(SLEEPER_WORKTREE, SLEEPER_BRANCH);
+  fs.rmSync(AGENTS_DIR, { recursive: true, force: true });
+});
+
+test('packaged app creates then wakes real Copilot agents without starving filesystem work', async () => {
+  await window.locator('button:has-text("+ Agent")').first().click();
+  await expect(window.locator('h2:has-text("New Agent")')).toBeVisible({ timeout: 5_000 });
+
+  await window.locator('input[type="text"]').first().fill(CREATED_NAME);
+  await window.getByText('Use git worktree', { exact: false }).click();
+  await window.locator('label:has-text("Orchestrator") select').selectOption('copilot-cli');
+  await window.locator('label:has-text("Free Agent Mode") input').check();
+  await window.locator('button:has-text("Create Agent")').click();
+
+  const createdItem = window.locator(
+    `[data-agent-name="${CREATED_NAME}"][data-testid^="agent-item-durable_"]`,
+  );
+  await expect(createdItem).toBeVisible({ timeout: 20_000 });
+  const createdTestId = await createdItem.getAttribute('data-testid');
+  expect(createdTestId).toMatch(/^agent-item-durable_/);
+  createdAgentId = createdTestId!.slice('agent-item-'.length);
+
+  await assertCopilotRunning(createdAgentId);
+  await assertFilesystemResponsive();
+
+  const sleeperItem = window.locator(`[data-testid="agent-item-${SLEEPER_ID}"]`);
+  await sleeperItem.click();
+  const wakeButton = window.locator('[data-testid="wake-button"]');
+  await expect(wakeButton).toBeVisible({ timeout: 5_000 });
+  await wakeButton.click();
+
+  await assertCopilotRunning(SLEEPER_ID);
+  await window.waitForTimeout(2_000);
+  await expect(createdItem).not.toContainText('Sleeping', { timeout: 5_000 });
+  await expect(sleeperItem).not.toContainText('Sleeping', { timeout: 5_000 });
+  await assertFilesystemResponsive();
+
+  await window.locator('[data-testid="nav-settings"]').click();
+  await expect(window.locator('[data-testid="title-bar"]')).toContainText('Settings', { timeout: 5_000 });
+});

--- a/e2e/fixtures/project-agent-transition/.gitignore
+++ b/e2e/fixtures/project-agent-transition/.gitignore
@@ -1,0 +1,7 @@
+# Clubhouse agent manager
+.clubhouse/agents/
+.clubhouse/.local/
+.clubhouse/agents.json
+.clubhouse/settings.local.json
+
+.clubhouse/agents.json.bak

--- a/e2e/fixtures/project-agent-transition/README.md
+++ b/e2e/fixtures/project-agent-transition/README.md
@@ -1,0 +1,3 @@
+# Agent transition fixture
+
+Used by the Playwright durable-agent create-to-wake regression test.

--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -27,6 +27,9 @@ export interface LaunchOptions {
    * without touching the real user dir.
    */
   pluginsDir?: string;
+
+  /** Launch a packaged Clubhouse executable instead of the webpack entry. */
+  executablePath?: string;
 }
 
 /**
@@ -51,7 +54,8 @@ export async function launchApp(opts: LaunchOptions = {}) {
   }
 
   const electronApp = await electron.launch({
-    args: [MAIN_ENTRY],
+    ...(opts.executablePath ? { executablePath: opts.executablePath } : {}),
+    args: opts.executablePath ? [] : [MAIN_ENTRY],
     cwd: APP_PATH,
     env,
   });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,16 @@ import { PLUGIN_PROTOCOL_SCHEME } from '../shared/plugin-protocol-url';
 import { getCommunityPluginsDir } from './services/plugin-discovery';
 import * as projectStore from './services/project-store';
 
+// On macOS, Electron's readable PTY handles can occupy the default four libuv
+// workers indefinitely, starving every fs.promises operation after an agent
+// starts. Force libuv to initialize a larger app pool, then remove only the
+// value injected here so spawned agent processes do not inherit 64 workers.
+if (process.platform === 'darwin' && !process.env.UV_THREADPOOL_SIZE) {
+  process.env.UV_THREADPOOL_SIZE = '64';
+  fs.stat(process.execPath, () => {});
+  delete process.env.UV_THREADPOOL_SIZE;
+}
+
 // Allow overriding userData path for running multiple isolated instances (e.g. testing,
 // dual-instance Annex V2 workflows). Must be set before app.name so that any early
 // app.getPath('userData') calls after 'ready' resolve to the custom directory.


### PR DESCRIPTION
## Summary
- Prevent macOS PTY sessions from exhausting Electron's default four-worker libuv pool.
- Initialize a larger pool for Clubhouse without leaking `UV_THREADPOOL_SIZE` into spawned agent processes.
- Add an opt-in packaged-app Playwright regression using real Copilot CLI processes and real git worktrees.

## Root cause

On the affected macOS 26 arm64 machine, starting the first `node-pty` session occupied Electron's default libuv workers. Subsequent `fs.promises` requests remained queued, so actions that needed project settings or other filesystem state appeared to hang. This affected create, wake, and delete-adjacent flows even though the renderer and cache-only IPC remained responsive.

The negative control reliably reproduces the problem with `UV_THREADPOOL_SIZE=4`: the created agent stalls at roughly the shell-startup buffer and teardown cannot complete normally. The same packaged workflow passes when Clubhouse initializes a larger pool.

## Changes
- On macOS, temporarily set `UV_THREADPOOL_SIZE=64` and submit `fs.stat(process.execPath)` before startup work queues filesystem I/O.
- Remove only the value injected by Clubhouse immediately after pool initialization, preventing Copilot and other child processes from inheriting 64 workers.
- Extend the Playwright Electron launcher with an optional packaged executable path.
- Add `e2e/agent-real-cli.spec.ts`, gated by `CLUBHOUSE_REAL_CLI_E2E=1`, which:
  - creates a real worktree-backed Copilot agent;
  - verifies substantial PTY output;
  - verifies filesystem IPC remains responsive;
  - wakes a second real worktree-backed Copilot agent;
  - verifies both agents remain live and filesystem IPC still responds;
  - shuts down PTYs gracefully and removes fixture worktrees.

## Investigation / approaches ruled out

The debugging loop also tested these hypotheses, but none are included in this PR because they were not the root cause:

- Missing Claude Code installation — Copilot-only agents reproduced identically.
- Stale worktree metadata and orphaned directories — these explained isolated create failures, not the repeatable second-interaction hang.
- Renderer click routing, active-project mismatches, and individual wake surfaces — Playwright proved the React wake handler entered and remained pending on spawn IPC.
- Temporary `creating_*` terminal rendering and terminal remount behavior — useful diagnostics, but insufficient to resolve the filesystem stall.
- Login-shell command flushing versus direct Copilot spawning — both paths could reach the failure.
- Delete-dialog state persistence and worktree-status inspection — deletion merely exposed the same post-PTY filesystem starvation.
- MCP handler registration and additional lifecycle logging — unrelated to the repeatable hang.
- Larger worker-pool experiments: 4 and 8 reproduced the stall; 16 and 64 passed during diagnosis. The app uses 64 for headroom with multiple concurrent agents.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run package`
- [x] `npm test` — 12,453 passed, 4 skipped
- [x] `npm run lint` — 0 errors (existing warnings remain)
- [x] Negative control: `UV_THREADPOOL_SIZE=4 CLUBHOUSE_REAL_CLI_E2E=1 npx playwright test e2e/agent-real-cli.spec.ts --retries=0` fails by reproducing the stall
- [x] Positive packaged test: `env -u UV_THREADPOOL_SIZE CLUBHOUSE_REAL_CLI_E2E=1 npx playwright test e2e/agent-real-cli.spec.ts --retries=0` passes
- [x] Final staged-diff code review found no significant issues

## Manual Validation

On macOS with Copilot CLI authenticated:

```bash
npm run package
env -u UV_THREADPOOL_SIZE CLUBHOUSE_REAL_CLI_E2E=1 npx playwright test e2e/agent-real-cli.spec.ts --retries=0
```

The test should create one agent, wake a second agent, retain both PTYs, and complete without filesystem IPC timeouts.