### PR TITLE
fix(agents): agent model setting no longer reverts to Custom/Default

### DIFF
--- a/src/renderer/features/agents/AgentSettingsView.test.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.test.tsx
@@ -70,16 +70,15 @@ vi.mock('./TemplateConfigDialog', () => ({
   },
 }));
 
-vi.mock('../../hooks/useModelOptions', () => ({
-  useModelOptions: () => ({
-    options: [
-      { id: 'default', label: 'Default' },
-      { id: 'opus', label: 'Opus' },
-      { id: 'sonnet', label: 'Sonnet' },
-    ],
-    loading: false,
-  }),
-}));
+// NOTE: useModelOptions is deliberately NOT mocked. It fetches asynchronously via
+// window.clubhouse.agent.getModelOptions and reports a `default`-only placeholder
+// while in flight — mocking it away with a synchronous full list is what hid the
+// "Sonnet loads as Custom..." bug. Tests drive the real hook through the IPC mock.
+const MODEL_OPTION_LIST = [
+  { id: 'default', label: 'Default' },
+  { id: 'opus', label: 'Opus' },
+  { id: 'sonnet', label: 'Sonnet' },
+];
 
 const defaultAgent: Agent = {
   id: 'agent-1',
@@ -160,7 +159,7 @@ describe('AgentSettingsView', () => {
     window.clubhouse.agentSettings.previewMaterialization = vi.fn().mockResolvedValue(mockPreview);
     (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({});
     (window.clubhouse.agent as any).updateDurableConfig = vi.fn().mockResolvedValue(undefined);
-    (window.clubhouse.agent as any).getModelOptions = vi.fn().mockResolvedValue([{ id: 'default', label: 'Default' }]);
+    (window.clubhouse.agent as any).getModelOptions = vi.fn().mockResolvedValue(MODEL_OPTION_LIST);
   });
 
   describe('header', () => {
@@ -598,6 +597,65 @@ describe('AgentSettingsView', () => {
         expect(modelSelect.value).toBe('custom');
       });
       expect(screen.getByDisplayValue('my-special-model-v3')).toBeInTheDocument();
+    });
+
+    it('loads a known persisted model as itself, not Custom', async () => {
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({ model: 'sonnet' });
+      renderSettings();
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Sonnet')).toBeInTheDocument();
+      });
+      expect(screen.queryByDisplayValue('Custom...')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('e.g. claude-opus-4-6')).not.toBeInTheDocument();
+    });
+
+    it('does not latch a known model as Custom when the option list resolves last', async () => {
+      // Regression: the model option list arrives after the durable config. If the
+      // known-vs-custom split runs against the in-flight `default`-only placeholder,
+      // `sonnet` is mislabelled "Custom..." and never re-corrected.
+      let releaseOptions!: (opts: typeof MODEL_OPTION_LIST) => void;
+      (window.clubhouse.agent as any).getModelOptions = vi.fn().mockReturnValue(
+        new Promise((resolve) => { releaseOptions = resolve; }),
+      );
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({ model: 'sonnet' });
+
+      renderSettings();
+      // Config has landed while the option list is still loading.
+      await waitFor(() => {
+        expect((window.clubhouse.agent as any).getDurableConfig).toHaveBeenCalled();
+      });
+      expect(screen.queryByDisplayValue('Custom...')).not.toBeInTheDocument();
+
+      releaseOptions(MODEL_OPTION_LIST);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Sonnet')).toBeInTheDocument();
+      });
+      expect(screen.queryByDisplayValue('Custom...')).not.toBeInTheDocument();
+    });
+
+    it('still classifies a genuinely unknown model as Custom once options load', async () => {
+      let releaseOptions!: (opts: typeof MODEL_OPTION_LIST) => void;
+      (window.clubhouse.agent as any).getModelOptions = vi.fn().mockReturnValue(
+        new Promise((resolve) => { releaseOptions = resolve; }),
+      );
+      (window.clubhouse.agent as any).getDurableConfig = vi.fn().mockResolvedValue({ model: 'claude-opus-4-6' });
+
+      renderSettings();
+      await waitFor(() => {
+        expect((window.clubhouse.agent as any).getDurableConfig).toHaveBeenCalled();
+      });
+      releaseOptions(MODEL_OPTION_LIST);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Custom...')).toBeInTheDocument();
+      });
+      expect(screen.getByDisplayValue('claude-opus-4-6')).toBeInTheDocument();
+    });
+
+    it('fetches model options for the agent own orchestrator', async () => {
+      renderSettings({ orchestrator: 'codex-cli' });
+      await waitFor(() => {
+        expect((window.clubhouse.agent as any).getModelOptions).toHaveBeenCalledWith('/project', 'codex-cli');
+      });
     });
 
     it('persists custom model on blur', async () => {

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -141,13 +141,15 @@ export function AgentSettingsView({ agent }: Props) {
   const { projects, activeProjectId } = useProjectStore();
   const activeProject = projects.find((p) => p.id === activeProjectId);
   const worktreePath = agent.worktreePath || activeProject?.path || '';
-  const { options: MODEL_OPTIONS } = useModelOptions();
   const allOrchestrators = useOrchestratorStore((s) => s.allOrchestrators);
   // Resolve orchestrators the same way AddAgentDialog does — profile-aware and scoped
   // to this agent's project — so the selector behaves consistently with agent creation.
   const projectPath = projects.find((p) => p.id === agent.projectId)?.path;
   const { effectiveOrchestrators } = useEffectiveOrchestrators(projectPath);
   const agentOrchestrator = agent.orchestrator || 'claude-code';
+  // Scope the model list to *this agent's* orchestrator, not the project default —
+  // otherwise a Codex/Copilot agent is offered (and validated against) Claude's ids.
+  const { options: MODEL_OPTIONS, loading: modelOptionsLoading } = useModelOptions(agentOrchestrator);
   // Always offer the agent's current orchestrator, even if it's disabled app-wide or
   // missing from this machine's settings (e.g. a worktree-synced agent whose project
   // profile wasn't synced). See buildOrchestratorOptions / #fix-orchestrator-selector AC #2.
@@ -293,11 +295,17 @@ export function AgentSettingsView({ agent }: Props) {
     });
   };
 
-  // Agent model state
+  // Agent model state.
+  //
+  // The persisted id is kept raw in `savedModel`; splitting it into the dropdown
+  // selection + custom text box happens in the effect below. That split MUST wait
+  // for useModelOptions to finish fetching — while the request is in flight the
+  // hook reports a `default`-only placeholder, and classifying against it would
+  // mislabel every real id (e.g. `sonnet`) as "Custom...".
   const isKnownModel = (id: string) => MODEL_OPTIONS.some((opt) => opt.id === id);
-  const initModel = agent.model || 'default';
-  const [agentModel, setAgentModel] = useState(isKnownModel(initModel) ? initModel : 'custom');
-  const [agentCustomModel, setAgentCustomModel] = useState(isKnownModel(initModel) ? '' : initModel);
+  const [savedModel, setSavedModel] = useState(agent.model || 'default');
+  const [agentModel, setAgentModel] = useState('default');
+  const [agentCustomModel, setAgentCustomModel] = useState('');
 
   const persistModel = async (value: string) => {
     if (!projectPath) return;
@@ -320,6 +328,7 @@ export function AgentSettingsView({ agent }: Props) {
       // Don't persist yet — wait for custom input
       setAgentCustomModel('');
     } else {
+      setSavedModel(value);
       await persistModel(value);
     }
   };
@@ -327,6 +336,7 @@ export function AgentSettingsView({ agent }: Props) {
   const handleCustomModelBlur = async () => {
     const trimmed = agentCustomModel.trim();
     if (trimmed) {
+      setSavedModel(trimmed);
       await persistModel(trimmed);
     }
   };
@@ -373,6 +383,29 @@ export function AgentSettingsView({ agent }: Props) {
   const [qadAllowedTools, setQadAllowedTools] = useState('');
   const [qadDefaultModel, setQadDefaultModel] = useState('');
   const [qadCustomModel, setQadCustomModel] = useState('');
+  const [qadSavedModel, setQadSavedModel] = useState('');
+
+  // Split the raw persisted model ids into dropdown selection + custom text box.
+  // Deliberately gated on `modelOptionsLoading` and re-run when MODEL_OPTIONS
+  // arrives, so a known id is never transiently latched as "Custom...".
+  useEffect(() => {
+    if (modelOptionsLoading) return;
+    if (isKnownModel(savedModel)) {
+      setAgentModel(savedModel);
+      setAgentCustomModel('');
+    } else {
+      setAgentModel('custom');
+      setAgentCustomModel(savedModel);
+    }
+    if (qadSavedModel && !isKnownModel(qadSavedModel)) {
+      setQadDefaultModel('custom');
+      setQadCustomModel(qadSavedModel);
+    } else {
+      setQadDefaultModel(qadSavedModel);
+      setQadCustomModel('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedModel, qadSavedModel, modelOptionsLoading, MODEL_OPTIONS]);
   const [qadFreeAgentMode, setQadFreeAgentMode] = useState(false);
   const [qadDirty, setQadDirty] = useState(false);
   const [qadSaving, setQadSaving] = useState(false);
@@ -557,24 +590,12 @@ export function AgentSettingsView({ agent }: Props) {
         if (defaults) {
           setQadSystemPrompt(defaults.systemPrompt || '');
           setQadAllowedTools((defaults.allowedTools || []).join('\n'));
-          const savedQadModel = defaults.defaultModel || '';
-          if (savedQadModel && !isKnownModel(savedQadModel)) {
-            setQadDefaultModel('custom');
-            setQadCustomModel(savedQadModel);
-          } else {
-            setQadDefaultModel(savedQadModel);
-          }
+          setQadSavedModel(defaults.defaultModel || '');
           setQadFreeAgentMode(defaults.freeAgentMode ?? false);
         }
-        // Sync agent model and free agent mode from disk
-        const savedModel = config?.model || 'default';
-        if (isKnownModel(savedModel)) {
-          setAgentModel(savedModel);
-          setAgentCustomModel('');
-        } else {
-          setAgentModel('custom');
-          setAgentCustomModel(savedModel);
-        }
+        // Sync agent model from disk — disk is the source of truth. Classification
+        // into known-vs-custom is left to the effect that waits on MODEL_OPTIONS.
+        setSavedModel(config?.model || 'default');
         setFreeAgentMode(config?.freeAgentMode ?? false);
         setStructuredMode(config?.structuredMode ?? false);
         setQadLoaded(true);

--- a/src/renderer/features/agents/AgentSettingsView.tsx
+++ b/src/renderer/features/agents/AgentSettingsView.tsx
@@ -404,7 +404,8 @@ export function AgentSettingsView({ agent }: Props) {
       setQadDefaultModel(qadSavedModel);
       setQadCustomModel('');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Intentionally keyed on the option list identity rather than isKnownModel,
+    // which is re-created every render.
   }, [savedModel, qadSavedModel, modelOptionsLoading, MODEL_OPTIONS]);
   const [qadFreeAgentMode, setQadFreeAgentMode] = useState(false);
   const [qadDirty, setQadDirty] = useState(false);

--- a/src/renderer/stores/agent/agentCrudSlice.test.ts
+++ b/src/renderer/stores/agent/agentCrudSlice.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCrudSlice } from './agentCrudSlice';
+import type { AgentState } from './types';
+
+function createMinimalState(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    agents: {},
+    agentActivity: {},
+    agentSpawnedAt: {},
+    agentTerminalAt: {},
+    agentDetailedStatus: {},
+    activeAgentId: null,
+    agentSettingsOpenFor: null,
+    deleteDialogAgent: null,
+    configChangesDialogAgent: null,
+    configChangesProjectPath: null,
+    sessionNamePromptFor: null,
+    projectActiveAgent: {},
+    cancelledAgentIds: {},
+    resumingAgents: {},
+    agentIcons: {},
+    pendingRecovery: null,
+    loadAgentIcon: vi.fn(),
+    ...overrides,
+  } as unknown as AgentState;
+}
+
+function createTestStore(initial: Partial<AgentState> = {}) {
+  let state = createMinimalState(initial);
+  const set = (
+    updater: Partial<AgentState> | ((s: AgentState) => Partial<AgentState> | AgentState),
+  ) => {
+    const result = typeof updater === 'function' ? updater(state) : updater;
+    state = { ...state, ...result };
+  };
+  const get = () => state;
+  const slice = createCrudSlice(set as any, get as any);
+  return { state: get, slice };
+}
+
+const PROJECT_ID = 'proj-1';
+const PROJECT_PATH = '/test/project';
+
+const CONFIG = {
+  id: 'durable-1',
+  name: 'Durable Agent',
+  color: 'blue',
+  model: 'sonnet',
+  worktreePath: '/test/worktree',
+  branch: 'main',
+  orchestrator: 'claude-code',
+} as any;
+
+describe('agentCrudSlice – loadDurableAgents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (window as any).clubhouse.agent.listDurable = vi.fn().mockResolvedValue([CONFIG]);
+    (window as any).clubhouse.agent.getRunningStatuses = vi.fn().mockResolvedValue([]);
+    (window as any).clubhouse.agent.getBackupInfo = vi.fn().mockResolvedValue(null);
+  });
+
+  it('seeds model from the durable config for a newly loaded agent', async () => {
+    const { state, slice } = createTestStore();
+
+    await slice.loadDurableAgents(PROJECT_ID, PROJECT_PATH);
+
+    expect(state().agents['durable-1']?.model).toBe('sonnet');
+  });
+
+  it('re-hydrates model on an agent already present in the store', async () => {
+    // Regression: agents.json is the source of truth for `model`. A store entry
+    // that lost the value (e.g. rebuilt on spawn) previously stayed stale for the
+    // lifetime of the window, showing "Default" in settings and on the list badge.
+    const { state, slice } = createTestStore({
+      agents: {
+        'durable-1': {
+          id: 'durable-1',
+          projectId: 'stale-proj',
+          name: 'Durable Agent',
+          kind: 'durable',
+          status: 'running',
+          color: 'blue',
+          model: undefined,
+        } as any,
+      },
+    });
+
+    await slice.loadDurableAgents(PROJECT_ID, PROJECT_PATH);
+
+    expect(state().agents['durable-1']?.model).toBe('sonnet');
+    // projectId reconciliation and existing status must survive the merge
+    expect(state().agents['durable-1']?.projectId).toBe(PROJECT_ID);
+    expect(state().agents['durable-1']?.status).toBe('running');
+  });
+
+  it('clears a stale model when the config no longer sets one', async () => {
+    (window as any).clubhouse.agent.listDurable = vi
+      .fn()
+      .mockResolvedValue([{ ...CONFIG, model: undefined }]);
+    const { state, slice } = createTestStore({
+      agents: {
+        'durable-1': {
+          id: 'durable-1',
+          projectId: PROJECT_ID,
+          name: 'Durable Agent',
+          kind: 'durable',
+          status: 'sleeping',
+          color: 'blue',
+          model: 'sonnet',
+        } as any,
+      },
+    });
+
+    await slice.loadDurableAgents(PROJECT_ID, PROJECT_PATH);
+
+    expect(state().agents['durable-1']?.model).toBeUndefined();
+  });
+});

--- a/src/renderer/stores/agent/agentCrudSlice.ts
+++ b/src/renderer/stores/agent/agentCrudSlice.ts
@@ -83,7 +83,10 @@ export function createCrudSlice(set: SetAgentState, get: GetAgentState): AgentCr
           // Always update projectId — the same agents.json may be loaded
           // under a different project store ID when a project is re-added
           // or when multiple store entries share the same path.
-          agents[config.id] = { ...agents[config.id], projectId };
+          // Re-hydrate `model` too: agents.json is the source of truth for it,
+          // and a store entry that lost the value (e.g. rebuilt on spawn) would
+          // otherwise stay stale for the lifetime of the window.
+          agents[config.id] = { ...agents[config.id], projectId, model: config.model };
         }
       }
 

