### PR TITLE
fix(canvas): atomic kv writes + defensive canvas load (data-loss fix, no quarantine)

### DIFF
--- a/src/main/services/plugin-storage.test.ts
+++ b/src/main/services/plugin-storage.test.ts
@@ -10,6 +10,7 @@ vi.mock('fs/promises', () => ({
   access: vi.fn(),
   readdir: vi.fn(),
   rm: vi.fn(),
+  rename: vi.fn(),
   realpath: vi.fn(),
 }));
 
@@ -74,17 +75,31 @@ describe('plugin-storage', () => {
   });
 
   describe('writeKey', () => {
-    it('writes JSON to kv directory and ensures dir exists', async () => {
+    it('writes JSON atomically (temp file then rename) and ensures dir exists', async () => {
       await writeKey({ pluginId: 'my-plugin', scope: 'global', key: 'config', value: { a: 1 } });
+      const finalPath = path.join(GLOBAL_BASE, 'my-plugin', 'kv', 'config.json');
       expect(fsp.mkdir).toHaveBeenCalledWith(
         path.join(GLOBAL_BASE, 'my-plugin', 'kv'),
         { recursive: true },
       );
-      expect(fsp.writeFile).toHaveBeenCalledWith(
-        path.join(GLOBAL_BASE, 'my-plugin', 'kv', 'config.json'),
-        JSON.stringify({ a: 1 }),
-        'utf-8',
-      );
+      // Content is written to a temp sibling, never directly to the destination.
+      const writeCall = vi.mocked(fsp.writeFile).mock.calls[0];
+      const tmpPath = writeCall[0] as string;
+      expect(tmpPath).toMatch(/config\.json\.tmp-/);
+      expect(writeCall[1]).toBe(JSON.stringify({ a: 1 }));
+      expect(fsp.writeFile).not.toHaveBeenCalledWith(finalPath, expect.anything(), expect.anything());
+      // Then atomically renamed over the real file.
+      expect(fsp.rename).toHaveBeenCalledWith(tmpPath, finalPath);
+    });
+
+    it('cleans up the temp file and rethrows if the write fails', async () => {
+      vi.mocked(fsp.writeFile).mockRejectedValueOnce(new Error('disk full'));
+      await expect(
+        writeKey({ pluginId: 'my-plugin', scope: 'global', key: 'config', value: { a: 1 } }),
+      ).rejects.toThrow('disk full');
+      const unlinked = vi.mocked(fsp.unlink).mock.calls[0]?.[0] as string | undefined;
+      expect(unlinked).toMatch(/config\.json\.tmp-/);
+      expect(fsp.rename).not.toHaveBeenCalled();
     });
 
     it('rejects path traversal in key', async () => {
@@ -327,11 +342,15 @@ describe('plugin-storage', () => {
       // The gitignore ensurer will try to readFile for .gitignore - mock that too
       vi.mocked(fsp.readFile).mockRejectedValue(new Error('ENOENT'));
       await writeKey({ pluginId: 'my-plugin', scope: 'project-local', key: 'config', value: 42, projectPath });
-      expect(fsp.writeFile).toHaveBeenCalledWith(
-        path.join(projectPath, '.clubhouse', 'plugin-data-local', 'my-plugin', 'kv', 'config.json'),
-        '42',
-        'utf-8',
+      const finalPath = path.join(projectPath, '.clubhouse', 'plugin-data-local', 'my-plugin', 'kv', 'config.json');
+      // Atomic write: content lands in a temp sibling, then rename onto the final path.
+      const kvWrite = vi.mocked(fsp.writeFile).mock.calls.find(
+        (c) => String(c[0]).includes(path.join('plugin-data-local', 'my-plugin', 'kv', 'config.json')),
       );
+      expect(kvWrite).toBeDefined();
+      expect(String(kvWrite![0])).toMatch(/config\.json\.tmp-/);
+      expect(kvWrite![1]).toBe('42');
+      expect(fsp.rename).toHaveBeenCalledWith(kvWrite![0], finalPath);
     });
 
     it('deleteKey uses plugin-data-local path', async () => {
@@ -382,6 +401,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -411,6 +431,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -439,6 +460,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -465,6 +487,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');
@@ -493,6 +516,7 @@ describe('plugin-storage', () => {
         access: vi.fn(),
         readdir: vi.fn(),
         rm: vi.fn(),
+        rename: vi.fn(),
         realpath: vi.fn(async (p: any) => String(p)),
       }));
       const freshFsp = await import('fs/promises');

--- a/src/main/services/plugin-storage.ts
+++ b/src/main/services/plugin-storage.ts
@@ -95,6 +95,14 @@ export async function readKey(req: PluginStorageReadRequest): Promise<unknown> {
   }
 }
 
+// Monotonic suffix for atomic-write temp filenames — avoids collisions within a
+// tight loop without depending on wall-clock granularity.
+let tmpCounter = 0;
+function nextTmpSuffix(): string {
+  tmpCounter += 1;
+  return `${Date.now()}-${process.pid}-${tmpCounter}`;
+}
+
 export async function writeKey(req: PluginStorageWriteRequest): Promise<void> {
   if (req.scope === 'project-local' && req.projectPath) {
     await ensurePluginDataLocalGitignored(req.projectPath);
@@ -103,7 +111,21 @@ export async function writeKey(req: PluginStorageWriteRequest): Promise<void> {
   await assertSafePath(dir, `${req.key}.json`);
   await ensureDir(dir);
   const file = path.join(dir, `${req.key}.json`);
-  await fs.writeFile(file, JSON.stringify(req.value), 'utf-8');
+
+  // Atomic write: serialize to a temp file in the same directory, then rename
+  // over the destination. rename() is atomic on POSIX and NTFS, so a reader
+  // (or a crash) never observes a half-written file — the destination is
+  // always either the old complete contents or the new complete contents.
+  // A plain fs.writeFile truncates-then-writes and can leave invalid JSON if
+  // the process dies mid-write, which silently wipes canvas/wire state.
+  const tmp = path.join(dir, `${req.key}.json.tmp-${nextTmpSuffix()}`);
+  try {
+    await fs.writeFile(tmp, JSON.stringify(req.value), 'utf-8');
+    await fs.rename(tmp, file);
+  } catch (err) {
+    try { await fs.unlink(tmp); } catch { /* already gone */ }
+    throw err;
+  }
 }
 
 export async function deleteKey(req: PluginStorageDeleteRequest): Promise<void> {

--- a/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.test.ts
@@ -53,6 +53,39 @@ describe('canvas-store', () => {
     expect(store2.getState().views[0].type).toBe('agent');
   });
 
+  // Regression: a single saved instance with a missing/non-array `views`
+  // (a partially-written record) must NOT throw and collapse ALL canvases to
+  // one empty canvas. The bad instance loads as empty; the good one is intact.
+  it('loads good canvases even when one saved instance has a malformed views field', async () => {
+    const storage = createMockStorage({
+      'canvas-instances': [
+        { id: 'canvas_bad', name: 'broken' /* no views field at all */ },
+        {
+          id: 'canvas_good',
+          name: 'goobers-bridge',
+          views: [
+            { id: 'v1', type: 'agent', position: { x: 10, y: 20 }, size: { width: 400, height: 300 }, title: 'A', zIndex: 1, agentId: 'durable_x' },
+          ],
+          viewport: { panX: 0, panY: 0, zoom: 1 },
+          nextZIndex: 2,
+        },
+      ],
+      'canvas-active-id': 'canvas_good',
+    });
+
+    await store.getState().loadCanvas(storage);
+
+    const state = store.getState();
+    expect(state.loaded).toBe(true);
+    expect(state.canvases).toHaveLength(2);
+    const bad = state.canvases.find((c) => c.id === 'canvas_bad');
+    const good = state.canvases.find((c) => c.id === 'canvas_good');
+    expect(bad?.views).toEqual([]);
+    expect(good?.views).toHaveLength(1);
+    expect(state.activeCanvasId).toBe('canvas_good');
+    expect(state.views).toHaveLength(1);
+  });
+
   // LB-M68: Mission 68 — sibling agent card from "+ New Agent" must survive
   // a save/load round-trip with its position intact. This guards against
   // regressions where addView + updateView produce a view whose position

--- a/src/renderer/plugins/builtin/canvas/canvas-store.ts
+++ b/src/renderer/plugins/builtin/canvas/canvas-store.ts
@@ -1,6 +1,7 @@
 import { create, StoreApi, UseBoundStore } from 'zustand';
 import type { ScopedStorage } from '../../../../shared/plugin-types';
 import { generateHubName } from '../../../../shared/name-generator';
+import { rendererLog } from '../../renderer-logger';
 import type { CanvasView, CanvasViewType, CanvasInstance, CanvasInstanceData, AgentCanvasView, ZoneCanvasView, Position, Size, Viewport } from './canvas-types';
 import type { CanvasWidgetMetadata, CanvasWidgetFilter, CanvasWidgetHandle } from '../../../../shared/plugin-types';
 import type { McpBindingEntry } from '../../../stores/mcpBindingStore';
@@ -229,32 +230,60 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         const savedInstances = await storage.read(STORAGE_KEY_INSTANCES) as CanvasInstanceData[] | null;
         if (savedInstances && Array.isArray(savedInstances) && savedInstances.length > 0) {
           const canvases: CanvasInstance[] = savedInstances.map((s): CanvasInstance => {
-            // Backfill displayName and metadata for views saved in older formats.
-            // Filter out legacy view types that no longer exist (browser, file,
-            // legacy-file, terminal, legacy-terminal, git-diff, legacy-git-diff) —
-            // these have been replaced by plugin-provided widgets.
-            const REMOVED_TYPES = new Set(['browser', 'file', 'legacy-file', 'terminal', 'legacy-terminal', 'git-diff', 'legacy-git-diff']);
-            const restoredViews = s.views
-              .filter((v: any) => !REMOVED_TYPES.has(v.type))
-              .map((v: any) => ({
-                ...v,
-                metadata: v.metadata ?? {},
-                displayName: v.displayName ?? v.title ?? v.type ?? '',
-                ...(v.type === 'zone' ? { containedViewIds: v.containedViewIds ?? [] } : {}),
-              })) as CanvasView[];
-            return {
-              id: s.id,
-              name: s.name,
-              views: restoredViews,
-              viewport: clampViewport(s.viewport),
-              nextZIndex: s.nextZIndex,
-              zoomedViewId: s.zoomedViewId ?? null,
-              selectedViewId: null,
-              minimapAutoHide: s.minimapAutoHide ?? true,
-              elkAlgorithm: s.elkAlgorithm ?? 'layered',
-              elkDirection: s.elkDirection ?? 'RIGHT',
-              layoutCenterId: s.layoutCenterId ?? null,
-            };
+            // Restore each instance defensively: a single partially-written or
+            // malformed record must degrade to an empty-but-valid canvas, NOT
+            // throw and send the outer catch into replacing ALL canvases with
+            // one fresh empty canvas — that is the silent, total card-loss bug.
+            try {
+              // Backfill displayName and metadata for views saved in older
+              // formats. Filter out legacy view types that no longer exist
+              // (browser, file, legacy-file, terminal, legacy-terminal,
+              // git-diff, legacy-git-diff) — replaced by plugin-provided widgets.
+              const REMOVED_TYPES = new Set(['browser', 'file', 'legacy-file', 'terminal', 'legacy-terminal', 'git-diff', 'legacy-git-diff']);
+              const restoredViews = (Array.isArray(s.views) ? s.views : [])
+                .filter((v: any) => !REMOVED_TYPES.has(v.type))
+                .map((v: any) => ({
+                  ...v,
+                  metadata: v.metadata ?? {},
+                  displayName: v.displayName ?? v.title ?? v.type ?? '',
+                  ...(v.type === 'zone' ? { containedViewIds: v.containedViewIds ?? [] } : {}),
+                })) as CanvasView[];
+              const rawViewport: Partial<Viewport> = (s.viewport && typeof s.viewport === 'object') ? s.viewport : {};
+              return {
+                id: s.id ?? generateCanvasId(),
+                name: s.name ?? generateHubName(),
+                views: restoredViews,
+                viewport: clampViewport({
+                  panX: rawViewport.panX ?? 0,
+                  panY: rawViewport.panY ?? 0,
+                  zoom: rawViewport.zoom ?? 1,
+                }),
+                nextZIndex: s.nextZIndex ?? restoredViews.length,
+                zoomedViewId: s.zoomedViewId ?? null,
+                selectedViewId: null,
+                minimapAutoHide: s.minimapAutoHide ?? true,
+                elkAlgorithm: s.elkAlgorithm ?? 'layered',
+                elkDirection: s.elkDirection ?? 'RIGHT',
+                layoutCenterId: s.layoutCenterId ?? null,
+              };
+            } catch (err) {
+              rendererLog('canvas', 'error', 'Skipped malformed canvas instance on load', {
+                meta: { id: s?.id, error: err instanceof Error ? err.message : String(err) },
+              });
+              return {
+                id: s?.id ?? generateCanvasId(),
+                name: s?.name ?? generateHubName(),
+                views: [],
+                viewport: { panX: 0, panY: 0, zoom: 1 },
+                nextZIndex: 0,
+                zoomedViewId: null,
+                selectedViewId: null,
+                minimapAutoHide: true,
+                elkAlgorithm: 'layered',
+                elkDirection: 'RIGHT',
+                layoutCenterId: null,
+              };
+            }
           });
           const savedActive = await storage.read(STORAGE_KEY_ACTIVE) as string | null;
           const activeCanvasId = (savedActive && canvases.find((c) => c.id === savedActive))
@@ -268,7 +297,12 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasState>> {
         // Fresh start
         const canvas = createCanvasInstance();
         set({ canvases: [canvas], activeCanvasId: canvas.id, zoneWireDefinitions: loadedZoneWires, loaded: true, ...syncDerivedState([canvas], canvas.id) });
-      } catch {
+      } catch (err) {
+        // Loading failed after data was already read — log loudly rather than
+        // silently discarding the user's canvas.
+        rendererLog('canvas', 'error', 'loadCanvas failed — substituting empty canvas', {
+          meta: { error: err instanceof Error ? err.message : String(err) },
+        });
         const canvas = createCanvasInstance();
         set({ canvases: [canvas], activeCanvasId: canvas.id, loaded: true, ...syncDerivedState([canvas], canvas.id) });
       }


### PR DESCRIPTION
## Context

Reland of the canvas silent-data-loss fix (originally #1548, reverted in #1551 for regressing ubuntu find-replace E2E). A CI experiment proved the regression came from the `plugin-storage` change, not the canvas-store change. This PR reintroduces the fix in **two isolated pieces** and deliberately **omits the quarantine-on-read** that is the suspected culprit — so CI confirms whether the atomic write alone is safe.

## Included
- **Atomic `writeKey`** — serialize to a temp sibling, then `rename()` over the destination. `rename` is atomic on POSIX/NTFS, so a reader or a crash never sees a half-written file. This is the part that actually **prevents** the corruption (a plain `fs.writeFile` truncates-then-writes → truncated JSON on crash → silent canvas wipe).
- **Defensive `loadCanvas`** — one malformed/partially-written instance degrades to an empty-but-valid canvas instead of throwing and nuking all canvases. (Renderer-only; already exonerated as a cause of the E2E regression.)

## Deliberately excluded
- The `readKey` quarantine-on-corrupt-read (renaming a corrupt file to a `.corrupt-<ts>` sidecar). This is the suspected cause of the ubuntu E2E regression. It'll be reintroduced separately in a **non-renaming** form (copy, not rename; empty file treated as missing) only after this reland is confirmed green.

## Verification
- `npm run typecheck` ✅ · `npm test` ✅ 12,686 passed · lint 0 errors.
- **The real gate is ubuntu E2E on this PR.** If green, the atomic write is confirmed safe and this lands as the core data-loss fix. If red, the atomic write itself is implicated and I'll dig into that specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)