### PR TITLE
fix(e2e): stop auto-update banner from flaking unrelated E2E tests

### DIFF
--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -46,6 +46,11 @@ export interface LaunchOptions {
 export async function launchApp(opts: LaunchOptions = {}) {
   let userDataDir: string | undefined;
   const env = { ...process.env };
+  // Never let the auto-updater run during E2E. A real "update available/ready"
+  // banner appearing mid-run overlays the UI and flakes unrelated tests (editor
+  // focus clicks, canvas context menus). Belt-and-suspenders with the
+  // isPackaged gate — this also covers a packaged smoke-test launch.
+  env.CLUBHOUSE_DISABLE_AUTO_UPDATE = '1';
   if (opts.experimental || opts.userDataFiles) {
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clubhouse-e2e-'));
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,7 +11,7 @@ import { getSettings as getThemeSettings } from './services/theme-service';
 import { getThemeColorsForTitleBar } from './title-bar-colors';
 import * as safeMode from './services/safe-mode';
 import { appLog } from './services/log-service';
-import { startPeriodicChecks as startUpdateChecks, stopPeriodicChecks as stopUpdateChecks, applyUpdateOnQuit } from './services/auto-update-service';
+import { startPeriodicChecks as startUpdateChecks, stopPeriodicChecks as stopUpdateChecks, applyUpdateOnQuit, shouldAutoCheckOnStartup } from './services/auto-update-service';
 import { startPeriodicPluginUpdateChecks, stopPeriodicPluginUpdateChecks } from './services/plugin-update-service';
 import * as annexServer from './services/annex-server';
 import { bridgeServer as mcpBridgeServer } from './services/clubhouse-mcp';
@@ -321,8 +321,13 @@ app.on('ready', () => {
 
   createWindow();
 
-  // Start periodic update checks (respects user's autoUpdate setting)
-  startUpdateChecks();
+  // Start periodic update checks (respects user's autoUpdate setting).
+  // Skipped for unpackaged builds (dev / E2E) so a mid-run "update ready"
+  // banner can't overlay the UI and flake unrelated tests. Manual checks
+  // still work via the "check for updates" action.
+  if (shouldAutoCheckOnStartup()) {
+    startUpdateChecks();
+  }
 
   // Start periodic plugin update checks
   startPeriodicPluginUpdateChecks();

--- a/src/main/services/auto-update-lifecycle.test.ts
+++ b/src/main/services/auto-update-lifecycle.test.ts
@@ -66,7 +66,8 @@ vi.mock('fs/promises', () => ({
 // Imports
 // ---------------------------------------------------------------------------
 
-import { startPeriodicChecks, stopPeriodicChecks } from './auto-update-service';
+import { startPeriodicChecks, stopPeriodicChecks, shouldAutoCheckOnStartup } from './auto-update-service';
+import { app } from 'electron';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -137,5 +138,34 @@ describe('startPeriodicChecks / stopPeriodicChecks', () => {
     await startPeriodicChecks();
     await startPeriodicChecks(); // second call should be a no-op
     stopPeriodicChecks();
+  });
+});
+
+describe('shouldAutoCheckOnStartup', () => {
+  const originalPackaged = app.isPackaged;
+  const originalEnv = process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE;
+
+  afterEach(() => {
+    (app as { isPackaged: boolean }).isPackaged = originalPackaged;
+    if (originalEnv === undefined) delete process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE;
+    else process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE = originalEnv;
+  });
+
+  it('returns false for an unpackaged build (dev / E2E)', () => {
+    (app as { isPackaged: boolean }).isPackaged = false;
+    delete process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE;
+    expect(shouldAutoCheckOnStartup()).toBe(false);
+  });
+
+  it('returns true for a packaged build', () => {
+    (app as { isPackaged: boolean }).isPackaged = true;
+    delete process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE;
+    expect(shouldAutoCheckOnStartup()).toBe(true);
+  });
+
+  it('returns false when the E2E disable override is set, even if packaged', () => {
+    (app as { isPackaged: boolean }).isPackaged = true;
+    process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE = '1';
+    expect(shouldAutoCheckOnStartup()).toBe(false);
   });
 });

--- a/src/main/services/auto-update-service.ts
+++ b/src/main/services/auto-update-service.ts
@@ -1184,6 +1184,24 @@ export function getStatus(): UpdateStatus {
   return { ...status };
 }
 
+/**
+ * Whether the app should kick off automatic update checks on startup.
+ *
+ * Auto-update only applies to packaged builds — an unpackaged build (dev run
+ * or the E2E harness, which launches via the main entry, not a packaged app)
+ * cannot apply a downloaded update anyway. Worse, letting the check run under
+ * E2E means a real "update available/ready" banner can appear mid-run, overlay
+ * the UI, and break otherwise-unrelated interactions (editor focus clicks,
+ * canvas context menus) — a flaky failure that depends purely on update-check
+ * timing. Manual "check for updates" (checkForUpdates) is unaffected; only the
+ * automatic startup trigger is gated. An explicit env override is honored so a
+ * packaged smoke test can opt out too.
+ */
+export function shouldAutoCheckOnStartup(): boolean {
+  if (process.env.CLUBHOUSE_DISABLE_AUTO_UPDATE === '1') return false;
+  return app.isPackaged;
+}
+
 export async function startPeriodicChecks(): Promise<void> {
   if (checkTimer) return;
 


### PR DESCRIPTION
## The flake

E2E intermittently fails on **ubuntu** with whole suites timing out — `find-replace.spec.ts` (editor focus click never resolves) and `canvas-golden-path.spec.ts` (canvas context menu never appears). Two reruns reproduced it; other PRs stay green, so it's timing-dependent.

## Root cause (from the trace snapshots)

The failure snapshots show an **"Update vX is ready — Restart to update" banner** overlaying the app. `src/main/index.ts` calls `startPeriodicChecks()` **unconditionally** on startup, with no guard for unpackaged builds. Under E2E (launched via the main entry, not a packaged app) the real update check runs; if it resolves **mid-run**, the banner appears, overlays the UI, and breaks otherwise-unrelated interactions (editor clicks, context menus). Because it hinges on update-check timing, it's flaky — hence ubuntu-only-this-run and invisible on other PRs.

Auto-update only applies to **packaged** builds anyway — an unpackaged dev/E2E build can't apply a downloaded update — so the automatic startup check has zero value there.

## Fix

- New `shouldAutoCheckOnStartup()` helper: **packaged builds only**, with a `CLUBHOUSE_DISABLE_AUTO_UPDATE=1` env override. `index.ts` gates the startup call on it. Manual "check for updates" is unaffected; `startPeriodicChecks()` itself is unchanged, so the other callers (settings toggle, managed settings) keep working — no existing lifecycle tests disturbed.
- `e2e/launch.ts` sets `CLUBHOUSE_DISABLE_AUTO_UPDATE=1` as belt-and-suspenders, so even a packaged smoke-test launch never shows the banner mid-run.

## Tests

`shouldAutoCheckOnStartup` returns `false` unpackaged, `true` packaged, and `false` when the env override is set even if packaged.

- `npm run typecheck` ✅
- `npm test` ✅ 496 files, 12518 passed
- `npm run lint` ✅ 0 errors (changed files clean)

The real proof is CI: this should turn the intermittent ubuntu E2E red green and keep it there. Separate from — and a prerequisite to cleanly landing — the canvas-persistence PR (#1548), whose only blocker was this flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)