### PR TITLE
fix(canvas): blueprint import targets the calling canvas's scope, not the active project

### DIFF
--- a/src/renderer/features/blueprints/BlueprintGallery.test.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.test.tsx
@@ -2,13 +2,17 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BlueprintGallery } from './BlueprintGallery';
 
-const state = { blueprintGalleryOpen: false };
+const state: { blueprintGalleryOpen: boolean; blueprintGalleryScope: any } = {
+  blueprintGalleryOpen: false,
+  blueprintGalleryScope: null,
+};
 const mockCloseBlueprintGallery = vi.fn();
 
 vi.mock('../../stores/uiStore', () => ({
   useUIStore: Object.assign(
     (selector: any) => selector({
       get blueprintGalleryOpen() { return state.blueprintGalleryOpen; },
+      get blueprintGalleryScope() { return state.blueprintGalleryScope; },
       closeBlueprintGallery: mockCloseBlueprintGallery,
     }),
     { getState: () => ({ closeBlueprintGallery: mockCloseBlueprintGallery }) },
@@ -53,11 +57,25 @@ vi.mock('./blueprint-import', () => ({
   importBlueprint: (...args: any[]) => mockManifestImport(...args),
 }));
 
-const mockInsertCanvas = vi.fn();
+const mockLoadAndInsertCanvas = vi.fn().mockResolvedValue(undefined);
 const mockAddWireDefinition = vi.fn();
+const mockGetProjectCanvasStore = vi.fn((projectId: string) => ({
+  __scope: `project:${projectId}`,
+  getState: () => ({ loadAndInsertCanvas: mockLoadAndInsertCanvas, addWireDefinition: mockAddWireDefinition }),
+}));
 vi.mock('../../plugins/builtin/canvas/main', () => ({
-  getProjectCanvasStore: () => ({ getState: () => ({ insertCanvas: mockInsertCanvas, addWireDefinition: mockAddWireDefinition }) }),
-  useAppCanvasStore: { getState: () => ({ insertCanvas: mockInsertCanvas, addWireDefinition: mockAddWireDefinition }) },
+  getProjectCanvasStore: (projectId: string) => mockGetProjectCanvasStore(projectId),
+  useAppCanvasStore: {
+    __scope: 'app',
+    getState: () => ({ loadAndInsertCanvas: mockLoadAndInsertCanvas, addWireDefinition: mockAddWireDefinition }),
+  },
+}));
+
+const mockCreateScopedStorage = vi.fn((pluginId: string, scope: string, projectPath?: string) => ({
+  pluginId, scope, projectPath,
+}));
+vi.mock('../../plugins/plugin-api-storage', () => ({
+  createScopedStorage: (...args: any[]) => (mockCreateScopedStorage as any)(...args),
 }));
 
 const mockBlueprintList = vi.fn();
@@ -86,7 +104,12 @@ function makeBp(overrides: Partial<any> = {}) {
 }
 
 describe('BlueprintGallery', () => {
-  beforeEach(() => { vi.clearAllMocks(); state.blueprintGalleryOpen = false; });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadAndInsertCanvas.mockResolvedValue(undefined);
+    state.blueprintGalleryOpen = false;
+    state.blueprintGalleryScope = null;
+  });
 
   it('renders nothing when closed', () => {
     const { container } = render(<BlueprintGallery />);
@@ -277,7 +300,7 @@ describe('BlueprintGallery', () => {
     fireEvent.dblClick(screen.getByTestId('blueprint-card-Test BP'));
     await waitFor(() => {
       expect(mockManifestImport).toHaveBeenCalled();
-      expect(mockInsertCanvas).toHaveBeenCalled();
+      expect(mockLoadAndInsertCanvas).toHaveBeenCalled();
     });
     // Legacy import should NOT have been called
     expect(mockLegacyImport).not.toHaveBeenCalled();
@@ -298,7 +321,7 @@ describe('BlueprintGallery', () => {
     fireEvent.dblClick(screen.getByTestId('blueprint-card-Test BP'));
     await waitFor(() => {
       expect(mockLegacyImport).toHaveBeenCalled();
-      expect(mockInsertCanvas).toHaveBeenCalled();
+      expect(mockLoadAndInsertCanvas).toHaveBeenCalled();
     });
     // Manifest import should NOT have been called
     expect(mockManifestImport).not.toHaveBeenCalled();
@@ -337,7 +360,7 @@ describe('BlueprintGallery', () => {
     await waitFor(() => {
       expect(mockBlueprintOpenAndRead).toHaveBeenCalled();
       expect(mockManifestImport).toHaveBeenCalled();
-      expect(mockInsertCanvas).toHaveBeenCalled();
+      expect(mockLoadAndInsertCanvas).toHaveBeenCalled();
     });
   });
 
@@ -361,7 +384,7 @@ describe('BlueprintGallery', () => {
 
     await waitFor(() => {
       expect(mockLegacyImport).toHaveBeenCalled();
-      expect(mockInsertCanvas).toHaveBeenCalled();
+      expect(mockLoadAndInsertCanvas).toHaveBeenCalled();
     });
   });
 
@@ -378,7 +401,7 @@ describe('BlueprintGallery', () => {
     await waitFor(() => {
       expect(mockBlueprintOpenAndRead).toHaveBeenCalled();
     });
-    expect(mockInsertCanvas).not.toHaveBeenCalled();
+    expect(mockLoadAndInsertCanvas).not.toHaveBeenCalled();
     expect(mockCloseBlueprintGallery).not.toHaveBeenCalled();
   });
 
@@ -400,5 +423,103 @@ describe('BlueprintGallery', () => {
       expect(screen.getByTestId('blueprint-gallery-error')).toBeDefined();
     });
     expect(screen.getByText(/Unexpected token/)).toBeDefined();
+  });
+
+  // ── Canvas store targeting by scope (#1563) ────────────────────
+
+  it('imports into the app canvas store + global storage when opened from the rail (app) Canvas', async () => {
+    state.blueprintGalleryOpen = true;
+    state.blueprintGalleryScope = { mode: 'app' };
+    mockBlueprintList.mockResolvedValue([makeBp()]);
+    mockBlueprintRead.mockResolvedValue({ version: 1, name: 'Legacy BP', views: [] });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByText('Test BP')).toBeDefined(); });
+
+    fireEvent.dblClick(screen.getByTestId('blueprint-card-Test BP'));
+
+    await waitFor(() => { expect(mockLoadAndInsertCanvas).toHaveBeenCalled(); });
+    // Store resolution never falls through to the project store for app scope,
+    // even though a project (p1) is globally active in this test setup.
+    expect(mockGetProjectCanvasStore).not.toHaveBeenCalled();
+    expect(mockCreateScopedStorage).toHaveBeenCalledWith('canvas', 'global');
+  });
+
+  it('imports into the matching project canvas store + project-local storage when opened from a project Canvas tab', async () => {
+    state.blueprintGalleryOpen = true;
+    state.blueprintGalleryScope = { mode: 'project', projectId: 'p2', projectPath: '/tmp/proj2' };
+    mockBlueprintList.mockResolvedValue([makeBp()]);
+    mockBlueprintRead.mockResolvedValue({ version: 1, name: 'Legacy BP', views: [] });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByText('Test BP')).toBeDefined(); });
+
+    fireEvent.dblClick(screen.getByTestId('blueprint-card-Test BP'));
+
+    await waitFor(() => { expect(mockLoadAndInsertCanvas).toHaveBeenCalled(); });
+    // Targets project p2's store, NOT the globally active project (p1) —
+    // this is the #1563 regression: opening from the rail Canvas with a
+    // different project open must not silently redirect the import.
+    expect(mockGetProjectCanvasStore).toHaveBeenCalledWith('p2');
+    expect(mockCreateScopedStorage).toHaveBeenCalledWith('canvas', 'project-local', '/tmp/proj2');
+  });
+
+  it('falls back to the globally active project when no scope is set (command palette entry points)', async () => {
+    state.blueprintGalleryOpen = true;
+    state.blueprintGalleryScope = null;
+    mockBlueprintList.mockResolvedValue([makeBp()]);
+    mockBlueprintRead.mockResolvedValue({ version: 1, name: 'Legacy BP', views: [] });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByText('Test BP')).toBeDefined(); });
+
+    fireEvent.dblClick(screen.getByTestId('blueprint-card-Test BP'));
+
+    await waitFor(() => { expect(mockLoadAndInsertCanvas).toHaveBeenCalled(); });
+    expect(mockGetProjectCanvasStore).toHaveBeenCalledWith('p1');
+    expect(mockCreateScopedStorage).toHaveBeenCalledWith('canvas', 'project-local', '/tmp/proj');
+  });
+
+  it('persists the import immediately via loadAndInsertCanvas so it survives a remount', async () => {
+    state.blueprintGalleryOpen = true;
+    state.blueprintGalleryScope = { mode: 'app' };
+    mockBlueprintList.mockResolvedValue([makeBp()]);
+    mockBlueprintRead.mockResolvedValue({ version: 1, name: 'Legacy BP', views: [] });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByText('Test BP')).toBeDefined(); });
+
+    fireEvent.dblClick(screen.getByTestId('blueprint-card-Test BP'));
+
+    await waitFor(() => {
+      // loadAndInsertCanvas (not the fire-and-forget insertCanvas) is what
+      // persists the canvas to storage, so a re-mount of the plugin panel
+      // picks up the imported canvas instead of losing it.
+      expect(mockLoadAndInsertCanvas).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ scope: 'global' }),
+      );
+    });
+  });
+
+  it('imports a blueprint opened via the OS file picker into the scoped project store', async () => {
+    state.blueprintGalleryOpen = true;
+    state.blueprintGalleryScope = { mode: 'project', projectId: 'p2', projectPath: '/tmp/proj2' };
+    mockBlueprintList.mockResolvedValue([]);
+    mockBlueprintOpenAndRead.mockResolvedValue({
+      canceled: false,
+      filePath: '/elsewhere/legacy.json',
+      data: { version: 1, name: 'Legacy from disk', views: [] },
+    });
+
+    render(<BlueprintGallery />);
+    await waitFor(() => { expect(screen.getByTestId('blueprint-gallery-open-from-file')).toBeDefined(); });
+
+    fireEvent.click(screen.getByTestId('blueprint-gallery-open-from-file'));
+
+    await waitFor(() => {
+      expect(mockGetProjectCanvasStore).toHaveBeenCalledWith('p2');
+      expect(mockLoadAndInsertCanvas).toHaveBeenCalled();
+    });
   });
 });

