### PR TITLE
fix(mcp): align fresh-install defaults in main

### DIFF
--- a/e2e/mcp-fresh-default.spec.ts
+++ b/e2e/mcp-fresh-default.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import * as fs from 'fs';
+import { launchApp } from './launch';
+
+let electronApp: Awaited<ReturnType<typeof electron.launch>>;
+let window: Page;
+let userDataDir: string | undefined;
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp({ experimental: {} }));
+});
+
+test.afterAll(async () => {
+  await electronApp?.close();
+  if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
+});
+
+test('fresh install registers MCP bindings using the shared enabled default', async () => {
+  const result = await window.evaluate(async () => {
+    const settings = await window.clubhouse.settings.get('mcp') as {
+      enabled?: boolean;
+      projectDefault?: boolean;
+    };
+    const groupProject = await window.clubhouse.groupProject.create('Fresh MCP Project') as {
+      id: string;
+      name: string;
+    };
+    await window.clubhouse.mcpBinding.bind('copilot-fresh-agent', {
+      targetId: groupProject.id,
+      targetKind: 'group-project',
+      label: groupProject.name,
+      agentName: 'Copilot Fresh Agent',
+      targetName: groupProject.name,
+    });
+    const bindings = await window.clubhouse.mcpBinding.getBindings();
+    return { settings, groupProject, bindings };
+  });
+
+  expect(result.settings).toMatchObject({ enabled: true, projectDefault: true });
+  expect(result.bindings).toContainEqual(expect.objectContaining({
+    agentId: 'copilot-fresh-agent',
+    targetId: result.groupProject.id,
+    targetKind: 'group-project',
+    agentName: 'Copilot Fresh Agent',
+  }));
+});

--- a/src/main/services/agent-system.test.ts
+++ b/src/main/services/agent-system.test.ts
@@ -68,6 +68,13 @@ vi.mock('./clubhouse-mode-settings', () => ({
   isClubhouseModeEnabled: (...args: unknown[]) => mockIsClubhouseModeEnabled(...args),
 }));
 
+// Most agent-system tests target non-MCP behavior. Enable MCP explicitly only
+// in tests that exercise MCP injection so snapshot assertions stay focused.
+const mockIsMcpEnabled = vi.fn(() => false);
+vi.mock('./mcp-settings', () => ({
+  isMcpEnabled: (...args: unknown[]) => mockIsMcpEnabled(...args),
+}));
+
 // Mock agent-config
 const mockGetDurableConfig = vi.fn(() => null);
 const mockAddSessionEntry = vi.fn();
