### PR TITLE
fix(canvas): keep widgets visible when a zone is dragged over them (#1543)

### DIFF
--- a/src/renderer/plugins/builtin/canvas/ZoneBackground.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoneBackground.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
-import { ZoneBackground } from './ZoneBackground';
+import { ZoneBackground, ZONE_BACKGROUND_Z_BASE } from './ZoneBackground';
 import type { ZoneCanvasView } from './canvas-types';
 
 function makeZone(overrides?: Partial<ZoneCanvasView>): ZoneCanvasView {
@@ -28,6 +28,27 @@ describe('ZoneBackground', () => {
     expect(el.style.top).toBe('200px');
     expect(el.style.width).toBe('600px');
     expect(el.style.height).toBe('400px');
+  });
+
+  it('paints in a band below every widget while preserving zone-vs-zone order', () => {
+    const lower = makeZone({ id: 'zone-lower', zIndex: 5 });
+    const higher = makeZone({ id: 'zone-higher', zIndex: 9 });
+    const { getByTestId } = render(
+      <>
+        <ZoneBackground zone={lower} />
+        <ZoneBackground zone={higher} />
+      </>,
+    );
+
+    const lowerZ = Number(getByTestId('zone-background-zone-lower').style.zIndex);
+    const higherZ = Number(getByTestId('zone-background-zone-higher').style.zIndex);
+
+    // Widgets live at zIndex >= 0, so backgrounds must stay strictly negative.
+    expect(lowerZ).toBe(ZONE_BACKGROUND_Z_BASE + 5);
+    expect(lowerZ).toBeLessThan(0);
+    expect(higherZ).toBeLessThan(0);
+    // Relative ordering between zones is preserved.
+    expect(lowerZ).toBeLessThan(higherZ);
   });
 
   it('applies drag offset as transform', () => {

--- a/src/renderer/plugins/builtin/canvas/ZoneBackground.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoneBackground.tsx
@@ -11,6 +11,20 @@ import { GRID_SIZE } from './canvas-types';
 import { getTheme } from '../../../themes';
 import type { ResizeDirection } from './CanvasView';
 
+/**
+ * Zone backgrounds paint in a dedicated band strictly below every widget.
+ *
+ * A zone's own zIndex comes from the same counter as widgets, so a zone created
+ * after a widget outranks it. Because zones deliberately do not swallow existing
+ * widgets on creation, the normal way to put an older widget into a zone is to
+ * drag or resize the zone over it — and the widget would then be painted behind
+ * the zone's opaque background, invisible until clicked (which bumps it to the
+ * front). Offsetting into a negative band keeps zone-vs-zone relative order while
+ * guaranteeing the background never covers a widget. See also #1117, which fixed
+ * the same class of bug for wires.
+ */
+export const ZONE_BACKGROUND_Z_BASE = -100000;
+
 /** Size of edge resize zones in pixels */
 const EDGE_SIZE = 6;
 /** Size of corner resize zones in pixels */
@@ -58,7 +72,7 @@ export function ZoneBackground({ zone, dragOffset, resizeOverride, onResizeStart
         top,
         width,
         height,
-        zIndex: zone.zIndex,
+        zIndex: ZONE_BACKGROUND_Z_BASE + zone.zIndex,
         backgroundColor: bgColor,
         borderColor: `${borderColor}60`,
         backgroundImage: `radial-gradient(circle, ${dotColor}73 0.75px, transparent 0.75px)`,

--- a/src/renderer/plugins/builtin/canvas/ZoneCard.tsx
+++ b/src/renderer/plugins/builtin/canvas/ZoneCard.tsx
@@ -71,6 +71,7 @@ export const ZoneCard = React.memo(function ZoneCard({ zone, mcpEnabled, dragOff
       <div
         className="w-[50px] h-[50px] flex items-center justify-center flex-shrink-0 cursor-grab active:cursor-grabbing text-ctp-overlay0"
         onMouseDown={onDragStart}
+        data-testid={`zone-drag-handle-${zone.id}`}
       >
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeDasharray="4 2">
           <rect x="3" y="3" width="18" height="18" rx="2" />

--- a/src/renderer/plugins/builtin/canvas/zone-inclusion-visibility.test.tsx
+++ b/src/renderer/plugins/builtin/canvas/zone-inclusion-visibility.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for #1543 — a widget that gets included in a zone by dragging
+ * the zone over it rendered invisible until it was clicked.
+ *
+ * Zones deliberately do not swallow existing widgets when created, so the
+ * supported way to put an older widget into a zone is to drag/resize the zone
+ * over it. The zone then outranks that widget on the shared zIndex counter, and
+ * its opaque background painted over the widget until a click bumped the widget
+ * to the front. These tests drive that exact path — gesture → store → render —
+ * and assert the widget is painted above the zone background straight away.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { CanvasWorkspace } from './CanvasWorkspace';
+import { createCanvasStore } from './canvas-store';
+import type { CanvasView, Viewport, ZoneCanvasView, Position } from './canvas-types';
+import type { PluginAPI } from '../../../../shared/plugin-types';
+
+const defaultViewport: Viewport = { panX: 0, panY: 0, zoom: 1 };
+
+function stubApi(): PluginAPI {
+  return {
+    agents: {
+      list: () => [],
+      onAnyChange: () => ({ dispose: () => {} }),
+      getDetailedStatus: () => null,
+    },
+    projects: { list: () => [] },
+    context: { mode: 'project', projectId: 'p1' },
+    widgets: {
+      AgentAvatar: () => null,
+      AgentTerminal: () => null,
+      SleepingAgent: () => null,
+    },
+    settings: {
+      get: () => undefined,
+      getAll: () => ({}),
+      set: () => {},
+      onChange: () => ({ dispose: () => {} }),
+    },
+  } as unknown as PluginAPI;
+}
+
+function renderWorkspace(views: CanvasView[], overrides: Partial<React.ComponentProps<typeof CanvasWorkspace>> = {}) {
+  const props = {
+    views,
+    viewport: defaultViewport,
+    zoomedViewId: null,
+    selectedViewId: null,
+    selectedViewIds: [] as string[],
+    wireDefinitions: [],
+    onAddWireDefinition: vi.fn(),
+    onRemoveWireDefinition: vi.fn(),
+    onUpdateWireDefinition: vi.fn(),
+    api: stubApi(),
+    onViewportChange: vi.fn(),
+    onAddView: vi.fn(),
+    onAddPluginView: vi.fn(),
+    onRemoveView: vi.fn(),
+    onMoveView: vi.fn(),
+    onMoveViews: vi.fn(),
+    onResizeView: vi.fn(),
+    onFocusView: vi.fn(),
+    onUpdateView: vi.fn(),
+    onZoomView: vi.fn(),
+    onSelectView: vi.fn(),
+    onToggleSelectView: vi.fn(),
+    onSetSelectedViewIds: vi.fn(),
+    onClearSelection: vi.fn(),
+    onRemoveZone: vi.fn(),
+    onUpdateZoneTheme: vi.fn(),
+    minimapAutoHide: false,
+    onMinimapAutoHideChange: vi.fn(),
+    elkAlgorithm: 'layered' as const,
+    elkDirection: 'RIGHT' as const,
+    layoutCenterId: null,
+    onElkAlgorithmChange: vi.fn(),
+    onElkDirectionChange: vi.fn(),
+    onSetLayoutCenterId: vi.fn(),
+    ...overrides,
+  };
+  return render(<CanvasWorkspace {...props} />);
+}
+
+/** Effective stacking value of a rendered element ('auto' → 0). */
+function zOf(el: HTMLElement): number {
+  const raw = el.style.zIndex;
+  return raw === '' || raw === 'auto' ? 0 : Number(raw);
+}
+
+/**
+ * Card first, then zone — so the zone outranks the card on the shared zIndex
+ * counter, which is what made the card disappear once it was included.
+ */
+function seedCardThenZone() {
+  const store = createCanvasStore();
+  const cardId = store.getState().addView('agent', { x: 900, y: 900 });
+  const zoneId = store.getState().addView('zone', { x: 0, y: 0 });
+  return { store, cardId, zoneId };
+}
+
+function getZone(store: ReturnType<typeof createCanvasStore>, zoneId: string): ZoneCanvasView {
+  return store.getState().views.find((v) => v.id === zoneId) as ZoneCanvasView;
+}
+
+function getView(store: ReturnType<typeof createCanvasStore>, viewId: string): CanvasView {
+  return store.getState().views.find((v) => v.id === viewId)!;
+}
+
+describe('zone inclusion by drag — widget visibility (#1543)', () => {
+  it('sets up the ordering that used to hide the widget: zone outranks the older card', () => {
+    const { store, cardId, zoneId } = seedCardThenZone();
+
+    expect(getView(store, cardId).zIndex).toBeLessThan(getZone(store, zoneId).zIndex);
+    // Creating a zone must not swallow the pre-existing card...
+    expect(getZone(store, zoneId).containedViewIds).toEqual([]);
+  });
+
+  it('includes the card when the zone is dragged over it', () => {
+    const { store, cardId, zoneId } = seedCardThenZone();
+
+    // Drag the zone so it covers >50% of the card.
+    store.getState().moveViews(new Map<string, Position>([[zoneId, { x: 800, y: 760 }]]));
+
+    expect(getZone(store, zoneId).containedViewIds).toContain(cardId);
+  });
+
+  it('paints the newly included card above the zone background', () => {
+    const { store, cardId, zoneId } = seedCardThenZone();
+    store.getState().moveViews(new Map<string, Position>([[zoneId, { x: 800, y: 760 }]]));
+    expect(getZone(store, zoneId).containedViewIds).toContain(cardId);
+
+    const { getByTestId } = renderWorkspace(store.getState().views);
+
+    const background = getByTestId(`zone-background-${zoneId}`);
+    const card = getByTestId(`canvas-view-${cardId}`);
+
+    // The card is not focused — it must still be visible on top of the zone.
+    expect(zOf(background)).toBeLessThan(zOf(card));
+  });
+
+  it('keeps the card above the zone through the full drag gesture', () => {
+    const { store, cardId, zoneId } = seedCardThenZone();
+
+    const onMoveViews = vi.fn((positions: Map<string, Position>) => {
+      store.getState().moveViews(positions);
+    });
+    const { getByTestId, rerender } = renderWorkspace(store.getState().views, { onMoveViews });
+
+    // Grab the zone by its card's drag handle and drag it over the widget.
+    const handle = getByTestId(`zone-drag-handle-${zoneId}`);
+    fireEvent.mouseDown(handle, { clientX: 0, clientY: 0 });
+    fireEvent.mouseMove(window, { clientX: 800, clientY: 760 });
+    fireEvent.mouseUp(window, { clientX: 800, clientY: 760 });
+
+    expect(onMoveViews).toHaveBeenCalled();
+    expect(getZone(store, zoneId).containedViewIds).toContain(cardId);
+
+    rerender(<div />);
+    const { getByTestId: get2 } = renderWorkspace(store.getState().views);
+    expect(zOf(get2(`zone-background-${zoneId}`))).toBeLessThan(zOf(get2(`canvas-view-${cardId}`)));
+  });
+
+  it('keeps every widget above the zone background regardless of creation order', () => {
+    const { store, cardId, zoneId } = seedCardThenZone();
+    // A widget created after the zone (higher zIndex) must stay above it too.
+    const laterCardId = store.getState().addView('agent', { x: 1000, y: 950 });
+    store.getState().moveViews(new Map<string, Position>([[zoneId, { x: 800, y: 760 }]]));
+
+    const { getByTestId } = renderWorkspace(store.getState().views);
+    const bgZ = zOf(getByTestId(`zone-background-${zoneId}`));
+
+    expect(bgZ).toBeLessThan(zOf(getByTestId(`canvas-view-${cardId}`)));
+    expect(bgZ).toBeLessThan(zOf(getByTestId(`canvas-view-${laterCardId}`)));
+  });
+});


### PR DESCRIPTION
Fixes #1543.

## Diagnosis

The reporter suspected z-index/stacking, and it *is* z-order — but not a CSS stacking-context bug. The cause is that zone backgrounds are painted at the zone's **own `zIndex`**, drawn from the same counter as widgets (`nextZIndex`).

Creating a zone deliberately skips `recomputeZones` so existing widgets aren't swallowed (`canvas-store.ts`), which means the supported way to put an older widget into a zone is to drag or resize the zone over it. But a zone created after a widget always outranks it — so the moment containment kicks in, the zone's **opaque** background (`theme.colors.crust`) paints over the widget. Clicking it calls `focusView` → `bringToFront`, which lifts it above the zone: "invisible until focused, then snaps to the foreground", exactly as reported.

Verified against the store: with a card created before the zone, card `zIndex: 0` vs zone `zIndex: 1`, and dragging the zone over the card includes it while leaving the card underneath.

This is the same class of bug as #1117 ("wires rendering below zone backgrounds — invisible inside zones").

## Fix

Zone backgrounds are decorative substrates, so they now paint in a dedicated band strictly below every widget (`ZONE_BACKGROUND_Z_BASE + zone.zIndex`), which preserves zone-vs-zone relative order. Widgets live at `zIndex >= 0`, so the band is negative.

Negative z is safe here: the backgrounds sit inside the workspace's transform container, which is its own stacking context (it has a `transform`), and the canvas dot-grid lives on an ancestor element — so backgrounds still paint above the canvas surface. No persisted state changes; nothing is rewritten on disk.

## Test coverage

New `zone-inclusion-visibility.test.tsx` drives the actual inclusion-by-drag path rather than asserting a z-index constant:
- the ordering precondition (zone outranks the older card; creating a zone doesn't swallow it)
- inclusion happens when the zone is dragged over the card
- the newly included, **unfocused** card paints above the zone background
- the full gesture — mousedown on the zone drag handle → mousemove → mouseup → store → re-render — still leaves the card above the zone
- widgets created both before and after the zone stay above it

Plus a unit assertion in `ZoneBackground.test.tsx` for the band invariant and preserved zone-vs-zone order.

All three render tests fail on `main` and pass with the fix (verified by reverting the one-line change).

`ZoneCard` gains a `data-testid` on the drag handle so the gesture is addressable.

## Overlap with open canvas PRs

Checked #1561, #1562, #1566, #1567, #1568 — no file overlap. #1561 touches `canvas-store.ts`/`canvas-store.test.ts`; this PR touches only `ZoneBackground.tsx`, `ZoneCard.tsx` and tests, and changes no store logic.

## Validation

`npm run typecheck` clean · `npm run lint` 0 errors · `npm test` 503 files, 12690 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)