--- a/src/renderer/features/blueprints/BlueprintGallery.tsx
+++ b/src/renderer/features/blueprints/BlueprintGallery.tsx
@@ -5,6 +5,7 @@ import { importBlueprint as legacyImportBlueprint, validateBlueprint } from '../
 import { importBlueprint as manifestImportBlueprint } from './blueprint-import';
 import { parseAnyBlueprint, buildWireDefinitionsFromResult } from './parse-blueprint';
 import { getProjectCanvasStore, useAppCanvasStore } from '../../plugins/builtin/canvas/main';
+import { createScopedStorage } from '../../plugins/plugin-api-storage';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAgentStore } from '../../stores/agentStore';
 import {
@@ -50,7 +51,42 @@ function sortBlueprints(items: BlueprintSummary[], mode: SortMode): BlueprintSum
 export function BlueprintGallery() {
   const isOpen = useUIStore((s) => s.blueprintGalleryOpen);
   const close = useUIStore((s) => s.closeBlueprintGallery);
+  const scope = useUIStore((s) => s.blueprintGalleryScope);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
+
+  // Resolve the canvas store + scoped storage the import should land in. When the
+  // opener specified a scope (rail Canvas vs. a project Canvas tab), use that —
+  // otherwise fall back to whichever project is globally active (command palette
+  // entry points that aren't tied to a specific canvas instance).
+  const resolveTarget = useCallback(() => {
+    if (scope) {
+      if (scope.mode === 'app') {
+        return {
+          store: useAppCanvasStore,
+          storage: createScopedStorage('canvas', 'global'),
+          projectId: undefined as string | undefined,
+        };
+      }
+      return {
+        store: getProjectCanvasStore(scope.projectId),
+        storage: createScopedStorage('canvas', 'project-local', scope.projectPath),
+        projectId: scope.projectId as string | undefined,
+      };
+    }
+    if (activeProjectId) {
+      const projectPath = useProjectStore.getState().projects.find((p) => p.id === activeProjectId)?.path;
+      return {
+        store: getProjectCanvasStore(activeProjectId),
+        storage: createScopedStorage('canvas', 'project-local', projectPath),
+        projectId: activeProjectId as string | undefined,
+      };
+    }
+    return {
+      store: useAppCanvasStore,
+      storage: createScopedStorage('canvas', 'global'),
+      projectId: undefined as string | undefined,
+    };
+  }, [scope, activeProjectId]);
 
   const [blueprints, setBlueprints] = useState<BlueprintSummary[]>([]);
   const [loading, setLoading] = useState(false);
@@ -112,9 +148,7 @@ export function BlueprintGallery() {
         : await window.clubhouse.blueprint.read(bp.filePath);
       if (!data) throw new Error('Failed to read blueprint file');
 
-      const store = activeProjectId
-        ? getProjectCanvasStore(activeProjectId)
-        : useAppCanvasStore;
+      const { store, storage, projectId: targetProjectId } = resolveTarget();
 
       // Use manifest-aware import for BlueprintManifest files (preserves agent bindings/wires)
       if (data && typeof data === 'object' && 'schemaVersion' in data) {
@@ -124,8 +158,8 @@ export function BlueprintGallery() {
           name: p.name,
           path: p.path,
         }));
-        const result = manifestImportBlueprint(data as any, agents, projects, activeProjectId ?? undefined);
-        store.getState().insertCanvas(result.canvas);
+        const result = manifestImportBlueprint(data as any, agents, projects, targetProjectId);
+        await store.getState().loadAndInsertCanvas(result.canvas, storage);
         // Restore wire definitions from the import
         for (const wire of result.pendingWires) {
           const sourceViewId = result.refIdToViewId.get(wire.sourceRef);
@@ -155,7 +189,7 @@ export function BlueprintGallery() {
         const validationError = validateBlueprint(data);
         if (validationError) throw new Error(validationError);
         const canvas = legacyImportBlueprint(data as any);
-        store.getState().insertCanvas(canvas);
+        await store.getState().loadAndInsertCanvas(canvas, storage);
       }
 
       close();
@@ -164,7 +198,7 @@ export function BlueprintGallery() {
     } finally {
       setImporting(null);
     }
-  }, [activeProjectId, close]);
+  }, [resolveTarget, close]);
 
   const handleOpenFromFile = useCallback(async () => {
     setError(null);
@@ -180,16 +214,14 @@ export function BlueprintGallery() {
       const projects = useProjectStore.getState().projects.map((p) => ({
         id: p.id, name: p.name, path: p.path,
       }));
+      const { store, storage, projectId: targetProjectId } = resolveTarget();
       const parsed = parseAnyBlueprint(result.data, {
         agents,
         projects,
-        activeProjectId: activeProjectId ?? undefined,
+        activeProjectId: targetProjectId,
       });
 
-      const store = activeProjectId
-        ? getProjectCanvasStore(activeProjectId)
-        : useAppCanvasStore;
-      store.getState().insertCanvas(parsed.canvas);
+      await store.getState().loadAndInsertCanvas(parsed.canvas, storage);
       for (const wire of buildWireDefinitionsFromResult(parsed)) {
         store.getState().addWireDefinition(wire);
       }
@@ -199,7 +231,7 @@ export function BlueprintGallery() {
     } finally {
       setImporting(null);
     }
-  }, [activeProjectId, close]);
+  }, [resolveTarget, close]);
 
   const handleDelete = useCallback(async (bp: BlueprintSummary) => {
     // Built-in templates are not file-backed and cannot be deleted.

--- a/src/renderer/plugins/builtin/canvas/main.test.ts
+++ b/src/renderer/plugins/builtin/canvas/main.test.ts
@@ -256,6 +256,29 @@ describe('canvas main', () => {
     expect(removeViewBlock).toContain('removeWireDefinition');
   });
 
+  it('handleAddFromBlueprint passes an explicit app/project scope to openBlueprintGallery (structural, GH-1563)', () => {
+    // #1563: the blueprint gallery previously picked its target canvas store from
+    // the globally active project (activeProjectId), which is wrong when the "+ →
+    // From Blueprint" button is clicked on the app-mode rail Canvas while a project
+    // happens to be open elsewhere. The fix is for the caller to tell the gallery
+    // which store it means via an explicit scope, instead of the gallery guessing.
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(path.resolve(__dirname, 'main.ts'), 'utf-8');
+
+    const block = source.slice(
+      source.indexOf('const handleAddFromBlueprint'),
+      source.indexOf('const handleAddFromBlueprint') + 400,
+    );
+    expect(block).toContain('openBlueprintGallery(');
+    expect(block).toContain("mode: 'app'");
+    expect(block).toContain("mode: 'project'");
+    expect(block).toContain('isAppMode');
+    // Must forward the actual project id/path, not rely on a global lookup.
+    expect(block).toContain('api.context.projectId');
+    expect(block).toContain('api.context.projectPath');
+  });
+
   it('per-project stores have isolated state', () => {
     const storeA = canvasModule.getProjectCanvasStore('canvas-proj-iso-a');
     const storeB = canvasModule.getProjectCanvasStore('canvas-proj-iso-b');

--- a/src/renderer/plugins/builtin/canvas/main.ts
+++ b/src/renderer/plugins/builtin/canvas/main.ts
@@ -396,8 +396,12 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   }, [store, remoteForward]);
 
   const handleAddFromBlueprint = useCallback(() => {
-    useUIStore.getState().openBlueprintGallery();
-  }, []);
+    useUIStore.getState().openBlueprintGallery(
+      isAppMode
+        ? { mode: 'app' }
+        : { mode: 'project', projectId: api.context.projectId!, projectPath: api.context.projectPath },
+    );
+  }, [isAppMode, api]);
 
   const handleRemoveCanvas = useCallback((canvasId: string) => {
     remoteForward({ type: 'removeCanvas', canvasId });

--- a/src/renderer/stores/uiStore.test.ts
+++ b/src/renderer/stores/uiStore.test.ts
@@ -200,6 +200,39 @@ describe('uiStore', () => {
     });
   });
 