@@ -238,6 +245,7 @@ import * as os from 'os';
 describe('agent-system', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsMcpEnabled.mockReturnValue(false);
     mockHeadlessSpawn.mockImplementation((agentId: string) => {
       mockIsHeadless.mockImplementation((trackedAgentId: string) => trackedAgentId === agentId);
     });

--- a/src/main/services/clubhouse-mcp/index.ts
+++ b/src/main/services/clubhouse-mcp/index.ts
@@ -2,7 +2,7 @@
  * Clubhouse MCP — public API.
  *
  * Provides agent-to-widget and agent-to-agent interaction via MCP tools.
- * Configured via MCP settings (mcp-settings.json). Defaults to OFF.
+ * Configured via MCP settings (mcp-settings.json).
  */
 
 export { bindingManager } from './binding-manager';

--- a/src/main/services/mcp-settings.test.ts
+++ b/src/main/services/mcp-settings.test.ts
@@ -2,13 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock dependencies before importing the module under test
 vi.mock('./settings-store', () => {
-  let stored: Record<string, unknown> = { enabled: false };
+  let defaults: Record<string, unknown> = {};
+  let stored: Record<string, unknown> = {};
   return {
-    createSettingsStore: vi.fn(() => ({
-      get: () => ({ ...stored }),
-      save: vi.fn(async (settings: Record<string, unknown>) => { stored = { ...settings }; }),
-    })),
-    resetAllSettingsStoresForTests: vi.fn(() => { stored = { enabled: false }; }),
+    createSettingsStore: vi.fn((_filename: string, initial: Record<string, unknown>) => {
+      defaults = { ...initial };
+      stored = { ...initial };
+      return {
+        get: () => ({ ...stored }),
+        save: vi.fn(async (settings: Record<string, unknown>) => { stored = { ...settings }; }),
+      };
+    }),
+    resetAllSettingsStoresForTests: vi.fn(() => { stored = { ...defaults }; }),
   };
 });
 
@@ -31,8 +36,8 @@ describe('mcp-settings', () => {
   });
 
   describe('isMcpEnabled', () => {
-    it('returns false by default', () => {
-      expect(isMcpEnabled()).toBe(false);
+    it('returns true using the shared default', () => {
+      expect(isMcpEnabled()).toBe(true);
     });
 
     it('returns true when globally enabled', async () => {
@@ -51,12 +56,14 @@ describe('mcp-settings', () => {
       expect(isMcpEnabled('/project')).toBe(false);
     });
 
-    it('falls back to clubhouse mode when all disabled', () => {
+    it('falls back to clubhouse mode when all disabled', async () => {
+      await saveSettings({ enabled: false });
       vi.mocked(isClubhouseModeEnabled).mockReturnValue(true);
       expect(isMcpEnabled()).toBe(true);
     });
 
-    it('clubhouse mode fallback receives project path', () => {
+    it('clubhouse mode fallback receives project path', async () => {
+      await saveSettings({ enabled: false });
       vi.mocked(isClubhouseModeEnabled).mockReturnValue(false);
       isMcpEnabled('/my-project');
       expect(isClubhouseModeEnabled).toHaveBeenCalledWith('/my-project');
@@ -64,7 +71,12 @@ describe('mcp-settings', () => {
   });
 
   describe('isMcpEnabledForAny', () => {
-    it('returns false when everything is disabled', () => {
+    it('returns true by default', () => {
+      expect(isMcpEnabledForAny()).toBe(true);
+    });
+
+    it('returns false when everything is disabled', async () => {
+      await saveSettings({ enabled: false });
       expect(isMcpEnabledForAny()).toBe(false);
     });
 
@@ -83,17 +95,20 @@ describe('mcp-settings', () => {
       expect(isMcpEnabledForAny()).toBe(false);
     });
 
-    it('returns true when Clubhouse Mode global toggle is on', () => {
+    it('returns true when Clubhouse Mode global toggle is on', async () => {
+      await saveSettings({ enabled: false });
       cmStored = { enabled: true };
       expect(isMcpEnabledForAny()).toBe(true);
     });
 
-    it('returns true when any Clubhouse Mode project override is true', () => {
+    it('returns true when any Clubhouse Mode project override is true', async () => {
+      await saveSettings({ enabled: false });
       cmStored = { enabled: false, projectOverrides: { '/x': false, '/y': true } };
       expect(isMcpEnabledForAny()).toBe(true);
     });
 
-    it('returns false when all Clubhouse Mode project overrides are false', () => {
+    it('returns false when all Clubhouse Mode project overrides are false', async () => {
+      await saveSettings({ enabled: false });
       cmStored = { enabled: false, projectOverrides: { '/x': false } };
       expect(isMcpEnabledForAny()).toBe(false);
     });

--- a/src/main/services/mcp-settings.ts
+++ b/src/main/services/mcp-settings.ts
@@ -9,11 +9,10 @@
 
 import { createSettingsStore } from './settings-store';
 import { isClubhouseModeEnabled, getSettings as getClubhouseModeSettings } from './clubhouse-mode-settings';
+import { MCP_SETTINGS } from '../../shared/settings-definitions';
 import type { McpSettings } from '../../shared/types';
 
-const store = createSettingsStore<McpSettings>('mcp-settings.json', {
-  enabled: false,
-});
+const store = createSettingsStore<McpSettings>(MCP_SETTINGS.filename, MCP_SETTINGS.defaults);
 
 export const getSettings = store.get;
 export const saveSettings = store.save;


### PR DESCRIPTION
## Summary
- Align main-process MCP defaults with the shared renderer settings definition.
- Ensure fresh installs register MCP binding handlers and start the bridge at boot.
- Restore Copilot Group Project bindings, visible membership, and per-session MCP injection when no settings file exists yet.

## Root cause

The renderer and main process used different defaults for the same `mcp-settings.json` file:

- Shared/renderer default: `{ enabled: true, projectDefault: true }`
- Legacy main-process default: `{ enabled: false }`

On a fresh install with no settings file, the renderer exposed MCP-gated Canvas widgets such as Group Project, while main startup treated MCP as disabled. Consequently:

- `registerMcpBindingHandlers()` returned without registering `mcp-binding:bind`;
- `maybeStartMcpBridge()` did not start the bridge server;
- Canvas wires could not enter `bindingManager`, so Group Project showed no members;
- Copilot spawn could not obtain a bridge port, so no Clubhouse `--additional-mcp-config` was injected.

Persisted user settings were not affected by the mismatch because both services read the same file once it existed.

## Changes
- Make `mcp-settings.ts` consume `MCP_SETTINGS.filename` and `MCP_SETTINGS.defaults` from the shared settings definition.
- Update the main MCP documentation comment to remove the stale “defaults to OFF” claim.
- Update MCP settings tests to derive mock state from the actual supplied defaults and explicitly disable MCP in fallback-specific cases.
- Keep unrelated agent-system tests explicit about MCP being disabled so their hook snapshot assertions remain focused.
- Add a fresh-userData Playwright regression that:
  1. launches with no MCP settings file;
  2. verifies settings report MCP enabled;
  3. creates a Group Project;
  4. binds a Copilot-named agent through main IPC;
  5. verifies the Group Project binding exists with agent metadata.

## Causal validation
- Pre-fix bundle: E2E fails with `No handler registered for 'mcp-binding:bind'`.
- Fixed bundle: the same E2E passes.
- Fixed bundle repeated 10/10 with retries disabled.
- Existing Copilot provider tests verify `buildMcpArgs()` emits valid `--additional-mcp-config` JSON containing the Clubhouse server definition.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run package`
- [x] 169 focused MCP/Copilot tests pass
- [x] 122 agent-system tests pass after explicit MCP isolation
- [x] Fresh-install Playwright regression passes
- [x] Fresh-install Playwright regression passes 10/10
- [x] Full `npm test` passes
- [x] `npm run lint` passes with 0 errors (existing warnings remain)
- [x] Staged-diff code review found no significant issues

## Manual Validation

```bash
npm run package
npx playwright test e2e/mcp-fresh-default.spec.ts --retries=0
```

Expected: a fresh install can create a Group Project and bind a Copilot agent without saving MCP settings first; the binding appears in `getBindings()`.