### PR TITLE
chore: bump version to 0.41.0-beta.5 (Preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clubhouse",
   "productName": "Clubhouse",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "description": "A place to hangout with your agent BFFs",
   "main": ".webpack/main",
   "private": true,


### PR DESCRIPTION
Release: Group Project Messaging Fix

# Bug Fixes
- Group-project bulletin channel names are now matched case-insensitively, so agents no longer miss messages or lose context when a channel is referenced with different capitalization. Existing boards are healed automatically on load.