### PR TITLE
chore: add dependabot with weekly grouped updates and 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # One grouped PR per ecosystem per week: ungrouped npm bumps all edit
+  # package-lock.json and conflict pairwise, cascading into rebase churn.
+  # Every ecosystem carries the same 7-day cooldown: let routine releases
+  # age before adoption. Security updates bypass cooldown automatically
+  # (a dependabot behavior, not something set here).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the two ecosystems in this repo: npm (root `package.json`) and GitHub Actions
- Mirrors the goobers setup: weekly schedule, one grouped PR per ecosystem, 7-day cooldown quarantine

## Changes
- **Weekly grouped updates**: all bumps per ecosystem land in a single PR, avoiding pairwise lockfile/workflow conflicts and rebase churn
- **7-day cooldown** (`cooldown.default-days: 7`): routine releases must age a week before dependabot proposes them; security updates bypass the cooldown automatically (built-in dependabot behavior)
- `open-pull-requests-limit: 10` per ecosystem

## Test Plan
- [ ] Config is valid YAML and follows the dependabot v2 schema (GitHub validates on merge; errors surface under Insights → Dependency graph → Dependabot)
- [ ] After merge, dependabot appears enabled for npm and github-actions ecosystems

## Manual Validation
After merging, check https://github.com/Agent-Clubhouse/Clubhouse/network/updates to confirm both update jobs are registered and run without config errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)