### PR TITLE
fix: persist per-channel read state so bulletin unread counts clear

### DIFF
--- a/src/main/ipc/group-project-handlers.test.ts
+++ b/src/main/ipc/group-project-handlers.test.ts
@@ -103,7 +103,7 @@ import { executeShoulderTap } from '../services/group-project-shoulder-tap';
 import * as annexEventBus from '../services/annex-event-bus';
 import { isMcpEnabledForAny } from '../services/mcp-settings';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
-import { registerGroupProjectHandlers, _resetHandlersForTesting } from './group-project-handlers';
+import { registerGroupProjectHandlers, _resetHandlersForTesting, digestSinceArg } from './group-project-handlers';
 
 type HandlerFn = (...args: unknown[]) => unknown;
 const handlers = new Map<string, HandlerFn>();
@@ -520,5 +520,78 @@ describe('group-project-handlers', () => {
       const handler = getHandler(IPC.GROUP_PROJECT.INJECT_MESSAGE);
       expect(() => handler(fakeEvent, 'agent-1')).toThrow();
     });
+  });
+});
+
+// ── digestSinceArg validator ────────────────────────────────────────
+
+describe('digestSinceArg', () => {
+  const validate = digestSinceArg();
+
+  it('accepts undefined', () => {
+    expect(validate(undefined, 'arg2')).toBeUndefined();
+  });
+
+  it('treats null as absent', () => {
+    expect(validate(null, 'arg2')).toBeUndefined();
+  });
+
+  it('accepts a single ISO timestamp string', () => {
+    expect(validate('2026-07-25T10:00:00.000Z', 'arg2')).toBe('2026-07-25T10:00:00.000Z');
+  });
+
+  it('accepts a per-topic map', () => {
+    const map = { general: '2026-07-25T10:00:00.000Z', tasks: '2026-07-25T11:00:00.000Z' };
+    expect(validate(map, 'arg2')).toEqual(map);
+  });
+
+  it('accepts an empty map', () => {
+    expect(validate({}, 'arg2')).toEqual({});
+  });
+
+  it('rejects arrays', () => {
+    expect(() => validate(['2026-07-25T10:00:00.000Z'], 'arg2')).toThrow('must be a string or an object');
+  });
+
+  it('rejects numbers', () => {
+    expect(() => validate(42, 'arg2')).toThrow('must be a string or an object');
+  });
+
+  it('rejects non-string map values', () => {
+    expect(() => validate({ general: 42 }, 'arg2')).toThrow('arg2.general must be a string');
+    expect(() => validate({ general: { nested: 'x' } }, 'arg2')).toThrow('arg2.general must be a string');
+  });
+
+  it('rejects an oversized map', () => {
+    const map: Record<string, string> = {};
+    for (let i = 0; i < 501; i++) map[`topic${i}`] = '2026-07-25T10:00:00.000Z';
+    expect(() => validate(map, 'arg2')).toThrow('at most 500 entries');
+  });
+
+  it('accepts a map at exactly the entry limit', () => {
+    const map: Record<string, string> = {};
+    for (let i = 0; i < 500; i++) map[`topic${i}`] = '2026-07-25T10:00:00.000Z';
+    expect(Object.keys(validate(map, 'arg2') as Record<string, string>)).toHaveLength(500);
+  });
+
+  it('rejects oversized topic keys', () => {
+    expect(() => validate({ ['x'.repeat(257)]: '2026-07-25T10:00:00.000Z' }, 'arg2'))
+      .toThrow('topic keys must be at most 256 characters');
+  });
+
+  it('rejects oversized timestamps', () => {
+    expect(() => validate('x'.repeat(65), 'arg2')).toThrow('at most 64 characters');
+    expect(() => validate({ general: 'x'.repeat(65) }, 'arg2')).toThrow('arg2.general must be at most 64 characters');
+  });
+
+  it('rejects prototype-polluting keys', () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": true}, "general": "2026-07-25T10:00:00.000Z"}');
+    expect(() => validate(payload, 'arg2')).toThrow('may not contain the key');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+    expect(() => validate({ constructor: '2026-07-25T10:00:00.000Z' }, 'arg2'))
+      .toThrow('may not contain the key "constructor"');
+    expect(() => validate({ prototype: '2026-07-25T10:00:00.000Z' }, 'arg2'))
+      .toThrow('may not contain the key "prototype"');
   });
 });

--- a/src/main/ipc/group-project-handlers.ts
+++ b/src/main/ipc/group-project-handlers.ts
@@ -12,13 +12,61 @@ import { executeShoulderTap } from '../services/group-project-shoulder-tap';
 import * as annexEventBus from '../services/annex-event-bus';
 import { appLog } from '../services/log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
-import { withValidatedArgs, stringArg, objectArg, numberArg, booleanArg } from './validation';
+import { withValidatedArgs, stringArg, objectArg, numberArg, booleanArg, type ArgValidator } from './validation';
+import type { DigestSince } from '../../shared/group-project-types';
 import { agentRegistry } from '../services/agent-registry';
 import * as ptyManager from '../services/pty-manager';
 import * as structuredManager from '../services/structured-manager';
 import { writeChunkedBracketedPaste, submitAfterPaste } from '../services/clubhouse-mcp/tools/agent-tools';
 import { getProvider } from '../orchestrators';
 import type { PasteSubmitTiming } from '../orchestrators';
