### PR TITLE
fix(annex): carry per-channel bulletin read state to remote projects

### DIFF
--- a/src/main/ipc/annex-client-handlers.test.ts
+++ b/src/main/ipc/annex-client-handlers.test.ts
@@ -31,6 +31,7 @@ vi.mock('../services/annex-client', () => ({
   requestCreateDurable: vi.fn(async () => ({})),
   requestDeleteDurable: vi.fn(async () => ({})),
   requestWorktreeStatus: vi.fn(async () => ({})),
+  requestBulletinDigest: vi.fn(async () => []),
 }));
 
 import { ipcMain } from 'electron';
@@ -222,4 +223,50 @@ describe('annex-client-handlers', () => {
       payload: { projectId: 'proj-1', orderedIds: ['a2', 'a1'] },
     });
   });
+
+  // ── Bulletin digest `since` validation at the annex boundary (#1556) ──────
+  describe('bulletin digest since', () => {
+    const ISO = '2026-07-25T10:00:00.000Z';
+
+    function digestHandler() {
+      return handlers.get(IPC.ANNEX_CLIENT.GP_BULLETIN_DIGEST)!;
+    }
+
+    it('forwards a single ISO timestamp', async () => {
+      await digestHandler()({} as any, 'sat-1', 'gp-1', ISO);
+      expect(annexClient.requestBulletinDigest).toHaveBeenCalledWith('sat-1', 'gp-1', ISO);
+    });
+
+    it('forwards a per-channel map', async () => {
+      const map = { general: ISO };
+      await digestHandler()({} as any, 'sat-1', 'gp-1', map);
+      expect(annexClient.requestBulletinDigest).toHaveBeenCalledWith('sat-1', 'gp-1', map);
+    });
+
+    it('forwards an absent cutoff', async () => {
+      await digestHandler()({} as any, 'sat-1', 'gp-1', undefined);
+      expect(annexClient.requestBulletinDigest).toHaveBeenCalledWith('sat-1', 'gp-1', undefined);
+    });
+
+    it('rejects a malformed cutoff before it reaches the satellite', () => {
+      expect(() => digestHandler()({} as any, 'sat-1', 'gp-1', ['array'])).toThrow('must be a string or an object');
+      expect(() => digestHandler()({} as any, 'sat-1', 'gp-1', { general: 42 })).toThrow('must be a string');
+      expect(annexClient.requestBulletinDigest).not.toHaveBeenCalled();
+    });
+
+    it('rejects prototype-polluting keys — same rules as the local boundary', () => {
+      const payload = JSON.parse(`{"__proto__": {"polluted": true}, "general": "${ISO}"}`);
+      expect(() => digestHandler()({} as any, 'sat-1', 'gp-1', payload)).toThrow('may not contain the key');
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(annexClient.requestBulletinDigest).not.toHaveBeenCalled();
+    });
+
+    it('rejects an over-large map', () => {
+      const huge: Record<string, string> = {};
+      for (let i = 0; i < 501; i++) huge[`t${i}`] = ISO;
+      expect(() => digestHandler()({} as any, 'sat-1', 'gp-1', huge)).toThrow('at most 500 entries');
+      expect(annexClient.requestBulletinDigest).not.toHaveBeenCalled();
+    });
+  });
 });
+

