### PR TITLE
fix(e2e): stop local runs launching a dozen Electron apps and leaking processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ clubhouse/
 
 # Playwright
 test-results/
+# Local-only E2E run state (launched Electron PIDs, for orphan cleanup)
+e2e/.run-state/
 
 # Git worktrees
 .worktrees/

--- a/e2e/annex-v2/dual-launch.ts
+++ b/e2e/annex-v2/dual-launch.ts
@@ -9,6 +9,7 @@ import { _electron as electron } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import { recordElectronApp, trackOpenApp } from '../e2e-cleanup';
 
 const APP_PATH = path.resolve(__dirname, '../..');
 const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
@@ -80,6 +81,9 @@ async function launchInstance(label: string): Promise<InstanceHandle> {
       CLUBHOUSE_USER_DATA: userDataDir,
     },
   });
+
+  recordElectronApp(electronApp.process().pid, userDataDir);
+  trackOpenApp(electronApp);
 
   const window = await findRendererWindow(electronApp);
   await window.waitForLoadState('load');

--- a/e2e/assistant/assistant-disabled.spec.ts
+++ b/e2e/assistant/assistant-disabled.spec.ts
@@ -21,6 +21,7 @@ import { _electron as electron } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import { recordElectronApp, trackOpenApp } from '../e2e-cleanup';
 
 const APP_PATH = path.resolve(__dirname, '../..');
 const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
@@ -87,6 +88,9 @@ async function launchDisabledInstance(): Promise<DisabledInstance> {
       CLUBHOUSE_USER_DATA: userDataDir,
     },
   });
+
+  recordElectronApp(electronApp.process().pid, userDataDir);
+  trackOpenApp(electronApp);
 
   const window = await findRendererWindow(electronApp);
   await window.waitForLoadState('load');

--- a/e2e/assistant/helpers.ts
+++ b/e2e/assistant/helpers.ts
@@ -8,9 +8,26 @@ import { _electron as electron, expect, Page } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import { recordElectronApp, trackOpenApp, untrackOpenApp } from '../e2e-cleanup';
 
 const APP_PATH = path.resolve(__dirname, '../..');
 const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
+
+/**
+ * Whether to drive these tests against a real orchestrator binary.
+ *
+ * The stub is the default everywhere, so a plain `npx playwright test` locally
+ * behaves exactly like CI: fast, deterministic, and free. Live coverage is an
+ * explicit opt-in — it makes real model calls that take many seconds each and
+ * routinely blow the 120s test timeout.
+ *
+ *   E2E_LIVE_ORCHESTRATOR=1 npx playwright test e2e/assistant/
+ *
+ * Never honored in CI, which has no orchestrator binary installed.
+ */
+export function useLiveOrchestrator(): boolean {
+  return !process.env.CI && process.env.E2E_LIVE_ORCHESTRATOR === '1';
+}
 
 export interface AssistantInstance {
   electronApp: Awaited<ReturnType<typeof electron.launch>>;
@@ -89,11 +106,16 @@ export async function launchAssistantInstance(): Promise<AssistantInstance> {
     },
   });
 
+  // Register for cleanup before window discovery, which can throw.
+  recordElectronApp(electronApp.process().pid, userDataDir);
+  trackOpenApp(electronApp);
+
   const window = await findRendererWindow(electronApp);
   await window.waitForLoadState('load');
 