+
+/** Upper bounds on the per-topic read map, so a bad caller can't send an unbounded object. */
+const MAX_SINCE_ENTRIES = 500;
+const MAX_TOPIC_LENGTH = 256;
+const MAX_TIMESTAMP_LENGTH = 64;
+/** Keys that must never be copied onto a plain object. */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * `since` for the digest: either a single ISO timestamp, or a per-topic
+ * `topic -> ISO timestamp` map.
+ */
+export function digestSinceArg(): ArgValidator<DigestSince | undefined> {
+  return (value, argName) => {
+    if (value === undefined || value === null) return undefined;
+    if (typeof value === 'string') {
+      if (value.length > MAX_TIMESTAMP_LENGTH) {
+        throw new Error(`${argName} timestamp must be at most ${MAX_TIMESTAMP_LENGTH} characters`);
+      }
+      return value;
+    }
+    if (typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(`${argName} must be a string or an object`);
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length > MAX_SINCE_ENTRIES) {
+      throw new Error(`${argName} must have at most ${MAX_SINCE_ENTRIES} entries`);
+    }
+    const map: Record<string, string> = {};
+    for (const [topic, timestamp] of entries) {
+      if (UNSAFE_KEYS.has(topic)) {
+        throw new Error(`${argName} may not contain the key "${topic}"`);
+      }
+      if (topic.length > MAX_TOPIC_LENGTH) {
+        throw new Error(`${argName} topic keys must be at most ${MAX_TOPIC_LENGTH} characters`);
+      }
+      if (typeof timestamp !== 'string') {
+        throw new Error(`${argName}.${topic} must be a string`);
+      }
+      if (timestamp.length > MAX_TIMESTAMP_LENGTH) {
+        throw new Error(`${argName}.${topic} must be at most ${MAX_TIMESTAMP_LENGTH} characters`);
+      }
+      map[topic] = timestamp;
+    }
+    return map;
+  };
+}
 
 function broadcastChanged(): void {
   groupProjectRegistry.list().then((projects) => {
@@ -110,10 +158,10 @@ export function registerGroupProjectHandlers(): void {
   ));
 
   ipcMain.handle(IPC.GROUP_PROJECT.GET_BULLETIN_DIGEST, withValidatedArgs(
-    [stringArg(), stringArg({ optional: true })],
+    [stringArg(), digestSinceArg()],
     async (_event, id, since) => {
       const board = getBulletinBoard(id as string);
-      return board.getDigest(since as string | undefined);
+      return board.getDigest(since as DigestSince | undefined);
     },
   ));
 

--- a/src/main/services/group-project-bulletin.test.ts
+++ b/src/main/services/group-project-bulletin.test.ts
@@ -96,6 +96,69 @@ describe('BulletinBoard', () => {
     expect(t.newMessageCount).toBe(1);
   });
 
+  it('digest accepts a per-topic since map', async () => {
+    const board = getBulletinBoard('gp_test');
+    await board.postMessage('a', 'read-topic', 'old');
+    await board.postMessage('a', 'unread-topic', 'old');
+
+    const cutoff = new Date().toISOString();
+    await new Promise(r => setTimeout(r, 5));
+    await board.postMessage('b', 'read-topic', 'new');
+    await board.postMessage('b', 'unread-topic', 'new');
+
+    const digest = await board.getDigest({ 'read-topic': cutoff });
+
+    const read = digest.find(d => d.topic === 'read-topic')!;
+    expect(read.messageCount).toBe(2);
+    expect(read.newMessageCount).toBe(1);
+
+    // A topic missing from the map has never been read — everything is new.
+    const unread = digest.find(d => d.topic === 'unread-topic')!;
+    expect(unread.messageCount).toBe(2);
+    expect(unread.newMessageCount).toBe(2);
+  });
+
+  it('digest reports zero unread for a topic read up to its latest message', async () => {
+    const board = getBulletinBoard('gp_test');
+    await board.postMessage('a', 'topic', 'msg1');
+    await board.postMessage('b', 'topic', 'msg2');
+
+    const first = await board.getDigest();
+    expect(first[0].newMessageCount).toBe(2);
+
+    // Mark read at the latest timestamp, as the UI does when a channel is opened.
+    const digest = await board.getDigest({ topic: first[0].latestTimestamp });
+    expect(digest[0].messageCount).toBe(2);
+    expect(digest[0].newMessageCount).toBe(0);
+  });
+
+  it('digest counts everything as unread when the per-topic timestamp is invalid', async () => {
+    const board = getBulletinBoard('gp_test');
+    await board.postMessage('a', 'topic', 'msg1');
+
+    const digest = await board.getDigest({ topic: 'not-a-timestamp' });
+    expect(digest[0].newMessageCount).toBe(1);
+  });
+
+  it('digest with an empty since map counts everything as unread', async () => {
+    const board = getBulletinBoard('gp_test');
+    await board.postMessage('a', 'topic', 'msg1');
+    await board.postMessage('b', 'topic', 'msg2');
+
+    const digest = await board.getDigest({});
+    expect(digest[0].newMessageCount).toBe(2);
+  });
+
+  it('digest ignores inherited properties on the since map', async () => {
+    const board = getBulletinBoard('gp_test');
+    await board.postMessage('a', 'toString', 'msg1');
+
+    // A topic named after an Object.prototype member must not pick up the
+    // inherited value as its cutoff.
+    const digest = await board.getDigest({} as Record<string, string>);
+    expect(digest[0].newMessageCount).toBe(1);
+  });
+
   it('getTopicMessages returns messages for a topic', async () => {
     const board = getBulletinBoard('gp_test');
     await board.postMessage('a', 'topic1', 'msg1');

--- a/src/main/services/group-project-bulletin.ts
+++ b/src/main/services/group-project-bulletin.ts
@@ -7,7 +7,7 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { app } from 'electron';
-import type { BulletinMessage, TopicDigest } from '../../shared/group-project-types';
+import type { BulletinMessage, TopicDigest, DigestSince } from '../../shared/group-project-types';
 import { appLog } from './log-service';
 
 /** Default max message body size in bytes. */
@@ -56,6 +56,36 @@ export function normalizeChannelName(topic: string): string {
 interface BulletinData {
   topics: Record<string, BulletinMessage[]>;
   protectedTopics?: string[];
+}
+
+/**
+ * Normalize a `since` argument into a lookup usable per topic: either a single
+ * cutoff applied everywhere, or a Map keyed by canonical channel name.
+ *
+ * A Map (not a plain object) so a channel named `toString` or `__proto__`
+ * cannot pick up an inherited prototype member as its cutoff. Keys are
+ * canonicalized because channel names are case-insensitive.
+ */
+function buildSinceLookup(since: DigestSince | undefined): string | Map<string, string> | null {
+  if (!since) return null;
+  if (typeof since === 'string') return since;
+  const lookup = new Map<string, string>();
+  for (const [topic, iso] of Object.entries(since)) {
+    if (typeof iso === 'string' && iso) lookup.set(normalizeChannelName(topic), iso);
+  }
+  return lookup;
+}
+
+/**
+ * Resolve the unread cutoff for a topic. Returns 0 (meaning "everything is
+ * unread") when there is no usable timestamp for that topic.
+ */
+function resolveSince(lookup: string | Map<string, string> | null, topic: string): number {
+  if (!lookup) return 0;
+  const iso = typeof lookup === 'string' ? lookup : lookup.get(topic);
+  if (!iso) return 0;
+  const time = new Date(iso).getTime();
+  return Number.isNaN(time) ? 0 : time;
 }
 
 class BulletinBoard {
@@ -215,10 +245,15 @@ class BulletinBoard {
    * Get a digest of topics (no message bodies). Pass `channels` to restrict the
    * digest to a named list — omitted topics are still present on the board but
    * skipped in the result to reduce token cost for agents polling a small set.
+   *
+   * `since` may be a single ISO timestamp applied to every topic, or a
+   * per-topic map of `topic -> ISO timestamp` (what the UI passes so each
+   * channel's unread count reflects when that channel was last read).
+   * Topics absent from the map are treated as never read.
    */
-  async getDigest(since?: string, channels?: string[]): Promise<TopicDigest[]> {
+  async getDigest(since?: DigestSince, channels?: string[]): Promise<TopicDigest[]> {
     await this.ensureLoaded();
-    const sinceTime = since ? new Date(since).getTime() : 0;
+    const sinceLookup = buildSinceLookup(since);
     const filter = channels && channels.length > 0
       ? new Set(channels.map(normalizeChannelName))
       : null;
@@ -227,6 +262,7 @@ class BulletinBoard {
     for (const [topic, messages] of this.topics) {
       if (messages.length === 0) continue;
       if (filter && !filter.has(topic)) continue;
+      const sinceTime = resolveSince(sinceLookup, topic);
       const newMessages = sinceTime > 0
         ? messages.filter(m => new Date(m.timestamp).getTime() > sinceTime)
         : messages;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1328,7 +1328,9 @@ const api = {
       ipcRenderer.invoke(IPC.GROUP_PROJECT.UPDATE, id, fields),
     delete: (id: string): Promise<boolean> =>
       ipcRenderer.invoke(IPC.GROUP_PROJECT.DELETE, id),
-    getBulletinDigest: (id: string, since?: string): Promise<unknown[]> =>
+    // `since` is either one ISO timestamp for all topics, or a per-topic
+    // `topic -> ISO timestamp` map (used for per-channel unread counts).
+    getBulletinDigest: (id: string, since?: string | Record<string, string>): Promise<unknown[]> =>
       ipcRenderer.invoke(IPC.GROUP_PROJECT.GET_BULLETIN_DIGEST, id, since),
     getTopicMessages: (id: string, topic: string, since?: string, limit?: number): Promise<unknown[]> =>
       ipcRenderer.invoke(IPC.GROUP_PROJECT.GET_TOPIC_MESSAGES, id, topic, since, limit),

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.test.ts
@@ -71,8 +71,9 @@ describe('GroupProjectCanvasWidget — activity summary', () => {
   });
 
   it('polls bulletin digest on the compact card via context hook', () => {
-    // Compact card should call fetchDigest for activity data (abstracted via context hook)
-    expect(source).toContain('fetchDigest(groupProjectId)');
+    // Compact card should call fetchDigest for activity data (abstracted via context hook),
+    // passing the per-channel read state so its "+N new" count reflects what's unread.
+    expect(source).toContain('fetchDigest(groupProjectId, getLastRead(groupProjectId))');
   });
 });
 

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -3,6 +3,7 @@ import { GroupProjectPanelSidebar, useGroupProjectPanelLayout } from './GroupPro
 import type { CanvasWidgetComponentProps, AnnexAPI } from '../../../../shared/plugin-types';
 import type { TopicDigest, BulletinMessage } from '../../../../shared/group-project-types';
 import { useGroupProjectStore } from '../../../stores/groupProjectStore';
+import { useBulletinReadStore } from '../../../stores/bulletinReadStore';
 import { renderMarkdownSafe } from '../../../utils/safe-markdown';
 import { useRemoteProject } from '../../../hooks/useRemoteProject';
 import { useAgentStore } from '../../../stores/agentStore';
@@ -206,6 +207,26 @@ function ProjectView({
   );
 }
 
+/* ---------- Unread / read-state helpers ---------- */
+
+/**
+ * The digest entry for the channel the user has open, or null.
+ *
+ * The "All" pane deliberately marks nothing read: it is the default selection,
+ * so treating it as a read of every channel would clear every badge the moment
+ * the widget renders and make unread counts useless.
+ */
+export function openChannel(topics: TopicDigest[], selectedTopic: string): TopicDigest | null {
+  if (selectedTopic === ALL_TOPICS_KEY) return null;
+  return topics.find((t) => t.topic === selectedTopic) ?? null;
+}
+
+/** Zero the unread badge for a channel, so it clears without a poll round-trip. */
+export function clearUnread(topics: TopicDigest[], channel: TopicDigest | null): TopicDigest[] {
+  if (!channel) return topics;
+  return topics.map((t) => (t.topic === channel.topic ? { ...t, newMessageCount: 0 } : t));
+}
+
 /* ---------- Compact Card ---------- */
 
 function ProjectCard({
@@ -221,25 +242,27 @@ function ProjectCard({
 
   const [showTapModal, setShowTapModal] = useState(false);
   const [topics, setTopics] = useState<TopicDigest[]>([]);
+  const getLastRead = useBulletinReadStore((s) => s.getLastRead);
 
   useEffect(() => {
     if (!loaded) loadProjects();
   }, [loaded, loadProjects]);
 
-  // Poll bulletin digest for activity summary
+  // Poll bulletin digest for activity summary. The compact card has no channel
+  // list to open, so it only reports unread — it never marks anything read.
   useEffect(() => {
     let cancelled = false;
     const refresh = async () => {
       if (cancelled) return;
       try {
-        const digest = await fetchDigest(groupProjectId);
+        const digest = await fetchDigest(groupProjectId, getLastRead(groupProjectId));
         if (!cancelled) setTopics(digest);
       } catch { /* ignore */ }
     };
     refresh();
     const interval = setInterval(refresh, POLL_INTERVAL_MS);
     return () => { cancelled = true; clearInterval(interval); };
-  }, [groupProjectId, fetchDigest]);
+  }, [groupProjectId, fetchDigest, getLastRead]);
 
   const hasActivity = members.length > 0;
   const description = project?.description || '';
@@ -403,6 +426,11 @@ function ExpandedProjectView({
   const [confirmDeleteTopic, setConfirmDeleteTopic] = useState<string | null>(null);
   const [confirmClearAll, setConfirmClearAll] = useState(false);
 
+  // Read state is pulled at call time rather than subscribed to, so marking a
+  // channel read doesn't tear down and restart the polling interval.
+  const getLastRead = useBulletinReadStore((s) => s.getLastRead);
+  const markTopicRead = useBulletinReadStore((s) => s.markTopicRead);
+
   useEffect(() => {
     if (!loaded) loadProjects();
   }, [loaded, loadProjects]);
@@ -495,10 +523,18 @@ function ExpandedProjectView({
     const refresh = async () => {
       if (cancelled) return;
       try {
-        const digest = await fetchDigest(groupProjectId);
-        if (!cancelled) setTopics(digest);
+        const digest = await fetchDigest(groupProjectId, getLastRead(groupProjectId));
+        if (!cancelled) {
+          // The channel the user has open counts as read, including messages
+          // that arrive while they are sitting on it.
+          const open = openChannel(digest, selectedTopic);
+          setTopics(clearUnread(digest, open));
+          if (open) markTopicRead(groupProjectId, open.topic, open.latestTimestamp);
+        }
       } catch { /* ignore */ }
 
+      // Message fetches stay unfiltered — `since` drives unread counts only,
+      // the panes still show the full history of the selected channel.
       if (selectedTopic === ALL_TOPICS_KEY) {
         try {
           const allMsgs = await fetchAllMessages(groupProjectId);
@@ -515,7 +551,7 @@ function ExpandedProjectView({
     refresh();
     const interval = setInterval(refresh, POLL_INTERVAL_MS);
     return () => { cancelled = true; clearInterval(interval); };
-  }, [groupProjectId, selectedTopic, fetchDigest, fetchAllMessages, fetchTopicMessages]);
+  }, [groupProjectId, selectedTopic, fetchDigest, fetchAllMessages, fetchTopicMessages, getLastRead, markTopicRead]);
 
   // Sort messages newest-first by the numeric timestamp embedded in the message ID
   // (msg_<epoch_ms>_<random>) to match the backend's numeric sort order and avoid
@@ -538,7 +574,13 @@ function ExpandedProjectView({
     setSelectedTopic(topic);
     setSelectedMessageId(null);
     setMessages([]);
-  }, []);
+    // Clear the badge immediately rather than waiting for the next poll.
+    const open = openChannel(topics, topic);
+    if (open) {
+      markTopicRead(groupProjectId, open.topic, open.latestTimestamp);
+      setTopics((prev) => clearUnread(prev, open));
+    }
+  }, [topics, groupProjectId, markTopicRead]);
 
   const handleTogglePolling = useCallback(async () => {
     const newVal = !pollingEnabled;

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.unread.test.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.unread.test.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { TopicDigest, DigestSince } from '../../../../shared/group-project-types';
+
+// ---------- localStorage mock ----------
+let storage: Record<string, string> = {};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, val: string) => { storage[key] = val; },
+    removeItem: (key: string) => { delete storage[key]; },
+  },
+  writable: true,
+});
+
+// ---------- ResizeObserver that reports an expanded (>500px) widget ----------
+class WideResizeObserver {
+  constructor(private cb: ResizeObserverCallback) {}
+  observe(target: Element) {
+    this.cb(
+      [{ target, contentRect: { width: 900, height: 600 } } as unknown as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, 'ResizeObserver', { value: WideResizeObserver, writable: true });
+
+// The widget reaches the board through this hook; mocking it is the seam that
+// lets us assert exactly what `since` the digest is fetched with.
+const fetchDigest = vi.fn();
+vi.mock('./useGroupProjectContext', () => ({
+  useGroupProjectContext: () => ({
+    isRemote: false,
+    satelliteId: null,
+    project: { id: 'gp1', name: 'Test Project', description: '', instructions: '', metadata: {} },
+    members: [],
+    loaded: true,
+    loadProjects: vi.fn(async () => {}),
+    update: vi.fn(async () => {}),
+    setPolling: vi.fn(async () => {}),
+    fetchDigest,
+    fetchTopicMessages: vi.fn(async () => []),
+    fetchAllMessages: vi.fn(async () => []),
+    injectMessage: vi.fn(async () => {}),
+    deleteMessage: vi.fn(async () => true),
+    deleteTopic: vi.fn(async () => true),
+    setTopicProtection: vi.fn(async () => true),
+    clearAllMessages: vi.fn(async () => ({ removed: 0 })),
+    estimateTrim: vi.fn(async () => ({ wouldRemove: 0 })),
+  }),
+}));
+
+vi.mock('../../../stores/mcpSettingsStore', () => ({
+  useMcpSettingsStore: (sel: (s: unknown) => unknown) => sel({ enabled: true }),
+}));
+
+vi.mock('../../../hooks/useRemoteProject', () => ({
+  useRemoteProject: () => ({ isRemote: false, satelliteId: null }),
+}));
+
+import { GroupProjectCanvasWidget, openChannel, clearUnread } from './GroupProjectCanvasWidget';
+import { useBulletinReadStore } from '../../../stores/bulletinReadStore';
+
+const PROJECT_ID = 'gp1';
+const READ_KEY = `bulletin_read_${PROJECT_ID}`;
+
+const GENERAL_LATEST = '2026-07-25T10:00:00.000Z';
+const TASKS_LATEST = '2026-07-25T11:00:00.000Z';
+
+/** Messages the fake board holds, one per topic timestamp. */
+const BOARD: Record<string, string[]> = {
+  general: ['2026-07-25T09:00:00.000Z', GENERAL_LATEST],
+  tasks: [TASKS_LATEST],
+};
+
+/** A digest server that honours `since` exactly like the real bulletin board. */
+function fakeDigest(since?: DigestSince): TopicDigest[] {
+  return Object.entries(BOARD).map(([topic, timestamps]) => {
+    const iso = typeof since === 'string' ? since : since?.[topic];
+    const cutoff = iso ? new Date(iso).getTime() : 0;
+    const unread = cutoff > 0
+      ? timestamps.filter((t) => new Date(t).getTime() > cutoff)
+      : timestamps;
+    return {
+      topic,
+      messageCount: timestamps.length,
+      newMessageCount: unread.length,
+      latestTimestamp: timestamps[timestamps.length - 1],
+    };
+  });
+}
+
+function renderWidget() {
+  return render(
+    <GroupProjectCanvasWidget
+      widgetId="w1"
+      api={{ context: { mode: 'app', projectId: undefined }, annex: {} } as never}
+      metadata={{ groupProjectId: PROJECT_ID }}
+      onUpdateMetadata={vi.fn()}
+      size={{ width: 900, height: 600 }}
+      {...({} as never)}
+    />,
+  );
+}
+
+/** The unread badge text rendered next to a topic, e.g. "+2". */
+function unreadBadge(topic: string): string | null {
+  const button = screen.getByText(topic).closest('button')!;
+  const badge = button.querySelector('.text-ctp-green');
+  return badge ? badge.textContent : null;
+}
+
+function storedReadState(): Record<string, string> {
+  const raw = storage[READ_KEY];
+  return raw ? JSON.parse(raw) : {};
+}
+
+describe('GroupProjectCanvasWidget — unread counts', () => {
+  beforeEach(() => {
+    storage = {};
+    useBulletinReadStore.setState({ lastRead: {} });
+    fetchDigest.mockImplementation(async (_id: string, since?: DigestSince) => fakeDigest(since));
+  });
+
+  it('passes the per-channel last-read map as `since` to the digest', async () => {
+    renderWidget();
+
+    await waitFor(() => expect(fetchDigest).toHaveBeenCalled());
+    expect(fetchDigest).toHaveBeenCalledWith(PROJECT_ID, expect.any(Object));
+  });
+
+  it('shows unread counts for channels that have never been read', async () => {
+    renderWidget();
+
+    // "All" is selected by default and does not exist as a real topic, so both
+    // channels start unread until one is opened.
+    await waitFor(() => expect(screen.getByText('tasks')).toBeInTheDocument());
+    expect(unreadBadge('tasks')).toBe('+1');
+  });
+
+  it('clears the unread badge when a channel is opened', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => expect(unreadBadge('tasks')).toBe('+1'));
+
+    await user.click(screen.getByText('tasks'));
+
+    await waitFor(() => expect(unreadBadge('tasks')).toBeNull());
+  });
+
+  it('persists the last-read timestamp when a channel is opened', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => expect(screen.getByText('tasks')).toBeInTheDocument());
+    await user.click(screen.getByText('tasks'));
+
+    await waitFor(() => expect(storedReadState().tasks).toBe(TASKS_LATEST));
+    // Opening one channel must not mark the others read.
+    expect(storedReadState().general).toBeUndefined();
+  });
+
+  it('keeps the badge cleared on the next poll — the bug being fixed', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => expect(screen.getByText('tasks')).toBeInTheDocument());
+    await user.click(screen.getByText('tasks'));
+    await waitFor(() => expect(storedReadState().tasks).toBe(TASKS_LATEST));
+
+    // Replay the digest exactly as the next poll would.
+    const digest = fakeDigest(useBulletinReadStore.getState().getLastRead(PROJECT_ID));
+    expect(digest.find((d) => d.topic === 'tasks')!.newMessageCount).toBe(0);
+    // ...while an unopened channel still reports its unread messages.
+    expect(digest.find((d) => d.topic === 'general')!.newMessageCount).toBe(2);
+  });
+
+  it('counts a message posted after the read as unread again', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => expect(screen.getByText('tasks')).toBeInTheDocument());
+    await user.click(screen.getByText('tasks'));
+    await waitFor(() => expect(storedReadState().tasks).toBe(TASKS_LATEST));
+
+    BOARD.tasks.push('2026-07-25T12:00:00.000Z');
+    try {
+      const digest = fakeDigest(useBulletinReadStore.getState().getLastRead(PROJECT_ID));
+      expect(digest.find((d) => d.topic === 'tasks')!.newMessageCount).toBe(1);
+    } finally {
+      BOARD.tasks.pop();
+    }
+  });
+
+  it('restores persisted read state on remount, without a poll round-trip', async () => {
+    storage[READ_KEY] = JSON.stringify({ tasks: TASKS_LATEST });
+
+    renderWidget();
+
+    await waitFor(() => expect(fetchDigest).toHaveBeenCalled());
+    // The very first fetch already carries the stored timestamp, so the badge
+    // never flashes back on after a reload.
+    expect(fetchDigest.mock.calls[0][1]).toEqual({ tasks: TASKS_LATEST });
+    await waitFor(() => expect(unreadBadge('tasks')).toBeNull());
+    expect(unreadBadge('general')).toBe('+2');
+  });
+
+  it('does not mark anything read from the default All pane', async () => {
+    renderWidget();
+
+    await waitFor(() => expect(fetchDigest).toHaveBeenCalled());
+    // "All" is the default selection, so treating it as a read would clear
+    // every badge before the user has opened anything.
+    expect(storedReadState()).toEqual({});
+    expect(unreadBadge('general')).toBe('+2');
+    expect(unreadBadge('tasks')).toBe('+1');
+  });
+});
+
+describe('GroupProjectCanvasWidget — unread helpers', () => {
+  const digest: TopicDigest[] = [
+    { topic: 'general', messageCount: 2, newMessageCount: 2, latestTimestamp: GENERAL_LATEST },
+    { topic: 'tasks', messageCount: 1, newMessageCount: 1, latestTimestamp: TASKS_LATEST },
+  ];
+
+  it('openChannel returns the selected topic', () => {
+    expect(openChannel(digest, 'tasks')).toBe(digest[1]);
+  });
+
+  it('openChannel returns null for the All pane', () => {
+    expect(openChannel(digest, '__all__')).toBeNull();
+  });
+
+  it('openChannel returns null for an unknown topic', () => {
+    expect(openChannel(digest, 'gone')).toBeNull();
+  });
+
+  it('clearUnread zeroes only the open channel', () => {
+    const cleared = clearUnread(digest, digest[1]);
+    expect(cleared.find((t) => t.topic === 'tasks')!.newMessageCount).toBe(0);
+    expect(cleared.find((t) => t.topic === 'general')!.newMessageCount).toBe(2);
+  });
+
+  it('clearUnread leaves the list untouched when no channel is open', () => {
+    expect(clearUnread(digest, null)).toBe(digest);
+  });
+});

--- a/src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts
+++ b/src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts
@@ -6,7 +6,7 @@
  */
 import { useMemo, useCallback } from 'react';
 import type { GroupProject } from '../../../../shared/group-project-types';
-import type { TopicDigest, BulletinMessage } from '../../../../shared/group-project-types';
+import type { TopicDigest, BulletinMessage, DigestSince } from '../../../../shared/group-project-types';
 import type { AnnexAPI } from '../../../../shared/plugin-types';
 import { useGroupProjectStore } from '../../../stores/groupProjectStore';
 import { useMcpBindingStore } from '../../../stores/mcpBindingStore';
@@ -46,7 +46,7 @@ export interface GroupProjectContextValue {
   setPolling: (groupProjectId: string, enabled: boolean) => Promise<void>;
 
   /** Fetch bulletin digest. */
-  fetchDigest: (groupProjectId: string, since?: string) => Promise<TopicDigest[]>;
+  fetchDigest: (groupProjectId: string, since?: DigestSince) => Promise<TopicDigest[]>;
 
   /** Fetch messages for a specific topic. */
   fetchTopicMessages: (groupProjectId: string, topic: string, since?: string, limit?: number) => Promise<BulletinMessage[]>;
@@ -196,9 +196,13 @@ export function useGroupProjectContext(
   }, [isRemote, satelliteId, annex, localSetPolling]);
 
   // --- Bulletin reads ---
-  const fetchDigest = useCallback(async (gpId: string, since?: string): Promise<TopicDigest[]> => {
+  const fetchDigest = useCallback(async (gpId: string, since?: DigestSince): Promise<TopicDigest[]> => {
     if (isRemote && satelliteId) {
-      return await annex.gpBulletinDigest(satelliteId, stripRemotePrefix(gpId), since) as TopicDigest[];
+      // The annex bulletin protocol carries a single ISO cutoff, not a
+      // per-channel map, so remote projects keep the existing behaviour until
+      // that wire format is widened.
+      const remoteSince = typeof since === 'string' ? since : undefined;
+      return await annex.gpBulletinDigest(satelliteId, stripRemotePrefix(gpId), remoteSince) as TopicDigest[];
     }
     return await window.clubhouse.groupProject.getBulletinDigest(gpId, since) as TopicDigest[];
   }, [isRemote, satelliteId, annex]);

--- a/src/renderer/stores/bulletinReadStore.test.ts
+++ b/src/renderer/stores/bulletinReadStore.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------- localStorage mock ----------
+let storage: Record<string, string> = {};
+const setItem = vi.fn((key: string, val: string) => { storage[key] = val; });
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, val: string) => setItem(key, val),
+    removeItem: (key: string) => { delete storage[key]; },
+  },
+  writable: true,
+});
+
+import { useBulletinReadStore } from './bulletinReadStore';
+
+const KEY = 'bulletin_read_gp1';
+
+function reset(): void {
+  storage = {};
+  setItem.mockImplementation((key: string, val: string) => { storage[key] = val; });
+  useBulletinReadStore.setState({ lastRead: {} });
+}
+
+describe('bulletinReadStore', () => {
+  beforeEach(reset);
+
+  it('starts with no read state for an unknown project', () => {
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({});
+  });
+
+  it('persists a per-topic last read timestamp to localStorage', () => {
+    useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({
+      general: '2026-07-25T10:00:00.000Z',
+    });
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual({
+      general: '2026-07-25T10:00:00.000Z',
+    });
+  });
+
+  it('keeps read state per project', () => {
+    useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+    useBulletinReadStore.getState().markTopicRead('gp2', 'general', '2026-07-25T11:00:00.000Z');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1').general).toBe('2026-07-25T10:00:00.000Z');
+    expect(useBulletinReadStore.getState().getLastRead('gp2').general).toBe('2026-07-25T11:00:00.000Z');
+  });
+
+  it('keeps read state per topic within a project', () => {
+    useBulletinReadStore.getState().markTopicsRead('gp1', [
+      { topic: 'general', timestamp: '2026-07-25T10:00:00.000Z' },
+      { topic: 'tasks', timestamp: '2026-07-25T11:00:00.000Z' },
+    ]);
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({
+      general: '2026-07-25T10:00:00.000Z',
+      tasks: '2026-07-25T11:00:00.000Z',
+    });
+  });
+
+  it('advances the timestamp forward', () => {
+    const s = useBulletinReadStore.getState();
+    s.markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+    s.markTopicRead('gp1', 'general', '2026-07-25T12:00:00.000Z');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1').general).toBe('2026-07-25T12:00:00.000Z');
+  });
+
+  it('never moves the timestamp backwards', () => {
+    const s = useBulletinReadStore.getState();
+    s.markTopicRead('gp1', 'general', '2026-07-25T12:00:00.000Z');
+    s.markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1').general).toBe('2026-07-25T12:00:00.000Z');
+  });
+
+  it('ignores empty and unparseable timestamps', () => {
+    const s = useBulletinReadStore.getState();
+    s.markTopicsRead('gp1', [
+      { topic: 'general', timestamp: '' },
+      { topic: 'tasks', timestamp: 'not-a-date' },
+      { topic: '', timestamp: '2026-07-25T10:00:00.000Z' },
+    ]);
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({});
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('does not write when nothing changed', () => {
+    useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T12:00:00.000Z');
+    const before = useBulletinReadStore.getState().lastRead;
+
+    useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+
+    // Same object identity — no state update, so no needless re-render.
+    expect(useBulletinReadStore.getState().lastRead).toBe(before);
+  });
+
+  it('hydrates read state from localStorage', () => {
+    localStorage.setItem(KEY, JSON.stringify({ general: '2026-07-25T10:00:00.000Z' }));
+
+    useBulletinReadStore.getState().loadLastRead('gp1');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({
+      general: '2026-07-25T10:00:00.000Z',
+    });
+  });
+
+  it('survives a reload — persisted state is readable by a fresh load', () => {
+    useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+    useBulletinReadStore.setState({ lastRead: {} });
+
+    useBulletinReadStore.getState().loadLastRead('gp1');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1').general).toBe('2026-07-25T10:00:00.000Z');
+  });
+
+  it('ignores corrupt localStorage payloads', () => {
+    localStorage.setItem(KEY, 'not json');
+    useBulletinReadStore.getState().loadLastRead('gp1');
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({});
+
+    localStorage.setItem(KEY, JSON.stringify(['array', 'payload']));
+    useBulletinReadStore.getState().loadLastRead('gp1');
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({});
+  });
+
+  it('drops non-string values from a partially corrupt payload', () => {
+    localStorage.setItem(KEY, JSON.stringify({ general: '2026-07-25T10:00:00.000Z', tasks: 42 }));
+    useBulletinReadStore.getState().loadLastRead('gp1');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({
+      general: '2026-07-25T10:00:00.000Z',
+    });
+  });
+
+  it('clears read state for a project', () => {
+    useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z');
+    useBulletinReadStore.getState().clearLastRead('gp1');
+
+    expect(useBulletinReadStore.getState().getLastRead('gp1')).toEqual({});
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('does not throw when localStorage writes fail', () => {
+    setItem.mockImplementation(() => { throw new Error('QuotaExceededError'); });
+
+    expect(() =>
+      useBulletinReadStore.getState().markTopicRead('gp1', 'general', '2026-07-25T10:00:00.000Z'),
+    ).not.toThrow();
+    // In-memory state still advances so the session behaves correctly.
+    expect(useBulletinReadStore.getState().getLastRead('gp1').general).toBe('2026-07-25T10:00:00.000Z');
+  });
+});

--- a/src/renderer/stores/bulletinReadStore.ts
+++ b/src/renderer/stores/bulletinReadStore.ts
@@ -1,0 +1,121 @@
+import { create } from 'zustand';
+
+/**
+ * Tracks the per-channel "last read" timestamp for group project bulletin boards.
+ *
+ * Read state is per-user (this machine), not project data, so it lives in
+ * localStorage keyed by group project id rather than in the shared project file.
+ */
+
+const STORAGE_PREFIX = 'bulletin_read_';
+
+/** topic -> ISO timestamp of the newest message the user has seen. */
+export type LastReadMap = Record<string, string>;
+
+function storageKey(groupProjectId: string): string {
+  return `${STORAGE_PREFIX}${groupProjectId}`;
+}
+
+function loadFromStorage(groupProjectId: string): LastReadMap {
+  try {
+    const raw = localStorage.getItem(storageKey(groupProjectId));
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const map: LastReadMap = {};
+    for (const [topic, timestamp] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof timestamp === 'string') map[topic] = timestamp;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+function saveToStorage(groupProjectId: string, map: LastReadMap): void {
+  try {
+    localStorage.setItem(storageKey(groupProjectId), JSON.stringify(map));
+  } catch {
+    // Ignore quota / serialization errors — read state is best-effort.
+  }
+}
+
+function timeOf(iso: string | undefined): number {
+  if (!iso) return 0;
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+interface BulletinReadState {
+  /** groupProjectId -> (topic -> last read ISO timestamp). */
+  lastRead: Record<string, LastReadMap>;
+  /** Hydrate a project's read state from localStorage. */
+  loadLastRead: (groupProjectId: string) => LastReadMap;
+  /**
+   * Current read state for a project, hydrating from localStorage on first
+   * access so the very first digest fetch already knows what has been read.
+   * Call from effects/callbacks, not during render — it may update the store.
+   */
+  getLastRead: (groupProjectId: string) => LastReadMap;
+  /** Mark a single topic read up to `timestamp`. Never moves backwards. */
+  markTopicRead: (groupProjectId: string, topic: string, timestamp: string) => void;
+  /** Mark several topics read in one update. Never moves any topic backwards. */
+  markTopicsRead: (
+    groupProjectId: string,
+    entries: Array<{ topic: string; timestamp: string }>,
+  ) => void;
+  /** Drop read state for a project (e.g. when the project is deleted). */
+  clearLastRead: (groupProjectId: string) => void;
+}
+
+export const useBulletinReadStore = create<BulletinReadState>((set, get) => ({
+  lastRead: {},
+
+  loadLastRead: (groupProjectId) => {
+    const map = loadFromStorage(groupProjectId);
+    set((s) => ({ lastRead: { ...s.lastRead, [groupProjectId]: map } }));
+    return map;
+  },
+
+  getLastRead: (groupProjectId) => {
+    const existing = get().lastRead[groupProjectId];
+    if (existing) return existing;
+    return get().loadLastRead(groupProjectId);
+  },
+
+  markTopicRead: (groupProjectId, topic, timestamp) => {
+    get().markTopicsRead(groupProjectId, [{ topic, timestamp }]);
+  },
+
+  markTopicsRead: (groupProjectId, entries) => {
+    const current = get().lastRead[groupProjectId] ?? {};
+    const next = { ...current };
+    let changed = false;
+
+    for (const { topic, timestamp } of entries) {
+      if (!topic || !timestamp) continue;
+      const incoming = timeOf(timestamp);
+      if (incoming === 0) continue;
+      if (incoming <= timeOf(next[topic])) continue;
+      next[topic] = timestamp;
+      changed = true;
+    }
+
+    if (!changed) return;
+    saveToStorage(groupProjectId, next);
+    set((s) => ({ lastRead: { ...s.lastRead, [groupProjectId]: next } }));
+  },
+
+  clearLastRead: (groupProjectId) => {
+    try {
+      localStorage.removeItem(storageKey(groupProjectId));
+    } catch {
+      // Ignore
+    }
+    set((s) => {
+      const next = { ...s.lastRead };
+      delete next[groupProjectId];
+      return { lastRead: next };
+    });
+  },
+}));

--- a/src/shared/group-project-types.ts
+++ b/src/shared/group-project-types.ts
@@ -36,3 +36,11 @@ export interface BulletinRetentionConfig {
   maxPerTopic: number;
   maxTotal: number;
 }
+
+/**
+ * Unread cutoff for a bulletin digest: a single ISO timestamp applied to every
+ * channel, or a per-channel `channel -> ISO timestamp` map. The map form is
+ * what the UI passes so each channel's unread count reflects when that channel
+ * was last read.
+ */
+export type DigestSince = string | Record<string, string>;


### PR DESCRIPTION
## Problem

Group project bulletin channels always showed every message as unread, and the badge never cleared.

`getDigest` computes `newMessageCount` from its `since` param, and that logic was correct — but the UI never passed `since`. It defaulted to `0`, so every message ever posted counted as new, forever. There was also no mark-as-read mechanism anywhere in the codebase: no API, no IPC handler, no store action. `handleTopicClick` only updated local selection state.

Broken since the channel-model redesign (#1382) that introduced this widget.

## Fix

**`bulletinReadStore` (new)** — per-user, per-channel last-read map persisted to localStorage, keyed by group project id. Timestamps only ever move forward, and hydration is lazy (`getLastRead` loads on first access) so the very first digest fetch after a reload already carries the stored state instead of flashing badges back on.

**`getDigest`** now accepts a per-channel `channel -> ISO timestamp` map in addition to the existing single-timestamp form, so each channel's unread count reflects when *that* channel was last read. Channels absent from the map are treated as never read. The map is canonicalized through `normalizeChannelName` and resolved through a `Map`, so it composes with case-insensitive channel names (#1549).

**Widget** passes the map as `since` and marks the open channel read — on click, and on each poll while the user sits on it (so messages arriving while you're reading don't pile up a phantom badge). The badge also clears locally on click rather than lingering for a poll interval. The compact card's aggregate "+N new" indicator had the same bug and is fixed the same way (it only reports unread; it has no channel list to open, so it never marks anything read).

## Three deliberate calls

- **The "All" pane marks nothing read.** It's the default selection, so treating it as a read of every channel would clear every badge the moment the widget renders and make unread counts useless. Only opening a specific channel clears it.
- **Message fetches stay unfiltered.** Passing `since` into `getTopicMessages`/`getAllMessages` would hide already-read history from the panes — you'd open a channel and see only new messages. `since` drives unread counts only.
- **Remote (annex) projects keep the old behaviour for now.** The annex bulletin protocol carries a single ISO cutoff, not a per-channel map, and widening it spans preload → annex client → wire protocol → satellite handler, which I can't verify without a live satellite. `fetchDigest` degrades to `undefined` on the remote path — no regression, but remote projects still show everything unread. Worth a follow-up.

## Security

The IPC boundary validates the map: entry count (≤500), key/value lengths, string-typed values, and rejects `__proto__`/`constructor`/`prototype` keys. The digest builds its lookup as a `Map` rather than a plain object, so a channel named `toString` can't inherit a cutoff from `Object.prototype`.

## Tests

45 new tests across four layers:

- `bulletinReadStore.test.ts` (14) — persistence, per-project/per-channel isolation, monotonic timestamps, corrupt-payload handling, quota failures.
- `group-project-bulletin.test.ts` (+6) — per-channel map, zero unread after a read, invalid/empty timestamps, inherited-property guard.
- `group-project-handlers.test.ts` (+13) — validator accept/reject cases including bounds and prototype-pollution keys.
- `GroupProjectCanvasWidget.unread.test.tsx` (new, 13) — component test through the context hook: badge shows, clears on open, persists, stays cleared on the next poll, comes back for a newer message, restores across remount, and the All pane marks nothing read.

Full suite green: 12563 passed, 4 skipped.

/cc @chirpy-mole for security/QA review.