--- a/src/main/ipc/annex-client-handlers.ts
+++ b/src/main/ipc/annex-client-handlers.ts
@@ -4,7 +4,8 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import * as annexClient from '../services/annex-client';
-import { withValidatedArgs, stringArg, numberArg, objectArg, arrayArg, booleanArg } from './validation';
+import { withValidatedArgs, stringArg, numberArg, objectArg, arrayArg, booleanArg, digestSinceArg } from './validation';
+import type { DigestSince } from '../../shared/group-project-types';
 
 export function registerAnnexClientHandlers(): void {
   ipcMain.handle(IPC.ANNEX_CLIENT.GET_SATELLITES, () => {
@@ -265,9 +266,9 @@ export function registerAnnexClientHandlers(): void {
 
   // Group Project proxy: get bulletin digest from satellite
   ipcMain.handle(IPC.ANNEX_CLIENT.GP_BULLETIN_DIGEST, withValidatedArgs(
-    [stringArg(), stringArg(), stringArg({ optional: true })],
+    [stringArg(), stringArg(), digestSinceArg()],
     async (_event, satelliteId, groupProjectId, since) => {
-      return annexClient.requestBulletinDigest(satelliteId, groupProjectId, since);
+      return annexClient.requestBulletinDigest(satelliteId, groupProjectId, since as DigestSince | undefined);
     },
   ));
 

--- a/src/main/ipc/group-project-handlers.test.ts
+++ b/src/main/ipc/group-project-handlers.test.ts
@@ -103,7 +103,8 @@ import { executeShoulderTap } from '../services/group-project-shoulder-tap';
 import * as annexEventBus from '../services/annex-event-bus';
 import { isMcpEnabledForAny } from '../services/mcp-settings';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
-import { registerGroupProjectHandlers, _resetHandlersForTesting, digestSinceArg } from './group-project-handlers';
+import { registerGroupProjectHandlers, _resetHandlersForTesting } from './group-project-handlers';
+import { digestSinceArg } from './validation';
 
 type HandlerFn = (...args: unknown[]) => unknown;
 const handlers = new Map<string, HandlerFn>();

--- a/src/main/ipc/group-project-handlers.ts
+++ b/src/main/ipc/group-project-handlers.ts
@@ -12,7 +12,7 @@ import { executeShoulderTap } from '../services/group-project-shoulder-tap';
 import * as annexEventBus from '../services/annex-event-bus';
 import { appLog } from '../services/log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
-import { withValidatedArgs, stringArg, objectArg, numberArg, booleanArg, type ArgValidator } from './validation';
+import { withValidatedArgs, stringArg, objectArg, numberArg, booleanArg, digestSinceArg } from './validation';
 import type { DigestSince } from '../../shared/group-project-types';
 import { agentRegistry } from '../services/agent-registry';
 import * as ptyManager from '../services/pty-manager';
@@ -20,53 +20,6 @@ import * as structuredManager from '../services/structured-manager';
 import { writeChunkedBracketedPaste, submitAfterPaste } from '../services/clubhouse-mcp/tools/agent-tools';
 import { getProvider } from '../orchestrators';
 import type { PasteSubmitTiming } from '../orchestrators';
-
-/** Upper bounds on the per-topic read map, so a bad caller can't send an unbounded object. */
-const MAX_SINCE_ENTRIES = 500;
-const MAX_TOPIC_LENGTH = 256;
-const MAX_TIMESTAMP_LENGTH = 64;
-/** Keys that must never be copied onto a plain object. */
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-/**
- * `since` for the digest: either a single ISO timestamp, or a per-topic
- * `topic -> ISO timestamp` map.
- */
-export function digestSinceArg(): ArgValidator<DigestSince | undefined> {
-  return (value, argName) => {
-    if (value === undefined || value === null) return undefined;
-    if (typeof value === 'string') {
-      if (value.length > MAX_TIMESTAMP_LENGTH) {
-        throw new Error(`${argName} timestamp must be at most ${MAX_TIMESTAMP_LENGTH} characters`);
-      }
-      return value;
-    }
-    if (typeof value !== 'object' || Array.isArray(value)) {
-      throw new Error(`${argName} must be a string or an object`);
-    }
-    const entries = Object.entries(value as Record<string, unknown>);
-    if (entries.length > MAX_SINCE_ENTRIES) {
-      throw new Error(`${argName} must have at most ${MAX_SINCE_ENTRIES} entries`);
-    }
-    const map: Record<string, string> = {};
-    for (const [topic, timestamp] of entries) {
-      if (UNSAFE_KEYS.has(topic)) {
-        throw new Error(`${argName} may not contain the key "${topic}"`);
-      }
-      if (topic.length > MAX_TOPIC_LENGTH) {
-        throw new Error(`${argName} topic keys must be at most ${MAX_TOPIC_LENGTH} characters`);
-      }
-      if (typeof timestamp !== 'string') {
-        throw new Error(`${argName}.${topic} must be a string`);
-      }
-      if (timestamp.length > MAX_TIMESTAMP_LENGTH) {
-        throw new Error(`${argName}.${topic} must be at most ${MAX_TIMESTAMP_LENGTH} characters`);
-      }
-      map[topic] = timestamp;
-    }
-    return map;
-  };
-}
 
 function broadcastChanged(): void {
   groupProjectRegistry.list().then((projects) => {

--- a/src/main/ipc/validation.ts
+++ b/src/main/ipc/validation.ts
@@ -1,4 +1,6 @@
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+import type { DigestSince } from '../../shared/group-project-types';
+import { parseDigestSince } from '../../shared/digest-since';
 
 type IpcEvent = IpcMainEvent | IpcMainInvokeEvent;
 type IpcHandler<Args extends unknown[], Result> = (event: IpcEvent, ...args: Args) => Result;
@@ -124,4 +126,18 @@ export function withValidatedArgs<Args extends unknown[], Result>(
     const args = validateArgs(rawArgs, validators);
     return handler(event, ...args);
   };
+}
+
+/**
+ * `since` for a bulletin digest: a single ISO timestamp, or a per-channel
+ * `channel -> ISO timestamp` map.
+ *
+ * Lives here rather than beside one handler because two IPC boundaries take
+ * this value — the local group-project digest and the annex client's proxy to
+ * a satellite — and both must enforce identical bounds and prototype-key
+ * rejection. The rules themselves are in the shared parser, which the
+ * satellite's HTTP handler also uses.
+ */
+export function digestSinceArg(): ArgValidator<DigestSince | undefined> {
+  return (value, argName) => parseDigestSince(value, argName);
 }

--- a/src/main/services/annex-client.test.ts
+++ b/src/main/services/annex-client.test.ts
@@ -1260,6 +1260,141 @@ describe('annex-client', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Per-channel bulletin read state over the annex REST call (#1556)
+  // -------------------------------------------------------------------------
+  describe('requestBulletinDigest since encoding', () => {
+    const ISO = '2026-07-25T10:00:00.000Z';
+    const FINGERPRINT = 'AA:BB:CC:FF';
+
+    async function connectSatellite() {
+      const { WebSocket: WsMock } = await import('ws');
+
+      mockHttpGetIdentity({
+        fingerprint: FINGERPRINT,
+        alias: 'Digest Satellite',
+        icon: 'server',
+        color: 'blue',
+        publicKey: 'digest-pub-key',
+      });
+
+      vi.mocked(annexPeers.getPeer).mockReturnValue({
+        fingerprint: FINGERPRINT,
+        alias: 'Digest Satellite',
+        icon: 'server',
+        color: 'blue',
+        publicKey: 'digest-pub-key',
+        pairedAt: '2024-01-01',
+        lastSeen: '2024-01-01',
+      });
+
+      let openCb: (() => void) | null = null;
+
+      vi.mocked(WsMock).mockImplementation(function (this: any) {
+        this.readyState = 1;
+        this.on = vi.fn().mockImplementation((event: string, cb: any) => {
+          if (event === 'open') openCb = cb;
+          return this;
+        });
+        this.send = vi.fn();
+        this.ping = vi.fn();
+        this.close = vi.fn();
+        this.terminate = vi.fn();
+        this.removeListener = vi.fn();
+        return this;
+      } as any);
+
+      vi.useFakeTimers();
+      annexClient.startClient();
+      await bonjourFindCallback!(makeService());
+      await vi.advanceTimersByTimeAsync(0);
+      openCb!();
+      vi.useRealTimers();
+    }
+
+    /** Capture the URL the client builds and answer with an empty digest. */
+    function captureUrl(): { get: () => string } {
+      let captured = '';
+      vi.mocked(https.get).mockImplementation((url: any, _opts: any, cb: any) => {
+        captured = String(url);
+        const res = {
+          statusCode: 200,
+          resume: vi.fn(),
+          on: vi.fn().mockImplementation((event: string, handler: any) => {
+            if (event === 'data') handler(Buffer.from('[]'));
+            if (event === 'end') handler();
+            return res;
+          }),
+        };
+        cb(res);
+        return { on: vi.fn().mockReturnThis(), setTimeout: vi.fn(), destroy: vi.fn() } as any;
+      });
+      return { get: () => captured };
+    }
+
+    function queryOf(url: string): URLSearchParams {
+      return new URLSearchParams(url.slice(url.indexOf('?') + 1));
+    }
+
+    it('sends no cutoff params when since is omitted', async () => {
+      await connectSatellite();
+      const url = captureUrl();
+
+      await annexClient.requestBulletinDigest(FINGERPRINT, 'gp-1');
+
+      expect(url.get()).not.toContain('?');
+    });
+
+    it('sends a single timestamp as `since`', async () => {
+      await connectSatellite();
+      const url = captureUrl();
+
+      await annexClient.requestBulletinDigest(FINGERPRINT, 'gp-1', ISO);
+
+      expect(queryOf(url.get()).get('since')).toBe(ISO);
+    });
+
+    it('sends a per-channel map as JSON in `sinceChannels`, not `since`', async () => {
+      await connectSatellite();
+      const url = captureUrl();
+      const map = { general: ISO, 'inbox-warm-alpaca': '2026-07-25T11:00:00.000Z' };
+
+      await annexClient.requestBulletinDigest(FINGERPRINT, 'gp-1', map);
+
+      const params = queryOf(url.get());
+      expect(JSON.parse(params.get('sinceChannels')!)).toEqual(map);
+      // Overloading `since` would make an older satellite parse JSON as a date.
+      expect(params.get('since')).toBeNull();
+    });
+
+    it('omits the cutoff and warns when the map is too large for a URL', async () => {
+      await connectSatellite();
+      const { appLog } = await import('./log-service');
+      vi.mocked(appLog).mockClear();
+      const url = captureUrl();
+      const huge: Record<string, string> = {};
+      for (let i = 0; i < 400; i++) huge[`channel-with-a-long-name-${i}`] = ISO;
+
+      await annexClient.requestBulletinDigest(FINGERPRINT, 'gp-1', huge);
+
+      expect(url.get()).not.toContain('sinceChannels');
+      expect(appLog).toHaveBeenCalledWith(
+        'core:annex-client', 'warn',
+        'Per-channel read map too large for digest request; requesting without a cutoff',
+        expect.objectContaining({ meta: expect.objectContaining({ channels: 400 }) }),
+      );
+    });
+
+    it('sends no params for an empty map', async () => {
+      await connectSatellite();
+      const url = captureUrl();
+
+      await annexClient.requestBulletinDigest(FINGERPRINT, 'gp-1', {});
+
+      expect(url.get()).not.toContain('?');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Bug fix LB-AN-003: pong timeout clears heartbeat interval before reconnect
   // -------------------------------------------------------------------------
 

--- a/src/main/services/annex-client.ts
+++ b/src/main/services/annex-client.ts
@@ -17,6 +17,8 @@ import * as headlessTerminal from './pty-headless-terminal';
 import { appLog } from './log-service';
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { IPC } from '../../shared/ipc-channels';
+import type { DigestSince } from '../../shared/group-project-types';
+import { encodeDigestSince } from '../../shared/digest-since';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -912,14 +914,23 @@ export function requestFileRead(fingerprint: string, projectId: string, path: st
 /**
  * Fetch group project bulletin digest from a satellite via HTTPS REST.
  */
-export function requestBulletinDigest(fingerprint: string, groupProjectId: string, since?: string): Promise<unknown[]> {
+export function requestBulletinDigest(fingerprint: string, groupProjectId: string, since?: DigestSince): Promise<unknown[]> {
   const sat = satellites.get(fingerprint);
   if (!sat || sat.state !== 'connected') return Promise.resolve([]);
 
   const identity = annexIdentity.getOrCreateIdentity();
   const tlsOptions = annexTls.createTlsClientOptions(identity);
   const params = new URLSearchParams();
-  if (since) params.set('since', since);
+  // A satellite predating per-channel read state ignores `sinceChannels` and
+  // answers with no cutoff — everything unread, the pre-#1555 behaviour —
+  // rather than erroring. That is the compatibility story for this endpoint.
+  const encoded = encodeDigestSince(since);
+  if (encoded.oversized) {
+    appLog('core:annex-client', 'warn', 'Per-channel read map too large for digest request; requesting without a cutoff', {
+      meta: { fingerprint, groupProjectId, channels: Object.keys(since as Record<string, string>).length },
+    });
+  }
+  for (const [key, value] of Object.entries(encoded.params)) params.set(key, value);
   const qs = params.toString() ? `?${params.toString()}` : '';
 
   return new Promise<unknown[]>((resolve) => {

--- a/src/main/services/annex-server.test.ts
+++ b/src/main/services/annex-server.test.ts
@@ -2044,6 +2044,151 @@ describe('annex-server', () => {
     });
   });
 
+  describe('group project bulletin digest endpoint', () => {
+    const ISO = '2026-07-25T10:00:00.000Z';
+
+    async function setupDigest() {
+      const { groupProjectRegistry } = await import('./group-project-registry');
+      const { getBulletinBoard } = await import('./group-project-bulletin');
+      vi.mocked(groupProjectRegistry.get).mockResolvedValue({ id: 'gp_1', name: 'GP' } as any);
+      const getDigest = vi.fn().mockResolvedValue([]);
+      vi.mocked(getBulletinBoard).mockReturnValue({ getDigest } as any);
+      return { getDigest, ...(await startAndPair()) };
+    }
+
+    it('passes a plain `since` through — an older controller keeps working', async () => {
+      const { port, token, getDigest } = await setupDigest();
+
+      const res = await request(
+        port, 'GET', `/api/v1/group-projects/gp_1/bulletin/digest?since=${encodeURIComponent(ISO)}`,
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(200);
+      expect(getDigest).toHaveBeenCalledWith(ISO);
+    });
+
+    it('decodes `sinceChannels` into a per-channel map', async () => {
+      const { port, token, getDigest } = await setupDigest();
+      const map = { general: ISO, tasks: '2026-07-25T11:00:00.000Z' };
+
+      const res = await request(
+        port, 'GET',
+        `/api/v1/group-projects/gp_1/bulletin/digest?sinceChannels=${encodeURIComponent(JSON.stringify(map))}`,
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(200);
+      expect(getDigest).toHaveBeenCalledWith(map);
+    });
+
+    it('requests no cutoff when neither param is sent', async () => {
+      const { port, token, getDigest } = await setupDigest();
+
+      const res = await request(
+        port, 'GET', '/api/v1/group-projects/gp_1/bulletin/digest',
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(200);
+      expect(getDigest).toHaveBeenCalledWith(undefined);
+    });
+
+    it('rejects malformed JSON in sinceChannels with 400', async () => {
+      const { port, token, getDigest } = await setupDigest();
+
+      const res = await request(
+        port, 'GET', '/api/v1/group-projects/gp_1/bulletin/digest?sinceChannels=not-json',
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(400);
+      expect(JSON.parse(res.body).error).toBe('invalid_since');
+      expect(getDigest).not.toHaveBeenCalled();
+    });
+
+    it('rejects prototype-polluting keys from a paired peer with 400', async () => {
+      const { port, token, getDigest } = await setupDigest();
+      const payload = '{"__proto__": {"polluted": true}}';
+
+      const res = await request(
+        port, 'GET',
+        `/api/v1/group-projects/gp_1/bulletin/digest?sinceChannels=${encodeURIComponent(payload)}`,
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(400);
+      expect(getDigest).not.toHaveBeenCalled();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('rejects an over-long sinceChannels param with 400 rather than doing the work', async () => {
+      const { port, token, getDigest } = await setupDigest();
+      // Past MAX_SINCE_PARAM_LENGTH but still inside Node's ~16KB request-line
+      // limit, so the handler's own guard is what rejects it. Anything larger
+      // never reaches us — Node answers 431 — which is why the controller caps
+      // the encoded length before sending (see encodeDigestSince).
+      const huge: Record<string, string> = {};
+      for (let i = 0; i < 200; i++) huge[`t${i}`] = ISO;
+
+      const res = await request(
+        port, 'GET',
+        `/api/v1/group-projects/gp_1/bulletin/digest?sinceChannels=${encodeURIComponent(JSON.stringify(huge))}`,
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(400);
+      expect(getDigest).not.toHaveBeenCalled();
+    });
+
+    it('accepts exactly what the controller\'s encoder produces', async () => {
+      const { encodeDigestSince } = await import('../../shared/digest-since');
+      const { port, token, getDigest } = await setupDigest();
+      const map = { general: ISO, 'inbox-warm-alpaca': '2026-07-25T11:30:00.000Z' };
+
+      // Build the query with the same function annex-client uses, then send it
+      // through the real HTTP route. Closes the encode/decode loop across the
+      // two halves without needing a live satellite pair.
+      const { params } = encodeDigestSince(map);
+      const qs = new URLSearchParams(params).toString();
+
+      const res = await request(
+        port, 'GET', `/api/v1/group-projects/gp_1/bulletin/digest?${qs}`,
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(200);
+      expect(getDigest).toHaveBeenCalledWith(map);
+    });
+
+    it('documents the compat contract: a pre-#1556 satellite ignores sinceChannels', async () => {
+      const { encodeDigestSince } = await import('../../shared/digest-since');
+      const { params } = encodeDigestSince({ general: ISO });
+      const qs = new URLSearchParams(params).toString();
+
+      // This is verbatim how the old handler read the query string. It yields
+      // no cutoff — everything unread, the pre-#1555 behaviour — rather than
+      // misparsing JSON as a date or erroring. Asserted here because running an
+      // actual older satellite build isn't possible in CI.
+      const oldParsed = new URLSearchParams(qs).get('since') || undefined;
+      expect(oldParsed).toBeUndefined();
+    });
+
+    it('still 404s for an unknown group project', async () => {
+      const { groupProjectRegistry } = await import('./group-project-registry');
+      vi.mocked(groupProjectRegistry.get).mockResolvedValue(null as any);
+      const { port, token } = await startAndPair();
+
+      const res = await request(
+        port, 'GET', '/api/v1/group-projects/gp_missing/bulletin/digest',
+        undefined, authHeaders(token),
+      );
+
+      expect(res.status).toBe(404);
+      expect(JSON.parse(res.body).error).toBe('group_project_not_found');
+    });
+  });
+
   describe('theme broadcast includes terminal colors', () => {
     it('snapshot includes terminalColors field', async () => {
       // eslint-disable-next-line no-restricted-syntax -- TODO(TC-CRIT-03): structural test pending behavioral conversion

--- a/src/main/services/annex-server.ts
+++ b/src/main/services/annex-server.ts
@@ -44,6 +44,8 @@ function isAgentRunning(agentId: string): boolean {
 }
 import { broadcastToAllWindows } from '../util/ipc-broadcast';
 import { IPC } from '../../shared/ipc-channels';
+import type { DigestSince } from '../../shared/group-project-types';
+import { decodeDigestSince, SINCE_CHANNELS_PARAM } from '../../shared/digest-since';
 import { THEMES } from '../../renderer/themes';
 import { generateQuickName } from '../../shared/name-generator';
 import { generateQuickAgentId } from '../../shared/agent-id';
@@ -1856,6 +1858,9 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
   }
 
   // GET /api/v1/group-projects/:id/bulletin/digest?since=<ISO8601>
+  //   or ?sinceChannels=<JSON {channel: ISO8601}> for per-channel unread counts.
+  // Controllers predating per-channel read state send only `since`; this handler
+  // still honours it, so an older controller against a newer satellite keeps working.
   const gpDigestMatch = url.match(/^\/api\/v1\/group-projects\/([^/]+)\/bulletin\/digest(\?.*)?$/);
   if (method === 'GET' && gpDigestMatch) {
     const gpId = decodeURIComponent(gpDigestMatch[1]);
@@ -1865,7 +1870,17 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
       return;
     }
     const params = new URLSearchParams(gpDigestMatch[2]?.slice(1) || '');
-    const since = params.get('since') || undefined;
+    let since: DigestSince | undefined;
+    try {
+      // Same bounds and prototype-key rejection the local IPC boundary applies.
+      since = decodeDigestSince(params.get('since'), params.get(SINCE_CHANNELS_PARAM));
+    } catch (err) {
+      appLog('core:annex-server', 'warn', 'Rejected bulletin digest request with invalid since', {
+        meta: { gpId, error: err instanceof Error ? err.message : String(err) },
+      });
+      sendJson(res, 400, { error: 'invalid_since' });
+      return;
+    }
     const board = getBulletinBoard(gpId);
     const digest = await board.getDigest(since);
     sendJson(res, 200, digest);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1054,7 +1054,7 @@ const api = {
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.GP_GET, satelliteId, groupProjectId),
     gpUpdate: (satelliteId: string, groupProjectId: string, fields: { name?: string; description?: string; instructions?: string; metadata?: Record<string, unknown> }): Promise<unknown> =>
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.GP_UPDATE, satelliteId, groupProjectId, fields),
-    gpBulletinDigest: (satelliteId: string, groupProjectId: string, since?: string): Promise<unknown[]> =>
+    gpBulletinDigest: (satelliteId: string, groupProjectId: string, since?: string | Record<string, string>): Promise<unknown[]> =>
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.GP_BULLETIN_DIGEST, satelliteId, groupProjectId, since),
     gpBulletinTopic: (satelliteId: string, groupProjectId: string, topic: string, since?: string, limit?: number): Promise<unknown[]> =>
       ipcRenderer.invoke(IPC.ANNEX_CLIENT.GP_BULLETIN_TOPIC, satelliteId, groupProjectId, topic, since, limit),

--- a/src/renderer/plugins/builtin/group-project/useGroupProjectContext.test.ts
+++ b/src/renderer/plugins/builtin/group-project/useGroupProjectContext.test.ts
@@ -128,6 +128,35 @@ describe('useGroupProjectContext — remote optimistic update', () => {
     expect(updated.metadata.shoulderTapEnabled).toBe(false);
   });
 
+  it('forwards a per-channel read map to the satellite when remote', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(GP_ID, true, SAT_ID, mockAnnex));
+
+    mockGpBulletinDigest.mockResolvedValue([]);
+    const map = { general: '2026-07-25T10:00:00.000Z', tasks: '2026-07-25T11:00:00.000Z' };
+
+    await act(async () => {
+      await result.current.fetchDigest(GP_ID, map);
+    });
+
+    // Previously degraded to undefined because the annex call only took a
+    // single ISO cutoff (#1556) — remote projects showed everything unread.
+    expect(mockGpBulletinDigest).toHaveBeenCalledWith(SAT_ID, GP_ID, map);
+  });
+
+  it('forwards a single timestamp to the satellite when remote', async () => {
+    seedRemoteGP();
+    const { result } = renderHook(() => useGroupProjectContext(GP_ID, true, SAT_ID, mockAnnex));
+
+    mockGpBulletinDigest.mockResolvedValue([]);
+
+    await act(async () => {
+      await result.current.fetchDigest(GP_ID, '2026-07-25T10:00:00.000Z');
+    });
+
+    expect(mockGpBulletinDigest).toHaveBeenCalledWith(SAT_ID, GP_ID, '2026-07-25T10:00:00.000Z');
+  });
+
   it('routes fetchDigest through annex client when remote', async () => {
     seedRemoteGP();
     const { result } = renderHook(() => useGroupProjectContext(GP_ID, true, SAT_ID, mockAnnex));

--- a/src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts
+++ b/src/renderer/plugins/builtin/group-project/useGroupProjectContext.ts
@@ -198,11 +198,9 @@ export function useGroupProjectContext(
   // --- Bulletin reads ---
   const fetchDigest = useCallback(async (gpId: string, since?: DigestSince): Promise<TopicDigest[]> => {
     if (isRemote && satelliteId) {
-      // The annex bulletin protocol carries a single ISO cutoff, not a
-      // per-channel map, so remote projects keep the existing behaviour until
-      // that wire format is widened.
-      const remoteSince = typeof since === 'string' ? since : undefined;
-      return await annex.gpBulletinDigest(satelliteId, stripRemotePrefix(gpId), remoteSince) as TopicDigest[];
+      // Carries the per-channel map too; a satellite that predates it ignores
+      // the param and answers with no cutoff rather than erroring.
+      return await annex.gpBulletinDigest(satelliteId, stripRemotePrefix(gpId), since) as TopicDigest[];
     }
     return await window.clubhouse.groupProject.getBulletinDigest(gpId, since) as TopicDigest[];
   }, [isRemote, satelliteId, annex]);

--- a/src/shared/digest-since.test.ts
+++ b/src/shared/digest-since.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseDigestSince,
+  encodeDigestSince,
+  decodeDigestSince,
+  SINCE_CHANNELS_PARAM,
+  MAX_SINCE_PARAM_LENGTH,
+} from './digest-since';
+
+const ISO = '2026-07-25T10:00:00.000Z';
+
+describe('parseDigestSince', () => {
+  it('accepts undefined and null', () => {
+    expect(parseDigestSince(undefined, 'since')).toBeUndefined();
+    expect(parseDigestSince(null, 'since')).toBeUndefined();
+  });
+
+  it('accepts a single ISO timestamp', () => {
+    expect(parseDigestSince(ISO, 'since')).toBe(ISO);
+  });
+
+  it('accepts a per-channel map', () => {
+    const map = { general: ISO, tasks: '2026-07-25T11:00:00.000Z' };
+    expect(parseDigestSince(map, 'since')).toEqual(map);
+  });
+
+  it('accepts an empty map', () => {
+    expect(parseDigestSince({}, 'since')).toEqual({});
+  });
+
+  it('rejects arrays and numbers', () => {
+    expect(() => parseDigestSince([ISO], 'since')).toThrow('must be a string or an object');
+    expect(() => parseDigestSince(42, 'since')).toThrow('must be a string or an object');
+  });
+
+  it('rejects non-string map values', () => {
+    expect(() => parseDigestSince({ general: 42 }, 'since')).toThrow('since.general must be a string');
+  });
+
+  it('rejects prototype-polluting keys', () => {
+    const payload = JSON.parse(`{"__proto__": {"polluted": true}, "general": "${ISO}"}`);
+    expect(() => parseDigestSince(payload, 'since')).toThrow('may not contain the key');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+    expect(() => parseDigestSince({ constructor: ISO }, 'since')).toThrow('may not contain the key "constructor"');
+    expect(() => parseDigestSince({ prototype: ISO }, 'since')).toThrow('may not contain the key "prototype"');
+  });
+
+  it('enforces the entry, key, and value bounds', () => {
+    const tooMany: Record<string, string> = {};
+    for (let i = 0; i < 501; i++) tooMany[`t${i}`] = ISO;
+    expect(() => parseDigestSince(tooMany, 'since')).toThrow('at most 500 entries');
+
+    expect(() => parseDigestSince({ ['x'.repeat(257)]: ISO }, 'since')).toThrow('at most 256 characters');
+    expect(() => parseDigestSince({ general: 'x'.repeat(65) }, 'since')).toThrow('at most 64 characters');
+    expect(() => parseDigestSince('x'.repeat(65), 'since')).toThrow('at most 64 characters');
+  });
+
+  it('names the offending value using the caller-supplied label', () => {
+    expect(() => parseDigestSince(42, 'arg3')).toThrow(/^arg3 /);
+    expect(() => parseDigestSince({ general: 42 }, SINCE_CHANNELS_PARAM))
+      .toThrow(`${SINCE_CHANNELS_PARAM}.general must be a string`);
+  });
+});
+
+describe('encodeDigestSince', () => {
+  it('emits nothing for an absent or empty cutoff', () => {
+    expect(encodeDigestSince(undefined)).toEqual({ params: {}, oversized: false });
+    expect(encodeDigestSince({})).toEqual({ params: {}, oversized: false });
+  });
+
+  it('emits `since` for the single-timestamp form', () => {
+    expect(encodeDigestSince(ISO)).toEqual({ params: { since: ISO }, oversized: false });
+  });
+
+  it('emits `sinceChannels` as JSON for the map form', () => {
+    const map = { general: ISO };
+    const { params, oversized } = encodeDigestSince(map);
+    expect(oversized).toBe(false);
+    expect(JSON.parse(params[SINCE_CHANNELS_PARAM])).toEqual(map);
+    // Never overloads `since` — an older satellite must not read JSON as a date.
+    expect(params.since).toBeUndefined();
+  });
+
+  it('reports oversized instead of emitting an unsendable URL', () => {
+    const huge: Record<string, string> = {};
+    for (let i = 0; i < 400; i++) huge[`channel-with-a-long-name-${i}`] = ISO;
+    const { params, oversized } = encodeDigestSince(huge);
+    expect(oversized).toBe(true);
+    expect(params).toEqual({});
+  });
+
+  it('stays well under the cap for a realistically sized board', () => {
+    const board: Record<string, string> = {};
+    for (let i = 0; i < 30; i++) board[`inbox-some-agent-name-${i}`] = ISO;
+    const { params, oversized } = encodeDigestSince(board);
+    expect(oversized).toBe(false);
+    expect(params[SINCE_CHANNELS_PARAM].length).toBeLessThan(MAX_SINCE_PARAM_LENGTH);
+  });
+});
+
+describe('decodeDigestSince', () => {
+  it('returns undefined when neither param is present', () => {
+    expect(decodeDigestSince(null, null)).toBeUndefined();
+  });
+
+  it('honours a plain `since` — an older controller keeps working', () => {
+    expect(decodeDigestSince(ISO, null)).toBe(ISO);
+  });
+
+  it('decodes `sinceChannels` into a map', () => {
+    expect(decodeDigestSince(null, JSON.stringify({ general: ISO }))).toEqual({ general: ISO });
+  });
+
+  it('prefers `sinceChannels` when both are sent', () => {
+    expect(decodeDigestSince(ISO, JSON.stringify({ general: ISO }))).toEqual({ general: ISO });
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(() => decodeDigestSince(null, 'not json')).toThrow('must be valid JSON');
+  });
+
+  it('rejects a JSON string where an object is required', () => {
+    expect(() => decodeDigestSince(null, '"2026-07-25T10:00:00.000Z"')).toThrow('must be an object');
+  });
+
+  it('rejects an oversized param before parsing it', () => {
+    expect(() => decodeDigestSince(null, 'x'.repeat(MAX_SINCE_PARAM_LENGTH + 1)))
+      .toThrow(`at most ${MAX_SINCE_PARAM_LENGTH} characters`);
+  });
+
+  it('applies the same bounds and prototype rejection as the local boundary', () => {
+    expect(() => decodeDigestSince(null, '{"__proto__": {"polluted": true}}')).toThrow('may not contain the key');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(() => decodeDigestSince(null, JSON.stringify({ general: 42 }))).toThrow('must be a string');
+  });
+
+  it('round-trips what encodeDigestSince produces', () => {
+    const map = { general: ISO, 'inbox-warm-alpaca': '2026-07-25T11:30:00.000Z' };
+    const { params } = encodeDigestSince(map);
+    expect(decodeDigestSince(null, params[SINCE_CHANNELS_PARAM])).toEqual(map);
+
+    const { params: strParams } = encodeDigestSince(ISO);
+    expect(decodeDigestSince(strParams.since, null)).toBe(ISO);
+  });
+});

--- a/src/shared/digest-since.ts
+++ b/src/shared/digest-since.ts
@@ -1,0 +1,136 @@
+/**
+ * Validation and wire encoding for the bulletin digest's `since` argument.
+ *
+ * Shared because the same value crosses three trust boundaries with the same
+ * rules: the local IPC bridge (renderer → main), the annex client's REST call
+ * (controller → satellite), and the satellite's HTTP handler.
+ */
+
+import type { DigestSince } from './group-project-types';
+
+/** Upper bounds so a bad caller can't send an unbounded object. */
+export const MAX_SINCE_ENTRIES = 500;
+export const MAX_TOPIC_LENGTH = 256;
+export const MAX_TIMESTAMP_LENGTH = 64;
+
+/**
+ * Cap on the encoded query-string value for the per-channel map.
+ *
+ * Node's HTTP server rejects request lines beyond `--max-http-header-size`
+ * (16KB by default), and intermediaries impose their own limits, so the
+ * controller degrades to "no cutoff" rather than emitting a request the
+ * satellite would reject outright. Well past any realistic board: a 30-channel
+ * project encodes to roughly 2KB.
+ */
+export const MAX_SINCE_PARAM_LENGTH = 6000;
+
+/** Keys that must never be copied onto a plain object. */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Validate an untrusted `since` value into a `DigestSince`.
+ *
+ * Accepts a single ISO timestamp string or a `channel -> ISO timestamp` map.
+ * Throws on anything else; `label` names the value in the error message so the
+ * caller's context (IPC arg position, query param name) survives into the log.
+ */
+export function parseDigestSince(value: unknown, label: string): DigestSince | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  if (typeof value === 'string') {
+    if (value.length > MAX_TIMESTAMP_LENGTH) {
+      throw new Error(`${label} timestamp must be at most ${MAX_TIMESTAMP_LENGTH} characters`);
+    }
+    return value;
+  }
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be a string or an object`);
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length > MAX_SINCE_ENTRIES) {
+    throw new Error(`${label} must have at most ${MAX_SINCE_ENTRIES} entries`);
+  }
+
+  const map: Record<string, string> = {};
+  for (const [topic, timestamp] of entries) {
+    if (UNSAFE_KEYS.has(topic)) {
+      throw new Error(`${label} may not contain the key "${topic}"`);
+    }
+    if (topic.length > MAX_TOPIC_LENGTH) {
+      throw new Error(`${label} topic keys must be at most ${MAX_TOPIC_LENGTH} characters`);
+    }
+    if (typeof timestamp !== 'string') {
+      throw new Error(`${label}.${topic} must be a string`);
+    }
+    if (timestamp.length > MAX_TIMESTAMP_LENGTH) {
+      throw new Error(`${label}.${topic} must be at most ${MAX_TIMESTAMP_LENGTH} characters`);
+    }
+    map[topic] = timestamp;
+  }
+  return map;
+}
+
+/**
+ * Query-param name carrying the per-channel map to a satellite.
+ *
+ * Deliberately separate from `since` rather than overloading it: a satellite
+ * built before this change ignores the unknown param and answers with no
+ * cutoff — i.e. the pre-#1555 behaviour of counting everything unread — instead
+ * of erroring or misreading a JSON blob as a timestamp. That is the whole
+ * version-negotiation story; no handshake is needed.
+ */
+export const SINCE_CHANNELS_PARAM = 'sinceChannels';
+
+/**
+ * Encode a `DigestSince` into query params for the satellite REST call.
+ *
+ * Returns the params to set. A map that would exceed
+ * `MAX_SINCE_PARAM_LENGTH` yields `{ oversized: true }` and no params — the
+ * caller should log and send the request without a cutoff.
+ */
+export function encodeDigestSince(
+  since: DigestSince | undefined,
+): { params: Record<string, string>; oversized: boolean } {
+  if (!since) return { params: {}, oversized: false };
+  if (typeof since === 'string') return { params: { since }, oversized: false };
+
+  const keys = Object.keys(since);
+  if (keys.length === 0) return { params: {}, oversized: false };
+
+  const encoded = JSON.stringify(since);
+  if (encoded.length > MAX_SINCE_PARAM_LENGTH) {
+    return { params: {}, oversized: true };
+  }
+  return { params: { [SINCE_CHANNELS_PARAM]: encoded }, oversized: false };
+}
+
+/**
+ * Decode the `since` / `sinceChannels` query params a satellite received.
+ *
+ * `sinceChannels` wins when both are present, so a controller that sends both
+ * for compatibility gets the per-channel behaviour. Throws on a malformed
+ * value so the handler can answer 400 rather than silently mis-counting.
+ */
+export function decodeDigestSince(
+  since: string | null,
+  sinceChannels: string | null,
+): DigestSince | undefined {
+  if (sinceChannels) {
+    if (sinceChannels.length > MAX_SINCE_PARAM_LENGTH) {
+      throw new Error(`${SINCE_CHANNELS_PARAM} must be at most ${MAX_SINCE_PARAM_LENGTH} characters`);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(sinceChannels);
+    } catch {
+      throw new Error(`${SINCE_CHANNELS_PARAM} must be valid JSON`);
+    }
+    if (typeof parsed === 'string') {
+      throw new Error(`${SINCE_CHANNELS_PARAM} must be an object`);
+    }
+    return parseDigestSince(parsed, SINCE_CHANNELS_PARAM);
+  }
+  return parseDigestSince(since ?? undefined, 'since');
+}

--- a/src/shared/digest-since.ts
+++ b/src/shared/digest-since.ts
@@ -8,19 +8,29 @@
 
 import type { DigestSince } from './group-project-types';
 
-/** Upper bounds so a bad caller can't send an unbounded object. */
+/**
+ * Validation bounds, applied at every boundary so a bad caller can't send an
+ * unbounded object. Independent of the transport bound below — see there.
+ */
 export const MAX_SINCE_ENTRIES = 500;
 export const MAX_TOPIC_LENGTH = 256;
 export const MAX_TIMESTAMP_LENGTH = 64;
 
 /**
- * Cap on the encoded query-string value for the per-channel map.
+ * Transport bound: cap on the encoded query-string value for the per-channel map.
  *
  * Node's HTTP server rejects request lines beyond `--max-http-header-size`
  * (16KB by default), and intermediaries impose their own limits, so the
  * controller degrades to "no cutoff" rather than emitting a request the
  * satellite would reject outright. Well past any realistic board: a 30-channel
  * project encodes to roughly 2KB.
+ *
+ * Deliberately NOT reconciled with `MAX_SINCE_ENTRIES`: that one bounds what
+ * any boundary will validate, this one bounds what a URL can carry. A map can
+ * therefore pass validation and still be dropped by the encoder on the remote
+ * path while working locally, where nothing is ever encoded into a query
+ * string. Raising this to "match" the entry bound would push requests into the
+ * 431 range, where the satellite never sees them at all.
  */
 export const MAX_SINCE_PARAM_LENGTH = 6000;
 

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -1,4 +1,5 @@
 import type { FileNode, ThemeColors, HljsColors, TerminalColors, ThemeFonts, ThemeGradients } from './types';
+import type { DigestSince } from './group-project-types';
 
 // ── Disposable ──────────────────────────────────────────────────────────
 export interface Disposable {
@@ -1227,7 +1228,7 @@ export interface AnnexAPI {
   /** Update group project fields on a satellite. */
   gpUpdate(satelliteId: string, groupProjectId: string, fields: { name?: string; description?: string; instructions?: string; metadata?: Record<string, unknown> }): Promise<unknown>;
   /** Get bulletin topic digest from a satellite group project. */
-  gpBulletinDigest(satelliteId: string, groupProjectId: string, since?: string): Promise<unknown[]>;
+  gpBulletinDigest(satelliteId: string, groupProjectId: string, since?: DigestSince): Promise<unknown[]>;
   /** Get messages for a bulletin topic from a satellite group project. */
   gpBulletinTopic(satelliteId: string, groupProjectId: string, topic: string, since?: string, limit?: number): Promise<unknown[]>;
   /** Get all bulletin messages from a satellite group project. */


### PR DESCRIPTION
Closes #1556.

## Problem

#1555 fixed per-channel unread counts for **local** group projects only. The annex REST call carried a single ISO cutoff, so `fetchDigest` degraded the per-channel map to `undefined` on the remote path and remote projects kept counting every message as unread forever — the original bug, unfixed.

## What changed, layer by layer

| Layer | Change |
|---|---|
| `shared/digest-since.ts` **(new)** | One parser (bounds, string-typed values, prototype-key rejection) + the query-string codec |
| `ipc/validation.ts` | `digestSinceArg()` moved here, delegating to the shared parser |
| `ipc/group-project-handlers.ts` | Imports the validator instead of defining it |
| `ipc/annex-client-handlers.ts` | `stringArg` → `digestSinceArg()` — same rules as the local boundary |
| `services/annex-client.ts` | Encodes the map into `sinceChannels`; caps encoded length |
| `services/annex-server.ts` | Decodes + validates; `400 invalid_since` on malformed input |
| `preload`, `plugin-types`, `useGroupProjectContext` | Signatures widened to `DigestSince`; remote degradation removed |

`digestSinceArg()` moved to `validation.ts` rather than being imported across handler modules — `annex-client-handlers` importing `group-project-handlers` pulled the entire main-process dependency tree into that module's tests. Both IPC boundaries now share it from one dependency-light place, and the satellite's HTTP handler shares the underlying parser.

## Wire format and compatibility

The map travels as a **`sinceChannels`** query param holding JSON, deliberately **separate from `since`** rather than overloading it. That choice is what makes compatibility work without a handshake, in both directions:

- **New controller → old satellite:** the old handler reads only `since`, ignores the unknown param, and answers with no cutoff — i.e. the pre-#1555 behaviour. Overloading `since` would instead have made it parse a JSON blob as a date.
- **Old controller → new satellite:** the new handler still honours a plain `since`.

There is a test asserting the first case explicitly, since running a genuinely older satellite build isn't possible in CI (see below).

## Bounds

Node rejects request lines past `--max-http-header-size` (16KB) with **431**, so an unbounded map would produce a request the satellite never sees. The controller caps the encoded value at 6000 chars and requests *without* a cutoff — logging a warn — rather than emitting an unsendable URL. A 30-channel board encodes to roughly 2KB, so this is well clear of realistic use. The satellite independently rejects anything over the same cap with 400.

## What I could and could not verify

**Verified, running real code:**
- The satellite route end-to-end through the **real annex-server HTTP harness** — real server, real pairing, real HTTP requests — asserting the exact `getDigest` argument for plain `since`, `sinceChannels`, and neither.
- 400 responses for malformed JSON, prototype-polluting keys, and over-long params, each asserting `getDigest` was **not** called.
- The controller's URL construction, by capturing the URL passed to `https.get`.
- **Cross-boundary:** a test builds the query with `encodeDigestSince` — the exact function the client calls — and sends it through the real HTTP route, closing the encode/decode loop.

**Not verified live — stated plainly:**
- **No live controller + satellite pair.** I have no second machine, so the two halves have never talked over real mTLS. The cross-boundary test above exercises the real encoder against the real HTTP handler, which covers the wire format itself, but not TLS, pairing, or network behaviour.
- **Backward compatibility against a genuinely older build** is asserted by reproducing the old handler's parsing verbatim (`new URLSearchParams(qs).get('since')` → `undefined`) rather than by running an old satellite. The assertion documents the contract; it is not a live interop test.

Both warrant a manual pass against a real satellite pair before this is relied on.

## Tests

64 new tests: shared codec (23), satellite HTTP route (9), annex client encoding (5), annex IPC boundary (6), renderer hook (2), plus the relocated validator suite still passing at its new home.

Full suite: 12627 passed, 4 skipped. Typecheck and lint clean.

/cc @chirpy-mole