### PR TITLE
fix(canvas): group project scroll no longer pans the canvas underneath

### DIFF
--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { GroupProjectPanelSidebar, useGroupProjectPanelLayout } from './GroupProjectPanelSidebar';
+import { GroupProjectPanelSidebar, useGroupProjectPanelLayout, stopPlainWheelPropagation } from './GroupProjectPanelSidebar';
 import type { CanvasWidgetComponentProps, AnnexAPI } from '../../../../shared/plugin-types';
 import type { TopicDigest, BulletinMessage } from '../../../../shared/group-project-types';
 import { useGroupProjectStore } from '../../../stores/groupProjectStore';
@@ -883,7 +883,11 @@ function ExpandedProjectView({
         </GroupProjectPanelSidebar>
 
         {/* Message Detail (main content area) */}
-        <div className="flex-1 min-w-0 overflow-y-auto p-3">
+        <div
+          className="flex-1 min-w-0 overflow-y-auto p-3"
+          onWheel={stopPlainWheelPropagation}
+          data-testid="group-project-message-detail-scroll"
+        >
           {selectedMessage ? (
             <div className="text-xs space-y-2">
               <div className="flex items-center gap-2 flex-wrap">

--- a/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.wheel.test.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectCanvasWidget.wheel.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { TopicDigest } from '../../../../shared/group-project-types';
+
+// ---------- localStorage mock ----------
+let storage: Record<string, string> = {};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, val: string) => { storage[key] = val; },
+    removeItem: (key: string) => { delete storage[key]; },
+  },
+  writable: true,
+});
+
+// ---------- ResizeObserver that reports an expanded (>500px) widget ----------
+// The 3-pane ExpandedProjectView only renders once the widget's measured
+// width crosses EXPANDED_WIDTH_THRESHOLD.
+class WideResizeObserver {
+  constructor(private cb: ResizeObserverCallback) {}
+  observe(target: Element) {
+    this.cb(
+      [{ target, contentRect: { width: 900, height: 600 } } as unknown as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, 'ResizeObserver', { value: WideResizeObserver, writable: true });
+
+const TOPIC: TopicDigest = {
+  topic: 'general',
+  messageCount: 1,
+  newMessageCount: 0,
+  latestTimestamp: '2026-07-25T10:00:00.000Z',
+};
+
+const MESSAGE = {
+  id: 'msg_1_a',
+  topic: 'general',
+  sender: 'agent-1',
+  body: 'hello world',
+  timestamp: '2026-07-25T10:00:00.000Z',
+};
+
+vi.mock('./useGroupProjectContext', () => ({
+  useGroupProjectContext: () => ({
+    isRemote: false,
+    satelliteId: null,
+    project: { id: 'gp1', name: 'Test Project', description: '', instructions: '', metadata: {} },
+    members: [],
+    loaded: true,
+    loadProjects: vi.fn(async () => {}),
+    update: vi.fn(async () => {}),
+    setPolling: vi.fn(async () => {}),
+    fetchDigest: vi.fn(async () => [TOPIC]),
+    fetchTopicMessages: vi.fn(async () => [MESSAGE]),
+    fetchAllMessages: vi.fn(async () => [MESSAGE]),
+    injectMessage: vi.fn(async () => {}),
+    deleteMessage: vi.fn(async () => true),
+    deleteTopic: vi.fn(async () => true),
+    setTopicProtection: vi.fn(async () => true),
+    clearAllMessages: vi.fn(async () => ({ removed: 0 })),
+    estimateTrim: vi.fn(async () => ({ wouldRemove: 0 })),
+  }),
+}));
+
+vi.mock('../../../stores/mcpSettingsStore', () => ({
+  useMcpSettingsStore: (sel: (s: unknown) => unknown) => sel({ enabled: true }),
+}));
+
+vi.mock('../../../hooks/useRemoteProject', () => ({
+  useRemoteProject: () => ({ isRemote: false, satelliteId: null }),
+}));
+
+import { GroupProjectCanvasWidget } from './GroupProjectCanvasWidget';
+
+function renderWidget() {
+  return render(
+    <div onWheel={onViewportChange} data-testid="workspace">
+      <GroupProjectCanvasWidget
+        widgetId="w1"
+        api={{ context: { mode: 'app', projectId: undefined }, annex: {} } as never}
+        metadata={{ groupProjectId: 'gp1' }}
+        onUpdateMetadata={vi.fn()}
+        size={{ width: 900, height: 600 }}
+        {...({} as never)}
+      />
+    </div>,
+  );
+}
+
+// #1545: Stands in for CanvasWorkspace's pan handler, which would call
+// onViewportChange for any wheel event that bubbles up to it.
+let onViewportChange: ReturnType<typeof vi.fn>;
+
+describe('ExpandedProjectView — wheel containment (#1545)', () => {
+  beforeEach(() => {
+    storage = {};
+    onViewportChange = vi.fn();
+  });
+
+  it('stops plain wheel propagation over the topics sidebar', async () => {
+    renderWidget();
+    await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
+
+    const sidebars = screen.getAllByTestId('group-project-panel-sidebar');
+    fireEvent.wheel(sidebars[0], { deltaY: 120 });
+
+    expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  it('stops plain wheel propagation over the message list', async () => {
+    renderWidget();
+    await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
+
+    const sidebars = screen.getAllByTestId('group-project-panel-sidebar');
+    fireEvent.wheel(sidebars[1], { deltaY: 120 });
+
+    expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  it('stops plain wheel propagation over the message detail pane', async () => {
+    renderWidget();
+    await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
+
+    const detail = screen.getByTestId('group-project-message-detail-scroll');
+    fireEvent.wheel(detail, { deltaY: 120 });
+
+    expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  it('lets Ctrl+wheel zoom gestures bubble past the message detail pane', async () => {
+    renderWidget();
+    await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
+
+    const detail = screen.getByTestId('group-project-message-detail-scroll');
+    fireEvent.wheel(detail, { deltaY: 120, ctrlKey: true });
+
+    expect(onViewportChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.test.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.test.tsx
@@ -237,6 +237,89 @@ describe('GroupProjectPanelSidebar', () => {
     // Overlay should still be visible
     expect(queryByTestId('panel-rail-overlay')).toBeInTheDocument();
   });
+
+  // ── #1545: panel wheel containment ────────────────────────────────
+  //
+  // Scrolling the topics/messages panel must not pan the canvas underneath.
+  // The canvas workspace turns any wheel event that bubbles up to it into a
+  // pan, so we model that by wrapping the panel in a parent whose onWheel spy
+  // stands in for the workspace pan handler and assert plain wheel events
+  // never reach it — while Ctrl/Cmd+wheel zoom gestures do (same pattern as
+  // the #1536/#1538 AgentCanvasView picker fix).
+  describe('wheel containment', () => {
+    it('stops plain wheel propagation over the sidebar list', () => {
+      const onViewportChange = vi.fn();
+      const { getByTestId } = render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <GroupProjectPanelSidebar
+            width={200}
+            collapsed={false}
+            onResize={vi.fn()}
+            onToggleCollapse={vi.fn()}
+          >
+            <div>Content</div>
+          </GroupProjectPanelSidebar>
+        </div>,
+      );
+      fireEvent.wheel(getByTestId('group-project-panel-sidebar'), { deltaY: 120 });
+      expect(onViewportChange).not.toHaveBeenCalled();
+    });
+
+    it('lets Ctrl+wheel zoom gestures bubble past the sidebar list', () => {
+      const onViewportChange = vi.fn();
+      const { getByTestId } = render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <GroupProjectPanelSidebar
+            width={200}
+            collapsed={false}
+            onResize={vi.fn()}
+            onToggleCollapse={vi.fn()}
+          >
+            <div>Content</div>
+          </GroupProjectPanelSidebar>
+        </div>,
+      );
+      fireEvent.wheel(getByTestId('group-project-panel-sidebar'), { deltaY: 120, ctrlKey: true });
+      expect(onViewportChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets Meta+wheel zoom gestures bubble past the sidebar list', () => {
+      const onViewportChange = vi.fn();
+      const { getByTestId } = render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <GroupProjectPanelSidebar
+            width={200}
+            collapsed={false}
+            onResize={vi.fn()}
+            onToggleCollapse={vi.fn()}
+          >
+            <div>Content</div>
+          </GroupProjectPanelSidebar>
+        </div>,
+      );
+      fireEvent.wheel(getByTestId('group-project-panel-sidebar'), { deltaY: 120, metaKey: true });
+      expect(onViewportChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops plain wheel propagation over the collapsed rail hover overlay', () => {
+      const onViewportChange = vi.fn();
+      const { getByTestId } = render(
+        <div onWheel={onViewportChange} data-testid="workspace">
+          <GroupProjectPanelSidebar
+            width={200}
+            collapsed={true}
+            onResize={vi.fn()}
+            onToggleCollapse={vi.fn()}
+          >
+            <div>Content</div>
+          </GroupProjectPanelSidebar>
+        </div>,
+      );
+      fireEvent.mouseEnter(getByTestId('panel-rail-toggle'));
+      fireEvent.wheel(getByTestId('panel-rail-overlay'), { deltaY: 120 });
+      expect(onViewportChange).not.toHaveBeenCalled();
+    });
+  });
 });
 
 /* ---------- useGroupProjectPanelLayout hook tests ---------- */

--- a/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.tsx
+++ b/src/renderer/plugins/builtin/group-project/GroupProjectPanelSidebar.tsx
@@ -98,6 +98,19 @@ export function useGroupProjectPanelLayout() {
   };
 }
 
+/* ---------- Wheel containment ---------- */
+
+// #1545: Contain plain wheel/trackpad scrolling inside this panel's scroll
+// regions so it never bubbles up to pan the canvas underneath (same fix as
+// #1536/#1538 for the Agent canvas picker in AgentCanvasView.tsx — see
+// handlePickerWheel there for the full rationale). Ctrl/Cmd+wheel is a canvas
+// zoom gesture and is intentionally allowed to bubble so zoom keeps working
+// while hovering the panel.
+export function stopPlainWheelPropagation(e: React.WheelEvent): void {
+  if (e.ctrlKey || e.metaKey) return;
+  e.stopPropagation();
+}
+
 /* ---------- Component ---------- */
 
 interface GroupProjectPanelSidebarProps {
@@ -165,6 +178,7 @@ export function GroupProjectPanelSidebar({
             style={{ width }}
             onMouseEnter={handleEnter}
             onMouseLeave={handleLeave}
+            onWheel={stopPlainWheelPropagation}
             data-testid="panel-rail-overlay"
           >
             {children}
@@ -179,6 +193,7 @@ export function GroupProjectPanelSidebar({
       <div
         className="flex-shrink-0 overflow-y-auto"
         style={{ width }}
+        onWheel={stopPlainWheelPropagation}
         data-testid="group-project-panel-sidebar"
       >
         {children}


### PR DESCRIPTION
## Summary
- Wheel/trackpad scrolling inside the maximized group project's topics list, message list, or message detail pane was bubbling up to the canvas workspace's pan handler, panning the canvas underneath instead of just scrolling the list.
- Same class of bug as #1536/#1538 (Agent canvas picker in `AgentCanvasView.tsx`), never applied to the group-project widget. This applies the same containment pattern.

## Changes
- Added `stopPlainWheelPropagation` to `GroupProjectPanelSidebar.tsx`: stops wheel event propagation unless Ctrl/Cmd is held (so canvas zoom gestures still work while hovering a scrollable pane).
- Applied it to the topics/messages sidebar (`group-project-panel-sidebar`), the collapsed-rail hover overlay (`panel-rail-overlay`), and the message detail pane in `ExpandedProjectView` (`GroupProjectCanvasWidget.tsx`).

## Test Plan
- [x] `GroupProjectPanelSidebar.test.tsx` — new `wheel containment` suite: plain wheel over the sidebar list and the collapsed rail's hover overlay never reaches a parent `onWheel` handler (standing in for the canvas pan handler); Ctrl/Cmd+wheel still bubbles through for zoom.
- [x] `GroupProjectCanvasWidget.wheel.test.tsx` (new) — renders the full expanded 3-pane view and asserts plain wheel over the topics list, message list, and message detail pane never reaches the simulated canvas pan handler, while Ctrl+wheel does.
- [x] `npm run typecheck`, `npm test` (503 files / 12692 tests passed), `npm run lint` (0 errors/warnings in changed files) all green.

## Manual Validation
- Open a group project, expand its card past the width threshold to render the 3-pane view, populate topics/messages to overflow vertically, and confirm wheel/trackpad scroll over each pane scrolls the list only — the canvas no longer pans.

## File overlap check
No overlap with currently open canvas PRs (#1561, #1562, #1566, #1567, #1568) — none touch `GroupProjectPanelSidebar.tsx` or `GroupProjectCanvasWidget.tsx`.

Fixes #1545