--- a/src/renderer/stores/agent/agentLifecycleSlice.test.ts
+++ b/src/renderer/stores/agent/agentLifecycleSlice.test.ts
@@ -167,6 +167,27 @@ describe('agentLifecycleSlice – spawnDurableAgent', () => {
     expect(state().agents['durable-1']?.status).toBe('error');
     expect((state().agents['durable-1'] as any).errorMessage).toBe('durable spawn failed');
   });
+
+  it('preserves the configured model on the store entry', async () => {
+    // Regression: the spawned Agent object REPLACES the store entry, so dropping
+    // `model` made Agent Settings and the list badge fall back to "Default" after
+    // every wake, even though agents.json still had the right value.
+    const { state, slice } = createTestStore();
+
+    await slice.spawnDurableAgent(PROJECT_ID, PROJECT_PATH, DURABLE_CONFIG, false);
+
+    expect(state().agents['durable-1']?.model).toBe('claude-3');
+  });
+
+  it('passes the configured model to the spawn IPC', async () => {
+    const { slice } = createTestStore();
+
+    await slice.spawnDurableAgent(PROJECT_ID, PROJECT_PATH, DURABLE_CONFIG, false);
+
+    expect((window as any).clubhouse.agent.spawnAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-3' }),
+    );
+  });
 });
 
 describe('agentLifecycleSlice – killAgent', () => {

--- a/src/renderer/stores/agent/agentLifecycleSlice.ts
+++ b/src/renderer/stores/agent/agentLifecycleSlice.ts
@@ -154,6 +154,10 @@ export function createLifecycleSlice(set: SetAgentState, get: GetAgentState): Ag
         branch: config.branch,
         exitCode: undefined,
         mission,
+        // Carry the durable config's model through — this object REPLACES the
+        // store entry, so omitting it wipes the agent's configured model on
+        // every wake (settings + list badge fall back to "Default").
+        model: config.model,
         orchestrator: config.orchestrator,
         freeAgentMode: config.freeAgentMode || undefined,
         structuredMode: config.structuredMode || undefined,


### PR DESCRIPTION
## Summary

Picking a model (e.g. **Sonnet**) for a durable agent looked like it didn't stick: reopening Agent Settings showed **Custom...** with a lowercase `sonnet` in the text box, and after waking the agent the selector fell back to **Default**. Waking passed `sonnet` correctly the whole time — the main process reads `durableConfig.model` straight off disk, and `agents.json` was always correct. All three defects were renderer-side display/state bugs.

## Changes

**1. Known model mislabelled as "Custom..." (`AgentSettingsView.tsx`)**

`useModelOptions` fetches its list over IPC and reports a `default`-only placeholder while in flight. The sync-from-disk effect classified the persisted id against that placeholder, so `sonnet` failed `isKnownModel()` and fell into the Custom branch — and never re-corrected, because `MODEL_OPTIONS` wasn't in the effect's dependency array (`[projectPath, agent.id, refreshKey]`). The same latch existed in the `useState` initializer and the Quick-Agent-Defaults mirror.

The raw persisted id now lives in `savedModel` / `qadSavedModel`, and the known-vs-custom split moved to a dedicated effect gated on `modelOptionsLoading` that re-runs when the options arrive.

**2. Wrong provider's model list**

`useModelOptions()` was called with no argument, so options came from the project's default provider rather than the agent's own orchestrator. A Codex/Copilot agent was therefore offered — and validated against — Claude's model ids. Now passes `agentOrchestrator`.

**3. Model wiped from the store on every wake (`agentLifecycleSlice.ts`, `agentCrudSlice.ts`)**

`spawnDurableAgent` rebuilds the `Agent` object from the durable config and that object *replaces* the store entry — but it omitted `model`, so waking an agent dropped the value. `loadDurableAgents` only set `model` for agents not already in the store, so it never healed. This is the "reverts to Default" half: both the settings selector (seeded from `agent.model`) and the `AgentListItem` badge fell back to Default.

Fixed by carrying `model` through the spawn rebuild and re-hydrating it from config on existing store entries.

## Test Plan

The `AgentSettingsView` suite mocked `useModelOptions` to return the full list synchronously with `loading: false` — precisely what hid bug 1. That mock is removed; tests now drive the real hook through the `getModelOptions` IPC mock, including deferred-resolution cases.

- [x] Known persisted model (`sonnet`) renders as "Sonnet", not "Custom..." + text box
- [x] Known model is not latched as Custom when the option list resolves *after* the durable config
- [x] A genuinely unknown id (`claude-opus-4-6`) still classifies as Custom once options load
- [x] Model options are fetched for the agent's own orchestrator (`codex-cli`)
- [x] `spawnDurableAgent` keeps `model` on the store entry and passes it to the spawn IPC
- [x] `loadDurableAgents` seeds, re-hydrates, and clears `model` from config (new `agentCrudSlice.test.ts`)

All six new assertions were confirmed to **fail against the pre-fix source** and pass with the fix.

Validation: `npm run typecheck` clean, `npm test` 503 files / 12,693 passed, `npm run lint` 0 errors (warnings pre-existing).

## Manual Validation

1. Open Agent Settings for a sleeping durable agent, set Model to **Sonnet**.
2. Navigate away and reopen Settings → should read **Sonnet**, not **Custom...** with `sonnet`.
3. Wake the agent → Settings and the agent list badge should still read **Sonnet**.
4. Set a genuinely custom id (`claude-opus-4-6`) and reopen → should still show **Custom...** with the id.
5. For an agent on a non-Claude orchestrator, confirm the dropdown lists that provider's models.

## Notes

The other `useModelOptions` consumers (`AddAgentDialog`, `TemplateConfigDialog`, `QuickAgentDialog`, `AgentList`, hub pickers) were checked for the same latch — they all start from a fresh user choice rather than classifying a persisted value, so none are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)