### PR TITLE
fix(plugins): recover from stuck plugin activation instead of spinning forever

### DIFF
--- a/src/renderer/plugins/builtin/canvas/CanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/CanvasView.tsx
@@ -11,7 +11,7 @@ import { usePluginStore } from '../../plugin-store';
 import { useRemoteProjectStore, isRemoteProjectId, parseNamespacedId } from '../../../stores/remoteProjectStore';
 import { AnnexUnsupportedPlaceholder } from '../../../features/annex/AnnexUnsupportedPlaceholder';
 import { LinkDropdown } from './LinkDropdown';
-import { Spinner } from '../../../components/Spinner';
+import { PendingWidgetPlaceholder } from './PendingWidgetPlaceholder';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -462,12 +462,7 @@ export function CanvasViewComponent({
           const widgetParts = parsePluginWidgetType(pluginView.pluginWidgetType);
           const pluginKnown = widgetParts && !!usePluginStore.getState().plugins[widgetParts.pluginId];
           if (pluginKnown) {
-            return (
-              <div className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 text-xs p-4 text-center" data-testid="widget-loading">
-                <Spinner size="sm" />
-                <span>Loading&hellip;</span>
-              </div>
-            );
+            return <PendingWidgetPlaceholder pluginId={widgetParts.pluginId} />;
           }
           return (
             <div className="flex items-center justify-center h-full text-ctp-overlay0 text-xs p-4 text-center">
@@ -478,11 +473,10 @@ export function CanvasViewComponent({
         }
         if (isWidgetPending(pluginView.pluginWidgetType)) {
           return (
-            <div className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 text-xs p-4 text-center" data-testid="widget-loading">
-              <span className="font-medium text-ctp-subtext0">{registered.declaration.label}</span>
-              <Spinner size="sm" />
-              <span>Loading…</span>
-            </div>
+            <PendingWidgetPlaceholder
+              pluginId={registered.pluginId}
+              label={registered.declaration.label}
+            />
           );
         }
         const Component = registered.descriptor.component;

--- a/src/renderer/plugins/builtin/canvas/PendingWidgetPlaceholder.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/PendingWidgetPlaceholder.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { PendingWidgetPlaceholder, PENDING_WIDGET_TIMEOUT_MS } from './PendingWidgetPlaceholder';
+import { usePluginStore } from '../../plugin-store';
+
+const retryPluginActivation = vi.hoisted(() => vi.fn(() => true));
+vi.mock('../../plugin-loader', () => ({ retryPluginActivation }));
+
+function registerPlugin(status: 'registered' | 'errored', error?: string): void {
+  usePluginStore.setState({
+    plugins: {
+      'demo-plugin': {
+        manifest: {
+          id: 'demo-plugin',
+          name: 'Demo',
+          version: '1.0.0',
+          engine: { api: 0.5 },
+          scope: 'project',
+          permissions: [],
+        },
+        source: 'builtin',
+        pluginPath: '',
+        status,
+        error,
+      },
+    },
+  } as Partial<ReturnType<typeof usePluginStore.getState>> as never);
+}
+
+describe('PendingWidgetPlaceholder', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    retryPluginActivation.mockReturnValue(true);
+    registerPlugin('registered');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the loading spinner before the timeout elapses', () => {
+    render(<PendingWidgetPlaceholder pluginId="demo-plugin" label="Group Project" />);
+
+    expect(screen.getByTestId('widget-loading')).toBeTruthy();
+
+    act(() => { vi.advanceTimersByTime(PENDING_WIDGET_TIMEOUT_MS - 1); });
+
+    expect(screen.getByTestId('widget-loading')).toBeTruthy();
+    expect(screen.queryByTestId('widget-load-failed')).toBeNull();
+  });
+
+  it('surfaces a failure state with a retry button once the timeout elapses', () => {
+    render(<PendingWidgetPlaceholder pluginId="demo-plugin" label="Group Project" />);
+
+    act(() => { vi.advanceTimersByTime(PENDING_WIDGET_TIMEOUT_MS); });
+
+    expect(screen.queryByTestId('widget-loading')).toBeNull();
+    expect(screen.getByTestId('widget-load-failed')).toBeTruthy();
+    expect(screen.getByTestId('widget-load-retry')).toBeTruthy();
+  });
+
+  it('honours a custom timeout', () => {
+    render(<PendingWidgetPlaceholder pluginId="demo-plugin" timeoutMs={50} />);
+
+    act(() => { vi.advanceTimersByTime(50); });
+
+    expect(screen.getByTestId('widget-load-failed')).toBeTruthy();
+  });
+
+  it('shows the failure state immediately when the plugin is errored', () => {
+    registerPlugin('errored', 'Activation failed: activate() timed out after 20000ms');
+
+    render(<PendingWidgetPlaceholder pluginId="demo-plugin" label="Group Project" />);
+
+    expect(screen.getByTestId('widget-load-failed')).toBeTruthy();
+    expect(screen.getByText(/timed out after 20000ms/)).toBeTruthy();
+  });
+
+  it('re-dispatches activation and restarts the spinner when Retry is clicked', () => {
+    render(<PendingWidgetPlaceholder pluginId="demo-plugin" timeoutMs={50} />);
+    act(() => { vi.advanceTimersByTime(50); });
+
+    fireEvent.click(screen.getByTestId('widget-load-retry'));
+
+    expect(retryPluginActivation).toHaveBeenCalledWith('demo-plugin');
+    // Back to loading, with a fresh timeout window.
+    expect(screen.getByTestId('widget-loading')).toBeTruthy();
+
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(screen.getByTestId('widget-load-failed')).toBeTruthy();
+  });
+
+  it('explains when a retry cannot be dispatched', () => {
+    retryPluginActivation.mockReturnValue(false);
+    render(<PendingWidgetPlaceholder pluginId="demo-plugin" timeoutMs={50} />);
+    act(() => { vi.advanceTimersByTime(50); });
+
+    fireEvent.click(screen.getByTestId('widget-load-retry'));
+
+    expect(screen.getByTestId('widget-retry-unavailable')).toBeTruthy();
+    // Stays on the failure state rather than pretending to reload.
+    expect(screen.getByTestId('widget-load-failed')).toBeTruthy();
+  });
+});

--- a/src/renderer/plugins/builtin/canvas/PendingWidgetPlaceholder.tsx
+++ b/src/renderer/plugins/builtin/canvas/PendingWidgetPlaceholder.tsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Spinner } from '../../../components/Spinner';
+import { usePluginStore } from '../../plugin-store';
+import { retryPluginActivation } from '../../plugin-loader';
+
+/**
+ * How long a plugin widget may sit on the loading placeholder before we treat
+ * it as stuck. Activation normally completes in well under a second; anything
+ * past this is a hung IPC call or a failed activation, and silently spinning
+ * forever gives the user nothing to act on.
+ */
+export const PENDING_WIDGET_TIMEOUT_MS = 15_000;
+
+interface PendingWidgetPlaceholderProps {
+  /** Plugin that owns the widget — used to re-dispatch activation. */
+  pluginId: string;
+  /** Human-readable widget label, when known. */
+  label?: string;
+  /** Override the stuck threshold (tests). */
+  timeoutMs?: number;
+}
+
+/**
+ * Loading placeholder for a plugin canvas widget whose plugin has not finished
+ * activating. Falls back to an error state with a retry affordance once the
+ * plugin has clearly failed to come up.
+ */
+export function PendingWidgetPlaceholder({
+  pluginId,
+  label,
+  timeoutMs = PENDING_WIDGET_TIMEOUT_MS,
+}: PendingWidgetPlaceholderProps): React.ReactElement {
+  const [timedOut, setTimedOut] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [retryUnavailable, setRetryUnavailable] = useState(false);
+
+  const pluginStatus = usePluginStore((s) => s.plugins[pluginId]?.status);
+  const pluginError = usePluginStore((s) => s.plugins[pluginId]?.error);
+
+  // Restart the clock on each retry so the spinner gets another full window.
+  useEffect(() => {
+    setTimedOut(false);
+    const timer = setTimeout(() => setTimedOut(true), timeoutMs);
+    return () => clearTimeout(timer);
+  }, [pluginId, timeoutMs, attempt]);
+
+  const handleRetry = useCallback(() => {
+    const dispatched = retryPluginActivation(pluginId);
+    setRetryUnavailable(!dispatched);
+    if (dispatched) setAttempt((n) => n + 1);
+  }, [pluginId]);
+
+  // An errored plugin is terminal for this render — surface it immediately
+  // rather than waiting out the timeout.
+  const isStuck = timedOut || pluginStatus === 'errored';
+
+  if (!isStuck) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 text-xs p-4 text-center"
+        data-testid="widget-loading"
+      >
+        {label && <span className="font-medium text-ctp-subtext0">{label}</span>}
+        <Spinner size="sm" />
+        <span>Loading&hellip;</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full gap-2 text-ctp-overlay0 text-xs p-4 text-center"
+      data-testid="widget-load-failed"
+    >
+      {label && <span className="font-medium text-ctp-subtext0">{label}</span>}
+      <span>{label || 'This widget'} failed to load.</span>
+      {pluginError && (
+        <span className="text-ctp-overlay0/80 line-clamp-2" title={pluginError}>
+          {pluginError.split('\n')[0]}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={handleRetry}
+        className="px-2 py-1 rounded border border-ctp-surface2 text-ctp-subtext0 hover:bg-ctp-surface0 transition-colors"
+        data-testid="widget-load-retry"
+      >
+        Retry
+      </button>
+      {retryUnavailable && (
+        <span data-testid="widget-retry-unavailable">
+          Could not restart the plugin — try re-enabling it in settings.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/plugins/plugin-loader.test.ts
+++ b/src/renderer/plugins/plugin-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { usePluginStore } from './plugin-store';
 import type { PluginManifest, PluginModule } from '../../shared/plugin-types';
 
@@ -80,6 +80,15 @@ import {
   rejectPluginPermissions,
   _resetActiveContexts,
   _resetPluginSystemReady,
+  withTimeout,
+  retryPluginActivation,
+  activationRetryDelay,
+  PluginActivationTimeoutError,
+  PLUGIN_IPC_TIMEOUT_MS,
+  PLUGIN_ACTIVATE_TIMEOUT_MS,
+  MAX_ACTIVATION_ATTEMPTS,
+  ACTIVATION_RETRY_BASE_MS,
+  ACTIVATION_RETRY_MAX_MS,
 } from './plugin-loader';
 import { dynamicImportModule } from './dynamic-import';
 import { getBuiltinPlugins, getDefaultEnabledIds } from './builtin';
@@ -716,17 +725,19 @@ describe('plugin-loader', () => {
       expect(usePluginStore.getState().plugins['bad'].status).toBe('incompatible');
     });
 
-    it('skips activation of errored plugin', async () => {
-      mockLog.write.mockClear();
+    it('retries an errored plugin rather than skipping it permanently', async () => {
+      // An errored status is not terminal: a transient activation failure (busy
+      // main process during an app update) must not require an app restart.
+      const mod: PluginModule = { activate: vi.fn() };
       usePluginStore.getState().registerPlugin(
-        makeManifest({ id: 'err' }), 'community', '/path', 'errored', 'load failed'
+        makeManifest({ id: 'err', scope: 'app' }), 'builtin', '', 'errored', 'load failed'
       );
+      usePluginStore.getState().setPluginModule('err', mod);
 
       await activatePlugin('err');
 
-      expect(mockLog.write).toHaveBeenCalledWith(
-        expect.objectContaining({ ns: 'core:plugins', level: 'warn', msg: expect.stringContaining('Skipping activation') }),
-      );
+      expect(mod.activate).toHaveBeenCalled();
+      expect(usePluginStore.getState().plugins['err'].status).toBe('activated');
     });
 
     it('skips activation of disabled plugin', async () => {
@@ -2381,6 +2392,230 @@ describe('plugin-loader', () => {
       expect(store.projectEnabled['proj-1']).not.toContain('terminal');
       // Terminal should NOT be activated for proj-1
       expect(getActiveContext('terminal', 'proj-1')).toBeUndefined();
+    });
+  });
+
+  // ── activation timeouts & retry/backoff ─────────────────────────────
+
+  describe('activation timeouts', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function registerBuiltin(id: string, mod: PluginModule): void {
+      usePluginStore.getState().registerPlugin(makeManifest({ id, scope: 'app' }), 'builtin', '', 'registered');
+      usePluginStore.getState().setPluginModule(id, mod);
+    }
+
+    it('times out a hung activate() and marks the plugin errored', async () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const never = new Promise<void>(() => { /* never settles */ });
+      const mod: PluginModule = { activate: vi.fn().mockReturnValue(never) };
+      registerBuiltin('hang', mod);
+
+      const pending = activatePlugin('hang');
+      await vi.advanceTimersByTimeAsync(PLUGIN_ACTIVATE_TIMEOUT_MS + 1);
+      await pending;
+
+      const entry = usePluginStore.getState().plugins['hang'];
+      expect(entry.status).toBe('errored');
+      expect(entry.error).toContain('timed out');
+      expect(getActiveContext('hang')).toBeUndefined();
+      spy.mockRestore();
+    });
+
+    it('does not block activation when the settings IPC read hangs', async () => {
+      mockPlugin.storageRead.mockReturnValue(new Promise(() => { /* never settles */ }));
+      const mod: PluginModule = { activate: vi.fn() };
+      registerBuiltin('slow-settings', mod);
+
+      const pending = activatePlugin('slow-settings');
+      await vi.advanceTimersByTimeAsync(PLUGIN_IPC_TIMEOUT_MS + 1);
+      await pending;
+
+      // Falls back to default settings and activates rather than spinning.
+      expect(usePluginStore.getState().plugins['slow-settings'].status).toBe('activated');
+      expect(mod.activate).toHaveBeenCalled();
+    });
+
+    it('withTimeout resolves normally when work finishes in time', async () => {
+      const result = await withTimeout('fast', 1_000, async () => 'ok');
+      expect(result).toBe('ok');
+    });
+
+    it('withTimeout aborts the signal when it fires', async () => {
+      let seen: AbortSignal | undefined;
+      const pending = withTimeout('slow', 100, (signal) => {
+        seen = signal;
+        return new Promise<never>(() => { /* never settles */ });
+      });
+      const assertion = expect(pending).rejects.toBeInstanceOf(PluginActivationTimeoutError);
+      await vi.advanceTimersByTimeAsync(101);
+      await assertion;
+      expect(seen?.aborted).toBe(true);
+    });
+  });
+
+  describe('activation retry & backoff', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    function registerBuiltin(id: string, mod: PluginModule): void {
+      usePluginStore.getState().registerPlugin(makeManifest({ id, scope: 'app' }), 'builtin', '', 'registered');
+      usePluginStore.getState().setPluginModule(id, mod);
+    }
+
+    it('retries a failed activation after a backoff and recovers', async () => {
+      const activate = vi.fn()
+        .mockRejectedValueOnce(new Error('main process busy'))
+        .mockResolvedValueOnce(undefined);
+      registerBuiltin('flaky', { activate });
+
+      await activatePlugin('flaky');
+      expect(usePluginStore.getState().plugins['flaky'].status).toBe('errored');
+      expect(activate).toHaveBeenCalledTimes(1);
+
+      // Nothing retries before the backoff elapses...
+      await vi.advanceTimersByTimeAsync(ACTIVATION_RETRY_BASE_MS - 1);
+      expect(activate).toHaveBeenCalledTimes(1);
+
+      // ...and the scheduled retry succeeds on its own, no restart needed.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(activate).toHaveBeenCalledTimes(2);
+      expect(usePluginStore.getState().plugins['flaky'].status).toBe('activated');
+      expect(getActiveContext('flaky')).toBeDefined();
+    });
+
+    it('backs off exponentially and gives up after MAX_ACTIVATION_ATTEMPTS', async () => {
+      const activate = vi.fn().mockRejectedValue(new Error('still broken'));
+      registerBuiltin('broken', { activate });
+
+      await activatePlugin('broken');
+      expect(activate).toHaveBeenCalledTimes(1);
+
+      // Attempt 2 after 1s, attempt 3 after 2s, attempt 4 after 4s.
+      await vi.advanceTimersByTimeAsync(activationRetryDelay(1));
+      expect(activate).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(activationRetryDelay(2));
+      expect(activate).toHaveBeenCalledTimes(3);
+      await vi.advanceTimersByTimeAsync(activationRetryDelay(3));
+      expect(activate).toHaveBeenCalledTimes(MAX_ACTIVATION_ATTEMPTS);
+
+      // Budget spent — no further automatic retries.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(activate).toHaveBeenCalledTimes(MAX_ACTIVATION_ATTEMPTS);
+      expect(usePluginStore.getState().plugins['broken'].status).toBe('errored');
+
+      // And an explicit activation request is skipped once retries are spent.
+      mockLog.write.mockClear();
+      await activatePlugin('broken');
+      expect(activate).toHaveBeenCalledTimes(MAX_ACTIVATION_ATTEMPTS);
+      expect(mockLog.write).toHaveBeenCalledWith(
+        expect.objectContaining({ msg: expect.stringContaining('retries exhausted') }),
+      );
+    });
+
+    it('defers a caller-initiated activation while a retry is already scheduled', async () => {
+      const activate = vi.fn().mockRejectedValue(new Error('boom'));
+      registerBuiltin('deferred', { activate });
+
+      await activatePlugin('deferred');
+      expect(activate).toHaveBeenCalledTimes(1);
+
+      // A project switch mid-backoff must not burn an attempt early.
+      await activatePlugin('deferred');
+      expect(activate).toHaveBeenCalledTimes(1);
+    });
+
+    it('activationRetryDelay grows exponentially and is capped', () => {
+      expect(activationRetryDelay(1)).toBe(ACTIVATION_RETRY_BASE_MS);
+      expect(activationRetryDelay(2)).toBe(ACTIVATION_RETRY_BASE_MS * 2);
+      expect(activationRetryDelay(3)).toBe(ACTIVATION_RETRY_BASE_MS * 4);
+      expect(activationRetryDelay(99)).toBe(ACTIVATION_RETRY_MAX_MS);
+    });
+
+    it('retryPluginActivation revives a plugin whose retries are exhausted', async () => {
+      const activate = vi.fn().mockRejectedValue(new Error('boom'));
+      registerBuiltin('revive', { activate });
+
+      await activatePlugin('revive');
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(usePluginStore.getState().plugins['revive'].status).toBe('errored');
+
+      activate.mockResolvedValue(undefined);
+      expect(retryPluginActivation('revive')).toBe(true);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(usePluginStore.getState().plugins['revive'].status).toBe('activated');
+    });
+
+    it('retryPluginActivation reuses the project context of the failed attempt', async () => {
+      const activate = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValue(undefined);
+      usePluginStore.getState().registerPlugin(
+        makeManifest({ id: 'proj-plugin', scope: 'project' }), 'builtin', '', 'registered'
+      );
+      usePluginStore.getState().setPluginModule('proj-plugin', { activate });
+
+      await activatePlugin('proj-plugin', 'proj-1', '/p1');
+      expect(usePluginStore.getState().plugins['proj-plugin'].status).toBe('errored');
+
+      // The canvas widget only knows the plugin id — the project context comes
+      // from the recorded attempt.
+      expect(retryPluginActivation('proj-plugin')).toBe(true);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const ctx = getActiveContext('proj-plugin', 'proj-1');
+      expect(ctx?.projectId).toBe('proj-1');
+      expect(ctx?.projectPath).toBe('/p1');
+    });
+
+    it('retryPluginActivation returns false for an unknown plugin', () => {
+      expect(retryPluginActivation('nope')).toBe(false);
+    });
+
+    it('deactivation cancels a pending activation retry', async () => {
+      const activate = vi.fn().mockRejectedValue(new Error('boom'));
+      registerBuiltin('cancelled', { activate });
+
+      await activatePlugin('cancelled');
+      expect(activate).toHaveBeenCalledTimes(1);
+
+      await deactivatePlugin('cancelled');
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(activate).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears failure state after a successful activation', async () => {
+      const activate = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValue(undefined);
+      registerBuiltin('recovered', { activate });
+
+      await activatePlugin('recovered');
+      await vi.advanceTimersByTimeAsync(ACTIVATION_RETRY_BASE_MS);
+      expect(usePluginStore.getState().plugins['recovered'].status).toBe('activated');
+
+      // Fresh budget: a later failure gets the full retry allowance again.
+      await deactivatePlugin('recovered');
+      usePluginStore.getState().setPluginStatus('recovered', 'registered');
+      activate.mockRejectedValue(new Error('boom again'));
+
+      await activatePlugin('recovered');
+      expect(activate).toHaveBeenCalledTimes(3);
+      await vi.advanceTimersByTimeAsync(ACTIVATION_RETRY_BASE_MS);
+      expect(activate).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/renderer/plugins/plugin-loader.ts
+++ b/src/renderer/plugins/plugin-loader.ts
@@ -15,6 +15,169 @@ import { registerTheme, unregisterTheme } from '../themes';
 
 const activeContexts = new Map<string, PluginContext>();
 
+// ── Activation timeouts ───────────────────────────────────────────────
+// Activation awaits several IPC round-trips into the main process. If the
+// main process is busy (e.g. mid app-update) one of those can hang forever,
+// which used to leave the plugin — and any canvas widget it provides —
+// spinning until a full app restart. Each await is bounded instead.
+
+/** Timeout for a single IPC round-trip during activation. */
+export const PLUGIN_IPC_TIMEOUT_MS = 10_000;
+/** Timeout for the plugin's own activate() hook. */
+export const PLUGIN_ACTIVATE_TIMEOUT_MS = 20_000;
+
+export class PluginActivationTimeoutError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`${label} timed out after ${timeoutMs}ms`);
+    this.name = 'PluginActivationTimeoutError';
+  }
+}
+
+/**
+ * Bound a promise by `timeoutMs`. The AbortSignal is handed to `work` so
+ * abort-aware callees can bail early; IPC calls that ignore it are simply
+ * abandoned — the timeout still unblocks activation either way.
+ */
+export async function withTimeout<T>(
+  label: string,
+  timeoutMs: number,
+  work: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new PluginActivationTimeoutError(label, timeoutMs));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([work(controller.signal), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+// ── Activation retry / backoff ────────────────────────────────────────
+// A plugin that errors during activation used to be skipped permanently, so
+// a transient failure was indistinguishable from a broken plugin and only a
+// restart recovered. Failures are now retried with exponential backoff.
+
+/** Max activation attempts (initial attempt + retries) before giving up. */
+export const MAX_ACTIVATION_ATTEMPTS = 4;
+/** Base delay for exponential backoff between activation retries. */
+export const ACTIVATION_RETRY_BASE_MS = 1_000;
+/** Upper bound on a single backoff delay. */
+export const ACTIVATION_RETRY_MAX_MS = 30_000;
+
+interface ActivationAttempt {
+  projectId?: string;
+  projectPath?: string;
+}
+
+interface ActivationFailure extends ActivationAttempt {
+  attempts: number;
+  nextEligibleAt: number;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+/** Last activation arguments per context key — lets a manual retry re-dispatch. */
+const lastActivationAttempt = new Map<string, ActivationAttempt>();
+/**
+ * Most recent activation arguments per plugin id, regardless of context. A
+ * canvas widget knows only the plugin id, so this is how a manual retry
+ * recovers the project context of the attempt that failed.
+ */
+const lastAttemptByPlugin = new Map<string, ActivationAttempt>();
+/** Failure bookkeeping per context key. */
+const activationFailures = new Map<string, ActivationFailure>();
+
+function activationContextKey(pluginId: string, projectId?: string): string {
+  return projectId ? `${pluginId}:${projectId}` : pluginId;
+}
+
+/** Backoff delay for the Nth attempt (1-based), capped. */
+export function activationRetryDelay(attempts: number): number {
+  return Math.min(ACTIVATION_RETRY_BASE_MS * 2 ** (attempts - 1), ACTIVATION_RETRY_MAX_MS);
+}
+
+/**
+ * Record a failed activation and schedule an automatic retry unless the
+ * attempt budget is exhausted.
+ */
+function recordActivationFailure(pluginId: string, projectId?: string, projectPath?: string): void {
+  const key = activationContextKey(pluginId, projectId);
+  const prev = activationFailures.get(key);
+  if (prev?.timer) clearTimeout(prev.timer);
+  const attempts = (prev?.attempts ?? 0) + 1;
+
+  if (attempts >= MAX_ACTIVATION_ATTEMPTS) {
+    activationFailures.set(key, { attempts, nextEligibleAt: Infinity, projectId, projectPath });
+    rendererLog('core:plugins', 'error', `Giving up on activating "${pluginId}" after ${attempts} attempts`, {
+      meta: { pluginId, projectId, attempts },
+    });
+    return;
+  }
+
+  const delay = activationRetryDelay(attempts);
+  const timer = setTimeout(() => {
+    const record = activationFailures.get(key);
+    if (record) record.timer = undefined;
+    void activatePlugin(pluginId, projectId, projectPath);
+  }, delay);
+  // Don't hold the process open for a retry (no-op in the renderer).
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  activationFailures.set(key, {
+    attempts,
+    nextEligibleAt: Date.now() + delay,
+    projectId,
+    projectPath,
+    timer,
+  });
+  rendererLog('core:plugins', 'warn', `Scheduling activation retry for "${pluginId}" in ${delay}ms`, {
+    meta: { pluginId, projectId, attempts, delay },
+  });
+}
+
+/** Clear failure bookkeeping after a successful activation. */
+function clearActivationFailure(pluginId: string, projectId?: string): void {
+  const key = activationContextKey(pluginId, projectId);
+  const record = activationFailures.get(key);
+  if (record?.timer) clearTimeout(record.timer);
+  activationFailures.delete(key);
+}
+
+/**
+ * User-initiated retry (e.g. from a stuck canvas widget). Clears the backoff
+ * state and the errored status so activation can run again immediately.
+ * Returns false when there's nothing to retry.
+ */
+export function retryPluginActivation(pluginId: string, projectId?: string): boolean {
+  const store = usePluginStore.getState();
+  const entry = store.plugins[pluginId];
+  if (!entry) return false;
+
+  // Fall back to the project context of the last attempt when the caller
+  // (e.g. a canvas widget) only knows the plugin id.
+  const fallback = lastAttemptByPlugin.get(pluginId);
+  const resolvedProjectId = projectId ?? fallback?.projectId;
+  const resolvedKey = activationContextKey(pluginId, resolvedProjectId);
+  const resolvedAttempt = lastActivationAttempt.get(resolvedKey) ?? fallback;
+
+  if (entry.manifest.scope === 'project' && !resolvedProjectId) return false;
+
+  clearActivationFailure(pluginId, resolvedProjectId);
+  if (entry.status === 'errored') {
+    store.setPluginStatus(pluginId, 'registered');
+  }
+  rendererLog('core:plugins', 'info', `Manual activation retry for "${pluginId}"`, {
+    meta: { pluginId, projectId: resolvedProjectId },
+  });
+  void activatePlugin(pluginId, resolvedProjectId, resolvedAttempt?.projectPath);
+  return true;
+}
+
 // ── Plugin system ready gate ─────────────────────────────────────────
 // Resolves when initializePluginSystem() completes (including safe mode).
 // Consumers (e.g. project switch in App.tsx) should await this before
@@ -301,11 +464,35 @@ export async function activatePlugin(
     return;
   }
 
-  if (entry.status === 'incompatible' || entry.status === 'errored' || entry.status === 'disabled' || entry.status === 'pending-approval') {
+  if (entry.status === 'incompatible' || entry.status === 'disabled' || entry.status === 'pending-approval') {
     rendererLog('core:plugins', 'warn', `Skipping activation of ${pluginId}: ${entry.status}`, {
       meta: { pluginId, status: entry.status, error: entry.error },
     });
     return;
+  }
+
+  // An errored plugin is retryable: activation failures are often transient
+  // (busy main process during an app update). Skip only while a backoff is
+  // still pending or the attempt budget is spent.
+  if (entry.status === 'errored') {
+    const failure = activationFailures.get(activationContextKey(pluginId, projectId));
+    const attempts = failure?.attempts ?? 0;
+    if (attempts >= MAX_ACTIVATION_ATTEMPTS) {
+      rendererLog('core:plugins', 'warn', `Skipping activation of ${pluginId}: errored, retries exhausted`, {
+        meta: { pluginId, status: entry.status, error: entry.error, attempts },
+      });
+      return;
+    }
+    if (failure && Date.now() < failure.nextEligibleAt) {
+      rendererLog('core:plugins', 'debug', `Deferring activation of ${pluginId}: retry already scheduled`, {
+        meta: { pluginId, attempts, nextEligibleAt: failure.nextEligibleAt },
+      });
+      return;
+    }
+    if (failure?.timer) {
+      clearTimeout(failure.timer);
+      failure.timer = undefined;
+    }
   }
 
   if (entry.manifest.scope === 'project' && !projectId) {
@@ -317,6 +504,11 @@ export async function activatePlugin(
   if (activeContexts.has(contextKey)) {
     return; // Already activated
   }
+
+  // Remember the arguments so a user-initiated retry can re-dispatch with the
+  // same project context.
+  lastActivationAttempt.set(contextKey, { projectId, projectPath });
+  lastAttemptByPlugin.set(pluginId, { projectId, projectPath });
 
   const ctx: PluginContext = {
     pluginId,
@@ -334,17 +526,27 @@ export async function activatePlugin(
   if (!savedSettings) {
     try {
       const scope = projectId || 'app';
-      const persisted = await window.clubhouse.plugin.storageRead({
-        pluginId: '_system',
-        scope: 'global',
-        key: `settings-${scope}-${pluginId}`,
-      }) as Record<string, unknown> | undefined;
+      const persisted = await withTimeout(
+        `settings read for "${pluginId}"`,
+        PLUGIN_IPC_TIMEOUT_MS,
+        () => window.clubhouse.plugin.storageRead({
+          pluginId: '_system',
+          scope: 'global',
+          key: `settings-${scope}-${pluginId}`,
+        }),
+      ) as Record<string, unknown> | undefined;
       if (persisted && typeof persisted === 'object') {
         store.loadPluginSettings(settingsKey, persisted);
         savedSettings = persisted;
       }
-    } catch {
-      // No persisted settings — use defaults
+    } catch (err) {
+      // No persisted settings (or the read hung) — use defaults rather than
+      // blocking activation forever.
+      if (err instanceof PluginActivationTimeoutError) {
+        rendererLog('core:plugins', 'warn', `Timed out reading settings for plugin "${pluginId}"`, {
+          meta: { pluginId, projectId, timeoutMs: PLUGIN_IPC_TIMEOUT_MS },
+        });
+      }
     }
   }
   if (savedSettings) {
@@ -398,6 +600,7 @@ export async function activatePlugin(
           meta: { pluginId, modulePath: fullModulePath, moduleUrl, error: errMsg, stack: errStack },
         });
         store.setPluginStatus(pluginId, 'errored', `Failed to load module: ${errMsg}`);
+        recordActivationFailure(pluginId, projectId, projectPath);
         return;
       }
 
@@ -406,6 +609,7 @@ export async function activatePlugin(
         const errMsg = `Plugin module at "${fullModulePath}" did not export a valid module object`;
         rendererLog('core:plugins', 'error', errMsg, { meta: { pluginId, modulePath: fullModulePath } });
         store.setPluginStatus(pluginId, 'errored', errMsg);
+        recordActivationFailure(pluginId, projectId, projectPath);
         return;
       }
 
@@ -420,9 +624,13 @@ export async function activatePlugin(
       // Ensure the plugin's data directory exists before activation
       try {
         const dataDirRelative = projectId ? `files/${projectId}` : 'files';
-        await window.clubhouse.plugin.mkdir(pluginId, 'global', dataDirRelative);
+        await withTimeout(
+          `data directory mkdir for "${pluginId}"`,
+          PLUGIN_IPC_TIMEOUT_MS,
+          () => window.clubhouse.plugin.mkdir(pluginId, 'global', dataDirRelative),
+        );
       } catch {
-        // Best-effort — don't block activation if mkdir fails
+        // Best-effort — don't block activation if mkdir fails or hangs
         rendererLog('core:plugins', 'warn', `Failed to create data directory for plugin "${pluginId}"`);
       }
 
@@ -430,15 +638,25 @@ export async function activatePlugin(
       if (entry.manifest.permissions?.includes('workspace')) {
         try {
           const workspaceDir = computeWorkspaceRoot(pluginId);
-          await window.clubhouse.file.mkdir(workspaceDir);
+          await withTimeout(
+            `workspace mkdir for "${pluginId}"`,
+            PLUGIN_IPC_TIMEOUT_MS,
+            () => window.clubhouse.file.mkdir(workspaceDir),
+          );
         } catch {
           rendererLog('core:plugins', 'warn', `Failed to create workspace directory for plugin "${pluginId}"`);
         }
       }
 
-      // Call activate if it exists
+      // Call activate if it exists. A hung activate() would otherwise leave the
+      // plugin's widgets on a placeholder spinner indefinitely — bound it so the
+      // failure surfaces and the retry path can run.
       if (mod.activate) {
-        await mod.activate(ctx, api);
+        await withTimeout(
+          `activate() for "${pluginId}"`,
+          PLUGIN_ACTIVATE_TIMEOUT_MS,
+          () => Promise.resolve(mod.activate!(ctx, api)),
+        );
       }
 
       // Auto-register manifest-declared command hotkeys (v0.6+)
@@ -468,6 +686,7 @@ export async function activatePlugin(
     // Update status
     store.setPluginStatus(pluginId, 'activated');
     activeContexts.set(contextKey, ctx);
+    clearActivationFailure(pluginId, projectId);
     store.bumpContextRevision();
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
@@ -478,6 +697,7 @@ export async function activatePlugin(
     // Store a detailed error: message on first line, stack on subsequent lines
     const errorDetail = errStack ? `Activation failed: ${errMsg}\n${errStack}` : `Activation failed: ${errMsg}`;
     store.setPluginStatus(pluginId, 'errored', errorDetail);
+    recordActivationFailure(pluginId, projectId, projectPath);
   }
 }
 
@@ -485,6 +705,10 @@ export async function deactivatePlugin(pluginId: string, projectId?: string): Pr
   const store = usePluginStore.getState();
   const contextKey = projectId ? `${pluginId}:${projectId}` : pluginId;
   const ctx = activeContexts.get(contextKey);
+
+  // Cancel any pending activation retry for this context regardless of whether
+  // a context exists — a deactivated plugin should not be revived by a timer.
+  clearActivationFailure(pluginId, projectId);
 
   if (!ctx) return;
 
@@ -699,8 +923,10 @@ export async function hotReloadPlugin(pluginId: string): Promise<void> {
     if (postEntry?.status === 'errored') {
       const label = projectId ? `project ${projectId}` : 'app';
       activationErrors.push(`${label}: ${postEntry.error || 'unknown error'}`);
-      // Reset status so subsequent activations aren't skipped
+      // Reset status so subsequent activations aren't skipped, and drop the
+      // backoff state — a hot reload is a fresh start for the attempt budget.
       usePluginStore.getState().setPluginStatus(pluginId, 'registered');
+      clearActivationFailure(pluginId, projectId);
     }
   };
 
@@ -963,6 +1189,17 @@ export async function refreshCommunityPlugins(opts?: {
 /** @internal — only for tests */
 export function _resetActiveContexts(): void {
   activeContexts.clear();
+  _resetActivationRetries();
+}
+
+/** @internal — only for tests */
+export function _resetActivationRetries(): void {
+  for (const record of activationFailures.values()) {
+    if (record.timer) clearTimeout(record.timer);
+  }
+  activationFailures.clear();
+  lastActivationAttempt.clear();
+  lastAttemptByPlugin.clear();
 }
 
 /** @internal — only for tests */


### PR DESCRIPTION
## Problem

A group project widget could get permanently stuck on its loading spinner after an app update + an agent settings change — only a full app restart cleared it.

Root cause (diagnosed by chirpy-mole):

- Group project renders through the canvas widget registry. Inactive widgets show a placeholder spinner until the plugin's `activate()` registers the real widget.
- Project switches re-run `activatePlugin()`, which did several **un-timed** IPC awaits (settings read, `mkdir`) plus the plugin's own `activate()`.
- If one of those hung or threw — plausible when the main process is busy during an app update — the plugin flipped to `status: 'errored'`.
- `activatePlugin()` then **permanently skipped** any errored plugin: no retry, no backoff, just a debug log. The widget spun forever.
- All the relevant state is in-memory, so a restart reset it and activation succeeded — masking the bug rather than fixing it.

## Changes

1. **Timeouts on every activation await** — `withTimeout(label, ms, work)` races the work against an `AbortController`-backed timer (10s per IPC round-trip, 20s for `activate()`). The signal is passed to the callee so abort-aware code can bail early; IPC calls that ignore it are abandoned, and activation unblocks either way. A hung settings read now falls back to defaults and still activates.
2. **Retry with backoff replaces the permanent skip** — errored plugins get 4 attempts with exponential backoff (1s / 2s / 4s, capped at 30s), scheduled automatically so the plugin self-heals with no user action. Success clears the failure record; `deactivatePlugin()` cancels a pending retry so a disabled plugin can't be revived by a stale timer; a hot reload resets the attempt budget. A caller (e.g. project switch) arriving mid-backoff defers rather than burning an attempt.
3. **Placeholder no longer spins silently** — new `PendingWidgetPlaceholder` swaps the spinner for a failure state after 15s, or immediately once the plugin is `errored`. It shows the activation error and a **Retry** button wired to `retryPluginActivation()`, which resolves the project context from the recorded attempt (the widget only knows the plugin id). If no retry can be dispatched it says so instead of pretending to reload.

## Tests

`plugin-loader.test.ts` (+11) and `PendingWidgetPlaceholder.test.tsx` (new, 6):

- timeout fires on a hung `activate()` → errored with a `timed out` message, no leaked context
- timeout fires on a hung settings IPC read → activation still completes
- `withTimeout` passthrough on success, and signal actually aborted on timeout
- failed activation auto-recovers on the scheduled retry
- backoff schedule is exponential and capped; attempts stop at `MAX_ACTIVATION_ATTEMPTS`, after which explicit calls are skipped
- caller-initiated activation defers while a retry is scheduled
- `retryPluginActivation()` revives an exhausted plugin, reuses the failed attempt's project context, returns false for unknown plugins
- deactivation cancels a pending retry; success clears failure state so a later failure gets a full budget
- placeholder: spinner before timeout, failure state after, custom timeout, immediate failure when errored, retry re-dispatches and restarts the spinner, unavailable-retry message

`npx vitest run --project renderer src/renderer/plugins/` — 135 files, 3678 tests pass. `tsc --noEmit` clean; lint clean (2 pre-existing warnings on untouched lines).

The existing test `skips activation of errored plugin` was rewritten to `retries an errored plugin rather than skipping it permanently` — that skip was the bug.

Note: this worktree was missing the `mermaid` dependency in `node_modules` (declared in package.json), which breaks test collection for 7 unrelated canvas/files test files. Installed locally with `--no-save`; no dependency changes are in this PR.

@chirpy-mole for security/QA review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)