-  // Install stub IPC handlers in CI where no real orchestrator is available
-  if (process.env.CI) {
+  // Install stub IPC handlers unless live orchestrator coverage was explicitly
+  // requested. CI always takes the stub path — unchanged.
+  if (!useLiveOrchestrator()) {
     await installAssistantStub(electronApp);
   }
 
@@ -212,6 +234,7 @@ async function installAssistantStub(
  * Clean up an assistant test instance.
  */
 export async function cleanupAssistantInstance(handle: AssistantInstance): Promise<void> {
+  untrackOpenApp(handle.electronApp);
   try {
     await handle.electronApp.close();
   } catch {

--- a/e2e/e2e-cleanup.ts
+++ b/e2e/e2e-cleanup.ts
@@ -1,0 +1,343 @@
+/**
+ * Local-only cleanup for E2E-launched Electron instances.
+ *
+ * `test.afterAll` only runs on a graceful worker shutdown. When a worker is
+ * killed — a 120s timeout, or Ctrl-C on the run — the Electron process tree is
+ * orphaned (~300–500 MB each) and its temp user-data dir is left on disk. This
+ * module reaps both at the end of a run.
+ *
+ * ## Why we track PIDs instead of pattern-matching `ps`
+ *
+ * The obvious sweep — "kill anything whose `--user-data-dir` looks like ours" —
+ * does not work in this codebase and is unsafe:
+ *
+ * - The E2E user-data dir is passed via the `CLUBHOUSE_USER_DATA` env var and
+ *   applied with `app.setPath('userData', …)` (`src/main/index.ts`). It never
+ *   reaches any command line, so no `clubhouse-e2e-*` path appears in `ps`.
+ * - The only processes that *do* carry `--user-data-dir=` on a dev machine are
+ *   real applications, and a developer's installed `/Applications/Clubhouse.app`
+ *   carries `.webpack` in its command line. Matching on either would miss every
+ *   process we want and risk killing ones we must never touch.
+ *
+ * So discovery is by the PIDs we actually launched, recorded to a run-state
+ * file (workers and global teardown are separate processes, so an in-memory
+ * registry would not survive the boundary). Every kill is then gated on the
+ * process running from this repo's `node_modules/electron/dist` — which an
+ * installed Clubhouse.app can never match.
+ *
+ * A developer's own `npm start` instance is never a candidate: it is not in the
+ * recorded set, and nothing is discovered by scanning.
+ *
+ * Everything here is a no-op when `CI` is set. CI runners are ephemeral and
+ * already upload `test-results/` as artifacts.
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** Where launched-instance PIDs are recorded, so global teardown can read them. */
+const RUN_STATE_DIR = path.resolve(__dirname, '.run-state');
+const PID_FILE_NAME = 'electron-pids.jsonl';
+
+/** Overridable locations, so tests can run hermetically. */
+export interface CleanupPaths {
+  /** Directory holding the recorded-PID file. */
+  stateDir?: string;
+  /** Root scanned for stray `clubhouse-e2e-*` directories. */
+  tmpDir?: string;
+}
+
+function stateDirOf(paths?: CleanupPaths): string {
+  return paths?.stateDir ?? RUN_STATE_DIR;
+}
+
+function pidFileOf(paths?: CleanupPaths): string {
+  return path.join(stateDirOf(paths), PID_FILE_NAME);
+}
+
+function tmpDirOf(paths?: CleanupPaths): string {
+  return paths?.tmpDir ?? os.tmpdir();
+}
+
+/** Shared prefix of every temp dir E2E creates under `os.tmpdir()`. */
+const TEMP_DIR_PREFIX = 'clubhouse-e2e-';
+
+/**
+ * This repo's Electron binary directory. Every E2E-launched process — the main
+ * process and its `Electron Helper` children — runs from under here. An
+ * installed `/Applications/Clubhouse.app` never does, which is what makes a
+ * kill safe.
+ */
+export const ELECTRON_DIST_DIR = path.resolve(__dirname, '..', 'node_modules', 'electron', 'dist');
+
+/** Local-only: never touch CI, whose runners are ephemeral. */
+export function isLocalRun(): boolean {
+  return !process.env.CI;
+}
+
+interface LaunchRecord {
+  pid: number;
+  userDataDir?: string;
+}
+
+/**
+ * Record an Electron instance so it can be reaped even if the worker that
+ * launched it is killed before `afterAll` runs. No-op in CI.
+ */
+export function recordElectronApp(pid: number | undefined, userDataDir?: string, paths?: CleanupPaths): void {
+  if (!isLocalRun() || !pid) return;
+  try {
+    fs.mkdirSync(stateDirOf(paths), { recursive: true });
+    fs.appendFileSync(pidFileOf(paths), JSON.stringify({ pid, userDataDir } as LaunchRecord) + '\n', 'utf-8');
+  } catch {
+    // Best-effort bookkeeping — never fail a test over it.
+  }
+}
+
+function readLaunchRecords(paths?: CleanupPaths): LaunchRecord[] {
+  try {
+    return fs.readFileSync(pidFileOf(paths), 'utf-8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line) as LaunchRecord)
+      .filter((r) => typeof r.pid === 'number');
+  } catch {
+    return [];
+  }
+}
+
+interface ProcessInfo {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+/** Snapshot the process table. Returns an empty list if it cannot be read. */
+function listProcesses(): ProcessInfo[] {
+  try {
+    if (process.platform === 'win32') {
+      const out = execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-Command',
+          'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress'],
+        { encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024 },
+      );
+      const parsed = JSON.parse(out) as Array<{ ProcessId: number; ParentProcessId: number; CommandLine: string | null }>;
+      return (Array.isArray(parsed) ? parsed : [parsed]).map((p) => ({
+        pid: p.ProcessId,
+        ppid: p.ParentProcessId,
+        command: p.CommandLine ?? '',
+      }));
+    }
+    const out = execFileSync('ps', ['-Ao', 'pid=,ppid=,command='], {
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return out.split('\n').flatMap((line) => {
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) return [];
+      return [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The safety gate: only a process running from this repo's Electron dist may
+ * ever be killed. Guarantees an installed Clubhouse.app is untouchable.
+ */
+function isRepoElectronProcess(info: ProcessInfo): boolean {
+  return info.command.includes(ELECTRON_DIST_DIR);
+}
+
+/** Collect a PID plus every live descendant of it. */
+function withDescendants(roots: number[], processes: ProcessInfo[]): Set<number> {
+  const childrenByParent = new Map<number, number[]>();
+  for (const p of processes) {
+    const siblings = childrenByParent.get(p.ppid);
+    if (siblings) siblings.push(p.pid);
+    else childrenByParent.set(p.ppid, [p.pid]);
+  }
+
+  const collected = new Set<number>();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const pid = queue.pop()!;
+    if (collected.has(pid)) continue;
+    collected.add(pid);
+    for (const child of childrenByParent.get(pid) ?? []) queue.push(child);
+  }
+  return collected;
+}
+
+function kill(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false; // Already gone, or not ours to signal.
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function realPath(p: string): string {
+  try {
+    return path.resolve(fs.realpathSync(p));
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Delete a temp dir — but only a direct child of the temp root whose name
+ * carries our prefix. Anything else (a repo path, a home directory, a nested
+ * path escaping via `..`) is refused.
+ */
+export function removeTempDir(dir: string, paths?: CleanupPaths): boolean {
+  const tmpRoot = realPath(tmpDirOf(paths));
+  const resolved = path.resolve(dir);
+  if (!path.basename(resolved).startsWith(TEMP_DIR_PREFIX)) return false;
+  // Compare the parent against the temp root, resolving symlinks on both sides
+  // (macOS /var → /private/var) so a legitimate dir is not skipped.
+  const parent = path.dirname(resolved);
+  if (realPath(parent) !== tmpRoot && path.resolve(parent) !== path.resolve(tmpDirOf(paths))) return false;
+  try {
+    fs.rmSync(resolved, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Remove every `clubhouse-e2e-*` directory left in the temp root. */
+function removeStrayTempDirs(paths?: CleanupPaths): number {
+  const tmpDir = tmpDirOf(paths);
+  let removed = 0;
+  try {
+    for (const entry of fs.readdirSync(tmpDir)) {
+      if (!entry.startsWith(TEMP_DIR_PREFIX)) continue;
+      if (removeTempDir(path.join(tmpDir, entry), paths)) removed++;
+    }
+  } catch {
+    // Temp dir unreadable — nothing to do.
+  }
+  return removed;
+}
+
+export interface SweepResult {
+  killed: number;
+  tempDirsRemoved: number;
+}
+
+/**
+ * Kill Electron instances left over from this run and remove their temp dirs.
+ * No-op in CI. Never throws — cleanup must not fail a run.
+ */
+export function sweepE2EProcesses(paths?: CleanupPaths): SweepResult {
+  const result: SweepResult = { killed: 0, tempDirsRemoved: 0 };
+  if (!isLocalRun()) return result;
+
+  try {
+    const records = readLaunchRecords(paths);
+    const livePids = records.map((r) => r.pid).filter(isAlive);
+
+    if (livePids.length > 0) {
+      const processes = listProcesses();
+      const byPid = new Map(processes.map((p) => [p.pid, p]));
+      const candidates = withDescendants(livePids, processes);
+
+      // Only ever kill processes running from this repo's Electron dist.
+      const targets = [...candidates].filter((pid) => {
+        const info = byPid.get(pid);
+        return info ? isRepoElectronProcess(info) : false;
+      });
+
+      for (const pid of targets) {
+        if (kill(pid, 'SIGTERM')) result.killed++;
+      }
+      // Escalate for anything that ignored SIGTERM.
+      for (const pid of targets) {
+        if (isAlive(pid)) kill(pid, 'SIGKILL');
+      }
+    }
+
+    for (const record of records) {
+      if (record.userDataDir) removeTempDir(record.userDataDir, paths);
+    }
+    result.tempDirsRemoved = removeStrayTempDirs(paths);
+
+    try {
+      fs.rmSync(stateDirOf(paths), { recursive: true, force: true });
+    } catch {
+      // Best-effort.
+    }
+  } catch {
+    // Cleanup is best-effort by design.
+  }
+
+  return result;
+}
+
+// ── Belt-and-braces: reap on an interrupted run ──────────────────────────
+//
+// Global teardown never runs when the process is interrupted, so each worker
+// also closes its own instances on the way out.
+
+type Closable = { close: () => Promise<void> };
+const openApps = new Set<Closable>();
+let exitHooksInstalled = false;
+
+/** Track an app handle so an interrupted run still tears it down. No-op in CI. */
+export function trackOpenApp(app: Closable): void {
+  if (!isLocalRun()) return;
+  openApps.add(app);
+  installExitHooks();
+}
+
+/** Stop tracking an app that was closed gracefully. */
+export function untrackOpenApp(app: Closable): void {
+  openApps.delete(app);
+}
+
+function closeAllSync(): void {
+  for (const app of openApps) {
+    // On exit there is no time to await — fire the close and let the OS reap
+    // whatever is left. sweepE2EProcesses() is the real backstop.
+    void app.close().catch(() => {});
+  }
+  openApps.clear();
+}
+
+function installExitHooks(): void {
+  if (exitHooksInstalled) return;
+  exitHooksInstalled = true;
+
+  process.on('exit', closeAllSync);
+
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    process.on(signal, () => {
+      closeAllSync();
+      // Deliberately do NOT sweep here. This runs inside a Playwright worker,
+      // and a sweep would shell out to `ps` and kill instances belonging to
+      // other workers mid-shutdown. An interrupted run is healed instead by
+      // the *next* run's global teardown: the recorded PIDs outlive this
+      // process in the state file, and that sweep clears the file when done.
+      //
+      // Restore default signal behaviour rather than calling process.exit(),
+      // so Playwright's own shutdown is not truncated.
+      process.removeAllListeners(signal);
+      process.kill(process.pid, signal);
+    });
+  }
+}

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,10 +1,12 @@
 /**
  * Playwright global teardown — clean up the .git directories created by
- * global-setup so they don't get accidentally committed.
+ * global-setup so they don't get accidentally committed, then (locally only)
+ * reap any Electron instances the run orphaned.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { sweepE2EProcesses, isLocalRun } from './e2e-cleanup';
 
 const FIXTURES_DIR = path.resolve(__dirname, 'fixtures');
 
@@ -18,5 +20,12 @@ export default function globalTeardown() {
     if (fs.existsSync(dotGit)) {
       fs.rmSync(dotGit, { recursive: true, force: true });
     }
+  }
+
+  // Local only — CI runners are ephemeral and already upload test-results/.
+  if (!isLocalRun()) return;
+  const { killed, tempDirsRemoved } = sweepE2EProcesses();
+  if (killed > 0 || tempDirsRemoved > 0) {
+    console.log(`[e2e cleanup] reaped ${killed} orphaned process(es), removed ${tempDirsRemoved} temp dir(s)`);
   }
 }

--- a/e2e/launch.ts
+++ b/e2e/launch.ts
@@ -2,6 +2,7 @@ import { _electron as electron, type Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { recordElectronApp, trackOpenApp } from './e2e-cleanup';
 
 const APP_PATH = path.resolve(__dirname, '..');
 const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
@@ -86,6 +87,11 @@ export async function launchApp(opts: LaunchOptions = {}) {
     cwd: APP_PATH,
     env,
   });
+
+  // Register for cleanup before doing anything else that can throw — a launch
+  // that dies during window discovery must still be reapable.
+  recordElectronApp(electronApp.process().pid, userDataDir);
+  trackOpenApp(electronApp);
 
   // Collect all windows that open, then pick the renderer (non-devtools) one.
   const rendererWindow = await findRendererWindow(electronApp);

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, _electron as electron, Page } from '@playwright/test';
 import * as path from 'path';
+import { recordElectronApp, trackOpenApp } from './e2e-cleanup';
 
 const APP_PATH = path.resolve(__dirname, '..');
 const MAIN_ENTRY = path.join(APP_PATH, '.webpack', process.arch, 'main');
@@ -17,6 +18,9 @@ async function launchFresh() {
     args: [MAIN_ENTRY],
     cwd: APP_PATH,
   });
+
+  recordElectronApp(electronApp.process().pid);
+  trackOpenApp(electronApp);
 
   // Find renderer window — DevTools may briefly have a non-devtools:// URL,
   // so after the URL check we verify the page has <div id="root">.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
   testDir: './e2e',
   testIgnore: process.env.PLAYWRIGHT_IGNORE_ANNEX ? '**/annex-v2/**' : undefined,
   timeout: 120_000,
-  retries: 1,
+  // CI keeps its flake tolerance. Locally a retry discards the worker and
+  // re-runs beforeAll, launching a brand-new Electron app for every failing
+  // test — a dozen live instances in minutes. Not worth it on a dev machine.
+  retries: process.env.CI ? 1 : 0,
   workers: 1,
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',

--- a/test/e2e-cleanup.test.ts
+++ b/test/e2e-cleanup.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for the local-only E2E orphan sweep (`e2e/e2e-cleanup.ts`).
+ *
+ * The sweep kills processes and deletes directories, so the safety properties
+ * matter more than the happy path: it must never kill a process that is not a
+ * repo-local Electron instance, and never delete a directory outside the temp
+ * root. Both are exercised here against real processes and real directories.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  isLocalRun,
+  recordElectronApp,
+  sweepE2EProcesses,
+  removeTempDir,
+  trackOpenApp,
+  untrackOpenApp,
+  ELECTRON_DIST_DIR,
+  type CleanupPaths,
+} from '../e2e/e2e-cleanup';
+
+/** Sandbox for state + temp roots, so tests never touch the real ones. */
+let sandbox: string;
+let paths: CleanupPaths;
+const spawned: ChildProcess[] = [];
+
+/**
+ * A long-lived process whose command line contains `marker`.
+ *
+ * The `--` terminates node's own option parsing, so a marker that looks like a
+ * flag (`--user-data-dir=…`) lands in argv instead of making node exit.
+ */
+function spawnMarked(marker: string): ChildProcess {
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)', '--', marker], {
+    stdio: 'ignore',
+  });
+  spawned.push(child);
+  return child;
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until `predicate` holds or the deadline passes. */
+async function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return predicate();
+}
+
+/**
+ * Give a freshly spawned process time to appear in the process table, and
+ * assert it is actually running — otherwise a process that exited on its own
+ * would look identical to one the sweep correctly spared.
+ */
+async function waitUntilVisible(pid: number): Promise<void> {
+  await waitFor(() => isAlive(pid));
+  await new Promise((r) => setTimeout(r, 150));
+  expect(isAlive(pid), `probe process ${pid} exited before the sweep ran`).toBe(true);
+}
+
+beforeEach(() => {
+  delete process.env.CI;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-cleanup-test-'));
+  paths = {
+    stateDir: path.join(sandbox, 'state'),
+    tmpDir: path.join(sandbox, 'tmp'),
+  };
+  fs.mkdirSync(paths.tmpDir!, { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.E2E_LIVE_ORCHESTRATOR;
+  for (const child of spawned) {
+    if (child.pid && isAlive(child.pid)) {
+      try { process.kill(child.pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
+  }
+  spawned.length = 0;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+// ── The safety gate ──────────────────────────────────────────────────────
+
+describe('kill safety', () => {
+  it('does NOT kill a recorded process that is not a repo-local Electron', async () => {
+    // Simulates a stale PID file entry whose PID has been recycled by an
+    // unrelated program. Killing it would be the worst-case bug.
+    const victim = spawnMarked('/Applications/Clubhouse.app/Contents/MacOS/Clubhouse');
+    await waitUntilVisible(victim.pid!);
+    recordElectronApp(victim.pid, undefined, paths);
+
+    const result = sweepE2EProcesses(paths);
+
+    expect(result.killed).toBe(0);
+    expect(isAlive(victim.pid!)).toBe(true);
+  });
+
+  it('does NOT kill a process merely because its command line mentions .webpack', async () => {
+    // A developer's installed Clubhouse.app runs from app.asar.unpacked/.webpack.
+    const victim = spawnMarked('/Applications/Clubhouse.app/Contents/Resources/app.asar.unpacked/.webpack/main/index.js');
+    await waitUntilVisible(victim.pid!);
+    recordElectronApp(victim.pid, undefined, paths);
+
+    sweepE2EProcesses(paths);
+
+    expect(isAlive(victim.pid!)).toBe(true);
+  });
+
+  it('does NOT kill a process carrying a --user-data-dir switch', async () => {
+    // On a dev machine the only processes with this switch are real apps.
+    const victim = spawnMarked('--user-data-dir=/Users/dev/Library/Application Support/Code');
+    await waitUntilVisible(victim.pid!);
+    recordElectronApp(victim.pid, undefined, paths);
+
+    sweepE2EProcesses(paths);
+
+    expect(isAlive(victim.pid!)).toBe(true);
+  });
+
+  it('kills a recorded process running from this repo\'s Electron dist', async () => {
+    const target = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    await waitUntilVisible(target.pid!);
+    recordElectronApp(target.pid, undefined, paths);
+
+    const result = sweepE2EProcesses(paths);
+
+    expect(result.killed).toBeGreaterThan(0);
+    expect(await waitFor(() => !isAlive(target.pid!))).toBe(true);
+  });
+
+  it('never kills a repo-local Electron that was not recorded', async () => {
+    // A developer's own `npm start` uses the same binary. It is not in the
+    // recorded set, and nothing is discovered by scanning, so it must survive.
+    const devInstance = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    await waitUntilVisible(devInstance.pid!);
+    // Deliberately not recorded.
+
+    const result = sweepE2EProcesses(paths);
+
+    expect(result.killed).toBe(0);
+    expect(isAlive(devInstance.pid!)).toBe(true);
+  });
+
+  it('kills recorded descendants, so Electron helper processes are reaped', async () => {
+    // The Electron main process spawns helper children. Only the main process
+    // PID is recorded, so the sweep must walk down to the helpers — killing
+    // just the root is what left ~300-500MB orphans behind.
+    const helperMarker = path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/Frameworks/Electron Helper.app/Contents/MacOS/Electron Helper');
+    const parentScript = `
+      const { spawn } = require('child_process');
+      const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)', '--', ${JSON.stringify(helperMarker)}], { stdio: 'ignore' });
+      console.log(child.pid);
+      setTimeout(() => {}, 60000);
+    `;
+    const parent = spawn(
+      process.execPath,
+      ['-e', parentScript, '--', path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron')],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    spawned.push(parent);
+
+    const helperPid = await new Promise<number>((resolve, reject) => {
+      parent.stdout!.on('data', (chunk) => resolve(Number(String(chunk).trim())));
+      parent.on('error', reject);
+      setTimeout(() => reject(new Error('helper pid never reported')), 5_000);
+    });
+    await waitUntilVisible(parent.pid!);
+    await waitUntilVisible(helperPid);
+
+    // Only the parent is recorded — the helper must be found by descent.
+    recordElectronApp(parent.pid, undefined, paths);
+
+    sweepE2EProcesses(paths);
+
+    expect(await waitFor(() => !isAlive(parent.pid!)), 'parent survived').toBe(true);
+    expect(await waitFor(() => !isAlive(helperPid)), 'helper survived').toBe(true);
+  });
+
+  it('tolerates a recorded PID that is already gone', async () => {
+    const child = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    const pid = child.pid!;
+    await waitUntilVisible(pid);
+    process.kill(pid, 'SIGKILL');
+    await waitFor(() => !isAlive(pid));
+    recordElectronApp(pid, undefined, paths);
+
+    expect(() => sweepE2EProcesses(paths)).not.toThrow();
+  });
+});
+
+// ── Temp directory safety ────────────────────────────────────────────────
+
+describe('temp directory safety', () => {
+  it('removes a clubhouse-e2e-* dir in the temp root', () => {
+    const dir = path.join(paths.tmpDir!, 'clubhouse-e2e-abc123');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Cache'), 'x');
+
+    expect(removeTempDir(dir, paths)).toBe(true);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('refuses a directory without the clubhouse-e2e- prefix', () => {
+    const dir = path.join(paths.tmpDir!, 'important-work');
+    fs.mkdirSync(dir, { recursive: true });
+
+    expect(removeTempDir(dir, paths)).toBe(false);
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+
+  it('refuses a correctly-prefixed directory outside the temp root', () => {
+    const outside = path.join(sandbox, 'elsewhere', 'clubhouse-e2e-evil');
+    fs.mkdirSync(outside, { recursive: true });
+
+    expect(removeTempDir(outside, paths)).toBe(false);
+    expect(fs.existsSync(outside)).toBe(true);
+  });
+
+  it('refuses a path that escapes the temp root via ..', () => {
+    const escapeTarget = path.join(sandbox, 'clubhouse-e2e-escape');
+    fs.mkdirSync(escapeTarget, { recursive: true });
+    const traversal = path.join(paths.tmpDir!, '..', 'clubhouse-e2e-escape');
+
+    expect(removeTempDir(traversal, paths)).toBe(false);
+    expect(fs.existsSync(escapeTarget)).toBe(true);
+  });
+
+  it('sweeps every stray clubhouse-e2e-* dir and reports the count', () => {
+    for (const name of ['clubhouse-e2e-assistant-a', 'clubhouse-e2e-builder-project-b', 'clubhouse-e2e-c']) {
+      fs.mkdirSync(path.join(paths.tmpDir!, name), { recursive: true });
+    }
+    const keep = path.join(paths.tmpDir!, 'unrelated-dir');
+    fs.mkdirSync(keep, { recursive: true });
+
+    const result = sweepE2EProcesses(paths);
+
+    expect(result.tempDirsRemoved).toBe(3);
+    expect(fs.existsSync(keep)).toBe(true);
+  });
+});
+
+// ── CI must be untouched ─────────────────────────────────────────────────
+
+describe('CI is never affected', () => {
+  it('reports a non-local run when CI is set', () => {
+    process.env.CI = '1';
+    expect(isLocalRun()).toBe(false);
+  });
+
+  it('records nothing when CI is set', () => {
+    process.env.CI = '1';
+    recordElectronApp(12345, '/tmp/clubhouse-e2e-x', paths);
+
+    expect(fs.existsSync(path.join(paths.stateDir!, 'electron-pids.jsonl'))).toBe(false);
+  });
+
+  it('sweeps nothing when CI is set', async () => {
+    const target = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    await waitUntilVisible(target.pid!);
+    recordElectronApp(target.pid, undefined, paths);
+    const strayDir = path.join(paths.tmpDir!, 'clubhouse-e2e-stray');
+    fs.mkdirSync(strayDir, { recursive: true });
+
+    process.env.CI = '1';
+    const result = sweepE2EProcesses(paths);
+
+    expect(result).toEqual({ killed: 0, tempDirsRemoved: 0 });
+    expect(isAlive(target.pid!)).toBe(true);
+    expect(fs.existsSync(strayDir)).toBe(true);
+  });
+
+  it('does not track app handles when CI is set', () => {
+    process.env.CI = '1';
+    let closed = false;
+    const app = { close: async () => { closed = true; } };
+    trackOpenApp(app);
+    untrackOpenApp(app);
+    expect(closed).toBe(false);
+  });
+});
+
+// ── Recording ────────────────────────────────────────────────────────────
+
+describe('PID recording', () => {
+  it('carries a launch across process boundaries, so teardown can reap it', async () => {
+    // A worker records; global teardown (a different process) reaps. Recording
+    // must therefore survive in the state file, not just in memory.
+    const target = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    const dir = path.join(paths.tmpDir!, 'clubhouse-e2e-crossproc');
+    fs.mkdirSync(dir, { recursive: true });
+    await waitUntilVisible(target.pid!);
+
+    recordElectronApp(target.pid, dir, paths);
+    const result = sweepE2EProcesses(paths);
+
+    expect(result.killed).toBeGreaterThan(0);
+    expect(await waitFor(() => !isAlive(target.pid!))).toBe(true);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('reaps every launch of a run, not just the most recent', async () => {
+    // beforeAll runs once per file, so a full run records many instances.
+    const first = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    const second = spawnMarked(path.join(ELECTRON_DIST_DIR, 'Electron.app/Contents/MacOS/Electron'));
+    await waitUntilVisible(first.pid!);
+    await waitUntilVisible(second.pid!);
+
+    recordElectronApp(first.pid, undefined, paths);
+    recordElectronApp(second.pid, undefined, paths);
+    sweepE2EProcesses(paths);
+
+    expect(await waitFor(() => !isAlive(first.pid!)), 'first survived').toBe(true);
+    expect(await waitFor(() => !isAlive(second.pid!)), 'second survived').toBe(true);
+  });
+
+  it('ignores an undefined pid', () => {
+    recordElectronApp(undefined, '/tmp/clubhouse-e2e-a', paths);
+    expect(fs.existsSync(path.join(paths.stateDir!, 'electron-pids.jsonl'))).toBe(false);
+  });
+
+  it('clears the state file after a sweep, so the next run starts clean', () => {
+    recordElectronApp(999999, undefined, paths);
+    sweepE2EProcesses(paths);
+    expect(fs.existsSync(path.join(paths.stateDir!, 'electron-pids.jsonl'))).toBe(false);
+  });
+
+  it('removes the userDataDir recorded for a launch', () => {
+    const dir = path.join(paths.tmpDir!, 'clubhouse-e2e-recorded');
+    fs.mkdirSync(dir, { recursive: true });
+    recordElectronApp(999999, dir, paths);
+
+    sweepE2EProcesses(paths);
+
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('survives a corrupt state file', () => {
+    fs.mkdirSync(paths.stateDir!, { recursive: true });
+    fs.writeFileSync(path.join(paths.stateDir!, 'electron-pids.jsonl'), 'not json\n{"pid":\n', 'utf-8');
+
+    expect(() => sweepE2EProcesses(paths)).not.toThrow();
+  });
+
+  it('returns zeroes when there is nothing to clean', () => {
+    expect(sweepE2EProcesses(paths)).toEqual({ killed: 0, tempDirsRemoved: 0 });
+  });
+});
+
+// ── Orchestrator stub gating ─────────────────────────────────────────────
+
+describe('useLiveOrchestrator', () => {
+  it('is false in CI, so CI always takes the stub path (unchanged)', async () => {
+    const { useLiveOrchestrator } = await import('../e2e/assistant/helpers');
+    process.env.CI = '1';
+    process.env.E2E_LIVE_ORCHESTRATOR = '1';
+    // Even with the opt-in set, CI never uses a live orchestrator: no binary.
+    expect(useLiveOrchestrator()).toBe(false);
+  });
+
+  it('is false locally by default, so a plain run matches CI', async () => {
+    const { useLiveOrchestrator } = await import('../e2e/assistant/helpers');
+    delete process.env.CI;
+    delete process.env.E2E_LIVE_ORCHESTRATOR;
+    expect(useLiveOrchestrator()).toBe(false);
+  });
+
+  it('is true locally only when explicitly opted in', async () => {
+    const { useLiveOrchestrator } = await import('../e2e/assistant/helpers');
+    delete process.env.CI;
+    process.env.E2E_LIVE_ORCHESTRATOR = '1';
+    expect(useLiveOrchestrator()).toBe(true);
+  });
+
+  it('ignores a non-"1" value, so a stray export cannot enable live calls', async () => {
+    const { useLiveOrchestrator } = await import('../e2e/assistant/helpers');
+    delete process.env.CI;
+    process.env.E2E_LIVE_ORCHESTRATOR = 'true';
+    expect(useLiveOrchestrator()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #1571.

Local E2E runs opened ~12 Clubhouse windows back-to-back and left orphaned Electron trees behind, consuming all machine memory and requiring a force-quit. **CI is byte-for-byte unaffected** — every change is gated on `!process.env.CI`.

## Changes

| | Local | CI |
|---|---|---|
| `retries` | `0` | `1` (unchanged) |
| Assistant orchestrator | stub by default, live via `E2E_LIVE_ORCHESTRATOR=1` | stub (unchanged) |
| Orphan sweep in `global-teardown` | runs | no-op |

1. **`retries: process.env.CI ? 1 : 0`.** A retry discards the worker and re-runs `beforeAll`, launching a brand-new app for every failing test — that is the window storm.
2. **Stub is now the default everywhere.** Previously it was installed only when `CI` was set, so a plain local run made real model calls that blew the 120s timeout and failed where CI passed. Live coverage is now a deliberate opt-in.
3. **`global-teardown` reaps orphans + temp dirs.** `afterAll` only fires on graceful shutdown, so timeouts and Ctrl-C left full app trees (~300–500 MB each) running.

## Why the sweep does not pattern-match `ps`

The issue proposed killing processes whose `--user-data-dir` matches `clubhouse-e2e-*`. I probed this before building it, and that approach **does not work here and is unsafe**:

- The E2E user-data dir is passed via the `CLUBHOUSE_USER_DATA` env var and applied with `app.setPath()` (`src/main/index.ts:44`). It never reaches a command line — I launched an instance, confirmed its user-data dir populated, and **no** process command line contained `clubhouse-e2e-`.
- The only processes carrying `--user-data-dir=` on a dev machine are real apps, and an installed `/Applications/Clubhouse.app` carries `.webpack` in its command line. Matching on either would miss every process we want and risk killing ones we must never touch.

**Instead:** each launch records its PID to a gitignored run-state file, so global teardown — a separate process from the workers — can reap them. Every kill is gated on the process running from this repo's `node_modules/electron/dist`, which an installed Clubhouse.app can never match. A developer's own `npm start` instance is never a candidate, because nothing is discovered by scanning. An interrupted run is healed by the *next* run's teardown, since recorded PIDs outlive the process that wrote them.

## Verification

- **Real Electron tree, end to end:** launched, recorded, orphaned it, swept → main + 2 helpers killed, temp dir removed, no survivors.
- **Single-spec local run:** teardown reported `reaped 0 orphaned process(es), removed 4 temp dir(s)` (clearing residue from the original incident); no orphans, run-state cleaned; no retry-relaunch.
- **Pre-existing failure confirmed, not caused here:** `app-launch.spec.ts` fails with a worker teardown timeout identically on unmodified `origin/main`. On `main` it also ran retries (`[5/3] (retries)`) — the storm this PR removes. That failure is out of scope and untouched.
- 27 new tests; full suite 12,715 passing; typecheck and lint clean (0 errors).
- No `.github/` changes; `retries` resolves to `1` under `CI=1` and `0` locally (asserted).

## Test coverage

`test/e2e-cleanup.test.ts` exercises the safety properties against **real processes and directories**, since this code kills and deletes:

- Refuses to kill a recorded PID that is not repo-local Electron (stale/recycled PID), one whose command line merely mentions `.webpack`, and one carrying `--user-data-dir=`.
- Kills a recorded repo-local Electron **and its descendants** (helper reaping), but never an unrecorded one (`npm start`).
- Refuses to delete a dir without the prefix, outside the temp root, or escaping via `..`.
- Asserts every path is a no-op when `CI` is set, including the stub gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)