### PR TITLE
fix(agents): freeze activity tick during drag so list reorder works with an awake agent selected

### DIFF
--- a/src/renderer/features/agents/AgentList.test.tsx
+++ b/src/renderer/features/agents/AgentList.test.tsx
@@ -824,6 +824,67 @@ describe('AgentList drag-reorder re-render', () => {
     expect(reorderAgents).toHaveBeenCalledWith('/project', ['b', 'c', 'a']);
   });
 
+  // The activity tick re-renders every row every 2 s while any agent streams
+  // pty output. That DOM churn under the drag source aborts the native macOS
+  // HTML5 drag loop, so reordering was impossible whenever the selected agent
+  // was awake (only the selected agent's terminal is mounted, so only it
+  // produces pty data). The tick must stay frozen for the whole gesture.
+  it('freezes the activity tick while a reorder drag is in flight, and resumes after', () => {
+    vi.useFakeTimers();
+    try {
+      let emitPtyData: ((agentId: string) => void) | undefined;
+      window.clubhouse.pty.onData = vi.fn((cb: (agentId: string) => void) => {
+        emitPtyData = cb;
+        return () => {};
+      });
+
+      const a: Agent = { id: 'a', projectId: 'proj-1', name: 'alpha', kind: 'durable', status: 'running', color: 'indigo' };
+      const b: Agent = { id: 'b', projectId: 'proj-1', name: 'bravo', kind: 'durable', status: 'sleeping', color: 'indigo' };
+      useAgentStore.setState({ agents: { a, b }, reorderAgents: vi.fn() });
+
+      render(<AgentList />);
+
+      // Awake agent streams output → tick starts and re-renders the rows.
+      act(() => { emitPtyData!('a'); });
+      isThinkingCaptures.length = 0;
+      act(() => { vi.advanceTimersByTime(4000); });
+      expect(isThinkingCaptures.length).toBeGreaterThan(0);
+
+      const store: Record<string, string> = {};
+      const dataTransfer = {
+        effectAllowed: '',
+        dropEffect: '',
+        setData: (k: string, v: string) => { store[k] = v; },
+        getData: (k: string) => store[k] ?? '',
+      } as unknown as DataTransfer;
+
+      fireEvent.dragStart(screen.getByTestId('durable-drag-0'), { dataTransfer });
+
+      // Mid-drag: continued pty output must not re-render the drag source.
+      isThinkingCaptures.length = 0;
+      act(() => {
+        emitPtyData!('a');
+        vi.advanceTimersByTime(6000);
+        emitPtyData!('a');
+        vi.advanceTimersByTime(6000);
+      });
+      expect(isThinkingCaptures).toEqual([]);
+
+      // Drag over/drop still work while frozen.
+      fireEvent.dragOver(screen.getByTestId('durable-drag-1'), { dataTransfer });
+      fireEvent.drop(screen.getByTestId('durable-drag-1'), { dataTransfer });
+      fireEvent.dragEnd(screen.getByTestId('durable-drag-0'));
+
+      // Drag over → the tick resumes so status labels stay live.
+      isThinkingCaptures.length = 0;
+      act(() => { emitPtyData!('a'); });
+      act(() => { vi.advanceTimersByTime(4000); });
+      expect(isThinkingCaptures.length).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('selects the dragged agent on drag start so reorder needs no prior click (GH #1521)', () => {
     const a: Agent = { id: 'a', projectId: 'proj-1', name: 'alpha', kind: 'durable', status: 'sleeping', color: 'indigo' };
     const b: Agent = { id: 'b', projectId: 'proj-1', name: 'bravo', kind: 'durable', status: 'sleeping', color: 'indigo' };

--- a/src/renderer/features/agents/AgentList.tsx
+++ b/src/renderer/features/agents/AgentList.tsx
@@ -124,6 +124,11 @@ function AgentListInner() {
   // Drag-to-reorder state for durable agents
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const isDragging = dragIndex !== null;
+  // Mirrors `isDragging` for long-lived callbacks (the pty.onData
+  // subscription) that must not re-subscribe on every drag.
+  const isDraggingRef = useRef(false);
+  isDraggingRef.current = isDragging;
 
   // Collapsible completed section (persisted in localStorage)
   const [completedCollapsed, setCompletedCollapsed] = useState(() => {
@@ -158,6 +163,8 @@ function AgentListInner() {
 
     const record = (agentId: string) => {
       activityTimestamps[agentId] = Date.now();
+      // Never start the tick mid-drag — see the tick effect below.
+      if (isDraggingRef.current) return;
       if (!isTickActiveRef.current) {
         isTickActiveRef.current = true;
         setIsTickActive(true);
@@ -191,8 +198,17 @@ function AgentListInner() {
   // Tick for activity status refresh — only while agents have recent activity.
   // The tick also auto-stops after 5 s of inactivity so we don't re-render
   // when the app is idle.
+  //
+  // Suspended while a reorder drag is in flight. The tick re-renders every row
+  // (flipping "Thinking..." labels, the pulse-ring class, and the running-vs-
+  // sleeping action buttons, which re-runs the responsive-collapse
+  // ResizeObserver). That DOM churn underneath the drag source aborts the
+  // native macOS HTML5 drag loop, so a reorder was impossible whenever an
+  // agent was streaming pty output — i.e. whenever the selected agent was
+  // awake, since only the selected agent's terminal is mounted. Refreshing
+  // activity labels mid-drag has no value; resume when the drag ends.
   useEffect(() => {
-    if (!isTickActive) return;
+    if (!isTickActive || isDragging) return;
     const interval = setInterval(() => {
       const now = Date.now();
       const anyRecent = Object.values(activityTimestamps).some(
@@ -205,7 +221,7 @@ function AgentListInner() {
       setTick((t) => t + 1);
     }, 2000);
     return () => clearInterval(interval);
-  }, [isTickActive]);
+  }, [isTickActive, isDragging]);
 
   const { durableAgents, quickAgents, orphanQuickAgents } = useProjectAgentBuckets(
     agents,


### PR DESCRIPTION
## Problem

Drag-to-reorder in the **sidebar agent list** (Explorer → Agents) silently fails whenever the selected agent is awake.

Reported behavior, all three of which this explains:
- Reordering works when a **sleeping** agent is selected ✅
- With a sleeping agent selected, you can even drag an **awake** agent's row ✅
- Once an **awake** agent is the active row, reordering stops working entirely ❌

## Root cause

`AgentList.tsx` runs a `setTick` interval every 2 s while any agent emits pty output (`AgentList.tsx:196-208`). `AgentListItem` is not memoized, so every tick re-renders **every row** — flipping the `"Thinking..."` label, the `animate-pulse-ring` class, and the running-vs-sleeping action buttons, which in turn re-runs the responsive-collapse `ResizeObserver`.

That DOM churn underneath the drag source aborts the native macOS HTML5 drag loop.

The reason the failure tracks the *selected* agent rather than the *dragged* one: only the selected agent's terminal is mounted, so only the selected agent produces pty data. Sleeping selected agent → no pty data → no tick → drag works.

This is the real cause behind the symptom #1521 worked around by force-selecting the dragged row at drag start.

## Fix

Suspend the tick for the duration of a reorder drag, and don't let incoming pty activity restart it mid-gesture (`isDraggingRef` guards the long-lived `pty.onData` subscription so it doesn't re-subscribe per drag). Refreshing activity labels during a drag has no value; the tick resumes on drag end.

Deliberately **not** memoizing `AgentListItem`: its `onSelect`/`onSpawnQuickChild` props are inline closures so `memo` would never bail out, and the row's other churn comes from `agentDetailedStatus` subscriptions *inside* the row, which `memo` can't stop either.

## Testing

New regression test in `AgentList.test.tsx` — drives pty activity, asserts the tick re-renders rows, then asserts **zero** row re-renders across 12 s of continued pty output mid-drag, and that ticking resumes after `dragEnd`.

Verified the test actually catches the bug: with the fix reverted it fails with `expected [ false, false ] to deeply equal []` (two spurious mid-drag re-renders).

- `npm run typecheck` ✅
- `npm test` ✅ 496 files, 12500 passed
- `npm run lint` ✅ 0 errors

⚠️ **Needs real-trackpad QA.** Synthetic input (Playwright / jsdom) cannot reproduce the native macOS drag-cancel, so the unit test pins the *re-render* behavior, not the drag outcome itself. Please confirm by hand: select an awake agent, then drag to reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)