### PR TITLE
fix(group-project): make bulletin channel names case-insensitive

### DIFF
--- a/src/main/services/group-project-bulletin.test.ts
+++ b/src/main/services/group-project-bulletin.test.ts
@@ -36,6 +36,7 @@ import {
   ensureProjectChannels,
   ensureInboxChannel,
   inboxChannelName,
+  normalizeChannelName,
 } from './group-project-bulletin';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
@@ -550,12 +551,203 @@ describe('BulletinBoard', () => {
       expect(digest[0].messageCount).toBe(2);
     });
   });
+
+  // ── Case-insensitive channels (go-forward routing) ───────────────────
+  describe('case-insensitive channel routing', () => {
+    it('routes a mixed-case post to the same channel read with lowercase (digest filter)', async () => {
+      const board = getBulletinBoard('gp_ci_digest');
+      await board.postMessage('a', 'inbox-My-Agent', 'hi');
+
+      const digest = await board.getDigest(undefined, ['inbox-my-agent']);
+      expect(digest).toHaveLength(1);
+      expect(digest[0].topic).toBe('inbox-my-agent');
+      expect(digest[0].messageCount).toBe(1);
+    });
+
+    it('reads messages regardless of the casing used to post or query', async () => {
+      const board = getBulletinBoard('gp_ci_read');
+      await board.postMessage('a', 'inbox-my-agent', 'hello');
+
+      const messages = await board.getTopicMessages('inbox-MY-AGENT');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].body).toBe('hello');
+    });
+
+    it('accumulates differently-cased posts under one canonical topic', async () => {
+      const board = getBulletinBoard('gp_ci_accum');
+      await board.postMessage('a', 'inbox-My-Agent', 'first');
+      await board.postMessage('b', 'INBOX-MY-AGENT', 'second');
+      await board.postMessage('c', 'inbox-my-agent', 'third');
+
+      const digest = await board.getDigest();
+      expect(digest).toHaveLength(1);
+      expect(digest[0].topic).toBe('inbox-my-agent');
+      expect(digest[0].messageCount).toBe(3);
+    });
+
+    it('stores the canonical (lowercased) form as the message topic', async () => {
+      const board = getBulletinBoard('gp_ci_msgtopic');
+      const msg = await board.postMessage('a', 'Inbox-Robin', 'yo');
+      expect(msg.topic).toBe('inbox-robin');
+    });
+
+    it('hasTopic is case-insensitive', async () => {
+      const board = getBulletinBoard('gp_ci_has');
+      await board.postMessage('a', 'inbox-robin', 'x');
+      expect(await board.hasTopic('inbox-Robin')).toBe(true);
+      expect(await board.hasTopic('INBOX-ROBIN')).toBe(true);
+    });
+
+    it('protection applies across casings and survives pruning', async () => {
+      const board = getBulletinBoard('gp_ci_prot');
+      board.setLimits(3, 1000);
+      board.setTopicProtected('Inbox-Safe', true);
+      expect(board.isTopicProtected('inbox-safe')).toBe(true);
+
+      for (let i = 0; i < 10; i++) {
+        await board.postMessage('a', 'INBOX-SAFE', `msg${i}`);
+      }
+      const messages = await board.getTopicMessages('inbox-safe', undefined, 100);
+      expect(messages).toHaveLength(10); // protected → not pruned to 3
+    });
+
+    it('delete paths resolve topics case-insensitively', async () => {
+      const board = getBulletinBoard('gp_ci_del');
+      const msg = await board.postMessage('a', 'inbox-x', 'one');
+      await board.postMessage('b', 'inbox-x', 'two');
+
+      expect(await board.deleteMessage('INBOX-X', msg.id)).toBe(true);
+      expect(await board.getTopicMessages('inbox-x')).toHaveLength(1);
+
+      expect(await board.deleteTopic('Inbox-X')).toBe(true);
+      expect(await board.hasTopic('inbox-x')).toBe(false);
+    });
+  });
+
+  // ── Silent one-time migration on load ─────────────────────────────────
+  describe('mixed-case migration on load', () => {
+    const bulletinPathFor = (projectId: string) =>
+      path.join('/tmp/test-clubhouse', '.clubhouse-dev', 'group-projects', projectId, 'bulletin.json');
+
+    // vitest config sets `mockReset: true`, which wipes the store-backed mock
+    // implementations before each test. These migration tests are the only ones
+    // that read seeded content back through readFile, so re-establish the impls.
+    beforeEach(() => {
+      vi.mocked(fsp.access).mockImplementation(async (p: string) => {
+        if (!store.has(p)) throw new Error('ENOENT');
+      });
+      vi.mocked(fsp.readFile).mockImplementation(async (p: string) => {
+        const data = store.get(p);
+        if (data === undefined) throw new Error('ENOENT');
+        return data;
+      });
+      vi.mocked(fsp.writeFile).mockImplementation(async (p: string, content: string) => {
+        store.set(p, content);
+      });
+    });
+
+    it('canonicalizes a lone mixed-case topic key on load', async () => {
+      store.set(bulletinPathFor('gp_mig_lone'), JSON.stringify({
+        topics: {
+          'inbox-My-Agent': [
+            { id: 'msg_1', sender: 'a', topic: 'inbox-My-Agent', body: 'hi', timestamp: '2026-01-01T00:00:00.000Z' },
+          ],
+        },
+      }));
+
+      const board = getBulletinBoard('gp_mig_lone');
+      const messages = await board.getTopicMessages('inbox-my-agent');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].topic).toBe('inbox-my-agent');
+    });
+
+    it('merges colliding keys, preserving all messages in timestamp order', async () => {
+      store.set(bulletinPathFor('gp_mig_merge'), JSON.stringify({
+        topics: {
+          'inbox-My-Agent': [
+            { id: 'm1', sender: 'a', topic: 'inbox-My-Agent', body: 'first',  timestamp: '2026-01-01T00:00:01.000Z' },
+            { id: 'm3', sender: 'a', topic: 'inbox-My-Agent', body: 'third',  timestamp: '2026-01-01T00:00:03.000Z' },
+          ],
+          'inbox-my-agent': [
+            { id: 'm2', sender: 'b', topic: 'inbox-my-agent', body: 'second', timestamp: '2026-01-01T00:00:02.000Z' },
+            { id: 'm4', sender: 'b', topic: 'inbox-my-agent', body: 'fourth', timestamp: '2026-01-01T00:00:04.000Z' },
+          ],
+        },
+      }));
+
+      const board = getBulletinBoard('gp_mig_merge');
+      const messages = await board.getTopicMessages('inbox-my-agent', undefined, 100);
+      expect(messages.map(m => m.body)).toEqual(['first', 'second', 'third', 'fourth']);
+      // No history lost.
+      expect(board.totalMessageCount()).toBe(4);
+      // Single canonical topic remains.
+      const digest = await board.getDigest();
+      expect(digest.map(d => d.topic)).toEqual(['inbox-my-agent']);
+    });
+
+    it('normalizes protectedTopics on load', async () => {
+      store.set(bulletinPathFor('gp_mig_prot'), JSON.stringify({
+        topics: {
+          'Inbox-Guard': [
+            { id: 'g1', sender: 'a', topic: 'Inbox-Guard', body: 'x', timestamp: '2026-01-01T00:00:00.000Z' },
+          ],
+        },
+        protectedTopics: ['Inbox-Guard'],
+      }));
+
+      const board = getBulletinBoard('gp_mig_prot');
+      expect(await board.hasTopic('inbox-guard')).toBe(true);
+      expect(board.isTopicProtected('inbox-guard')).toBe(true);
+    });
+
+    it('persists the canonical form back to disk (migration is durable)', async () => {
+      const p = bulletinPathFor('gp_mig_persist');
+      store.set(p, JSON.stringify({
+        topics: {
+          'inbox-My-Agent': [
+            { id: 'm1', sender: 'a', topic: 'inbox-My-Agent', body: 'a', timestamp: '2026-01-01T00:00:01.000Z' },
+          ],
+          'inbox-my-agent': [
+            { id: 'm2', sender: 'b', topic: 'inbox-my-agent', body: 'b', timestamp: '2026-01-01T00:00:02.000Z' },
+          ],
+        },
+      }));
+
+      const board = getBulletinBoard('gp_mig_persist');
+      await board.hasTopic('anything'); // triggers ensureLoaded → migration
+      await board.flush();
+
+      const written = JSON.parse(store.get(p)!);
+      expect(Object.keys(written.topics)).toEqual(['inbox-my-agent']);
+      expect(written.topics['inbox-my-agent']).toHaveLength(2);
+    });
+  });
 });
 
 describe('channel bootstrap helpers', () => {
   beforeEach(() => {
     store.clear();
     _resetAllBoardsForTesting();
+  });
+
+  describe('normalizeChannelName', () => {
+    it('lowercases mixed-case channel names', () => {
+      expect(normalizeChannelName('inbox-My-Agent')).toBe('inbox-my-agent');
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(normalizeChannelName('  Inbox-X  ')).toBe('inbox-x');
+    });
+
+    it('leaves already-canonical reserved channels unchanged', () => {
+      expect(normalizeChannelName('general')).toBe('general');
+      expect(normalizeChannelName('control')).toBe('control');
+    });
+
+    it('is idempotent', () => {
+      const once = normalizeChannelName('Inbox-My-Agent');
+      expect(normalizeChannelName(once)).toBe(once);
+    });
   });
 
   describe('inboxChannelName', () => {

--- a/src/main/services/group-project-bulletin.ts
+++ b/src/main/services/group-project-bulletin.ts
@@ -41,6 +41,18 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+/**
+ * Canonicalize a channel/topic name for storage and lookup. Channel names are
+ * case-insensitive — `inbox-My-Agent` and `inbox-my-agent` are the same channel —
+ * so an agent posting with one casing and reading with another must converge on a
+ * single key. Lowercasing (plus surrounding-whitespace trim) mirrors the
+ * normalization already applied by `inboxChannelName()`, and is idempotent and
+ * safe for the already-lowercase reserved channels (`general`, `control`).
+ */
+export function normalizeChannelName(topic: string): string {
+  return topic.trim().toLowerCase();
+}
+
 interface BulletinData {
   topics: Record<string, BulletinMessage[]>;
   protectedTopics?: string[];
@@ -75,13 +87,40 @@ class BulletinBoard {
     if (await pathExists(bp)) {
       try {
         const data: BulletinData = JSON.parse(await fsp.readFile(bp, 'utf-8'));
+        // Silent one-time migration: canonicalize topic keys to lowercase. Boards
+        // written before channel names were case-insensitive may hold mixed-case
+        // keys (e.g. `inbox-My-Agent`) that collide with the canonical form once
+        // lowercased. Merge colliding topics — concatenated and re-sorted by
+        // timestamp — so no message history is dropped.
+        let migrated = false;
         for (const [topic, messages] of Object.entries(data.topics || {})) {
-          this.topics.set(topic, messages);
+          const key = normalizeChannelName(topic);
+          if (key !== topic) migrated = true;
+          // Rewrite each message's stored topic to the canonical form too.
+          const canonical = messages.map(m => (m.topic === key ? m : { ...m, topic: key }));
+          const existing = this.topics.get(key);
+          if (existing) {
+            migrated = true;
+            const merged = [...existing, ...canonical].sort(
+              (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+            );
+            this.topics.set(key, merged);
+          } else {
+            this.topics.set(key, canonical);
+          }
         }
         if (Array.isArray(data.protectedTopics)) {
           for (const t of data.protectedTopics) {
-            this.protectedTopics.add(t);
+            const key = normalizeChannelName(t);
+            if (key !== t) migrated = true;
+            this.protectedTopics.add(key);
           }
+        }
+        // Persist the canonical form once so the migration is durable rather than
+        // re-run on every load.
+        if (migrated) {
+          this.dirty = true;
+          this.scheduleFlush();
         }
       } catch (err) {
         appLog('core:group-project', 'error', 'Failed to parse bulletin board', {
@@ -137,23 +176,24 @@ class BulletinBoard {
       throw new Error(`Message body exceeds ${MAX_BODY_BYTES} byte limit`);
     }
 
+    const canonicalTopic = normalizeChannelName(topic);
     const message: BulletinMessage = {
       id: `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
       sender,
-      topic,
+      topic: canonicalTopic,
       body,
       timestamp: new Date().toISOString(),
     };
 
-    let topicMessages = this.topics.get(topic);
+    let topicMessages = this.topics.get(canonicalTopic);
     if (!topicMessages) {
       topicMessages = [];
-      this.topics.set(topic, topicMessages);
+      this.topics.set(canonicalTopic, topicMessages);
     }
     topicMessages.push(message);
 
     // Prune per-topic (skip protected topics)
-    if (!this.protectedTopics.has(topic) && topicMessages.length > this.maxPerTopic) {
+    if (!this.protectedTopics.has(canonicalTopic) && topicMessages.length > this.maxPerTopic) {
       topicMessages.splice(0, topicMessages.length - this.maxPerTopic);
     }
 
@@ -168,7 +208,7 @@ class BulletinBoard {
   /** Check whether a topic has been created (has at least one message). */
   async hasTopic(topic: string): Promise<boolean> {
     await this.ensureLoaded();
-    return this.topics.has(topic);
+    return this.topics.has(normalizeChannelName(topic));
   }
 
   /**
@@ -179,7 +219,9 @@ class BulletinBoard {
   async getDigest(since?: string, channels?: string[]): Promise<TopicDigest[]> {
     await this.ensureLoaded();
     const sinceTime = since ? new Date(since).getTime() : 0;
-    const filter = channels && channels.length > 0 ? new Set(channels) : null;
+    const filter = channels && channels.length > 0
+      ? new Set(channels.map(normalizeChannelName))
+      : null;
     const digests: TopicDigest[] = [];
 
     for (const [topic, messages] of this.topics) {
@@ -222,7 +264,7 @@ class BulletinBoard {
   /** Get messages from a specific topic. */
   async getTopicMessages(topic: string, since?: string, limit?: number): Promise<BulletinMessage[]> {
     await this.ensureLoaded();
-    let messages = this.topics.get(topic) ?? [];
+    let messages = this.topics.get(normalizeChannelName(topic)) ?? [];
     if (since) {
       const sinceTime = new Date(since).getTime();
       messages = messages.filter(m => new Date(m.timestamp).getTime() > sinceTime);
@@ -278,10 +320,11 @@ class BulletinBoard {
 
   /** Mark a topic as protected (skip pruning) or unprotected. */
   setTopicProtected(topic: string, isProtected: boolean): void {
+    const canonicalTopic = normalizeChannelName(topic);
     if (isProtected) {
-      this.protectedTopics.add(topic);
+      this.protectedTopics.add(canonicalTopic);
     } else {
-      this.protectedTopics.delete(topic);
+      this.protectedTopics.delete(canonicalTopic);
     }
     this.dirty = true;
     this.scheduleFlush();
@@ -289,7 +332,7 @@ class BulletinBoard {
 
   /** Check whether a topic is protected. */
   isTopicProtected(topic: string): boolean {
-    return this.protectedTopics.has(topic);
+    return this.protectedTopics.has(normalizeChannelName(topic));
   }
 
   /** Return all protected topic names. */
@@ -302,7 +345,8 @@ class BulletinBoard {
   /** Delete a single message by ID within a topic. Returns true if found. */
   async deleteMessage(topic: string, messageId: string): Promise<boolean> {
     await this.ensureLoaded();
-    const messages = this.topics.get(topic);
+    const canonicalTopic = normalizeChannelName(topic);
+    const messages = this.topics.get(canonicalTopic);
     if (!messages) return false;
 
     const idx = messages.findIndex(m => m.id === messageId);
@@ -310,8 +354,8 @@ class BulletinBoard {
 
     messages.splice(idx, 1);
     if (messages.length === 0) {
-      this.topics.delete(topic);
-      this.protectedTopics.delete(topic);
+      this.topics.delete(canonicalTopic);
+      this.protectedTopics.delete(canonicalTopic);
     }
 
     this.dirty = true;
@@ -322,11 +366,12 @@ class BulletinBoard {
   /** Delete an entire topic and all its messages. Returns true if the topic existed. */
   async deleteTopic(topic: string): Promise<boolean> {
     await this.ensureLoaded();
-    const existed = this.topics.has(topic);
+    const canonicalTopic = normalizeChannelName(topic);
+    const existed = this.topics.has(canonicalTopic);
     if (!existed) return false;
 
-    this.topics.delete(topic);
-    this.protectedTopics.delete(topic);
+    this.topics.delete(canonicalTopic);
+    this.protectedTopics.delete(canonicalTopic);
 
     this.dirty = true;
     this.scheduleFlush();


### PR DESCRIPTION
## Summary
- Group-project agents were **missing messages and losing context** because bulletin channel/topic names were matched **case-sensitively**: an agent posting to `inbox-My-Agent` and another reading `inbox-my-agent` landed on two different storage keys.
- This normalizes topic keys (trim + lowercase) at the single `BulletinBoard` storage choke point, so all casings of a channel converge on one canonical key.
- Includes a **silent one-time migration** that heals existing on-disk boards by merging already-split mixed-case topics without dropping any message history.

## Root cause
`inboxChannelName()` already lowercases names when the *platform* seeds channels and routes shoulder-tap replies, but agent-driven `post_bulletin` / `read_bulletin` / `read_topic` stored and looked up the raw `topic`/`channels` string verbatim. The in-memory `Map<string, BulletinMessage[]>` and `bulletin.json` keys were therefore case-sensitive, and `getDigest` / `getTopicMessages` filtering silently missed messages stored under a different casing.

## Changes
`src/main/services/group-project-bulletin.ts`
- New exported `normalizeChannelName(topic)` = `topic.trim().toLowerCase()` — the canonical rule. Idempotent and safe for the already-lowercase reserved channels (`general`, `control`) and for `inboxChannelName()` output.
- Normalize at every storage-boundary operation: `postMessage` (key + stored `message.topic` + protection check), `hasTopic`, `getDigest` channel filter, `getTopicMessages`, `setTopicProtected` / `isTopicProtected`, `deleteMessage`, `deleteTopic`.
- **Migration on load** (`ensureLoaded`): lowercase each persisted topic key; when two mixed-case keys collapse to one, **merge** their messages (concat + re-sort by timestamp) so nothing is lost; normalize `protectedTopics`; mark the board dirty so the canonical form is written back once (durable, not re-run every load).
- No changes needed at the MCP tool layer — every caller funnels through `BulletinBoard`.

## Test Plan
Added to `src/main/services/group-project-bulletin.test.ts` (70 pass):
- [x] `normalizeChannelName`: lowercases mixed case, trims whitespace, leaves `general`/`control` unchanged, idempotent
- [x] Mixed-case post is visible via a lowercase digest filter and via `getTopicMessages` with any casing
- [x] Differently-cased posts accumulate under **one** canonical topic; stored `message.topic` is canonical
- [x] `hasTopic`, protection (survives pruning), and both delete paths resolve case-insensitively
- [x] Migration: lone mixed-case key canonicalized on load
- [x] Migration: colliding keys merged, all messages retained in timestamp order, no history lost, single canonical topic remains
- [x] Migration: `protectedTopics` normalized; canonical form persisted back to disk

## Validation
- `npm run typecheck` — clean
- `npm test` — 12,515 passed / 4 skipped (496 files)
- `npm run lint` — 0 errors
- `npm run package` — webpack build + package succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)