+  describe('blueprintGallery scope (GH-1563)', () => {
+    it('starts closed with no scope', () => {
+      expect(getState().blueprintGalleryOpen).toBe(false);
+      expect(getState().blueprintGalleryScope).toBeNull();
+    });
+
+    it('openBlueprintGallery with no scope opens with a null scope (back-compat callers)', () => {
+      getState().openBlueprintGallery();
+      expect(getState().blueprintGalleryOpen).toBe(true);
+      expect(getState().blueprintGalleryScope).toBeNull();
+    });
+
+    it('openBlueprintGallery records an app scope', () => {
+      getState().openBlueprintGallery({ mode: 'app' });
+      expect(getState().blueprintGalleryOpen).toBe(true);
+      expect(getState().blueprintGalleryScope).toEqual({ mode: 'app' });
+    });
+
+    it('openBlueprintGallery records a project scope with id and path', () => {
+      getState().openBlueprintGallery({ mode: 'project', projectId: 'proj-1', projectPath: '/tmp/proj-1' });
+      expect(getState().blueprintGalleryScope).toEqual({
+        mode: 'project', projectId: 'proj-1', projectPath: '/tmp/proj-1',
+      });
+    });
+
+    it('closeBlueprintGallery clears both open and scope', () => {
+      getState().openBlueprintGallery({ mode: 'project', projectId: 'proj-1' });
+      getState().closeBlueprintGallery();
+      expect(getState().blueprintGalleryOpen).toBe(false);
+      expect(getState().blueprintGalleryScope).toBeNull();
+    });
+  });
+
   describe('settingsContext', () => {
     it('defaults to app', () => {
       expect(getState().settingsContext).toBe('app');

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -9,6 +9,17 @@ interface ViewPrefs {
   showHome: boolean;
 }
 
+/**
+ * Which canvas store a blueprint import should target. Set by the caller that
+ * opened the gallery (e.g. the app-mode rail Canvas vs. a project-mode Canvas
+ * tab) so the import doesn't fall back to guessing from the globally active
+ * project — that guess is wrong whenever a project is open but the gallery
+ * was opened from the app-level rail Canvas.
+ */
+export type BlueprintGalleryScope =
+  | { mode: 'app' }
+  | { mode: 'project'; projectId: string; projectPath?: string };
+
 function loadViewPrefs(): ViewPrefs {
   try {
     const raw = localStorage.getItem(VIEW_PREFS_KEY);
@@ -64,7 +75,8 @@ interface UIState {
   openQuickAgentDialog: () => void;
   closeQuickAgentDialog: () => void;
   blueprintGalleryOpen: boolean;
-  openBlueprintGallery: () => void;
+  blueprintGalleryScope: BlueprintGalleryScope | null;
+  openBlueprintGallery: (scope?: BlueprintGalleryScope) => void;
   closeBlueprintGallery: () => void;
 }
 
@@ -180,6 +192,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   openQuickAgentDialog: () => set({ quickAgentDialogOpen: true }),
   closeQuickAgentDialog: () => set({ quickAgentDialogOpen: false }),
   blueprintGalleryOpen: false,
-  openBlueprintGallery: () => set({ blueprintGalleryOpen: true }),
-  closeBlueprintGallery: () => set({ blueprintGalleryOpen: false }),
+  blueprintGalleryScope: null,
+  openBlueprintGallery: (scope) => set({ blueprintGalleryOpen: true, blueprintGalleryScope: scope ?? null }),
+  closeBlueprintGallery: () => set({ blueprintGalleryOpen: false, blueprintGalleryScope: null }),
 }));


### PR DESCRIPTION
## Summary
Fixes #1563 — "+ → From Blueprint" on the app-level rail Canvas silently imported into the wrong canvas store (or appeared to do nothing) whenever a project was open, because `BlueprintGallery` picked its target store from the globally active project (`activeProjectId`) instead of from whichever Canvas instance actually opened it.

- `uiStore.openBlueprintGallery` now accepts an optional `BlueprintGalleryScope` (`{ mode: 'app' }` or `{ mode: 'project', projectId, projectPath }`), stored alongside `blueprintGalleryOpen`.
- `canvas/main.ts`'s rail "+ → From Blueprint" button (`handleAddFromBlueprint`) now passes its own app/project scope explicitly instead of leaving the gallery to guess.
- `BlueprintGallery` resolves its target store + scoped storage from that explicit scope when present, falling back to the previous `activeProjectId`-based guess only for callers that don't specify one (command palette entries not tied to a specific canvas instance).
- Switched `insertCanvas` → `loadAndInsertCanvas` for both the gallery import and "Open from file…" paths so imported canvases persist to disk immediately and survive a remount, instead of only living in memory until the next save cycle.

## Test plan
- [x] `BlueprintGallery.test.tsx` — added coverage for app-scope import, project-scope import (including the regression case: scoped project differs from the globally active project), no-scope fallback, `loadAndInsertCanvas` persistence, and the file-picker path with a scope.
- [x] `uiStore.test.ts` — added coverage for `openBlueprintGallery`/`closeBlueprintGallery` scope storage and reset.
- [x] `main.test.ts` — added a structural test asserting `handleAddFromBlueprint` forwards an explicit app/project scope.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — all 1136 tests across `command-palette` and `canvas` directories pass, plus the 3 directly-touched files (90 tests).
- [x] `npx eslint` on all changed files — no new warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)