### PR TITLE
test(canvas): cover group project creation after MCP enable

### DIFF
--- a/e2e/canvas-group-project-create.spec.ts
+++ b/e2e/canvas-group-project-create.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { launchApp } from './launch';
+import { addProject } from './smoke-helpers';
+
+const FIXTURE_PROJECT = path.resolve(__dirname, 'fixtures/project-group-project');
+const FIXTURE_STATE = path.join(FIXTURE_PROJECT, '.clubhouse');
+const GROUP_PROJECT_WIDGET = 'plugin:group-project:group-project';
+
+let electronApp: Awaited<ReturnType<typeof electron.launch>>;
+let window: Page;
+let userDataDir: string | undefined;
+
+async function navigateToCanvas(page: Page): Promise<void> {
+  const canvasButton = page.locator('[data-testid="explorer-tab-plugin:canvas"]');
+  await expect(canvasButton).toBeVisible({ timeout: 10_000 });
+  await canvasButton.click();
+  await expect(page.locator('[data-testid="canvas-panel"]')).toBeVisible({ timeout: 10_000 });
+}
+
+test.beforeAll(async () => {
+  fs.rmSync(FIXTURE_STATE, { recursive: true, force: true });
+  ({ electronApp, window, userDataDir } = await launchApp({
+    userDataFiles: {
+      'mcp-settings.json': { enabled: false, projectDefault: false },
+    },
+  }));
+  await window.evaluate(async () => {
+    await window.clubhouse.settings.save('mcp', { enabled: true, projectDefault: true });
+  });
+  await window.reload();
+  await window.waitForLoadState('load');
+  await addProject(electronApp, window, FIXTURE_PROJECT);
+  await navigateToCanvas(window);
+});
+
+test.afterAll(async () => {
+  await electronApp?.close();
+  if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
+  fs.rmSync(FIXTURE_STATE, { recursive: true, force: true });
+});
+
+test('creating a group project advances from naming form to initialized card', async () => {
+  const workspace = window.locator('[data-testid="canvas-workspace"]');
+  await expect(workspace).toBeVisible({ timeout: 5_000 });
+
+  const workspaceBox = await workspace.boundingBox();
+  expect(workspaceBox).not.toBeNull();
+  await workspace.dispatchEvent('contextmenu', {
+    bubbles: true,
+    button: 2,
+    clientX: workspaceBox!.x + 220,
+    clientY: workspaceBox!.y + 180,
+  });
+  const contextMenu = window.locator('[data-testid="canvas-context-menu"]');
+  await expect(contextMenu).toBeVisible({ timeout: 5_000 });
+
+  const addGroupProject = window.locator(
+    `[data-testid="canvas-context-menu-${GROUP_PROJECT_WIDGET}"]`,
+  );
+  await expect(addGroupProject).toBeVisible({ timeout: 5_000 });
+  await addGroupProject.dispatchEvent('click');
+
+  const widget = workspace.locator('[data-testid^="canvas-view-cv_"]').first();
+  await expect(widget).toBeVisible({ timeout: 8_000 });
+  const nameInput = widget.locator('input[placeholder="Project name..."]');
+  await expect(nameInput).toBeVisible({ timeout: 5_000 });
+  await nameInput.fill('E2E Group Project');
+  const createButton = widget.getByRole('button', { name: 'Create', exact: true });
+  await expect(createButton).toBeEnabled();
+  await createButton.dispatchEvent('click');
+
+  await expect(nameInput).not.toBeVisible({ timeout: 10_000 });
+  await expect(widget.getByRole('alert')).toHaveCount(0);
+  await expect(widget.getByText('0 agents', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect(widget.getByText('Poll: Off', { exact: true })).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/fixtures/project-group-project/.gitignore
+++ b/e2e/fixtures/project-group-project/.gitignore
@@ -1,0 +1,8 @@
+.clubhouse/plugin-data-local/
+
+# Clubhouse agent manager
+.clubhouse/agents/
+.clubhouse/.local/
+.clubhouse/agents.json
+.clubhouse/agents.json.bak
+.clubhouse/settings.local.json

--- a/e2e/fixtures/project-group-project/README.md
+++ b/e2e/fixtures/project-group-project/README.md
@@ -1,0 +1,3 @@
+# Group project fixture
+
+Used by the Canvas group-project creation regression test.

--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -27,6 +27,12 @@ export interface LaunchOptions {
    * without touching the real user dir.
    */
   pluginsDir?: string;
+
+  /**
+   * JSON files to seed in the isolated Electron userData directory before
+   * launch, keyed by filename (for example `mcp-settings.json`).
+   */
+  userDataFiles?: Record<string, unknown>;
 }
 
 /**
@@ -37,13 +43,29 @@ export interface LaunchOptions {
 export async function launchApp(opts: LaunchOptions = {}) {
   let userDataDir: string | undefined;
   const env = { ...process.env };
-  if (opts.experimental) {
+  if (opts.experimental || opts.userDataFiles) {
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clubhouse-e2e-'));
+  }
+  if (opts.experimental && userDataDir) {
     fs.writeFileSync(
       path.join(userDataDir, 'experimental-settings.json'),
       JSON.stringify(opts.experimental, null, 2),
       'utf-8',
     );
+  }
+  if (opts.userDataFiles && userDataDir) {
+    for (const [filename, value] of Object.entries(opts.userDataFiles)) {
+      if (path.basename(filename) !== filename) {
+        throw new Error(`Invalid userData seed filename: ${filename}`);
+      }
+      fs.writeFileSync(
+        path.join(userDataDir, filename),
+        JSON.stringify(value, null, 2),
+        'utf-8',
+      );
+    }
+  }
+  if (userDataDir) {
     env.CLUBHOUSE_USER_DATA = userDataDir;
   }
   if (opts.pluginsDir) {


### PR DESCRIPTION
## Summary
- Add end-to-end coverage for the fresh-Mac Group Project creation failure fixed by #1516.
- Reproduce the original boot ordering: main starts with MCP disabled, MCP is enabled later in the renderer, and the main process is not restarted.
- Verify Canvas creation advances from the naming form to the initialized, usable Group Project card.

## Context

The reported behavior is already fixed on current `main` by #1516 (`fix: group-project creation silently fails on fresh Mac`). The installed diagnostic build predates that change.

Before #1516, group-project IPC handlers registered only when MCP was enabled at main-process startup. Enabling MCP later made the Canvas widget visible, but `group-project:create` still had no main-process handler. Clicking Create therefore reset the form without initializing the card.

This PR adds the missing E2E regression so that boot-ordering failure cannot return unnoticed.

## Changes
- Extend `launchApp()` with safe, filename-validated JSON seeding for isolated Electron `userData` fixtures.
- Add a dedicated Group Project fixture that ignores generated project-local Canvas state.
- Add a Playwright flow that:
  1. boots main with MCP disabled;
  2. enables MCP through the settings IPC after startup;
  3. reloads only the renderer;
  4. opens a project Canvas;
  5. creates a Group Project from the context menu;
  6. enters a name and clicks Create;
  7. verifies the naming form disappears with no alert;
  8. verifies the initialized card shows `0 agents` and `Poll: Off`.
- Clean isolated userData and project-local Canvas state after the test.

## Test Plan
- [x] `npm run typecheck`
- [x] Focused Playwright test passes
- [x] Focused Playwright test passes 10/10 with retries disabled
- [x] `npm test` passes
- [x] `npm run lint` passes with 0 errors (existing warnings remain)
- [x] Staged-diff code review found no significant issues

## Manual Validation

```bash
npx playwright test e2e/canvas-group-project-create.spec.ts --retries=0
```

Expected: Group Project creation leaves the naming form and displays the initialized card.