### PR TITLE
test(agents): guard [...] overflow menu portal (gh-1471)

### DIFF
--- a/src/renderer/features/agents/AgentListItem.test.tsx
+++ b/src/renderer/features/agents/AgentListItem.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentListItem } from './AgentListItem';
 import { useAgentStore } from '../../stores/agentStore';
 import { useProjectStore } from '../../stores/projectStore';
@@ -245,6 +245,76 @@ describe('AgentListItem context menu', () => {
     // so PTY/content-view stacking contexts cannot obscure it.
     expect(document.body.contains(menu)).toBe(true);
     expect(container.contains(menu)).toBe(false);
+  });
+});
+
+describe('AgentListItem overflow menu', () => {
+  // The [...] trigger only appears when the actions row is too narrow to fit
+  // every action. jsdom never performs layout, so ResizeObserver has to be
+  // stubbed to report a narrow row — otherwise maxVisible stays at
+  // actions.length, hasOverflow is false, and the [...] button never renders.
+  // ACTION_BUTTON_WIDTH is 26, so a 52px row fits 2 buttons and collapses the rest.
+  // Assign/restore directly rather than via vi.stubGlobal: vi.unstubAllGlobals()
+  // would also drop the window.clubhouse bridge mock that setup-renderer.ts
+  // installs with stubGlobal, breaking every later describe in this file.
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  function stubNarrowActionsRow(width: number) {
+    globalThis.ResizeObserver = class {
+      constructor(private cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        this.cb(
+          [{ target, contentRect: { width } } as unknown as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as unknown as typeof ResizeObserver;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.clubhouse.window.createPopout = vi.fn().mockResolvedValue(1);
+    stubNarrowActionsRow(52);
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it('renders the [...] trigger when actions do not fit the row', () => {
+    renderItem({ status: 'sleeping' }, { onSpawnQuickChild: vi.fn() });
+    expect(screen.getByTestId('action-overflow')).toBeInTheDocument();
+  });
+
+  it('opens the overflow menu when [...] is clicked', () => {
+    renderItem({ status: 'sleeping' }, { onSpawnQuickChild: vi.fn() });
+    expect(screen.queryByTestId('agent-context-menu')).toBeNull();
+    fireEvent.click(screen.getByTestId('action-overflow'));
+    expect(screen.getByTestId('agent-context-menu')).toBeInTheDocument();
+  });
+
+  // Regression guard for gh-1471: the [...] menu rendered behind the
+  // pseudoterminal / content view. The fix portals it to document.body so no
+  // ancestor stacking context (e.g. CanvasWorkspace's transform: scale(...))
+  // can trap or obscure it. The right-click path has its own guard above;
+  // this covers the [...] path the issue was actually filed against.
+  it('overflow menu portals to document.body so it is not trapped by stacking contexts', () => {
+    const { container } = renderItem({ status: 'sleeping' }, { onSpawnQuickChild: vi.fn() });
+    fireEvent.click(screen.getByTestId('action-overflow'));
+
+    const menu = screen.getByTestId('agent-context-menu');
+    expect(document.body.contains(menu)).toBe(true);
+    expect(container.contains(menu)).toBe(false);
+  });
+
+  it('overflow menu closes on escape', () => {
+    renderItem({ status: 'sleeping' }, { onSpawnQuickChild: vi.fn() });
+    fireEvent.click(screen.getByTestId('action-overflow'));
+    expect(screen.getByTestId('agent-context-menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('agent-context-menu')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What this is — read this first

**#1471 is already fixed on `main`.** I was assigned it as an open bug; diagnosis found the fix landed in `a94e6770` ("fix(gh-1471, nf-006): portal agent context menu…", PR #1473), which is an ancestor of current `main`. There is no product bug left to fix.

What I found instead is a **coverage gap on the exact path the issue was filed against**, which this PR closes. **Test-only — zero production code changes.**

## The gap

`AgentListItem.tsx` has one `ContextMenu` component serving two entry points:

- **right-click** on the agent row (`AgentListItem.tsx:525-531`)
- **the `[...]` overflow button** (`AgentListItem.tsx:534-540`)

`a94e6770` wrapped `ContextMenu`'s return in `createPortal(…, document.body)` (`AgentListItem.tsx:103-123`), fixing both, and added a portal regression guard — but only for the **right-click** path (`AgentListItem.test.tsx:237-248`).

The `[...]` path had no portal assertion. Since the issue title is specifically *"Agent list [...] context menu renders behind pseudoterminal"*, the one entry point the bug was reported against was the one not guarded. A future refactor could un-portal it without failing a test.

## What this adds

A `describe('AgentListItem overflow menu')` block covering the `[...]` path:

- the `[...]` trigger renders when actions don't fit the row
- clicking it opens the menu
- **the menu portals to `document.body`, not the component container** — the gh-1471 guard
- it closes on escape

## Why the ResizeObserver stub is needed

The `[...]` trigger only renders when `hasOverflow` is true, which depends on a `ResizeObserver` measuring the actions row (`AgentListItem.tsx:384-402`). jsdom performs no layout, so the observer never fires, `maxVisible` stays at `actions.length`, and the trigger never appears — the tests would silently pass against a component that renders nothing.

The stub reports a 52px row; `ACTION_BUTTON_WIDTH` is 26, so `fitCount` is 2 and the remaining actions collapse into the overflow menu.

**One subtlety worth flagging for review:** the stub is assigned and restored **directly**, not via `vi.stubGlobal`. `vi.unstubAllGlobals()` would also drop the `window.clubhouse` bridge mock that `test/setup-renderer.ts` installs with `stubGlobal` at module scope, which breaks every later `describe` in the file. I hit exactly that failure and backed it out — noting it because the surrounding repo convention (e.g. `ProjectRail.test.tsx:102`) *is* `vi.stubGlobal`, and this file is a justified exception rather than an oversight.

## Verification

- **The guard is meaningful, not decorative.** Reverting the `createPortal` call in `AgentListItem.tsx` fails both the new overflow test and the existing right-click test; restoring it passes all 29. I did not ship a test that passes either way.
- `npx vitest run src/renderer/features/agents` — **34 files, 627 tests, all pass**
- `npx tsc --noEmit` — clean
- `npx eslint` on the changed file — clean
- **No E2E run.** Respecting the team-wide freeze pending #1571. Nothing here needs it — test-only change, no runtime behaviour touched.

## Overlap

No file overlap with the seven open canvas PRs (#1561, #1562, #1566, #1567, #1568, #1569, #1570). This touches exactly one file: `src/renderer/features/agents/AgentListItem.test.tsx`.

## Recommended follow-up for #1471 itself

Since the fix already shipped, **#1471 should be verified against a current build and closed** rather than kept open as an assigned bug. Flagging rather than closing it myself — that's clubhouse-lead's call, and the issue was found during a 0.40 manual test pass, so a human should confirm the observed behaviour is actually gone before it's closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)