### PR TITLE
fix(canvas): New Agent create no longer silently fails with Free Agent Mode

### DIFF
--- a/src/renderer/features/agents/AddAgentDialog.test.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.test.tsx
@@ -146,6 +146,26 @@ describe('AddAgentDialog', () => {
     );
   });
 
+  describe('error surfacing (#1564)', () => {
+    it('shows no error banner by default', () => {
+      render(<AddAgentDialog {...defaultProps} />);
+      expect(screen.queryByTestId('add-agent-dialog-error')).not.toBeInTheDocument();
+    });
+
+    it('shows the error banner when an error prop is passed', () => {
+      render(<AddAgentDialog {...defaultProps} error="Plugin 'canvas' requires 'agents.free-agent-mode' permission" />);
+      expect(screen.getByTestId('add-agent-dialog-error')).toBeInTheDocument();
+      expect(screen.getByText(/requires 'agents.free-agent-mode' permission/)).toBeInTheDocument();
+    });
+
+    it('hides the error banner when error is null', () => {
+      const { rerender } = render(<AddAgentDialog {...defaultProps} error="boom" />);
+      expect(screen.getByTestId('add-agent-dialog-error')).toBeInTheDocument();
+      rerender(<AddAgentDialog {...defaultProps} error={null} />);
+      expect(screen.queryByTestId('add-agent-dialog-error')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Structured Mode gating (experimental flag)', () => {
     it('hides Structured Mode toggle when experimental.structuredMode is off (default)', async () => {
       render(<AddAgentDialog {...defaultProps} />);

--- a/src/renderer/features/agents/AddAgentDialog.tsx
+++ b/src/renderer/features/agents/AddAgentDialog.tsx
@@ -11,9 +11,11 @@ interface Props {
   onClose: () => void;
   onCreate: (name: string, color: string, model: string, useWorktree: boolean, orchestrator?: string, freeAgentMode?: boolean, mcpIds?: string[], structuredMode?: boolean) => void;
   projectPath?: string;
+  /** Surfaced when the most recent create attempt failed, so the user sees why instead of a silently dead button. */
+  error?: string | null;
 }
 
-export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
+export function AddAgentDialog({ onClose, onCreate, projectPath, error }: Props) {
   const [name, setName] = useState(generateDurableName());
   const [color, setColor] = useState<string>(AGENT_COLORS[0].id);
   const [model, setModel] = useState('default');
@@ -69,6 +71,14 @@ export function AddAgentDialog({ onClose, onCreate, projectPath }: Props) {
   return (
     <Modal open={true} onClose={onClose}>
         <h2 className="text-base font-semibold text-ctp-text mb-4">New Agent</h2>
+        {error && (
+          <div
+            className="px-3 py-2 mb-3 text-xs text-ctp-error bg-ctp-error/10 rounded-md"
+            data-testid="add-agent-dialog-error"
+          >
+            {error}
+          </div>
+        )}
         <form onSubmit={handleSubmit}>
           {/* Name */}
           <label className="block mb-3">

--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.test.tsx
@@ -12,13 +12,28 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 // we can drive handleCreateDurable without rendering the full form (which has
 // orchestrator/model store dependencies that would balloon test setup).
 vi.mock('../../../features/agents/AddAgentDialog', () => ({
-  AddAgentDialog: ({ onCreate }: { onCreate: (name: string, color: string, model: string, useWorktree: boolean) => void }) => (
-    <button
-      data-testid="stub-add-agent-submit"
-      onClick={() => onCreate('NewAgent', 'emerald', 'default', false)}
-    >
-      Submit
-    </button>
+  AddAgentDialog: ({ onCreate, error }: {
+    onCreate: (
+      name: string, color: string, model: string, useWorktree: boolean,
+      orchestrator?: string, freeAgentMode?: boolean, mcpIds?: string[], structuredMode?: boolean,
+    ) => void;
+    error?: string | null;
+  }) => (
+    <div>
+      {error && <div data-testid="stub-add-agent-error">{error}</div>}
+      <button
+        data-testid="stub-add-agent-submit"
+        onClick={() => onCreate('NewAgent', 'emerald', 'default', false)}
+      >
+        Submit
+      </button>
+      <button
+        data-testid="stub-add-agent-submit-free-agent"
+        onClick={() => onCreate('NewAgent', 'emerald', 'default', false, 'claude-code', true, undefined, true)}
+      >
+        Submit (free agent + structured)
+      </button>
+    </div>
   ),
 }));
 
@@ -313,6 +328,82 @@ describe('AgentCanvasView', () => {
       // No position field should be in the update — caller relies on existing
       // store behavior of preserving position via spread merge.
       expect(updateArg).not.toHaveProperty('position');
+    });
+  });
+
+  // ── #1564: error surfacing + structuredMode/freeAgentMode pass-through ──
+
+  describe('create-agent failure surfacing (#1564)', () => {
+    it('surfaces the createDurable error in the dialog instead of swallowing it', async () => {
+      const view = makeView({ agentId: null });
+      const onUpdate = vi.fn();
+      const api = stubApi({
+        projects: [{ id: 'proj-1', name: 'Proj', path: '/tmp/proj' }],
+        createDurable: async () => {
+          throw new Error("Plugin 'canvas' requires 'agents.free-agent-mode' permission to use freeAgentMode");
+        },
+      });
+
+      render(<AgentCanvasView view={view} api={api} onUpdate={onUpdate} />);
+
+      fireEvent.click(screen.getByTestId('canvas-create-agent'));
+      fireEvent.click(screen.getByTestId('stub-add-agent-submit'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('stub-add-agent-error')).toBeTruthy();
+      });
+      expect(screen.getByTestId('stub-add-agent-error').textContent).toContain('agents.free-agent-mode');
+      // Dialog stays open (the stub submit button is still present) so the user can retry.
+      expect(screen.getByTestId('stub-add-agent-submit')).toBeTruthy();
+      // No card should have been assigned/created on failure.
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('clears a previous error on the next successful create attempt', async () => {
+      const view = makeView({ agentId: null });
+      const onUpdate = vi.fn();
+      let shouldFail = true;
+      const api = stubApi({
+        projects: [{ id: 'proj-1', name: 'Proj', path: '/tmp/proj' }],
+        createDurable: async () => {
+          if (shouldFail) throw new Error('boom');
+          return 'agent-recovered';
+        },
+      });
+
+      render(<AgentCanvasView view={view} api={api} onUpdate={onUpdate} />);
+
+      fireEvent.click(screen.getByTestId('canvas-create-agent'));
+      fireEvent.click(screen.getByTestId('stub-add-agent-submit'));
+      await waitFor(() => expect(screen.getByTestId('stub-add-agent-error')).toBeTruthy());
+
+      shouldFail = false;
+      fireEvent.click(screen.getByTestId('stub-add-agent-submit'));
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+    });
+
+    it('passes freeAgentMode and structuredMode through to api.agents.createDurable', async () => {
+      const view = makeView({ agentId: null });
+      const onUpdate = vi.fn();
+      const createDurableSpy = vi.fn(async () => 'agent-new-id');
+      const api = stubApi({
+        projects: [{ id: 'proj-1', name: 'Proj', path: '/tmp/proj' }],
+        createDurable: createDurableSpy,
+      });
+
+      render(<AgentCanvasView view={view} api={api} onUpdate={onUpdate} />);
+
+      fireEvent.click(screen.getByTestId('canvas-create-agent'));
+      fireEvent.click(screen.getByTestId('stub-add-agent-submit-free-agent'));
+
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      expect(createDurableSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orchestrator: 'claude-code',
+          freeAgentMode: true,
+          structuredMode: true,
+        }),
+      );
     });
   });
 });

--- a/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
+++ b/src/renderer/plugins/builtin/canvas/AgentCanvasView.tsx
@@ -35,6 +35,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
   const [agentTick, setAgentTick] = useState(0);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
 
   useEffect(() => {
     const sub = api.agents.onAnyChange(() => setAgentTick((n) => n + 1));
@@ -116,10 +117,11 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
 
   const handleCreateDurable = useCallback(async (
     name: string, color: string, model: string, useWorktree: boolean,
-    orchestrator?: string, freeAgentMode?: boolean, mcpIds?: string[],
+    orchestrator?: string, freeAgentMode?: boolean, mcpIds?: string[], structuredMode?: boolean,
   ) => {
     const project = activeProjectForCreate;
     if (!project) return;
+    setCreateError(null);
     try {
       const agentId = await api.agents.createDurable({
         projectId: project.id,
@@ -130,6 +132,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
         orchestrator,
         freeAgentMode,
         mcpIds,
+        structuredMode,
       });
       setShowCreateDialog(false);
       const newAgent = api.agents.list().find((a) => a.id === agentId);
@@ -144,8 +147,12 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
         handlePickAgent(newAgent);
       }
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       console.error('Failed to create durable agent:', err);
-      // Keep dialog open so user can see the failure context and retry
+      // Surface the failure in the dialog instead of a silently dead Create
+      // button — the previous swallow-to-console left the user with no
+      // signal at all (#1564). Keep the dialog open so they can retry.
+      setCreateError(message);
     }
   }, [activeProjectForCreate, api.agents, handlePickAgent, onCreateAgentCard, view]);
 
@@ -279,7 +286,7 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
           )}
         </div>
         <button
-          onClick={() => setShowCreateDialog(true)}
+          onClick={() => { setCreateError(null); setShowCreateDialog(true); }}
           data-testid="canvas-create-agent"
           className="w-full mt-2 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg
             bg-ctp-accent/20 text-ctp-accent hover:bg-ctp-accent/30 transition-colors text-xs cursor-pointer"
@@ -288,9 +295,10 @@ export function AgentCanvasView({ view, api, onUpdate, zoneThemeId, onCreateAgen
         </button>
         {showCreateDialog && activeProjectForCreate && (
           <AddAgentDialog
-            onClose={() => setShowCreateDialog(false)}
+            onClose={() => { setShowCreateDialog(false); setCreateError(null); }}
             onCreate={handleCreateDurable}
             projectPath={activeProjectForCreate.path}
+            error={createError}
           />
         )}
       </div>

--- a/src/renderer/plugins/builtin/canvas/manifest.test.ts
+++ b/src/renderer/plugins/builtin/canvas/manifest.test.ts
@@ -37,6 +37,14 @@ describe('canvas manifest', () => {
     expect(manifest.permissions!.length).toBeGreaterThanOrEqual(7);
   });
 
+  it('declares agents.free-agent-mode alongside its agents parent (#1564)', () => {
+    // Deliberate grant: the "+ New Agent" picker exposes a user-initiated Free
+    // Agent Mode toggle, so canvas needs this permission or every create with
+    // it checked silently throws at the plugin-api-agents.ts gate.
+    expect(manifest.permissions).toContain('agents.free-agent-mode');
+    expect(manifest.permissions).toContain('agents');
+  });
+
   it('contributes a tab with label and full layout', () => {
     expect(manifest.contributes?.tab).toBeDefined();
     expect(manifest.contributes!.tab!.label).toBe('Canvas');

--- a/src/renderer/plugins/builtin/canvas/manifest.ts
+++ b/src/renderer/plugins/builtin/canvas/manifest.ts
@@ -14,7 +14,11 @@ export const manifest: PluginManifest = {
   author: 'Clubhouse',
   engine: { api: 0.9 },
   scope: 'dual',
-  permissions: ['commands', 'storage', 'agents', 'projects', 'widgets', 'navigation', 'files', 'git', 'terminal', 'annex'],
+  // 'agents.free-agent-mode' (dangerous) is granted deliberately: the "+ New Agent"
+  // picker exposes a user-initiated Free Agent Mode toggle (AddAgentDialog), and
+  // without this permission every create silently threw at the plugin-api-agents.ts
+  // gate. Usage is limited to that single opt-in call site — never defaulted on.
+  permissions: ['commands', 'storage', 'agents', 'agents.free-agent-mode', 'projects', 'widgets', 'navigation', 'files', 'git', 'terminal', 'annex'],
   contributes: {
     tab: { label: 'Canvas', title: 'Canvas', icon: CANVAS_TAB_ICON, layout: 'full' },
     railItem: { label: 'Canvas', title: 'Canvas', icon: CANVAS_RAIL_ICON, position: 'top' },

--- a/src/renderer/plugins/plugin-api-agents.ts
+++ b/src/renderer/plugins/plugin-api-agents.ts
@@ -55,6 +55,7 @@ export function createAgentsAPI(ctx: PluginContext, manifest?: PluginManifest): 
       orchestrator?: string;
       freeAgentMode?: boolean;
       mcpIds?: string[];
+      structuredMode?: boolean;
     }): Promise<string> {
       if (options.freeAgentMode && !hasPermission(manifest, 'agents.free-agent-mode')) {
         throw new Error(`Plugin '${ctx.pluginId}' requires 'agents.free-agent-mode' permission to use freeAgentMode`);
@@ -76,7 +77,7 @@ export function createAgentsAPI(ctx: PluginContext, manifest?: PluginManifest): 
 
       const model = options.model && options.model !== 'default' ? options.model : undefined;
       const config = await window.clubhouse.agent.createDurable(
-        projectPath, options.name, options.color, model, options.useWorktree ?? false, options.orchestrator, options.freeAgentMode, options.mcpIds, undefined,
+        projectPath, options.name, options.color, model, options.useWorktree ?? false, options.orchestrator, options.freeAgentMode, options.mcpIds, undefined, options.structuredMode,
       );
       return useAgentStore.getState().spawnDurableAgent(projectId, projectPath, config, false);
     },

--- a/src/renderer/plugins/plugin-api-factory.test.ts
+++ b/src/renderer/plugins/plugin-api-factory.test.ts
@@ -2827,7 +2827,7 @@ describe('plugin-api-factory', () => {
         const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
         const result = await api.agents.createDurable({ name: 'test-agent', color: 'blue' });
         expect(mockAgent.createDurable).toHaveBeenCalledWith(
-          '/projects/my-project', 'test-agent', 'blue', undefined, false, undefined, undefined, undefined, undefined,
+          '/projects/my-project', 'test-agent', 'blue', undefined, false, undefined, undefined, undefined, undefined, undefined,
         );
         expect(spawnSpy).toHaveBeenCalledWith('proj-1', '/projects/my-project', durableConfig, false);
         expect(result).toBe('new-agent');
@@ -2847,7 +2847,7 @@ describe('plugin-api-factory', () => {
         const api = createPluginAPI(makeCtx({ projectId: 'proj-1', projectPath: '/projects/p1' }), undefined, allPermsManifest);
         await api.agents.createDurable({ projectId: 'proj-2', name: 'other-agent', color: 'red' });
         expect(mockAgent.createDurable).toHaveBeenCalledWith(
-          '/projects/p2', 'other-agent', 'red', undefined, false, undefined, undefined, undefined, undefined,
+          '/projects/p2', 'other-agent', 'red', undefined, false, undefined, undefined, undefined, undefined, undefined,
         );
         expect(spawnSpy).toHaveBeenCalledWith('proj-2', '/projects/p2', durableConfig, false);
       });
@@ -2874,7 +2874,7 @@ describe('plugin-api-factory', () => {
           useWorktree: true, orchestrator: 'claude-code', mcpIds: ['mcp-1'],
         });
         expect(mockAgent.createDurable).toHaveBeenCalledWith(
-          '/projects/my-project', 'full-agent', 'green', 'opus', true, 'claude-code', undefined, ['mcp-1'], undefined,
+          '/projects/my-project', 'full-agent', 'green', 'opus', true, 'claude-code', undefined, ['mcp-1'], undefined, undefined,
         );
       });
 
@@ -2885,7 +2885,42 @@ describe('plugin-api-factory', () => {
         const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
         await api.agents.createDurable({ name: 'agent', color: 'red', model: 'default' });
         expect(mockAgent.createDurable).toHaveBeenCalledWith(
-          '/projects/my-project', 'agent', 'red', undefined, false, undefined, undefined, undefined, undefined,
+          '/projects/my-project', 'agent', 'red', undefined, false, undefined, undefined, undefined, undefined, undefined,
+        );
+      });
+
+      it('passes structuredMode through (#1564)', async () => {
+        const durableConfig = { id: 'new-agent', name: 'structured-agent' };
+        mockAgent.createDurable.mockResolvedValue(durableConfig);
+        vi.spyOn(useAgentStore.getState(), 'spawnDurableAgent').mockResolvedValue('new-agent');
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        await api.agents.createDurable({ name: 'structured-agent', color: 'blue', structuredMode: true });
+        expect(mockAgent.createDurable).toHaveBeenCalledWith(
+          '/projects/my-project', 'structured-agent', 'blue', undefined, false, undefined, undefined, undefined, undefined, true,
+        );
+      });
+
+      it('throws when freeAgentMode is requested without the agents.free-agent-mode permission (#1564)', async () => {
+        const manifestWithoutFreeAgent = makeAllPermsManifest({
+          permissions: ALL_PLUGIN_PERMISSIONS.filter((p) => p !== 'agents.free-agent-mode'),
+        });
+        const api = createPluginAPI(makeCtx(), undefined, manifestWithoutFreeAgent);
+        await expect(
+          api.agents.createDurable({ name: 'x', color: 'red', freeAgentMode: true }),
+        ).rejects.toThrow(/free-agent-mode/);
+        expect(mockAgent.createDurable).not.toHaveBeenCalled();
+      });
+
+      it('still succeeds with freeAgentMode when the permission is granted (#1564)', async () => {
+        const durableConfig = { id: 'new-agent', name: 'free-agent' };
+        mockAgent.createDurable.mockResolvedValue(durableConfig);
+        vi.spyOn(useAgentStore.getState(), 'spawnDurableAgent').mockResolvedValue('new-agent');
+        const api = createPluginAPI(makeCtx(), undefined, allPermsManifest);
+        await expect(
+          api.agents.createDurable({ name: 'free-agent', color: 'red', freeAgentMode: true }),
+        ).resolves.toBe('new-agent');
+        expect(mockAgent.createDurable).toHaveBeenCalledWith(
+          '/projects/my-project', 'free-agent', 'red', undefined, false, undefined, true, undefined, undefined, undefined,
         );
       });
     });

--- a/src/shared/plugin-types.ts
+++ b/src/shared/plugin-types.ts
@@ -659,6 +659,7 @@ export interface AgentsAPI {
     orchestrator?: string;
     freeAgentMode?: boolean;
     mcpIds?: string[];
+    structuredMode?: boolean;
   }): Promise<string>;
   runQuick(mission: string, options?: { model?: string; systemPrompt?: string; projectId?: string; orchestrator?: string; freeAgentMode?: boolean; metadata?: Record<string, string> }): Promise<string>;
   kill(agentId: string): Promise<void>;


### PR DESCRIPTION
## Summary
Fixes #1564 — canvas's "+ New Agent" picker exposes a **Free Agent Mode** toggle, but the canvas plugin manifest never declared the `agents.free-agent-mode` permission that gates it (`plugin-api-agents.ts:59`). Every create attempt with the toggle checked threw, and `AgentCanvasView.tsx:146` swallowed that throw into `console.error` — so the user just saw a dead Create button with zero signal.

**⚠️ Dangerous permission grant — please review carefully, no need to rush.**
- `canvas/manifest.ts` now declares `agents.free-agent-mode`, classified `dangerous` in `plugin-types.ts`. This is the first builtin to hold a dangerous permission.
- This was crafty-toad's explicit call over the alternative (disabling the toggle instead) — see `#canvas-agent-bugs` for the full rationale and the four conditions attached to the grant.
- Conditions honored in this diff: the gate itself (`plugin-api-agents.ts:59`) is **untouched** — this is a manifest-only change; usage is limited to exactly one user-initiated call site (`AddAgentDialog`'s Free Agent Mode checkbox → `AgentCanvasView.handleCreateDurable` → `api.agents.createDurable`); it is never defaulted on (`useState(false)` in `AddAgentDialog`).
- **Verified empirically** (not just asserted): builtins bypass the permission-escalation/pending-approval flow. `plugin-loader.ts` line ~823 returns immediately for `entry.source === 'builtin'` before ever reaching the added-permission escalation check further down in `handleHotReload`. Builtins ship via app version bumps and re-register through the normal bootstrap path, which doesn't gate on escalation — so this grant can't strand canvas in a `pending-approval` state for existing users.

## Other fixes bundled (same root cause investigation)
- **Error surfacing**: `AddAgentDialog` now accepts an optional `error` prop and renders it inline (same visual pattern as `BlueprintGallery`'s error banner). `AgentCanvasView` tracks `createError` state, clears it on dialog open/successful retry, and passes the caught error message through instead of only logging it. The dialog stays open on failure so the user can see why and retry.
- **Arity mismatch**: `AddAgentDialog`'s `onCreate` passes 8 args (including `structuredMode`), but `handleCreateDurable` only destructured 7 — `structuredMode` was silently dropped on the canvas path. Threaded it through `AgentCanvasView.handleCreateDurable` → `AgentsAPI.createDurable` (added `structuredMode?: boolean` to the options type in `shared/plugin-types.ts`) → `plugin-api-agents.ts`'s `createDurable()` → the existing IPC `window.clubhouse.agent.createDurable(...)` call (which already accepted a `structuredMode` positional arg — it just wasn't being passed from this path).

## Test plan
- [x] `manifest.test.ts` — new test asserting `agents.free-agent-mode` is declared alongside its `agents` parent permission.
- [x] `plugin-api-factory.test.ts` — new tests: `createDurable` still **throws** without the permission (gate untouched), succeeds with it granted, and `structuredMode` passes through to the IPC call. Updated 4 existing call-assertions for the new trailing `structuredMode` arg position.
- [x] `AddAgentDialog.test.tsx` — new tests for the `error` prop (hidden by default, shown when set, hidden again when cleared).
- [x] `AgentCanvasView.test.tsx` — new tests: create failure surfaces into the dialog (and the dialog stays open with no card mutation), a previous error clears on the next successful attempt, and `freeAgentMode`/`structuredMode` both reach `api.agents.createDurable`.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run src/renderer/plugins src/renderer/features/agents` — all 4326 tests pass.
- [x] `npx eslint` on all changed files — no new warnings/errors (only pre-existing `no-explicit-any` warnings elsewhere in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)