### PR TITLE
fix(canvas): contain picker wheel scroll so it no longer pans the canvas (#1536)

### DIFF
--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.test.tsx
@@ -153,6 +153,98 @@ describe('AgentCanvasView', () => {
     expect(screen.getByText('Connecting...')).toBeTruthy();
   });
 
+  // ── #1536: picker wheel containment ───────────────────────────────
+  //
+  // Scrolling the picker list must not pan the canvas underneath. The canvas
+  // workspace turns any wheel event that bubbles up to it into a pan (which in
+  // turn calls onViewportChange), so we model that by wrapping the picker in a
+  // parent whose onWheel spy stands in for the workspace pan handler and assert
+  // plain wheel events never reach it — while Ctrl/Cmd+wheel zoom gestures do.
+
+  describe('picker wheel containment', () => {
+    it('stops plain wheel propagation over the agent list (no canvas pan)', () => {
+      const view = makeView({ agentId: null });
+      const api = stubApi({
+        agents: [{ id: 'agent-1', name: 'Alpha', status: 'sleeping', kind: 'durable', projectId: 'proj-1' }],
+      });
+      // Parent onWheel stands in for CanvasWorkspace's pan handler, which would
+      // call onViewportChange for any wheel event that reaches it.
+      const onViewportChange = vi.fn();
+
+      render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <AgentCanvasView view={view} api={api} onUpdate={noop} />
+        </div>
+      );
+
+      const scroll = screen.getByTestId('canvas-agent-picker-scroll');
+      fireEvent.wheel(scroll, { deltaY: 120 });
+
+      expect(onViewportChange).not.toHaveBeenCalled();
+    });
+
+    it('stops plain wheel propagation over the project list (app mode)', () => {
+      const view = makeView({ agentId: null });
+      const api = stubApi({
+        mode: 'app',
+        projects: [{ id: 'proj-1', name: 'Proj', path: '/tmp/proj' }],
+      });
+      const onViewportChange = vi.fn();
+
+      render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <AgentCanvasView view={view} api={api} onUpdate={noop} />
+        </div>
+      );
+
+      // App mode starts on the project-selection step.
+      expect(screen.getByText('Select a project')).toBeTruthy();
+      const scroll = screen.getByTestId('canvas-agent-picker-scroll');
+      fireEvent.wheel(scroll, { deltaY: -120 });
+
+      expect(onViewportChange).not.toHaveBeenCalled();
+    });
+
+    it('lets Ctrl+wheel zoom gestures bubble to the canvas', () => {
+      const view = makeView({ agentId: null });
+      const api = stubApi({
+        agents: [{ id: 'agent-1', name: 'Alpha', status: 'sleeping', kind: 'durable', projectId: 'proj-1' }],
+      });
+      const onViewportChange = vi.fn();
+
+      render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <AgentCanvasView view={view} api={api} onUpdate={noop} />
+        </div>
+      );
+
+      const scroll = screen.getByTestId('canvas-agent-picker-scroll');
+      fireEvent.wheel(scroll, { deltaY: 120, ctrlKey: true });
+
+      // Zoom gesture must reach the workspace so canvas zoom keeps working.
+      expect(onViewportChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets Meta+wheel zoom gestures bubble to the canvas', () => {
+      const view = makeView({ agentId: null });
+      const api = stubApi({
+        agents: [{ id: 'agent-1', name: 'Alpha', status: 'sleeping', kind: 'durable', projectId: 'proj-1' }],
+      });
+      const onViewportChange = vi.fn();
+
+      render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <AgentCanvasView view={view} api={api} onUpdate={noop} />
+        </div>
+      );
+
+      const scroll = screen.getByTestId('canvas-agent-picker-scroll');
+      fireEvent.wheel(scroll, { deltaY: 120, metaKey: true });
+
+      expect(onViewportChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ── LB-M68: create-from-card flow ─────────────────────────────────
 
   describe('"+ New Agent" create-from-card flow', () => {

--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -93,6 +93,20 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
     setSelectedProjectId(null);
   }, []);
 
+  // #1536: Contain plain wheel/trackpad scrolling inside the picker's scroll
+  // regions so it never pans the canvas underneath. The canvas workspace
+  // routes any wheel event that bubbles up to it into a pan (see
+  // useViewportControls.handleWheel), and the card content wrapper only stops
+  // wheel propagation while the view is selected (CanvasView.tsx), so an
+  // unselected — or even selected — picker would otherwise scroll the list AND
+  // pan the canvas at the same time, including at the list's top/bottom
+  // boundary. Ctrl/Cmd+wheel is a canvas zoom gesture and is intentionally
+  // allowed to bubble so zoom keeps working while hovering the picker.
+  const handlePickerWheel = useCallback((e: React.WheelEvent) => {
+    if (e.ctrlKey || e.metaKey) return;
+    e.stopPropagation();
+  }, []);
+
   // Resolve the active project for agent creation
   const activeProjectForCreate = useMemo(() => {
     const pid = isAppMode ? selectedProjectId : api.context.projectId;
@@ -177,7 +191,11 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
           <div className="text-xs font-medium text-ctp-subtext1 uppercase tracking-wider mb-2">
             Select a project
           </div>
-          <div className="flex-1 overflow-y-auto space-y-1">
+          <div
+            className="flex-1 overflow-y-auto overscroll-contain space-y-1"
+            onWheel={handlePickerWheel}
+            data-testid="canvas-agent-picker-scroll"
+          >
             {projects.length === 0 ? (
               <EmptyState title="No projects open" compact />
             ) : (
@@ -232,7 +250,11 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
         <div className="text-xs font-medium text-ctp-subtext1 uppercase tracking-wider mb-2">
           Assign an agent
         </div>
-        <div className="flex-1 overflow-y-auto space-y-1">
+        <div
+          className="flex-1 overflow-y-auto overscroll-contain space-y-1"
+          onWheel={handlePickerWheel}
+          data-testid="canvas-agent-picker-scroll"
+        >
           {filteredAgents.length === 0 ? (
             <EmptyState title={isAppMode ? 'No agents in this project' : 'No agents available'} compact />
           ) : (


### PR DESCRIPTION
## Summary

Fixes #1536. Scrolling the project/agent picker list inside an **unassigned** Agent canvas card also panned the canvas underneath it. The nested list scrolled, but the same wheel/trackpad event bubbled up to the workspace viewport handler (`useViewportControls.handleWheel`), which turned it into a pan — so both surfaces moved at once, and at the list's top/bottom boundary the wheel kept moving the canvas.

## Fix

`src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx`

- Added a `handlePickerWheel` callback that **stops propagation for plain wheel/trackpad events**, so they're consumed by the picker list and never reach the workspace pan handler — including at list boundaries.
- **Ctrl/Cmd+wheel is intentionally allowed to bubble** so the canvas zoom gesture keeps working while hovering the picker (matches the existing `useViewportControls` zoom-vs-pan branch).
- Applied `onWheel={handlePickerWheel}` + `overscroll-contain` to **both** picker scroll regions (project list in app mode, and the agent list).

This works whether the card is selected or unselected: the card content wrapper (`CanvasView.tsx`) only stops wheel propagation while selected, so containing at the scroll region itself covers both cases. Follows the existing containment precedent in `ZoomedViewOverlay.tsx` and `ZoneCard.tsx`.

## Tests

Added a `picker wheel containment` suite to `AgentCanvasView.test.tsx`. A stand-in parent `onWheel` spy models the workspace pan handler (which would call `onViewportChange`):

- Plain wheel over the **agent list** → spy not called.
- Plain wheel over the **project list** (app mode) → spy not called.
- **Ctrl+wheel** and **Meta+wheel** → spy called once (zoom bubbles through).

## Acceptance criteria

- [x] Project list scrolls without panning the canvas.
- [x] Agent list scrolls without panning the canvas.
- [x] Canvas stays stationary at either list boundary (`overscroll-contain` + stopped propagation).
- [x] Works whether the Agent card is selected or unselected.
- [x] Ctrl/Command+wheel zoom preserved (explicitly allowed to bubble).
- [x] Wheel over non-scrollable unselected card content retains canvas-pan behavior (containment scoped to the picker scroll regions only).
- [x] Regression test verifies `onViewportChange` is not called for nested-list scrolling.

## Validation

- `npm run typecheck` — clean
- `npm test` — 12466 passed, 4 skipped (494 files)
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)