### PR TITLE
fix(canvas): atomic kv writes + quarantine corrupt files to stop silent canvas data loss

### DIFF
--- a/src/main/services/plugin-storage.test.ts
+++ b/src/main/services/plugin-storage.test.ts
@@ -10,6 +10,7 @@ vi.mock('fs/promises', () => ({
   access: vi.fn(),
   readdir: vi.fn(),
   rm: vi.fn(),
+  rename: vi.fn(),
   realpath: vi.fn(),
 }));
 
@@ -50,9 +51,32 @@ describe('plugin-storage', () => {
       );
     });
 
-    it('returns undefined when file does not exist', async () => {
+    it('returns undefined when file does not exist (no quarantine)', async () => {
       vi.mocked(fsp.readFile).mockRejectedValue(new Error('ENOENT'));
       const result = await readKey({ pluginId: 'my-plugin', scope: 'global', key: 'missing' });
+      expect(result).toBeUndefined();
+      // A missing file is a normal fresh-start — must NOT be quarantined.
+      expect(fsp.rename).not.toHaveBeenCalled();
+    });
+
+    it('quarantines a corrupt (invalid-JSON) file instead of silently discarding it', async () => {
+      // Simulate a truncated write from a crash mid-save.
+      vi.mocked(fsp.readFile).mockResolvedValue('[{"id":"canvas_1","views":[{"ty');
+      const result = await readKey({ pluginId: 'canvas', scope: 'global', key: 'canvas-instances' });
+      // Caller sees "no value" so it can fall back...
+      expect(result).toBeUndefined();
+      // ...but the corrupt bytes are preserved to a timestamped sidecar rather
+      // than left in place to be overwritten by the next save.
+      const finalPath = path.join(GLOBAL_BASE, 'canvas', 'kv', 'canvas-instances.json');
+      const renameCall = vi.mocked(fsp.rename).mock.calls[0];
+      expect(renameCall[0]).toBe(finalPath);
+      expect(renameCall[1] as string).toMatch(/canvas-instances\.json\.corrupt-/);
+    });
+
+    it('still returns undefined if quarantining the corrupt file fails', async () => {
+      vi.mocked(fsp.readFile).mockResolvedValue('not json');
+      vi.mocked(fsp.rename).mockRejectedValueOnce(new Error('EPERM'));
+      const result = await readKey({ pluginId: 'canvas', scope: 'global', key: 'canvas-instances' });
       expect(result).toBeUndefined();
     });
 
@@ -74,17 +98,33 @@ describe('plugin-storage', () => {
   });
 
   describe('writeKey', () => {
-    it('writes JSON to kv directory and ensures dir exists', async () => {
+    it('writes JSON atomically (temp file then rename) and ensures dir exists', async () => {
       await writeKey({ pluginId: 'my-plugin', scope: 'global', key: 'config', value: { a: 1 } });
+      const finalPath = path.join(GLOBAL_BASE, 'my-plugin', 'kv', 'config.json');
       expect(fsp.mkdir).toHaveBeenCalledWith(
         path.join(GLOBAL_BASE, 'my-plugin', 'kv'),
         { recursive: true },
       );
-      expect(fsp.writeFile).toHaveBeenCalledWith(
-        path.join(GLOBAL_BASE, 'my-plugin', 'kv', 'config.json'),
-        JSON.stringify({ a: 1 }),
-        'utf-8',
-      );
+      // Content is written to a temp sibling, never directly to the destination.
+      const writeCall = vi.mocked(fsp.writeFile).mock.calls[0];
+      const tmpPath = writeCall[0] as string;
+      expect(tmpPath).toMatch(/config\.json\.tmp-/);
+      expect(writeCall[1]).toBe(JSON.stringify({ a: 1 }));
+      expect(fsp.writeFile).not.toHaveBeenCalledWith(finalPath, expect.anything(), expect.anything());
+      // Then atomically renamed over the real file.
+      expect(fsp.rename).toHaveBeenCalledWith(tmpPath, finalPath);
+    });
+
+    it('cleans up the temp file and rethrows if the write fails', async () => {
+      vi.mocked(fsp.writeFile).mockRejectedValueOnce(new Error('disk full'));
+      await expect(
+        writeKey({ pluginId: 'my-plugin', scope: 'global', key: 'config', value: { a: 1 } }),
+      ).rejects.toThrow('disk full');
+      // Temp file removed so a failed write leaves no litter.
+      const unlinked = vi.mocked(fsp.unlink).mock.calls[0]?.[0] as string | undefined;
+      expect(unlinked).toMatch(/config\.json\.tmp-/);
+      // The real file was never renamed over.
+      expect(fsp.rename).not.toHaveBeenCalled();
     });
 
     it('rejects path traversal in key', async () => {
@@ -327,11 +367,15 @@ describe('plugin-storage', () => {
       // The gitignore ensurer will try to readFile for .gitignore - mock that too
       vi.mocked(fsp.readFile).mockRejectedValue(new Error('ENOENT'));
       await writeKey({ pluginId: 'my-plugin', scope: 'project-local', key: 'config', value: 42, projectPath });
-      expect(fsp.writeFile).toHaveBeenCalledWith(
-        path.join(projectPath, '.clubhouse', 'plugin-data-local', 'my-plugin', 'kv', 'config.json'),
-        '42',
-        'utf-8',
+      const finalPath = path.join(projectPath, '.clubhouse', 'plugin-data-local', 'my-plugin', 'kv', 'config.json');
+      // Atomic write: content lands in a temp sibling, then rename onto the final path.
+      const kvWrite = vi.mocked(fsp.writeFile).mock.calls.find(
+        (c) => String(c[0]).includes(path.join('plugin-data-local', 'my-plugin', 'kv', 'config.json')),
       );
+      expect(kvWrite).toBeDefined();
+      expect(String(kvWrite![0])).toMatch(/config\.json\.tmp-/);
+      expect(kvWrite![1]).toBe('42');
+      expect(fsp.rename).toHaveBeenCalledWith(kvWrite![0], finalPath);
     });
 
     it('deleteKey uses plugin-data-local path', async () => {
@@ -382,6 +426,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -411,6 +456,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -439,6 +485,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -465,6 +512,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -493,6 +541,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');

--- a/src/main/services/plugin-storage.ts
+++ b/src/main/services/plugin-storage.ts
@@ -87,12 +87,50 @@ export async function readKey(req: PluginStorageReadRequest): Promise<unknown> {
   const dir = path.join(getStorageDir(req.pluginId, req.scope, req.projectPath), 'kv');
   const file = path.join(dir, `${req.key}.json`);
   await assertSafePath(dir, `${req.key}.json`);
+
+  // Read and parse as two separate steps so a missing file (expected — no data
+  // saved yet) is distinguishable from a corrupt one (a real problem).
+  let raw: string;
   try {
-    const raw = await fs.readFile(file, 'utf-8');
-    return JSON.parse(raw);
+    raw = await fs.readFile(file, 'utf-8');
   } catch {
+    // File doesn't exist yet — a genuine fresh-start, return no value.
     return undefined;
   }
+
+  try {
+    return JSON.parse(raw);
+  } catch (parseErr) {
+    // The file exists but holds invalid JSON — almost always a truncated write
+    // from a crash/force-quit mid-save. Returning undefined here makes the
+    // caller treat it as "no data", and callers that auto-save on load will
+    // then overwrite the file, destroying the bytes permanently. Instead,
+    // quarantine the corrupt file to a timestamped sidecar so the data can be
+    // recovered, and log loudly rather than failing silently.
+    try {
+      const quarantine = `${file}.corrupt-${nextQuarantineSuffix()}`;
+      await fs.rename(file, quarantine);
+      appLog('plugin-storage', 'error', 'Quarantined corrupt kv file', {
+        meta: {
+          pluginId: req.pluginId, scope: req.scope, key: req.key, quarantine,
+          bytes: raw.length, error: String(parseErr),
+        },
+      });
+    } catch (quarantineErr) {
+      appLog('plugin-storage', 'error', 'Failed to quarantine corrupt kv file', {
+        meta: { pluginId: req.pluginId, key: req.key, error: String(quarantineErr) },
+      });
+    }
+    return undefined;
+  }
+}
+
+// Monotonic suffix for temp/quarantine filenames — avoids collisions within a
+// tight loop without depending on wall-clock granularity.
+let quarantineCounter = 0;
+function nextQuarantineSuffix(): string {
+  quarantineCounter += 1;
+  return `${Date.now()}-${process.pid}-${quarantineCounter}`;
 }
 
 export async function writeKey(req: PluginStorageWriteRequest): Promise<void> {
@@ -103,7 +141,22 @@ export async function writeKey(req: PluginStorageWriteRequest): Promise<void> {
   await assertSafePath(dir, `${req.key}.json`);
   await ensureDir(dir);
   const file = path.join(dir, `${req.key}.json`);
-  await fs.writeFile(file, JSON.stringify(req.value), 'utf-8');
+
+  // Atomic write: serialize to a temp file in the same directory, then rename
+  // over the destination. rename() is atomic on POSIX and NTFS, so a reader
+  // (or a crash) never observes a half-written file — the destination is
+  // always either the old complete contents or the new complete contents.
+  // A plain fs.writeFile truncates-then-writes and can leave invalid JSON if
+  // the process dies mid-write, which silently wipes canvas/wire state.
+  const tmp = path.join(dir, `${req.key}.json.tmp-${nextQuarantineSuffix()}`);
+  try {
+    await fs.writeFile(tmp, JSON.stringify(req.value), 'utf-8');
+    await fs.rename(tmp, file);
+  } catch (err) {
+    // Best-effort cleanup of the temp file so a failed write doesn't litter.
+    try { await fs.unlink(tmp); } catch { /* already gone */ }
+    throw err;
+  }
 }
 
 export async function deleteKey(req: PluginStorageDeleteRequest): Promise<void> {

--- a/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
@@ -53,6 +53,43 @@ describe('canvas-store', () => {
     expect(store2.getState().views[0].type).toBe('agent');
   });
 
+  // Regression: a single saved instance with a missing/non-array `views`
+  // (a partially-written record) must NOT throw and collapse ALL canvases to
+  // one empty canvas. The bad instance loads as empty; the good one is intact.
+  // This is the defensive guard behind the "canvas went blank, cards gone"
+  // data-loss bug — see the atomic-write + quarantine fix in plugin-storage.
+  it('loads good canvases even when one saved instance has a malformed views field', async () => {
+    const storage = createMockStorage({
+      'canvas-instances': [
+        { id: 'canvas_bad', name: 'broken' /* no views field at all */ },
+        {
+          id: 'canvas_good',
+          name: 'goobers-bridge',
+          views: [
+            { id: 'v1', type: 'agent', position: { x: 10, y: 20 }, size: { width: 400, height: 300 }, title: 'A', zIndex: 1, agentId: 'durable_x' },
+          ],
+          viewport: { panX: 0, panY: 0, zoom: 1 },
+          nextZIndex: 2,
+        },
+      ],
+      'canvas-active-id': 'canvas_good',
+    });
+
+    await store.getState().loadCanvas(storage);
+
+    const state = store.getState();
+    expect(state.loaded).toBe(true);
+    // Both canvases survived — the malformed one did not nuke everything.
+    expect(state.canvases).toHaveLength(2);
+    const bad = state.canvases.find((c) => c.id === 'canvas_bad');
+    const good = state.canvases.find((c) => c.id === 'canvas_good');
+    expect(bad?.views).toEqual([]);
+    expect(good?.views).toHaveLength(1);
+    // Active canvas (the good one) is shown with its card intact.
+    expect(state.activeCanvasId).toBe('canvas_good');
+    expect(state.views).toHaveLength(1);
+  });
+
   // LB-M68: Mission 68 — sibling agent card from "+ New Agent" must survive
   // a save/load round-trip with its position intact. This guards against
   // regressions where addView + updateView produce a view whose position

--- a/src/renderer/plugins/builtin/canvas/canvas-store.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.ts
@@ -1,6 +1,7 @@
 import { create, StoreApi, UseBoundStore } from 'zustand';
 import type { ScopedStorage } from '../../../../shared/plugin-types';
 import { generateHubName } from '../../../../shared/name-generator';
+import { rendererLog } from '../../renderer-logger';
 import type { CanvasView, CanvasViewType, CanvasInstance, CanvasInstanceData, AgentCanvasView, ZoneCanvasView, Position, Size, Viewport } from './canvas-types';
 import type { CanvasWidgetMetadata, CanvasWidgetFilter, CanvasWidgetHandle } from '../../../../shared/plugin-types';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
@@ -229,32 +230,60 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         const savedInstances = await storage.read(STORAGE_KEY_INSTANCES) as CanvasInstanceData[] | null;
         if (savedInstances && Array.isArray(savedInstances) && savedInstances.length > 0) {
           const canvases: CanvasInstance[] = savedInstances.map((s): CanvasInstance => {
-            // Backfill displayName and metadata for views saved in older formats.
-            // Filter out legacy view types that no longer exist (browser, file,
-            // legacy-file, terminal, legacy-terminal, git-diff, legacy-git-diff) —
-            // these have been replaced by plugin-provided widgets.
-            const REMOVED_TYPES = new Set(['browser', 'file', 'legacy-file', 'terminal', 'legacy-terminal', 'git-diff', 'legacy-git-diff']);
-            const restoredViews = s.views
-              .filter((v: any) => !REMOVED_TYPES.has(v.type))
-              .map((v: any) => ({
-                ...v,
-                metadata: v.metadata ?? {},
-                displayName: v.displayName ?? v.title ?? v.type ?? '',
-                ...(v.type === 'zone' ? { containedViewIds: v.containedViewIds ?? [] } : {}),
-              })) as CanvasView[];
-            return {
-              id: s.id,
-              name: s.name,
-              views: restoredViews,
-              viewport: clampViewport(s.viewport),
-              nextZIndex: s.nextZIndex,
-              zoomedViewId: s.zoomedViewId ?? null,
-              selectedViewId: null,
-              minimapAutoHide: s.minimapAutoHide ?? true,
-              elkAlgorithm: s.elkAlgorithm ?? 'layered',
-              elkDirection: s.elkDirection ?? 'RIGHT',
-              layoutCenterId: s.layoutCenterId ?? null,
-            };
+            // Restore each instance defensively: a single partially-written or
+            // malformed record must degrade to an empty-but-valid canvas, NOT
+            // throw and send the outer catch into replacing ALL canvases with
+            // one fresh empty canvas — that is the silent, total card-loss bug.
+            try {
+              // Backfill displayName and metadata for views saved in older
+              // formats. Filter out legacy view types that no longer exist
+              // (browser, file, legacy-file, terminal, legacy-terminal,
+              // git-diff, legacy-git-diff) — replaced by plugin-provided widgets.
+              const REMOVED_TYPES = new Set(['browser', 'file', 'legacy-file', 'terminal', 'legacy-terminal', 'git-diff', 'legacy-git-diff']);
+              const restoredViews = (Array.isArray(s.views) ? s.views : [])
+                .filter((v: any) => !REMOVED_TYPES.has(v.type))
+                .map((v: any) => ({
+                  ...v,
+                  metadata: v.metadata ?? {},
+                  displayName: v.displayName ?? v.title ?? v.type ?? '',
+                  ...(v.type === 'zone' ? { containedViewIds: v.containedViewIds ?? [] } : {}),
+                })) as CanvasView[];
+              const rawViewport: Partial<Viewport> = (s.viewport && typeof s.viewport === 'object') ? s.viewport : {};
+              return {
+                id: s.id ?? generateCanvasId(),
+                name: s.name ?? generateHubName(),
+                views: restoredViews,
+                viewport: clampViewport({
+                  panX: rawViewport.panX ?? 0,
+                  panY: rawViewport.panY ?? 0,
+                  zoom: rawViewport.zoom ?? 1,
+                }),
+                nextZIndex: s.nextZIndex ?? restoredViews.length,
+                zoomedViewId: s.zoomedViewId ?? null,
+                selectedViewId: null,
+                minimapAutoHide: s.minimapAutoHide ?? true,
+                elkAlgorithm: s.elkAlgorithm ?? 'layered',
+                elkDirection: s.elkDirection ?? 'RIGHT',
+                layoutCenterId: s.layoutCenterId ?? null,
+              };
+            } catch (err) {
+              rendererLog('canvas', 'error', 'Skipped malformed canvas instance on load', {
+                meta: { id: s?.id, error: err instanceof Error ? err.message : String(err) },
+              });
+              return {
+                id: s?.id ?? generateCanvasId(),
+                name: s?.name ?? generateHubName(),
+                views: [],
+                viewport: { panX: 0, panY: 0, zoom: 1 },
+                nextZIndex: 0,
+                zoomedViewId: null,
+                selectedViewId: null,
+                minimapAutoHide: true,
+                elkAlgorithm: 'layered',
+                elkDirection: 'RIGHT',
+                layoutCenterId: null,
+              };
+            }
           });
           const savedActive = await storage.read(STORAGE_KEY_ACTIVE) as string | null;
           const activeCanvasId = (savedActive && canvases.find((c) => c.id === savedActive))
@@ -268,7 +297,14 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         // Fresh start
         const canvas = createCanvasInstance();
         set({ canvases: [canvas], activeCanvasId: canvas.id, zoneWireDefinitions: loadedZoneWires, loaded: true, ...syncDerivedState([canvas], canvas.id) });
-      } catch {
+      } catch (err) {
+        // Loading failed after data was already read — log loudly rather than
+        // silently discarding the user's canvas. The storage layer quarantines
+        // corrupt files, so the underlying bytes are still recoverable; this
+        // records that the fallback empty canvas was substituted.
+        rendererLog('canvas', 'error', 'loadCanvas failed — substituting empty canvas', {
+          meta: { error: err instanceof Error ? err.message : String(err) },
+        });
         const canvas = createCanvasInstance();
         set({ canvases: [canvas], activeCanvasId: canvas.id, loaded: true, ...syncDerivedState([canvas], canvas.id) });
       }


### PR DESCRIPTION
## The bug (real user report)

A canvas went **permanently blank** — every agent card and wire gone from the view, replaced by an empty canvas with a random name ("shadowy-depot") — **yet the awake agents stayed connected and working** against their group project. The wiring clearly still existed somewhere; only the visual canvas was wiped.

## Root cause — corruption-then-overwrite in plugin KV storage

Confirmed against on-disk evidence (the affected project's `canvas-instances.json` held one empty freshly-named canvas; the sibling `canvas-wires.json` still had all wires intact):

1. **`writeKey` was non-atomic** (`plugin-storage.ts`) — a plain `fs.writeFile` (truncate-then-write). The canvas auto-saves every ~500ms while agents stream output, so a crash / force-quit / OS kill mid-write leaves a **truncated, invalid-JSON file**.
2. **`readKey` couldn't tell "missing" from "corrupt"** — it caught the `JSON.parse` error and returned `undefined` for both.
3. **`loadCanvas` treated `undefined` as first-run** → created a new empty canvas (`generateHubName()` → the random name).
4. The debounced **auto-save wrote that empty canvas over the corrupt file** — destroying the bytes permanently, and **silently** (bare `catch {}`, no logging, which is why nothing was in `~/.clubhouse/logs`).

Wire definitions live in a **separate file** (`canvas-wires.json`), and empty-canvas load *keeps and re-binds* all wires — so the agents reconnected and kept working while every card vanished. That file split is exactly why the symptom looked so strange.

## Fixes

- **`writeKey` — atomic write:** serialize to a temp sibling, then `rename()` over the destination. `rename` is atomic on POSIX/NTFS, so a reader (or a crash) never observes a half-written file. Temp file is cleaned up on failure. *This is the primary root-cause fix — corruption can no longer happen this way.*
- **`readKey` — quarantine, don't discard:** split read from parse. A missing file still returns `undefined` silently (normal fresh start); an **invalid-JSON file is renamed to a timestamped `.corrupt-<ts>` sidecar** (recoverable) and logged, instead of being left in place to be overwritten.
- **`loadCanvas` — defensive per-instance restore:** guard non-array `views` and missing/partial `viewport` so a single malformed record degrades to an empty-but-valid canvas instead of throwing and collapsing **all** canvases to one fresh empty canvas. Fallback paths now log instead of failing silently.

## Tests

`plugin-storage.test.ts`: atomic temp+rename write · temp cleanup + rethrow on write failure · corrupt-file quarantine · missing-file returns undefined **without** quarantine · quarantine-failure still returns undefined.
`canvas-store.test.ts`: a saved set with one malformed-`views` instance loads the **good** canvas intact (both survive) rather than nuking everything. (Verified it fails pre-fix: collapses to 1 empty canvas.)

- `npm run typecheck` ✅
- `npm test` ✅ 496 files, 12504 passed
- `npm run lint` ✅ 0 errors

## Note on recovery

This PR prevents recurrence. The **already-corrupted** canvas from the original report is separately recoverable — all 13 wires survived, so the cards can be rebuilt from them. That's a one-off data repair, handled outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)